### PR TITLE
Promote rc/2026-06-19-1507 → main

### DIFF
--- a/docs/methodology/keeping-the-factory-dark.md
+++ b/docs/methodology/keeping-the-factory-dark.md
@@ -1,0 +1,89 @@
+# Keeping the core factory dark (no humans in the loop)
+
+Lessons distilled from the 2026-06-13 → 2026-06-18 incident arc, where the HITL
+queue repeatedly filled to 30–40 issues. The pattern across every incident: the
+factory was **working correctly** but a small number of *systemic* gaps turned
+transient conditions into human-intervention pile-ups. "Dark" doesn't mean "no
+HITL" — it means **HITL contains only work a human genuinely must do**, and the
+factory never escalates work it could have handled itself.
+
+This is the operating companion to [`docs/wiki/dark-factory.md`](../wiki/dark-factory.md).
+
+## The dominant failure mode: unrecognized billing-limit messages
+
+A single unrecognized subscription-cap string is the #1 dark-factory killer.
+When an agent's output isn't classified as credit exhaustion, the runner scores
+it as a normal failure: attempts are **burned**, in-flight PRs are **closed**,
+and the issues are **dumped to HITL** en masse.
+
+- **2026-06-13** — `"You've hit your session limit · resets 5:50am"` not matched
+  ("session" between "hit your" and "limit") → ~8 PRs closed, queue flooded
+  (PR #9529).
+- **2026-06-17** — `"You've hit your weekly limit · resets Jun 18 at 5pm"` — the
+  *same class*, recurred for the weekly cap; one issue logged 492 billing-message
+  comments before anyone noticed (PR #9589).
+
+**Invariants:**
+1. Detect the **entire** `hit your <period> limit` family with one regex, not
+   per-phrase substrings — a new cap type (daily/monthly) must not need a code
+   change to be caught. Word-boundary anchor it so prose can't false-positive.
+2. Parse **every** reset format (`5pm`, `5:50am`, `Jun 18 at 5pm`,
+   `Wednesday at 5pm`, ISO-UTC). When unparseable, fall back to a short default
+   pause and re-evaluate — never idle for a year, never resume in seconds.
+3. On detection: **pause all loops + refund the attempt.** Detection is
+   load-bearing precisely because it drives the refund — that's what stops the
+   HITL escalation. (Refund logic already existed; only detection was broken.)
+4. The moment a new limit wording is observed in the wild, add it the same day.
+
+## Run current code, verify against origin
+
+- A **stale local checkout** (15 commits behind `origin/main`) meant merged
+  fixes never took effect *and* grepping the working copy produced wrong
+  "not fixed" conclusions (two issues were misjudged as over-closed).
+- **Invariants:** run the factory from an isolated workspace that hard-syncs to
+  base each launch (`make factory`, PR #9538); always check fix-state with
+  `git show origin/main:<file>`, never the working copy.
+
+## Don't pollute the checkout you run from
+
+Loops mutate `repo_root`; PRs are built in ephemeral worktrees that never clean
+the originals → perpetual dirt and **uncommitted knowledge** (248 wiki entries
+stranded). Untrack pure runtime caches (PR #9537); generate inside the worktree,
+never `repo_root` (proposal #9539); isolated workspace is the catch-all.
+
+## Auditors must dispose, not escalate
+
+Over-eager auditors manufacture false-positive HITL: ADR-drift on shared /
+high-churn modules, fake-coverage re-fires. Right-size at the source
+(shared-infra exclusion + symbol-qualified citations, PR #9530). An auto-resolver
+that can't "fix" an in-scope/false-positive finding must be able to **close it as
+a no-op** — looping to HITL forever is the anti-pattern.
+
+## Don't bulk-requeue un-auto-resolvable work
+
+Requeuing 39 stuck issues re-escalated 21 of them: work that genuinely needs a
+human (provision infra) or exceeds the agent belongs in HITL, and requeuing only
+delays the inevitable while burning cost. **Triage before requeue; only unstick
+genuinely-bounded, auto-doable fixes.** HITL filling with real human tasks is the
+system working — not a bug to paper over.
+
+## Verify factory-core changes adversarially before merge
+
+An adversarial review caught a **data-loss bug in a one-line safety guard** (a
+relative `HYDRAFLOW_FACTORY_WORKSPACE` bypassed an in-place check, so a
+hard-reset could wipe the dev checkout). Invariants: run a diff through
+adversarial review before merging anything that mutates the repo or git state;
+canonicalize paths before equality guards.
+
+## Tell graceful-stop from crash
+
+A clean `"Stop requested — terminating active processes"` shutdown is not a
+crash — don't auto-restart it (it may be intentional). Surface the state and the
+exit cause; don't assume.
+
+## The scoreboard that matters
+
+Not "HITL count = 0" but: **(a)** zero attempts burned on billing pauses,
+**(b)** zero PRs closed by transient conditions, **(c)** HITL contains only
+genuine human tasks, **(d)** the running factory is on current code. When those
+hold, the queue self-drains and humans only see what truly needs them.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0012-issue-synthesis-use-type-checking-guards-for-forward-reference-ann.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0012-issue-synthesis-use-type-checking-guards-for-forward-reference-ann.md
@@ -1,0 +1,18 @@
+---
+id: 0012
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.692826+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Use TYPE_CHECKING guards for forward-reference annotations
+
+Use `from __future__ import annotations` with `TYPE_CHECKING` guards for forward-reference type annotations.
+
+Example: `if TYPE_CHECKING: from mymodule import MyType` keeps the import from executing at runtime.
+
+**Why:** Without the guard the symbol is evaluated at import time, creating circular imports or `ImportError` in modules that aren't always available.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0013-issue-synthesis-grep-for-runtime-references-before-removing-an-imp.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0013-issue-synthesis-grep-for-runtime-references-before-removing-an-imp.md
@@ -1,0 +1,18 @@
+---
+id: 0013
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.693090+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Grep for runtime references before removing an import
+
+Before deleting an import, grep the file for runtime uses: `isinstance()` calls, variable assignments, and decorator calls.
+
+Example: `grep -n 'MyClass' src/foo.py` — a hit in `isinstance(x, MyClass)` means the import is load-bearing even if type checkers flag it as unused.
+
+**Why:** Ruff's `F401` rule does not inspect `isinstance` call sites; removing an apparently-unused import that is used at runtime produces `NameError`.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0014-issue-synthesis-use-is-none-is-not-none-for-optional-sentinels.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0014-issue-synthesis-use-is-none-is-not-none-for-optional-sentinels.md
@@ -1,0 +1,18 @@
+---
+id: 0014
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.693302+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Use `is None` / `is not None` for optional sentinels
+
+Prefer identity checks (`is None`, `is not None`) over equality checks for optional objects, especially callables and stores.
+
+Example: `if callback is None: return` — not `if callback == None`.
+
+**Why:** Identity checks are O(1) and immune to overridden `__eq__`; equality checks against `None` can accidentally match falsy custom objects with a permissive `__eq__`.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0015-issue-synthesis-sync-all-protocol-implementations-in-one-pr-when-a.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0015-issue-synthesis-sync-all-protocol-implementations-in-one-pr-when-a.md
@@ -1,0 +1,18 @@
+---
+id: 0015
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.693526+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Sync all protocol implementations in one PR when a port signature changes
+
+When a port or protocol method signature changes, update every concrete implementation atomically in the same PR — never staggered across tasks.
+
+Example: adding `ctx: Context` to `def process(self, item)` requires changing every class implementing the protocol before merging.
+
+**Why:** Staggered updates leave implementations out of sync with the protocol, causing Pyright errors that block CI until every site is updated.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0016-issue-synthesis-delete-code-blocks-bottom-to-top-to-avoid-line-num.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0016-issue-synthesis-delete-code-blocks-bottom-to-top-to-avoid-line-num.md
@@ -1,0 +1,18 @@
+---
+id: 0016
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.693726+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Delete code blocks bottom-to-top to avoid line-number shifting
+
+When removing multiple code blocks from the same file in a single session, delete the lowest block first (highest line number) and work upward.
+
+Example: delete lines 120–130 before deleting lines 80–90; reversing the order shifts targets for the second deletion.
+
+**Why:** Deleting a higher block shifts all lower line numbers; later deletions then target wrong lines or miss content entirely.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0017-issue-synthesis-patch-functions-at-their-definition-site-not-the-i.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0017-issue-synthesis-patch-functions-at-their-definition-site-not-the-i.md
@@ -1,0 +1,18 @@
+---
+id: 0017
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.693915+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Patch functions at their definition site, not the import site
+
+Always patch functions at where they are defined, not where they are imported into the module under test.
+
+Example: `@patch('hindsight.retain_safe')` not `@patch('my_module.retain_safe')` when `my_module` imports from `hindsight`.
+
+**Why:** Patching the import site only replaces that module's local reference; all other callers continue using the real function, making the mock ineffective.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0018-issue-synthesis-verify-a-file-exists-before-writing-a-plan-task-th.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0018-issue-synthesis-verify-a-file-exists-before-writing-a-plan-task-th.md
@@ -1,0 +1,18 @@
+---
+id: 0018
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.694110+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Verify a file exists before writing a plan task that modifies it
+
+Before adding a plan task that edits a specific file, confirm the file exists via `git ls-files <path>` or grep.
+
+Example: `git ls-files src/shared_prompt_prefix.py` returns empty → file never existed; update the plan before implementation starts.
+
+**Why:** Planning tasks against nonexistent files wastes implementation work and causes confusing "file not found" failures mid-execution.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0019-issue-synthesis-test-pydantic-serialization-with-both-round-trip-a.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0019-issue-synthesis-test-pydantic-serialization-with-both-round-trip-a.md
@@ -1,0 +1,18 @@
+---
+id: 0019
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.694293+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Test Pydantic serialization with both round-trip and save/load tests
+
+Validate Pydantic models with both a `model_dump_json() → model_validate_json()` round-trip (serialization fidelity) and a full save/load cycle (persistence integration).
+
+Example: a JSON round-trip catches field-name mismatches; a save/load test catches type coercion surprises from JSONL storage that round-trips hide.
+
+**Why:** JSON round-trips can pass while save/load fails due to type coercion or missing `model_config` settings at the persistence layer.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0020-issue-synthesis-run-full-make-quality-before-declaring-implementat.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0020-issue-synthesis-run-full-make-quality-before-declaring-implementat.md
@@ -1,0 +1,18 @@
+---
+id: 0020
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.694480+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Run full `make quality` before declaring implementation complete
+
+Always run the full `make quality` gate — never a file-targeted test subset — before declaring a task done.
+
+Example: `pytest tests/test_foo.py` passes; `make quality` reveals 7 failures in `test_audit_prompts.py` caused by the same change (PR #8460 → hotfix #8463).
+
+**Why:** Targeted runs miss cross-module regressions; cleanup PRs have higher blast radius than their diffs suggest.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0021-issue-synthesis-use-log-exception-with-bug-classification-to-separ.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0021-issue-synthesis-use-log-exception-with-bug-classification-to-separ.md
@@ -1,0 +1,18 @@
+---
+id: 0021
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.694669+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Use `log_exception_with_bug_classification()` to separate bugs from transient errors
+
+Use `log_exception_with_bug_classification()` or `is_likely_bug()` to distinguish bug exceptions (TypeError, AttributeError, KeyError) from transient errors (OSError, network errors).
+
+Example: in `finally` blocks use `log_exception_with_bug_classification(exc)` rather than `reraise`, to preserve finally semantics while still classifying.
+
+**Why:** Logging all exceptions as bugs floods Sentry with transient noise; wrong classification makes signal-to-noise ratio useless.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0022-issue-synthesis-use-logger-warning-exc-info-true-for-transient-err.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0022-issue-synthesis-use-logger-warning-exc-info-true-for-transient-err.md
@@ -1,0 +1,18 @@
+---
+id: 0022
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.694860+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Use `logger.warning(..., exc_info=True)` for transient errors, not `logger.exception()`
+
+Log transient operational failures with `logger.warning(msg, exc_info=True)`. Reserve `logger.exception()` for genuine bugs.
+
+Example: `except (OSError, httpx.NetworkError) as exc: logger.warning('fetch failed', exc_info=True)`.
+
+**Why:** When migrating from `logger.exception()` to `logger.warning()`, forgetting `exc_info=True` silently drops the traceback, making failures undebuggable in production.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0023-issue-synthesis-timeoutexpired-and-calledprocesserror-are-siblings.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0023-issue-synthesis-timeoutexpired-and-calledprocesserror-are-siblings.md
@@ -1,0 +1,24 @@
+---
+id: 0023
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.695033+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# `TimeoutExpired` and `CalledProcessError` are siblings — catch both
+
+Catch `subprocess.TimeoutExpired` and `subprocess.CalledProcessError` in separate `except` clauses.
+
+Example:
+```python
+except subprocess.TimeoutExpired:
+    handle_timeout()
+except subprocess.CalledProcessError:
+    handle_failure()
+```
+
+**Why:** `TimeoutExpired` is not a subclass of `CalledProcessError`; a single `except CalledProcessError` silently misses timeouts, letting them propagate as unhandled exceptions.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0024-issue-synthesis-omitting-await-on-an-async-call-silently-returns-a.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0024-issue-synthesis-omitting-await-on-an-async-call-silently-returns-a.md
@@ -1,0 +1,18 @@
+---
+id: 0024
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.695205+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Omitting `await` on an async call silently returns a coroutine object
+
+Always `await` async method calls; storing an unawaited coroutine silently never executes its body.
+
+Example: `result = fetch_data()` stores a `Coroutine` object; `result = await fetch_data()` executes it. Pyright flags the former if a type annotation is present.
+
+**Why:** Unawaited coroutines silently no-op; Pyright only catches them at `make typecheck` time when call sites have annotations.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0025-issue-synthesis-store-asyncio-create-task-results-unreferenced-tas.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0025-issue-synthesis-store-asyncio-create-task-results-unreferenced-tas.md
@@ -1,0 +1,18 @@
+---
+id: 0025
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.695381+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Store `asyncio.create_task()` results — unreferenced tasks are GC'd silently
+
+Assign every `asyncio.create_task()` result to a set and add a done callback for error logging.
+
+Example: `self._tasks.add(t := asyncio.create_task(work())); t.add_done_callback(self._tasks.discard)`.
+
+**Why:** Tasks without a live reference are garbage-collected mid-execution, silently dropping their work and exceptions with no observable signal.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0026-issue-synthesis-new-pydantic-fields-must-have-defaults-so-existing.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0026-issue-synthesis-new-pydantic-fields-must-have-defaults-so-existing.md
@@ -1,0 +1,18 @@
+---
+id: 0026
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.695559+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# New Pydantic fields must have defaults so existing state files still load
+
+Add new fields to Pydantic models as `field: Type = default_value` — never as required fields — so existing serialized state files continue to deserialize.
+
+Example: `retry_count: int = 0` allows old state JSONs that lack the key to load without error.
+
+**Why:** A required field with no default causes `ValidationError` on every existing persisted object, breaking recovery from saved state on the first restart after deploy.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0027-issue-synthesis-use-atomic-write-instead-of-path-write-text-for-js.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0027-issue-synthesis-use-atomic-write-instead-of-path-write-text-for-js.md
@@ -1,0 +1,18 @@
+---
+id: 0027
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.695739+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Use `atomic_write()` instead of `Path.write_text()` for JSON state files
+
+Write JSON state files via `file_util.atomic_write()`, not `Path.write_text()`.
+
+Example: `atomic_write(state_path, json_str)` writes to a `.tmp` sibling then renames atomically — a crash mid-write leaves the original intact.
+
+**Why:** `Path.write_text()` truncates before writing; a crash mid-operation produces a zero-byte or partial JSON that fails to parse on restart, corrupting persisted state.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0028-issue-synthesis-use-typeddict-total-false-for-backward-compatible-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0028-issue-synthesis-use-typeddict-total-false-for-backward-compatible-.md
@@ -1,0 +1,18 @@
+---
+id: 0028
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.695927+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Use `TypedDict(total=False)` for backward-compatible event payloads
+
+Define event payload TypedDicts with `total=False` so all fields are optional, allowing old producers and new consumers to interoperate.
+
+Example: `class MergePayload(TypedDict, total=False): pr_number: int; labels: list[str]`.
+
+**Why:** A `total=True` TypedDict requires all fields; adding a new field breaks any existing producer that doesn't include it, preventing rolling deployments.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0029-issue-synthesis-new-hydraflowconfig-label-fields-must-be-optional-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0029-issue-synthesis-new-hydraflowconfig-label-fields-must-be-optional-.md
@@ -1,0 +1,18 @@
+---
+id: 0029
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.696116+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# New HydraFlowConfig label fields must be optional params in ConfigFactory
+
+When adding a `list[str]` label field to `HydraFlowConfig`, add it as an optional `ConfigFactory.create()` parameter with a sensible default.
+
+Example: omitting the parameter causes `TypeError: create() got an unexpected keyword argument` in every test fixture that constructs a config.
+
+**Why:** `ConfigFactory.create()` is called across the entire test suite; missing parameters break all tests that construct a config without the new field.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0030-issue-synthesis-reverse-state-transitions-on-non-fatal-exceptions-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0030-issue-synthesis-reverse-state-transitions-on-non-fatal-exceptions-.md
@@ -1,0 +1,18 @@
+---
+id: 0030
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.696297+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Reverse state transitions on non-fatal exceptions to avoid stuck issues
+
+Wrap label-swap + operation + cleanup in a try/except that reverses the transition on non-fatal errors.
+
+Example: if a label is swapped `plan → implement` but the API call fails, swap it back to `plan` before re-raising.
+
+**Why:** An exception after a successful state transition but before cleanup leaves issues stuck in intermediate states with no automated recovery path.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0031-issue-synthesis-use-the-same-id-extraction-logic-everywhere-files-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0031-issue-synthesis-use-the-same-id-extraction-logic-everywhere-files-.md
@@ -1,0 +1,18 @@
+---
+id: 0031
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.696488+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Use the same ID extraction logic everywhere files are keyed by issue
+
+Define ID prefix lengths as named constants and centralize extraction so every site that keys files by issue uses identical logic.
+
+Example: define `DISCOVER_PREFIX_LEN = 9`; use it in both the writer and the reader rather than hardcoding `fname[9:]` in each.
+
+**Why:** Inconsistent ID logic causes silent lookup failures — a plan is written under key A but read back under key B, producing phantom missing plans.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0032-issue-synthesis-join-factory-pipeline-metrics-by-issue-number-not-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0032-issue-synthesis-join-factory-pipeline-metrics-by-issue-number-not-.md
@@ -1,0 +1,18 @@
+---
+id: 0032
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.696672+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Join factory pipeline metrics by `issue_number`, not `pr_number`
+
+When correlating factory metrics or reviews across pipeline tables, join on `issue_number` rather than `pr_number`.
+
+Example: a PR can be closed and recreated with a new number; `issue_number` is stable across the full lifecycle.
+
+**Why:** `pr_number` changes when PRs are recycled; joining on it silently drops or duplicates records for any issue where the PR was recreated.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0033-issue-synthesis-test-pipeline-stage-ordering-not-just-status-value.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0033-issue-synthesis-test-pipeline-stage-ordering-not-just-status-value.md
@@ -1,0 +1,18 @@
+---
+id: 0033
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.696858+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Test pipeline stage ordering, not just status values, after inserting a stage
+
+After inserting a new stage into `PIPELINE_STAGES`, assert both that the stage's status value is correct and that its array index is correct.
+
+Example: inserting a stage at index 2 shifts all downstream indices; a test checking only `status == 'active'` passes while skip-detection silently breaks.
+
+**Why:** Index-based progression logic produces incorrect skip decisions when stages are reordered, with no immediate test failure.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0034-issue-synthesis-filter-evicted-memories-on-both-content-prefix-and.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0034-issue-synthesis-filter-evicted-memories-on-both-content-prefix-and.md
@@ -1,0 +1,18 @@
+---
+id: 0034
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.697057+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Filter evicted memories on both content prefix AND metadata status
+
+Apply dual filters when loading recalled memories: check both the `[EVICTED]` content prefix and `status: evicted` in metadata before injecting into prompts.
+
+Example: `if mem.content.startswith('[EVICTED]') or mem.metadata.get('status') == 'evicted': skip`.
+
+**Why:** A single filter has a failure path; if one guard is missing or malformed, a tombstone leaks into agent prompts and produces confusing or incorrect agent behavior.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0035-issue-synthesis-new-automated-skills-must-start-with-blocking-fals.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0035-issue-synthesis-new-automated-skills-must-start-with-blocking-fals.md
@@ -1,0 +1,18 @@
+---
+id: 0035
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.697259+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# New automated skills must start with `blocking=False` until proven stable
+
+Register new dynamic skills with `blocking=False` and graduate to `blocking=True` only after ≥20 runs at ≥95% success rate.
+
+Example: a new lint-skill marked `blocking=True` on day one fails builds on edge cases the author didn't anticipate.
+
+**Why:** Unproven blocking skills immediately break CI on legitimate code; graduated promotion ensures checks are stable before they can gate merges.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0036-issue-synthesis-validate-parsers-against-realistic-multi-paragraph.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0036-issue-synthesis-validate-parsers-against-realistic-multi-paragraph.md
@@ -1,0 +1,18 @@
+---
+id: 0036
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.697465+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Validate parsers against realistic multi-paragraph agent output
+
+Write parser tests against realistic multi-paragraph transcripts — prose interspersed with structured markers — not bare marker strings.
+
+Example: test input should resemble real `claude` CLI output; assert on structured markers, not prose wording, so transcript rewords don't break tests.
+
+**Why:** Bare-marker tests pass even when the parser fails on the surrounding prose context present in real output, hiding real format regressions.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0037-issue-synthesis-log-a-warning-when-transcript-extraction-finds-zer.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0037-issue-synthesis-log-a-warning-when-transcript-extraction-finds-zer.md
@@ -1,0 +1,18 @@
+---
+id: 0037
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.697666+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Log a warning when transcript extraction finds zero matches on non-empty input
+
+When extracting structured data from CLI transcripts, wrap regex in try/except and log a warning on zero matches against non-empty input.
+
+Example: `matches = RE.findall(text); if not matches and text.strip(): logger.warning('parser found 0 matches on non-empty transcript')`.
+
+**Why:** Silent zero-match returns hide format drift between transcript versions; warnings surface parser breakage before it causes downstream data loss.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0038-issue-synthesis-use-portable-shell-commands-in-alpine-containers-p.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0038-issue-synthesis-use-portable-shell-commands-in-alpine-containers-p.md
@@ -1,0 +1,18 @@
+---
+id: 0038
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.697862+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Use portable shell commands in Alpine containers — Python is absent
+
+In Alpine-based Docker containers, avoid Python and non-standard utilities. Use portable POSIX commands for memory/CPU operations.
+
+Example: `dd if=/dev/zero bs=1M count=32 of=/dev/null` or `head -c 33554432 /dev/zero > /dev/null` instead of a Python `bytearray` allocation.
+
+**Why:** Alpine's minimal tooling excludes Python and many GNU utilities; scripts that rely on them fail with `command not found` in constrained CI environments.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0039-issue-synthesis-separate-silent-with-result-events-from-purely-sil.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0039-issue-synthesis-separate-silent-with-result-events-from-purely-sil.md
@@ -1,0 +1,18 @@
+---
+id: 0039
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.698054+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Separate silent-with-result events from purely silent events in dispatch dicts
+
+In event dispatch tables, distinguish events that produce no display output but set a result value (e.g., `agent_end`, `turn_end`) from events that are truly silent and set nothing.
+
+Example: check `_SILENT_WITH_RESULT` before `_SILENT_EVENTS` so result-setting events are routed correctly.
+
+**Why:** Treating silent-with-result events as purely silent discards their return values, causing downstream state to silently receive `None` instead of the real result.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0040-issue-synthesis-create-a-specialized-method-rather-than-overloadin.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0040-issue-synthesis-create-a-specialized-method-rather-than-overloadin.md
@@ -1,0 +1,18 @@
+---
+id: 0040
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.698248+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Create a specialized method rather than overloading a general one
+
+When a general method returns insufficient data for a specific use case, create a separate focused method rather than adding optional parameters.
+
+Example: `list_issues_by_label()` returns basic metadata; `get_issue_updated_at()` handles timestamps in a separate call — not an optional flag on the list method.
+
+**Why:** Overloading general methods couples unrelated concerns and complicates callers that need only one piece of data.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0041-issue-synthesis-ruff-strips-unused-imports-mid-tdd-cycle.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0041-issue-synthesis-ruff-strips-unused-imports-mid-tdd-cycle.md
@@ -1,0 +1,20 @@
+---
+id: 0041
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.698454+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Ruff strips unused imports mid-TDD cycle
+
+During TDD, write the test body (which uses the new symbol) before adding its import — or use a function-local import inside the test body.
+
+Example: add `from scripts.audit import score_rule` only after `score_rule` appears in the test function body. Alternative: `def test_score(): from scripts.audit import score_rule; assert score_rule(...)`.
+
+**Why:** Pre-commit `ruff --fix` removes imports not yet referenced on the first save, producing `NameError` on the second save and breaking the TDD red-phase.
+
+See also: Testing — feedback memory `feedback_ruff_strips_unused_imports_during_tdd.md`.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0042-issue-synthesis-verify-implementation-files-are-in-the-diff-before.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0042-issue-synthesis-verify-implementation-files-are-in-the-diff-before.md
@@ -1,0 +1,18 @@
+---
+id: 0042
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:13:17.698658+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+---
+
+# Verify implementation files are in the diff before merging a feature PR
+
+Before merging, confirm the target source file appears in `git diff --name-only origin/main`.
+
+Example: PR closes #7644 but `git diff --name-only` shows only `docs/` and `tests/` — `src/makefile_scaffold.py` has 0 changes; the implementation was never committed.
+
+**Why:** Tests can pass against stubs or unchanged code; a green CI with no implementation changes ships dead-end work that silently does nothing.

--- a/repo_wiki/T-rav/hydraflow/patterns/0008-issue-synthesis-use-optional-fields-with-defaults-for-backward-com.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0008-issue-synthesis-use-optional-fields-with-defaults-for-backward-com.md
@@ -1,0 +1,18 @@
+---
+id: 0008
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.312835+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Use optional fields with defaults for backward-compatible schema changes
+
+New Pydantic fields must be optional with sensible defaults so existing state.json files load without migration validators.
+
+Example: `field: str = "default"` or `field: str | None = None`; read with `.get("scope", "repo")`.
+
+**Why:** Pydantic v2 auto-coerces raw dicts from state.json into typed models — no migration step exists, so non-optional new fields crash on load.

--- a/repo_wiki/T-rav/hydraflow/patterns/0009-issue-synthesis-distinguish-bare-str-from-str-none-before-narrowin.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0009-issue-synthesis-distinguish-bare-str-from-str-none-before-narrowin.md
@@ -1,0 +1,18 @@
+---
+id: 0009
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.313084+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Distinguish bare `str` from `str | None` before narrowing a field type
+
+Narrowing a bare `str` field to a StrEnum is safe when all stored values already conform. Narrowing a union like `str | None` requires union narrowing, not direct replacement.
+
+Example: grep all state.json consumers and call sites exhaustively before narrowing; treat union fields separately.
+
+**Why:** Narrowing a union type as if it were a bare type causes `ValidationError` on load for any stored `None` values.

--- a/repo_wiki/T-rav/hydraflow/patterns/0010-issue-synthesis-use-strenum-coercion-to-auto-convert-stored-string.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0010-issue-synthesis-use-strenum-coercion-to-auto-convert-stored-string.md
@@ -1,0 +1,18 @@
+---
+id: 0010
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.313296+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Use StrEnum coercion to auto-convert stored string values on load
+
+Declare Pydantic fields as StrEnum when values already conform, so Pydantic v2 auto-coerces stored strings at load time.
+
+Example: `class Phase(StrEnum): READY = "hydraflow-ready"` — field `phase: Phase` coerces `"hydraflow-ready"` from state.json automatically.
+
+**Why:** Manual `Phase(raw)` coercions at every read site diverge when new read paths are added; StrEnum coercion centralises conversion.

--- a/repo_wiki/T-rav/hydraflow/patterns/0011-issue-synthesis-define-canonical-constants-as-single-source-of-tru.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0011-issue-synthesis-define-canonical-constants-as-single-source-of-tru.md
@@ -1,0 +1,18 @@
+---
+id: 0011
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.313486+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Define canonical constants as single source of truth for label lists
+
+Establish a canonical constant (e.g., `ALL_LIFECYCLE_LABEL_FIELDS`) and derive every label list from it; never duplicate the list inline.
+
+Example: reset code, validators, and display logic all reference `ALL_LIFECYCLE_LABEL_FIELDS` — no magic strings.
+
+**Why:** Duplicated label lists diverge silently; a canonical constant makes omissions a grep-findable gap, not a runtime miss.

--- a/repo_wiki/T-rav/hydraflow/patterns/0012-issue-synthesis-use-metadata-tags-instead-of-enum-variants-for-sha.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0012-issue-synthesis-use-metadata-tags-instead-of-enum-variants-for-sha.md
@@ -1,0 +1,18 @@
+---
+id: 0012
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.313684+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Use metadata tags instead of enum variants for shared-bank categorization
+
+Tag items with metadata (e.g., `{"source": "adr_council"}`) rather than adding new enum variants for each category.
+
+Example: `retain(bank=Bank.LEARNINGS, metadata={"source": "adr_council"})` — no new enum variant needed.
+
+**Why:** Enum variants require syncing type checks, prompts, and display order across the codebase; a metadata tag adds a category with no schema change.

--- a/repo_wiki/T-rav/hydraflow/patterns/0013-issue-synthesis-grep-all-call-sites-before-changing-a-function-sig.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0013-issue-synthesis-grep-all-call-sites-before-changing-a-function-sig.md
@@ -1,0 +1,18 @@
+---
+id: 0013
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.313872+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Grep all call sites before changing a function signature
+
+Run `git grep <function_name>` before modifying any signature; for public functions, verify zero remaining unpatched matches after the change.
+
+Example: `git grep 'load_state'` before changing its return type — update every caller in the same commit.
+
+**Why:** Missing even one call site causes `TypeError` at runtime; exhaustive grep audit is the only way to confirm full coverage.

--- a/repo_wiki/T-rav/hydraflow/patterns/0014-issue-synthesis-update-all-callers-atomically-when-a-return-type-c.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0014-issue-synthesis-update-all-callers-atomically-when-a-return-type-c.md
@@ -1,0 +1,18 @@
+---
+id: 0014
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.314046+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Update all callers atomically when a return type changes
+
+When a function's return type changes (e.g., `str | None` → `dict | None`), update every caller in a single commit — never in separate PRs.
+
+Example: change `parse()` return type and grep + update all `result[0]` / `result[1]` unpack sites before committing.
+
+**Why:** A partially-migrated codebase compiles but crashes at runtime on unpatched callers.

--- a/repo_wiki/T-rav/hydraflow/patterns/0015-issue-synthesis-preserve-public-api-during-extraction-via-thin-del.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0015-issue-synthesis-preserve-public-api-during-extraction-via-thin-del.md
@@ -1,0 +1,18 @@
+---
+id: 0015
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.314227+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Preserve public API during extraction via thin delegation stubs
+
+When extracting code that tests or external callers depend on, keep the original method as a thin stub delegating to the new location.
+
+Example: leave `Client.old_method(self, x)` calling `new_module.old_method(x)` after extraction.
+
+**Why:** Removing public/semi-public methods during refactoring breaks callers that aren't visible in local grep (e.g., dynamically assembled call sites or test mocks).

--- a/repo_wiki/T-rav/hydraflow/patterns/0016-issue-synthesis-extract-pure-transform-functions-before-moving-cod.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0016-issue-synthesis-extract-pure-transform-functions-before-moving-cod.md
@@ -1,0 +1,18 @@
+---
+id: 0016
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.314407+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Extract pure transform functions before moving code to new classes
+
+Identify pure functions (no mutable closure state, no side effects) and extract them to module-level first; only then move to a class if ownership is clear.
+
+Example: extract `_format_label(name)` before creating `LabelFormatter` — the extracted form is independently testable.
+
+**Why:** Pure functions have the smallest blast radius and validate the extraction boundary before higher-risk class restructuring.

--- a/repo_wiki/T-rav/hydraflow/patterns/0017-issue-synthesis-preserve-per-concern-try-except-blocks-during-refa.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0017-issue-synthesis-preserve-per-concern-try-except-blocks-during-refa.md
@@ -1,0 +1,18 @@
+---
+id: 0017
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.314606+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Preserve per-concern try/except blocks during refactoring
+
+Do not merge or widen separate try/except blocks that each guard a specific concern — keep them as-is when extracting surrounding code.
+
+Example: if `fetch_labels()` and `post_comment()` each have their own try/except, extracted helpers must not share a single outer handler.
+
+**Why:** Merging exception scopes lets a failure in one concern silently suppress or skip a different concern.

--- a/repo_wiki/T-rav/hydraflow/patterns/0018-issue-synthesis-extract-duplicated-jsonl-reading-logic-to-a-shared.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0018-issue-synthesis-extract-duplicated-jsonl-reading-logic-to-a-shared.md
@@ -1,0 +1,18 @@
+---
+id: 0018
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.314799+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Extract duplicated JSONL-reading logic to a shared `_load_jsonl()` helper
+
+Shared JSONL-reading logic must be extracted to a `_load_jsonl(path, label)` helper rather than duplicated inline.
+
+Example: `records = _load_jsonl(path, "events")` — one implementation, multiple callers.
+
+**Why:** Inline duplication causes silent divergence when one copy gets a bug fix (e.g., empty-file guard) that the other copies miss.

--- a/repo_wiki/T-rav/hydraflow/patterns/0019-issue-synthesis-mock-at-the-definition-site-not-the-import-site.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0019-issue-synthesis-mock-at-the-definition-site-not-the-import-site.md
@@ -1,0 +1,18 @@
+---
+id: 0019
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.315009+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Mock at the definition site, not the import site
+
+Patch `hindsight.tombstone_safe`, not `module_under_test.tombstone_safe`; combine with deferred imports inside test methods.
+
+Example: `@patch('hindsight.tombstone_safe')` not `@patch('mymodule.tombstone_safe')`.
+
+**Why:** Import-site patches fail when the import is deferred or when optional dependencies are conditionally loaded — definition-site patches intercept regardless of import order.

--- a/repo_wiki/T-rav/hydraflow/patterns/0020-issue-synthesis-retarget-mock-patches-to-the-new-location-before-m.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0020-issue-synthesis-retarget-mock-patches-to-the-new-location-before-m.md
@@ -1,0 +1,18 @@
+---
+id: 0020
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.315212+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Retarget mock patches to the new location before moving a method
+
+Before moving a method to a new module, update all `@patch` decorators in tests to point to the destination path, then move the implementation.
+
+Example: change `@patch('old.module.Method')` → `@patch('new.module.Method')` before the move commit.
+
+**Why:** Moving a method without updating patches leaves tests patching a now-unused import, so the live code runs unpatched and the test silently stops covering the real path.

--- a/repo_wiki/T-rav/hydraflow/patterns/0021-issue-synthesis-generated-test-content-must-reference-function-nam.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0021-issue-synthesis-generated-test-content-must-reference-function-nam.md
@@ -1,0 +1,18 @@
+---
+id: 0021
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.315425+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Generated test content must reference function names, not line numbers
+
+Test skeletons, comments, and generated assertions must use exact function/class names for stability across refactors.
+
+Example: `# tests path through calculate_drift()` not `# tests line 42 in drift.py`.
+
+**Why:** Line numbers shift on every edit, making generated references immediately stale and misleading.

--- a/repo_wiki/T-rav/hydraflow/patterns/0022-issue-synthesis-use-meta-tests-to-enforce-anti-pattern-absence-acr.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0022-issue-synthesis-use-meta-tests-to-enforce-anti-pattern-absence-acr.md
@@ -1,0 +1,18 @@
+---
+id: 0022
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.315634+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Use meta-tests to enforce anti-pattern absence across the test suite
+
+Write meta-tests that scan `tests/test_*.py` for forbidden patterns (e.g., `sys.path.insert`, "Should..." docstrings, AAA comments) and fail CI if any are found.
+
+Example: `assert not any('sys.path.insert' in line for line in test_files)` as a standalone test.
+
+**Why:** Manual review misses anti-patterns introduced across hundreds of test files; a meta-test turns the check into a permanent CI gate.

--- a/repo_wiki/T-rav/hydraflow/patterns/0023-issue-synthesis-use-threading-lock-for-thread-pool-code-asyncio-lo.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0023-issue-synthesis-use-threading-lock-for-thread-pool-code-asyncio-lo.md
@@ -1,0 +1,18 @@
+---
+id: 0023
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.315867+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Use `threading.Lock` for thread-pool code; `asyncio.Lock` only for pure coroutines
+
+When code runs via `asyncio.to_thread()` or is called from both sync and async contexts, use `threading.Lock`. Use `asyncio.Lock` only for coordinating pure coroutines without thread-pool involvement.
+
+Example: `self._lock = threading.Lock()` for a cache shared between thread-pool workers.
+
+**Why:** `asyncio.Lock` is not thread-safe — acquiring it from a thread pool raises or silently corrupts state.

--- a/repo_wiki/T-rav/hydraflow/patterns/0024-issue-synthesis-extract-unlocked-helpers-to-prevent-re-entrant-loc.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0024-issue-synthesis-extract-unlocked-helpers-to-prevent-re-entrant-loc.md
@@ -1,0 +1,18 @@
+---
+id: 0024
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.316066+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Extract `_unlocked()` helpers to prevent re-entrant lock attempts
+
+When a lock-holding method needs to call another method that also acquires the same lock, extract an `_unlocked()` variant and call that from both.
+
+Example: `def update(self): with self._lock: self._update_unlocked()` — `batch_update` calls `_update_unlocked()` too.
+
+**Why:** Re-entrant `threading.Lock` acquisition deadlocks; re-entrant `asyncio.Lock` raises — `_unlocked()` variants eliminate both failure modes.

--- a/repo_wiki/T-rav/hydraflow/patterns/0025-issue-synthesis-use-file-util-append-jsonl-for-crash-safe-jsonl-ap.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0025-issue-synthesis-use-file-util-append-jsonl-for-crash-safe-jsonl-ap.md
@@ -1,0 +1,18 @@
+---
+id: 0025
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.316252+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Use `file_util.append_jsonl()` for crash-safe JSONL appends
+
+Wrap JSONL appends in `file_util.append_jsonl()`, which calls `flush()` + `os.fsync()` inside a `file_lock()`.
+
+Example: `file_util.append_jsonl(path, record)` — not `with open(path, 'a') as f: f.write(...)`.
+
+**Why:** Bare `open(..., 'a')` without fsync loses the last record on crash; the lock prevents interleaved writes from concurrent processes.

--- a/repo_wiki/T-rav/hydraflow/patterns/0026-issue-synthesis-use-file-util-atomic-write-for-critical-state-file.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0026-issue-synthesis-use-file-util-atomic-write-for-critical-state-file.md
@@ -1,0 +1,18 @@
+---
+id: 0026
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.316464+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Use `file_util.atomic_write()` for critical state file updates
+
+Write critical state via `file_util.atomic_write()`, which writes to a temp file then calls `os.replace()` atomically.
+
+Example: `file_util.atomic_write(state_path, json.dumps(state))` — not `open(path, 'w').write(...)`.
+
+**Why:** A crash mid-write with `open(..., 'w')` truncates the file, producing an empty or partial state that cannot be loaded.

--- a/repo_wiki/T-rav/hydraflow/patterns/0027-issue-synthesis-use-claim-then-merge-for-async-queue-processing-to.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0027-issue-synthesis-use-claim-then-merge-for-async-queue-processing-to.md
@@ -1,0 +1,18 @@
+---
+id: 0027
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.316653+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Use claim-then-merge for async queue processing to prevent lost entries
+
+Atomically claim queue items (clear/load under lock), release lock, perform async work, re-acquire lock, reload new items, merge, then atomically write.
+
+Example: `with lock: batch = queue.copy(); queue.clear()` → async work → `with lock: queue.update(new); queue.update(results); write(queue)`.
+
+**Why:** Releasing the lock during async work is needed to avoid deadlock, but re-acquiring before write prevents entries appended during the async gap from being lost.

--- a/repo_wiki/T-rav/hydraflow/patterns/0028-issue-synthesis-set-and-clear-trace-context-in-a-single-try-finall.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0028-issue-synthesis-set-and-clear-trace-context-in-a-single-try-finall.md
@@ -1,0 +1,18 @@
+---
+id: 0028
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.316844+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Set and clear trace context in a single try/finally block
+
+Set/clear or begin/end pairs for tracing context MUST execute within a single try/finally — never split across separate methods.
+
+Example: `token = ctx.set(val); try: ... finally: ctx.reset(token)` — both in one scope.
+
+**Why:** Splitting the set/clear across call boundaries leaks trace state across issues or loop iterations, corrupting span attribution.

--- a/repo_wiki/T-rav/hydraflow/patterns/0029-issue-synthesis-keep-event-publishing-coupled-with-the-condition-t.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0029-issue-synthesis-keep-event-publishing-coupled-with-the-condition-t.md
@@ -1,0 +1,18 @@
+---
+id: 0029
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.317043+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Keep event publishing coupled with the condition that gates it
+
+The `if should_alert:` check and `event_bus.publish(ALERT)` must live in the same method body — never separated into different methods.
+
+Example: inline both in `_check_and_notify()` rather than calling `_check()` then `_publish()`.
+
+**Why:** Separating them creates code paths where the gate is checked but the event isn't fired (or vice versa), breaking observability silently.

--- a/repo_wiki/T-rav/hydraflow/patterns/0030-issue-synthesis-preserve-exact-retry-counter-state-during-dispatch.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0030-issue-synthesis-preserve-exact-retry-counter-state-during-dispatch.md
@@ -1,0 +1,18 @@
+---
+id: 0030
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.317258+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Preserve exact retry counter state during dispatcher refactoring
+
+When refactoring state machine dispatchers, carry over retry counters and escalation conditions (e.g., epic-child label swaps) exactly — do not reset or re-derive them.
+
+Example: copy `issue.attempt_count` and `issue.escalation_triggered` into the refactored handler without modification.
+
+**Why:** Dropping retry state silently resets attempt budgets, allowing previously-exhausted issues to cycle again or miss escalation thresholds.

--- a/repo_wiki/T-rav/hydraflow/patterns/0031-issue-synthesis-dry-run-mode-must-not-emit-state-changing-events.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0031-issue-synthesis-dry-run-mode-must-not-emit-state-changing-events.md
@@ -1,0 +1,18 @@
+---
+id: 0031
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.317466+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Dry-run mode must not emit state-changing events
+
+Gate every side-effecting event bus publish behind `if not self.dry_run:` to ensure dry-run has no observable side effects.
+
+Example: `if not self.dry_run: self.event_bus.publish(TRIAGE_ROUTING, ...)` — not emitted during dry-run.
+
+**Why:** An emitted event in dry-run triggers downstream label mutations and state transitions, making dry-run non-idempotent.

--- a/repo_wiki/T-rav/hydraflow/patterns/0032-issue-synthesis-maintain-immutable-return-contract-for-parse-tuple.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0032-issue-synthesis-maintain-immutable-return-contract-for-parse-tuple.md
@@ -1,0 +1,18 @@
+---
+id: 0032
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.317676+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Maintain immutable return contract for `parse()` — `tuple[str, str | None]`
+
+Phase result `parse()` must always return `tuple[str, str | None]`; refactors that widen or change this shape break all callers.
+
+Example: return `("approved", None)` or `("rejected", "reason")` — never a plain `str` or `dict`.
+
+**Why:** Callers destructure the tuple positionally; a shape change produces `TypeError` or silent data corruption at the unpack site.

--- a/repo_wiki/T-rav/hydraflow/patterns/0033-issue-synthesis-define-event-to-stage-and-source-to-stage-mappings.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0033-issue-synthesis-define-event-to-stage-and-source-to-stage-mappings.md
@@ -1,0 +1,18 @@
+---
+id: 0033
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.317893+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Define EVENT_TO_STAGE and SOURCE_TO_STAGE mappings before skip detection
+
+Implement event/worker-to-stage mappings together with skip detection logic — never add a mapping after skip detection is wired.
+
+Example: define `EVENT_TO_STAGE = {...}` and `SOURCE_TO_STAGE = {...}` before the `if event in skip_set: return` guard.
+
+**Why:** Mappings added after the early-return guard are never evaluated, making the new stage silently unreachable.

--- a/repo_wiki/T-rav/hydraflow/patterns/0034-issue-synthesis-pre-allocate-memory-budget-upfront-before-prompt-a.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0034-issue-synthesis-pre-allocate-memory-budget-upfront-before-prompt-a.md
@@ -1,0 +1,18 @@
+---
+id: 0034
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.318127+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Pre-allocate memory budget upfront before prompt assembly
+
+Call `get_allocation()` and consume all budget caps before starting `_inject_memory()` — post-hoc surplus reclamation is not possible.
+
+Example: allocate wiki budget first, deduct from surplus, then distribute remaining memory budget proportionally.
+
+**Why:** Prompt assembly is streaming; once a section is written, its token budget cannot be reclaimed for a different section.

--- a/repo_wiki/T-rav/hydraflow/patterns/0035-issue-synthesis-use-a-two-round-allocator-section-minimums-first-t.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0035-issue-synthesis-use-a-two-round-allocator-section-minimums-first-t.md
@@ -1,0 +1,18 @@
+---
+id: 0035
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.318328+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Use a two-round allocator: section minimums first, then proportional surplus
+
+Round one gives each memory section its minimum budget; round two distributes the remainder proportionally by `_DEFAULT_PRIORITIES` label.
+
+Example: `min_alloc = {k: MINIMUMS[k] for k in sections}; surplus = total - sum(min_alloc.values()); prop += surplus * weights`.
+
+**Why:** A single-round proportional allocator can starve low-priority sections below their functional minimum, breaking prompt structure.

--- a/repo_wiki/T-rav/hydraflow/patterns/0036-issue-synthesis-deduct-wiki-budget-from-memory-surplus-before-redi.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0036-issue-synthesis-deduct-wiki-budget-from-memory-surplus-before-redi.md
@@ -1,0 +1,18 @@
+---
+id: 0036
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.318537+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Deduct wiki budget from memory surplus before redistributing
+
+Compute the wiki budget (`max_repo_wiki_chars`) and subtract it from the memory surplus BEFORE distributing the remainder proportionally across memory sections.
+
+Example: `surplus -= wiki_budget; memory_alloc = distribute(surplus, weights)`.
+
+**Why:** Not deducting first causes memory sections to over-allocate, then the wiki gets truncated when both compete for the same token pool.

--- a/repo_wiki/T-rav/hydraflow/patterns/0037-issue-synthesis-lazy-load-memory-context-on-explicit-user-action-n.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0037-issue-synthesis-lazy-load-memory-context-on-explicit-user-action-n.md
@@ -1,0 +1,18 @@
+---
+id: 0037
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.318752+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Lazy-load memory context on explicit user action, not on list render
+
+Fetch memory context only when the user expands a section — not when the HITL list view renders.
+
+Example: expand button triggers `fetchMemoryContext(issueId)` — the list view fires no memory API calls.
+
+**Why:** Pre-fetching on render causes N+1 API calls on every HITL list load, amplified by the number of open issues.

--- a/repo_wiki/T-rav/hydraflow/patterns/0038-issue-synthesis-use-sha-256-truncated-to-16-chars-for-memory-dedup.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0038-issue-synthesis-use-sha-256-truncated-to-16-chars-for-memory-dedup.md
@@ -1,0 +1,18 @@
+---
+id: 0038
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.318976+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Use SHA-256 truncated to 16 chars for memory dedup keys
+
+Compute dedup keys and recall-hit tracking via `SHA-256(content)[:16]`.
+
+Example: `key = hashlib.sha256(item['text'].encode()).hexdigest()[:16]`.
+
+**Why:** Consistent hashing ensures the same content maps to the same key across process restarts; truncation keeps keys human-scannable in logs.

--- a/repo_wiki/T-rav/hydraflow/patterns/0039-issue-synthesis-use-asymmetric-word-set-overlap-for-memory-dedupli.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0039-issue-synthesis-use-asymmetric-word-set-overlap-for-memory-dedupli.md
@@ -1,0 +1,18 @@
+---
+id: 0039
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.319206+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Use asymmetric word-set overlap for memory deduplication
+
+Compute dedup similarity as `len(words & existing) / max(len(words), 1)` with a configurable threshold (default 0.85).
+
+Example: new item with 10 words sharing 9 with an existing item → score 0.9 → suppress.
+
+**Why:** Symmetric Jaccard penalises short additions to long entries; asymmetric overlap correctly identifies content that's mostly a subset of existing memory.

--- a/repo_wiki/T-rav/hydraflow/patterns/0040-issue-synthesis-batch-load-scoring-data-once-per-eviction-operatio.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0040-issue-synthesis-batch-load-scoring-data-once-per-eviction-operatio.md
@@ -1,0 +1,18 @@
+---
+id: 0040
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.319423+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Batch-load scoring data once per eviction operation, not per item
+
+Call `MemoryScorer.load_item_scores()` once per eviction pass and reuse the result across all items.
+
+Example: `scores = scorer.load_item_scores(); for item in items: rank(item, scores)`.
+
+**Why:** Per-item score loading reads the same file N times; batch loading makes eviction O(1) in I/O regardless of corpus size.

--- a/repo_wiki/T-rav/hydraflow/patterns/0041-issue-synthesis-hindsightclient-retain-coerces-metadata-to-str-use.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0041-issue-synthesis-hindsightclient-retain-coerces-metadata-to-str-use.md
@@ -1,0 +1,18 @@
+---
+id: 0041
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.319646+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# HindsightClient.retain() coerces metadata to `str` — use `== "true"`, not `is True`
+
+`retain()` calls `str(v)` on all metadata values; boolean `True` becomes string `"true"`.
+
+Example: `metadata={"warning": "true"}` not `{"warning": True}`; check with `metadata.get("warning") == "true"`.
+
+**Why:** `metadata.get("warning") is True` always returns `False` after coercion, silently disabling warning-based filtering.

--- a/repo_wiki/T-rav/hydraflow/patterns/0042-issue-synthesis-memory-contradiction-resolution-provenance-wins-ov.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0042-issue-synthesis-memory-contradiction-resolution-provenance-wins-ov.md
@@ -1,0 +1,18 @@
+---
+id: 0042
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.319935+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Memory contradiction resolution: provenance wins over recency
+
+When two memory items contradict, human-sourced wins over agent-sourced regardless of timestamp; among equal provenance, newer wins.
+
+Example: a human-written learning from 2024 beats an agent-written one from 2025.
+
+**Why:** Agent-sourced items can encode hallucinations; provenance-first resolution ensures human corrections are never overwritten by automated entries.

--- a/repo_wiki/T-rav/hydraflow/patterns/0043-issue-synthesis-memory-eviction-must-atomically-update-both-item-s.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0043-issue-synthesis-memory-eviction-must-atomically-update-both-item-s.md
@@ -1,0 +1,18 @@
+---
+id: 0043
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.320233+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Memory eviction must atomically update both `item_scores.json` and `items.jsonl`
+
+An eviction operation must write `item_scores.json` and `items.jsonl` together within the same lock scope — never update one without the other.
+
+Example: `atomic_write(scores_path, ...)` then `atomic_write(items_path, ...)` under a single lock acquire.
+
+**Why:** A partial update leaves scores referencing evicted items (or items with stale scores), corrupting ranking on the next eviction pass.

--- a/repo_wiki/T-rav/hydraflow/patterns/0044-issue-synthesis-guard-close-with-a-closed-flag-to-make-it-idempote.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0044-issue-synthesis-guard-close-with-a-closed-flag-to-make-it-idempote.md
@@ -1,0 +1,18 @@
+---
+id: 0044
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.320497+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Guard `close()` with a `_closed` flag to make it idempotent
+
+All cleanup methods must check and set a `_closed` flag as their first step.
+
+Example: `def close(self): if self._closed: return; self._closed = True; await self._resource.aclose()`.
+
+**Why:** Double-close on an async resource (e.g., HTTP session) raises; idempotent close makes teardown order-independent in test fixtures.

--- a/repo_wiki/T-rav/hydraflow/patterns/0045-issue-synthesis-memory-staleness-detection-should-emit-events-not-.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0045-issue-synthesis-memory-staleness-detection-should-emit-events-not-.md
@@ -1,0 +1,18 @@
+---
+id: 0045
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.320763+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Memory staleness detection should emit events, not silently mutate state
+
+Staleness detection must emit events or log warnings rather than silently deleting or modifying stale entries.
+
+Example: `event_bus.publish(STALE_MEMORY, item_id=item.id, age_days=age)` instead of `self._items.pop(item.id)`.
+
+**Why:** Silent mutation removes the operator's ability to review or override staleness decisions; events keep the action reversible.

--- a/repo_wiki/T-rav/hydraflow/patterns/0046-issue-synthesis-adr-files-without-readme-entries-are-invisible-to-.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0046-issue-synthesis-adr-files-without-readme-entries-are-invisible-to-.md
@@ -1,0 +1,18 @@
+---
+id: 0046
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.320983+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# ADR files without README entries are invisible to tooling
+
+Every ADR file in `docs/adr/` must have a corresponding row in `docs/adr/README.md` to be canonically referenceable.
+
+Example: adding `docs/adr/0055-new-decision.md` requires a matching `| 0055 | New Decision | Accepted |` row in README.
+
+**Why:** `scan_adr_directory()` builds its index from README rows; a file without a row is silently skipped by drift detection and cross-reference tooling.

--- a/repo_wiki/T-rav/hydraflow/patterns/0047-issue-synthesis-preserve-the-hf-namespace-prefix-when-renaming-ski.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0047-issue-synthesis-preserve-the-hf-namespace-prefix-when-renaming-ski.md
@@ -1,0 +1,18 @@
+---
+id: 0047
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.321204+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Preserve the `hf.` namespace prefix when renaming skill or command files
+
+When renaming fixture or command files, keep the `hf.` or `hf-` prefix intact.
+
+Example: rename `hf.audit-code.md` → `hf.audit-contracts.md`, not `audit-contracts.md`.
+
+**Why:** Skill lookup strips the prefix at registration; dropping it makes the skill unreachable via `/hf.audit-contracts` and breaks namespace consistency.

--- a/repo_wiki/T-rav/hydraflow/patterns/0048-issue-synthesis-keep-skill-prompts-in-sync-across-all-four-backend.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0048-issue-synthesis-keep-skill-prompts-in-sync-across-all-four-backend.md
@@ -1,0 +1,18 @@
+---
+id: 0048
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:09:18.321427+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007
+---
+
+# Keep skill prompts in sync across all four backend locations
+
+Skill prompt text lives in `src/`, `.claude/commands/`, `.pi/skills/`, and `.codex/skills/` — update all four locations when changing a prompt.
+
+Example: editing `.claude/commands/hf.diff-sanity.md` requires mirroring the change to the other three locations.
+
+**Why:** Missed updates cause the same skill to behave differently depending on which backend routes the request, producing inconsistent LLM behavior.

--- a/repo_wiki/T-rav/hydraflow/testing/0007-issue-synthesis-mock-at-definition-site-not-usage-site.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0007-issue-synthesis-mock-at-definition-site-not-usage-site.md
@@ -1,0 +1,22 @@
+---
+id: 0007
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.826932+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Mock at definition site, not usage site
+
+Patch symbols at the module where they are defined, not where they are imported.
+
+- Bad: `patch("tests.test_foo.MyClass")`
+- Good: `patch("src.mymodule.MyClass")`
+
+For optional dependencies like `sentry_sdk`, use `patch.dict("sys.modules", {"sentry_sdk": mock, "sentry_sdk.integrations": mock})` to guarantee cleanup across all tests in the session.
+
+**Why:** Usage-site patches intercept only that one import; other callers and subsequent imports still see the real object, producing inconsistent test behavior.

--- a/repo_wiki/T-rav/hydraflow/testing/0008-issue-synthesis-reserve-pytest-mark-integration-for-real-external-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0008-issue-synthesis-reserve-pytest-mark-integration-for-real-external-.md
@@ -1,0 +1,19 @@
+---
+id: 0008
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.827243+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Reserve @pytest.mark.integration for real external dependencies only
+
+Mark a test `@pytest.mark.integration` only when it exercises Docker, network, filesystem, real worktrees, or live service instances — not when all deps are `AsyncMock` or `MagicMock`.
+
+Use `pytest.mark.skipif(not shutil.which("cli"), ...)` for optional CLI tools.
+
+**Why:** Over-marking slows the fast suite and blurs the boundary between unit and integration layers, making targeted test runs unreliable.

--- a/repo_wiki/T-rav/hydraflow/testing/0009-issue-synthesis-await-asyncio-sleep-0-before-asserting-on-create-t.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0009-issue-synthesis-await-asyncio-sleep-0-before-asserting-on-create-t.md
@@ -1,0 +1,23 @@
+---
+id: 0009
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.827468+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Await asyncio.sleep(0) before asserting on create_task() side effects
+
+After triggering fire-and-forget async tasks via `asyncio.create_task()`, yield the event loop before making assertions.
+
+```python
+task = asyncio.create_task(fn())
+await asyncio.sleep(0)
+mock.assert_called_once()
+```
+
+**Why:** Without yielding, the created task has not yet run; assertions on its side effects will fail spuriously and non-deterministically.

--- a/repo_wiki/T-rav/hydraflow/testing/0010-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0010-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
@@ -1,0 +1,22 @@
+---
+id: 0010
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.827672+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Test async context managers in three standard scenarios
+
+Test async context managers with three scenarios: (1) idempotent close — calling `close()` twice is safe, (2) context manager exit triggers `close()` exactly once, (3) `__aenter__` returns `self`.
+
+```python
+async with resource as r:
+    assert r is resource
+```
+
+**Why:** Missing any scenario leaves an incomplete behavioral contract, hiding bugs in external-connection or file-handle management.

--- a/repo_wiki/T-rav/hydraflow/testing/0011-issue-synthesis-use-python-script-stand-ins-to-test-subprocess-bou.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0011-issue-synthesis-use-python-script-stand-ins-to-test-subprocess-bou.md
@@ -1,0 +1,19 @@
+---
+id: 0011
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.827860+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Use Python script stand-ins to test subprocess boundaries
+
+Create small Python scripts that log invocations to JSON-lines files instead of mocking subprocess calls directly.
+
+Example: Pass `subprocess_runner = ["python3", "fake_gh.py"]` to the system under test; assert via `json.loads(log_path.read_text())`.
+
+**Why:** Real subprocess boundaries catch shell-quoting, PATH resolution, and argument-passing bugs that mock-based patches cannot detect.

--- a/repo_wiki/T-rav/hydraflow/testing/0012-issue-synthesis-reset-module-level-global-state-in-both-setup-and-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0012-issue-synthesis-reset-module-level-global-state-in-both-setup-and-.md
@@ -1,0 +1,24 @@
+---
+id: 0012
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.828040+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Reset module-level global state in both setup and teardown
+
+Global state (e.g., `_gh_semaphore`, `_rate_limit_until`) must be explicitly reset in both `setup_method` and `teardown_method`.
+
+```python
+def setup_method(self):
+    module._rate_limit_until = 0
+def teardown_method(self):
+    module._rate_limit_until = 0
+```
+
+**Why:** Omitting setup reset leaves stale state from a prior run; omitting teardown reset infects the next test — both produce non-deterministic failures.

--- a/repo_wiki/T-rav/hydraflow/testing/0013-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0013-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md
@@ -1,0 +1,22 @@
+---
+id: 0013
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.828219+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Use tmp_path with ConfigFactory for all file-based test I/O
+
+All tests that read or write files must use `tmp_path` combined with `ConfigFactory.create(base_path=tmp_path)` — never write to real project paths.
+
+```python
+def test_something(tmp_path):
+    config = ConfigFactory.create(base_path=tmp_path)
+```
+
+**Why:** Tests writing to real project paths corrupt the working directory and produce hard-to-reproduce cross-test pollution.

--- a/repo_wiki/T-rav/hydraflow/testing/0014-issue-synthesis-wire-real-business-logic-in-phase-runner-integrati.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0014-issue-synthesis-wire-real-business-logic-in-phase-runner-integrati.md
@@ -1,0 +1,19 @@
+---
+id: 0014
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.828398+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Wire real business logic in phase-runner integration tests
+
+Phase-runner integration tests should use real `StateTracker`, `EventBus`, and `VerificationJudge` instances, mocking only the `_execute()` subprocess boundary. Provide configurable transcript strings for real runner parsing.
+
+Validate via `StateTracker` APIs and `EventBus.get_history()`, not mock call assertions.
+
+**Why:** Fully-mocked runners hide mismatches between transcript parsing logic and real output formats — exactly the bugs integration tests exist to catch.

--- a/repo_wiki/T-rav/hydraflow/testing/0015-issue-synthesis-test-protocol-compliance-with-both-structural-typi.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0015-issue-synthesis-test-protocol-compliance-with-both-structural-typi.md
@@ -1,0 +1,19 @@
+---
+id: 0015
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.828576+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Test protocol compliance with both structural typing and duck-typing
+
+Verify protocol satisfaction with two complementary checks: (1) `isinstance(obj, Protocol)` with `@runtime_checkable`, and (2) `hasattr(obj, 'method_name')`. Add `inspect.signature()` comparison to detect parameter drift.
+
+Parametrize over each protocol method so failures are specific.
+
+**Why:** Either check alone misses a class of violations; structural typing catches missing methods, signature comparison catches arity and keyword drift.

--- a/repo_wiki/T-rav/hydraflow/testing/0016-issue-synthesis-test-fa-ade-getattr-routing-attributeerror-and-pro.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0016-issue-synthesis-test-fa-ade-getattr-routing-attributeerror-and-pro.md
@@ -1,0 +1,19 @@
+---
+id: 0016
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.828759+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Test façade __getattr__ routing, AttributeError, and protocol delegation
+
+When adding a façade over sub-clients, explicitly test: (1) `__getattr__` routes calls to the correct sub-client, (2) unknown attributes raise `AttributeError`, (3) the façade satisfies protocols via delegation, (4) existing mocks of the original class still pass.
+
+Assert sub-components receive mutable dict/set references, not copies, to shared state owned by the façade.
+
+**Why:** Façade delegation bugs pass all pre-existing tests because those tests mock the original class directly, not the façade.

--- a/repo_wiki/T-rav/hydraflow/testing/0017-issue-synthesis-assert-relative-event-id-ordering-never-absolute-v.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0017-issue-synthesis-assert-relative-event-id-ordering-never-absolute-v.md
@@ -1,0 +1,20 @@
+---
+id: 0017
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.828947+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Assert relative event ID ordering, never absolute values
+
+Tests for events backed by a global counter (`_event_counter`) must assert relative ordering and uniqueness within one test, never absolute ID values.
+
+- Good: `assert event_a.id < event_b.id`
+- Bad: `assert event_a.id == 1`
+
+**Why:** Global ID counters are shared across tests and imports; absolute assertions produce non-deterministic failures under parallel or reordered execution.

--- a/repo_wiki/T-rav/hydraflow/testing/0018-issue-synthesis-add-structural-tests-before-property-based-transit.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0018-issue-synthesis-add-structural-tests-before-property-based-transit.md
@@ -1,0 +1,19 @@
+---
+id: 0018
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.829118+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Add structural tests before property-based transition graph tests
+
+Before using hypothesis or similar tools to exercise a label/stage transition graph, add explicit structural assertions: every target is a valid stage, every stage has a transition entry, no dangling references.
+
+Example: `assert set(VALID_TRANSITIONS.keys()) == VALID_STAGES`
+
+**Why:** Property-based tests on a malformed graph surface as mysterious assertion failures rather than clear "bad graph definition" errors.

--- a/repo_wiki/T-rav/hydraflow/testing/0019-issue-synthesis-grep-all-model-usages-before-committing-pydantic-o.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0019-issue-synthesis-grep-all-model-usages-before-committing-pydantic-o.md
@@ -1,0 +1,19 @@
+---
+id: 0019
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.829281+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Grep all model usages before committing Pydantic or TypedDict field changes
+
+Before adding or removing a field, grep the test suite for the model name and update all affected assertions: model definition, factory defaults, `all_fields` tests, and round-trip serialization tests.
+
+For `NotRequired` fields, update exact-match assertions but not missing-key assertions.
+
+**Why:** Missed exact-match assertions silently pass when the field is optional, masking the coverage gap until a stricter test runs later.

--- a/repo_wiki/T-rav/hydraflow/testing/0020-issue-synthesis-feature-toggles-require-both-a-config-field-and-an.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0020-issue-synthesis-feature-toggles-require-both-a-config-field-and-an.md
@@ -1,0 +1,19 @@
+---
+id: 0020
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.829459+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Feature toggles require both a config field and an _ENV_INT_OVERRIDES entry
+
+Each new feature toggle needs a field in `src/config.py` AND an entry in `_ENV_INT_OVERRIDES`. Test both the default field value and the env-var override behavior.
+
+See also: architecture-state-persistence — `_ENV_INT_OVERRIDES` tuple default must equal the Field default or env override silently stops applying.
+
+**Why:** A config field alone makes the toggle code-only; without the `_ENV_INT_OVERRIDES` entry, the environment variable silently has no effect.

--- a/repo_wiki/T-rav/hydraflow/testing/0021-issue-synthesis-test-concurrent-jsonl-appends-with-exact-counts-no.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0021-issue-synthesis-test-concurrent-jsonl-appends-with-exact-counts-no.md
@@ -1,0 +1,21 @@
+---
+id: 0021
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.829642+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Test concurrent JSONL appends with exact counts, not timing
+
+Use `ThreadPoolExecutor` with fixed thread and iteration counts; assert the exact expected line count after completion.
+
+Example: `10 threads × 20 events = 200 lines` — assert `len(lines) == 200`.
+
+POSIX guarantees atomicity for writes under ~4 KB; validate empirically before relying on this.
+
+**Why:** Timing-based assertions are non-deterministic; exact counts reliably expose real data loss or line corruption.

--- a/repo_wiki/T-rav/hydraflow/testing/0022-issue-synthesis-use-identical-string-keys-across-memory-bank-dedup.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0022-issue-synthesis-use-identical-string-keys-across-memory-bank-dedup.md
@@ -1,0 +1,19 @@
+---
+id: 0022
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.829807+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Use identical string keys across memory bank deduplication and assembly
+
+The `bank_order` list and bank dict keys must use identical strings throughout (e.g., `"review_insights"` everywhere, never a mix of `"review_insights"` and `"review-insights"`).
+
+Fallback recall functions should try multiple field names (`learning`, `text`, `content`, `display_text`) to extract the text payload.
+
+**Why:** Key mismatches silently skip entire banks during deduplication or assembly with no error or warning.

--- a/repo_wiki/T-rav/hydraflow/testing/0023-issue-synthesis-skill-definition-changes-must-update-all-4-backend.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0023-issue-synthesis-skill-definition-changes-must-update-all-4-backend.md
@@ -1,0 +1,19 @@
+---
+id: 0023
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.829989+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Skill definition changes must update all 4 backend copies
+
+HydraFlow skills are replicated across `.claude/commands/`, `.pi/skills/`, `.codex/skills/`, and `src/*.py`. Use a manual `SKILL_MARKERS` mapping (not regex introspection) to validate that all copies contain matching output markers via substring search.
+
+A single skill change can require updates across 3+ test fixture files.
+
+**Why:** Missing updates in any one copy cause consistency test failures and silent runtime behavior divergence.

--- a/repo_wiki/T-rav/hydraflow/testing/0024-issue-synthesis-auto-generated-adr-pattern-tests-must-use-pytest-m.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0024-issue-synthesis-auto-generated-adr-pattern-tests-must-use-pytest-m.md
@@ -1,0 +1,17 @@
+---
+id: 0024
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.830164+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Auto-generated ADR pattern tests must use @pytest.mark.skip by default
+
+When auto-generating tests from ADR Decision sections, emit all tests with `@pytest.mark.skip(reason="skeleton: requires human review")`. Extract only 4 high-confidence baseline patterns per ADR: uniqueness, usage, negative, coverage.
+
+**Why:** Automated pattern matching on ADR language is ambiguous; unskipped generated tests produce false-positive CI failures until a human validates each pattern.

--- a/repo_wiki/T-rav/hydraflow/testing/0025-issue-synthesis-every-adr-must-pass-structural-section-validation-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0025-issue-synthesis-every-adr-must-pass-structural-section-validation-.md
@@ -1,0 +1,17 @@
+---
+id: 0025
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.830335+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Every ADR must pass structural section validation before merge
+
+ADRs must pass `tests/test_adr_pre_validator.py`, which enforces required sections (Status, Context, Decision, Consequences) and valid status values: Proposed, Accepted, Deprecated, Superseded.
+
+**Why:** ADRs missing required sections are ambiguous to automated drift-detection tooling, causing false-positive or false-negative ADR drift reports.

--- a/repo_wiki/T-rav/hydraflow/testing/0026-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0026-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md
@@ -1,0 +1,26 @@
+---
+id: 0026
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.830512+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Never import private helpers at module level in test files
+
+Import private or internal functions (`_foo`) inside the test function or a `pytest.fixture`, never at the top of the test module.
+
+```python
+# bad — kills entire file if symbol doesn't exist
+from src.makefile_scaffold import _check_prereq_deps
+
+# good — failure scoped to the test that needs it
+def test_check_prereq():
+    from src.makefile_scaffold import _check_prereq_deps
+```
+
+**Why:** A module-level `ImportError` prevents pytest from collecting the file, silently destroying all pre-existing passing tests in that module.

--- a/repo_wiki/T-rav/hydraflow/testing/0027-issue-synthesis-pin-function-signatures-in-the-source-file-before-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0027-issue-synthesis-pin-function-signatures-in-the-source-file-before-.md
@@ -1,0 +1,21 @@
+---
+id: 0027
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.830691+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Pin function signatures in the source file before writing tests or docs
+
+Decide the authoritative signature (argument order, return tuple shape) in the source file first; write docs and tests to match that single source of truth.
+
+1. Write the function stub
+2. Copy its exact signature into the docstring
+3. Then write the test
+
+**Why:** When docs and tests are authored before implementation, signature drift goes undetected until runtime — both artifacts can be wrong simultaneously.

--- a/repo_wiki/T-rav/hydraflow/testing/0028-issue-synthesis-specify-exact-logger-name-in-caplog-at-level-asser.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0028-issue-synthesis-specify-exact-logger-name-in-caplog-at-level-asser.md
@@ -1,0 +1,23 @@
+---
+id: 0028
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.830864+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Specify exact logger name in caplog.at_level() assertions
+
+Always pass the exact logger name to `caplog.at_level()` and clear caplog before the action under test.
+
+```python
+with caplog.at_level(logging.WARNING, logger="src.billing"):
+    trigger_action()
+assert "expected substring" in caplog.text
+```
+
+**Why:** Without the logger filter, unrelated log messages from other modules pollute the captured output and produce false positives.

--- a/repo_wiki/T-rav/hydraflow/testing/0029-issue-synthesis-js-rendered-accessibility-attributes-require-playw.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0029-issue-synthesis-js-rendered-accessibility-attributes-require-playw.md
@@ -1,0 +1,17 @@
+---
+id: 0029
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.831052+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# JS-rendered accessibility attributes require Playwright, not TestClient
+
+Server-side `TestClient` (Django/FastAPI) returns only the initial HTML shell; `aria-labelledby` and other JS-rendered attributes are absent. Delete dead Python `TestClient` tests for these attributes and replace with Playwright tests.
+
+**Why:** TestClient assertions on JS-rendered attributes always pass vacuously — the attribute is missing from the initial render, so assertions check an empty string or missing key.

--- a/repo_wiki/T-rav/hydraflow/testing/0030-issue-synthesis-use-word-boundary-matching-in-name-coverage-checks.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0030-issue-synthesis-use-word-boundary-matching-in-name-coverage-checks.md
@@ -1,0 +1,20 @@
+---
+id: 0030
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.831241+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Use word-boundary matching in name-coverage checks to prevent collisions
+
+Substring matching in coverage or name checks produces false positives when short names appear inside longer ones.
+
+- Bad: `"Foo" in text` — also matches `FooBar`, `PrefixFoo`
+- Good: `re.search(r'\bFoo\b', text)` or full-name match
+
+**Why:** Short-name collisions silently mark unrelated targets as covered, hiding real gaps in coverage.

--- a/repo_wiki/T-rav/hydraflow/testing/0031-issue-synthesis-keep-test-label-stage-constants-synchronized-with-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0031-issue-synthesis-keep-test-label-stage-constants-synchronized-with-.md
@@ -1,0 +1,21 @@
+---
+id: 0031
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.831435+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Keep test label/stage constants synchronized with production definitions
+
+Test constants (`ALL_PIPELINE_LABELS`, `VALID_STAGES`, `VALID_TRANSITIONS`) must mirror production definitions. Add a sync test asserting set equality via dynamic field extraction.
+
+Example: `assert set(VALID_TRANSITIONS.keys()) == VALID_STAGES`
+
+Direct-swap labels (`hitl-active`, `fixed`) are set via `swap_pipeline_labels()`, not transitions — test them separately.
+
+**Why:** Stale test constants become false documentation and silently mask missing transition or label coverage.

--- a/repo_wiki/T-rav/hydraflow/testing/0032-issue-synthesis-allow-3-line-drift-tolerance-in-ast-based-structur.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0032-issue-synthesis-allow-3-line-drift-tolerance-in-ast-based-structur.md
@@ -1,0 +1,19 @@
+---
+id: 0032
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.831626+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Allow ±3 line drift tolerance in AST-based structure assertions
+
+For tests that verify code structure by parsing source ASTs (e.g., checking function length or nesting depth), allow ±3 line tolerance.
+
+Example: Assert `len(func.body) <= 53` rather than `<= 50` to account for blank lines and decorator variations.
+
+**Why:** Exact line-count assertions redden CI on whitespace-only diffs, creating maintenance noise without improving correctness.

--- a/repo_wiki/T-rav/hydraflow/testing/0033-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0033-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md
@@ -1,0 +1,19 @@
+---
+id: 0033
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T05:17:49.831811+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0034
+---
+
+# Existing tests cover private-method extractions; add tests only for new behavior
+
+When extracting a private method from a public one with an unchanged public API, the existing test suite provides full coverage — no new tests are needed for the extraction itself.
+
+When extracting prompt-building methods, run prompt-assertion tests in isolation immediately after extraction to verify parity.
+
+**Why:** Adding duplicate tests for unchanged behavior inflates the suite; the real regression risk is behavioral, which existing tests already guard.

--- a/repo_wiki/T-rav/hydraflow/testing/0034-issue-synthesis-mock-at-definition-site-not-at-the-import-site.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0034-issue-synthesis-mock-at-definition-site-not-at-the-import-site.md
@@ -1,0 +1,22 @@
+---
+id: 0034
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.210514+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Mock at definition site, not at the import site
+
+Patch symbols at the module where they are defined, not where they are imported.
+
+- Bad: `patch("tests.test_foo.MyClass")`
+- Good: `patch("src.mymodule.MyClass")`
+
+For optional deps like `sentry_sdk`, use `patch.dict("sys.modules", {"sentry_sdk": mock, "sentry_sdk.integrations": mock})`; patch sub-modules explicitly to prevent import leaks.
+
+**Why:** Usage-site patches intercept only that one import; other callers and subsequent imports still see the real object, producing inconsistent test behavior.

--- a/repo_wiki/T-rav/hydraflow/testing/0035-issue-synthesis-reserve-pytest-mark-integration-for-real-external-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0035-issue-synthesis-reserve-pytest-mark-integration-for-real-external-.md
@@ -1,0 +1,19 @@
+---
+id: 0035
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.210721+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Reserve @pytest.mark.integration for real external dependencies only
+
+Mark a test `@pytest.mark.integration` only when it exercises Docker, network, filesystem, real worktrees, or live service instances — not when all deps are `AsyncMock` or `MagicMock`.
+
+Use `pytest.mark.skipif(not shutil.which("cli"), ...)` for optional CLI tools.
+
+**Why:** Over-marking slows the fast suite and blurs the unit/integration boundary, making targeted test runs unreliable.

--- a/repo_wiki/T-rav/hydraflow/testing/0036-issue-synthesis-await-asyncio-sleep-0-before-asserting-on-create-t.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0036-issue-synthesis-await-asyncio-sleep-0-before-asserting-on-create-t.md
@@ -1,0 +1,23 @@
+---
+id: 0036
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.210910+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Await asyncio.sleep(0) before asserting on create_task() side effects
+
+After triggering fire-and-forget async tasks via `asyncio.create_task()`, yield the event loop before making assertions.
+
+```python
+task = asyncio.create_task(fn())
+await asyncio.sleep(0)
+mock.assert_called_once()
+```
+
+**Why:** Without yielding, the created task has not yet run; assertions on its side effects will fail spuriously and non-deterministically.

--- a/repo_wiki/T-rav/hydraflow/testing/0037-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0037-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
@@ -1,0 +1,22 @@
+---
+id: 0037
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.211087+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Test async context managers in three standard scenarios
+
+Test async context managers with three scenarios: (1) idempotent close — calling `close()` twice is safe, (2) context manager exit triggers `close()` exactly once, (3) `__aenter__` returns `self`.
+
+```python
+async with resource as r:
+    assert r is resource
+```
+
+**Why:** Missing any scenario leaves an incomplete behavioral contract, hiding bugs in external-connection or file-handle management.

--- a/repo_wiki/T-rav/hydraflow/testing/0038-issue-synthesis-use-python-script-stand-ins-to-test-subprocess-bou.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0038-issue-synthesis-use-python-script-stand-ins-to-test-subprocess-bou.md
@@ -1,0 +1,19 @@
+---
+id: 0038
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.211253+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Use Python script stand-ins to test subprocess boundaries
+
+Create small Python scripts that log invocations to JSON-lines files instead of mocking subprocess calls directly.
+
+Example: Pass `subprocess_runner = ["python3", "fake_gh.py"]` to the system under test; assert via `json.loads(log_path.read_text())`.
+
+**Why:** Real subprocess boundaries catch shell-quoting, PATH resolution, and argument-passing bugs that mock-based patches cannot detect.

--- a/repo_wiki/T-rav/hydraflow/testing/0039-issue-synthesis-reset-module-level-global-state-in-both-setup-and-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0039-issue-synthesis-reset-module-level-global-state-in-both-setup-and-.md
@@ -1,0 +1,24 @@
+---
+id: 0039
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.211405+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Reset module-level global state in both setup and teardown
+
+Global state (e.g., `_gh_semaphore`, `_rate_limit_until`) must be explicitly reset in both `setup_method` and `teardown_method`.
+
+```python
+def setup_method(self):
+    module._rate_limit_until = 0
+def teardown_method(self):
+    module._rate_limit_until = 0
+```
+
+**Why:** Omitting setup reset leaves stale state from a prior run; omitting teardown reset infects the next test — both produce non-deterministic failures.

--- a/repo_wiki/T-rav/hydraflow/testing/0040-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0040-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md
@@ -1,0 +1,22 @@
+---
+id: 0040
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.211556+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Use tmp_path with ConfigFactory for all file-based test I/O
+
+All tests that read or write files must use `tmp_path` combined with `ConfigFactory.create(base_path=tmp_path)` — never write to real project paths.
+
+```python
+def test_something(tmp_path):
+    config = ConfigFactory.create(base_path=tmp_path)
+```
+
+**Why:** Tests writing to real project paths corrupt the working directory and produce hard-to-reproduce cross-test pollution.

--- a/repo_wiki/T-rav/hydraflow/testing/0041-issue-synthesis-wire-real-business-logic-in-phase-runner-integrati.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0041-issue-synthesis-wire-real-business-logic-in-phase-runner-integrati.md
@@ -1,0 +1,19 @@
+---
+id: 0041
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.211710+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Wire real business logic in phase-runner integration tests
+
+Use real `StateTracker`, `EventBus`, and `VerificationJudge` instances in phase-runner integration tests; mock only the `_execute()` subprocess boundary. Provide configurable transcript strings for real runner parsing.
+
+Validate via `StateTracker` APIs and `EventBus.get_history()`, not mock call assertions.
+
+**Why:** Fully-mocked runners hide mismatches between transcript parsing logic and real output formats — exactly the bugs integration tests exist to catch.

--- a/repo_wiki/T-rav/hydraflow/testing/0042-issue-synthesis-test-protocol-compliance-with-structural-typing-an.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0042-issue-synthesis-test-protocol-compliance-with-structural-typing-an.md
@@ -1,0 +1,17 @@
+---
+id: 0042
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.211890+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Test protocol compliance with structural typing and duck-typing
+
+Verify protocol satisfaction with two complementary checks: (1) `isinstance(obj, Protocol)` with `@runtime_checkable`, and (2) `hasattr(obj, 'method_name')`. Add `inspect.signature()` comparison to detect parameter drift. Parametrize over each protocol method so failures are specific.
+
+**Why:** Either check alone misses a class of violations; structural typing catches missing methods, signature comparison catches arity and keyword drift.

--- a/repo_wiki/T-rav/hydraflow/testing/0043-issue-synthesis-test-fa-ade-getattr-routing-attributeerror-and-pro.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0043-issue-synthesis-test-fa-ade-getattr-routing-attributeerror-and-pro.md
@@ -1,0 +1,19 @@
+---
+id: 0043
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.212051+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Test façade __getattr__ routing, AttributeError, and protocol delegation
+
+When adding a façade over sub-clients, explicitly test: (1) `__getattr__` routes to the correct sub-client, (2) unknown attributes raise `AttributeError`, (3) the façade satisfies protocols via delegation, (4) existing mocks of the original class still pass.
+
+Assert sub-components receive mutable dict/set references — not copies — to shared state owned by the façade.
+
+**Why:** Façade delegation bugs pass all pre-existing tests because those tests mock the original class directly, not the façade.

--- a/repo_wiki/T-rav/hydraflow/testing/0044-issue-synthesis-assert-relative-event-id-ordering-never-absolute-v.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0044-issue-synthesis-assert-relative-event-id-ordering-never-absolute-v.md
@@ -1,0 +1,20 @@
+---
+id: 0044
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.212214+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Assert relative event ID ordering, never absolute values
+
+Tests for events backed by a global counter (`_event_counter`) must assert relative ordering and uniqueness within one test, never absolute ID values.
+
+- Good: `assert event_a.id < event_b.id`
+- Bad: `assert event_a.id == 1`
+
+**Why:** Global ID counters are shared across tests and imports; absolute assertions produce non-deterministic failures under parallel or reordered execution.

--- a/repo_wiki/T-rav/hydraflow/testing/0045-issue-synthesis-add-structural-tests-before-property-based-transit.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0045-issue-synthesis-add-structural-tests-before-property-based-transit.md
@@ -1,0 +1,19 @@
+---
+id: 0045
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.212373+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Add structural tests before property-based transition graph tests
+
+Before using hypothesis or similar tools to exercise a label/stage transition graph, add explicit structural assertions: every target is a valid stage, every stage has a transition entry, no dangling references.
+
+Example: `assert set(VALID_TRANSITIONS.keys()) == VALID_STAGES`
+
+**Why:** Property-based tests on a malformed graph surface as mysterious assertion failures rather than clear "bad graph definition" errors.

--- a/repo_wiki/T-rav/hydraflow/testing/0046-issue-synthesis-grep-all-model-usages-before-committing-pydantic-o.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0046-issue-synthesis-grep-all-model-usages-before-committing-pydantic-o.md
@@ -1,0 +1,19 @@
+---
+id: 0046
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.212525+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Grep all model usages before committing Pydantic or TypedDict changes
+
+Before adding or removing a field, grep the test suite for the model name and update all affected assertions: model definition, factory defaults, `all_fields` tests, and round-trip serialization tests.
+
+For `NotRequired` fields, update exact-match assertions but not missing-key assertions.
+
+**Why:** Missed exact-match assertions silently pass when a field is optional, masking the coverage gap until a stricter test runs later.

--- a/repo_wiki/T-rav/hydraflow/testing/0047-issue-synthesis-feature-toggles-require-both-a-config-field-and-an.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0047-issue-synthesis-feature-toggles-require-both-a-config-field-and-an.md
@@ -1,0 +1,19 @@
+---
+id: 0047
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.212679+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Feature toggles require both a config field and an _ENV_INT_OVERRIDES entry
+
+Each new feature toggle needs a field in `src/config.py` AND an entry in `_ENV_INT_OVERRIDES`. Test both the default field value and the env-var override behavior.
+
+See also: architecture-state-persistence — `_ENV_INT_OVERRIDES` tuple default must equal the Field default or env override silently stops applying.
+
+**Why:** A config field alone makes the toggle code-only; without `_ENV_INT_OVERRIDES`, the environment variable silently has no effect.

--- a/repo_wiki/T-rav/hydraflow/testing/0048-issue-synthesis-test-concurrent-jsonl-appends-with-exact-counts-no.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0048-issue-synthesis-test-concurrent-jsonl-appends-with-exact-counts-no.md
@@ -1,0 +1,21 @@
+---
+id: 0048
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.212853+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Test concurrent JSONL appends with exact counts, not timing
+
+Use `ThreadPoolExecutor` with fixed thread and iteration counts; assert the exact expected line count after completion.
+
+Example: `10 threads × 20 events = 200 lines` — assert `len(lines) == 200`.
+
+POSIX guarantees atomicity for writes under ~4 KB; validate empirically before relying on this.
+
+**Why:** Timing-based assertions are non-deterministic; exact counts reliably expose real data loss or line corruption.

--- a/repo_wiki/T-rav/hydraflow/testing/0049-issue-synthesis-use-identical-string-keys-across-memory-bank-dedup.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0049-issue-synthesis-use-identical-string-keys-across-memory-bank-dedup.md
@@ -1,0 +1,19 @@
+---
+id: 0049
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.213021+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Use identical string keys across memory bank deduplication and assembly
+
+The `bank_order` list and bank dict keys must use identical strings throughout (e.g., `"review_insights"` everywhere, never mixed with `"review-insights"`).
+
+Fallback recall functions should try multiple field names (`learning`, `text`, `content`, `display_text`) to extract the text payload.
+
+**Why:** Key mismatches silently skip entire banks during deduplication or assembly with no error or warning.

--- a/repo_wiki/T-rav/hydraflow/testing/0050-issue-synthesis-skill-definition-changes-must-update-all-4-backend.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0050-issue-synthesis-skill-definition-changes-must-update-all-4-backend.md
@@ -1,0 +1,19 @@
+---
+id: 0050
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.213192+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Skill definition changes must update all 4 backend copies
+
+HydraFlow skills are replicated across `.claude/commands/`, `.pi/skills/`, `.codex/skills/`, and `src/*.py`. Use a manual `SKILL_MARKERS` mapping (not regex introspection) to validate all copies contain matching output markers via substring search.
+
+A single skill change can require updates across 3+ test fixture files.
+
+**Why:** Missing updates in any one copy cause consistency test failures and silent runtime behavior divergence.

--- a/repo_wiki/T-rav/hydraflow/testing/0051-issue-synthesis-auto-generated-adr-tests-must-use-pytest-mark-skip.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0051-issue-synthesis-auto-generated-adr-tests-must-use-pytest-mark-skip.md
@@ -1,0 +1,17 @@
+---
+id: 0051
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.213362+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Auto-generated ADR tests must use @pytest.mark.skip by default
+
+When auto-generating tests from ADR Decision sections, emit all tests with `@pytest.mark.skip(reason="skeleton: requires human review")`. Extract only 4 high-confidence baseline patterns per ADR: uniqueness, usage, negative, coverage.
+
+**Why:** Automated pattern matching on ADR language is ambiguous; unskipped generated tests produce false-positive CI failures until a human validates each pattern.

--- a/repo_wiki/T-rav/hydraflow/testing/0052-issue-synthesis-every-adr-must-pass-structural-section-validation-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0052-issue-synthesis-every-adr-must-pass-structural-section-validation-.md
@@ -1,0 +1,17 @@
+---
+id: 0052
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.213527+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Every ADR must pass structural section validation before merge
+
+ADRs must pass `tests/test_adr_pre_validator.py`, which enforces required sections (Status, Context, Decision, Consequences) and valid status values: Proposed, Accepted, Deprecated, Superseded.
+
+**Why:** ADRs missing required sections are ambiguous to automated drift-detection tooling, causing false-positive or false-negative ADR drift reports.

--- a/repo_wiki/T-rav/hydraflow/testing/0053-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0053-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md
@@ -1,0 +1,26 @@
+---
+id: 0053
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.213688+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Never import private helpers at module level in test files
+
+Import private or internal functions (`_foo`) inside the test function or a `pytest.fixture`, never at the top of the test module.
+
+```python
+# bad — kills entire file if symbol doesn't exist
+from src.makefile_scaffold import _check_prereq_deps
+
+# good — failure scoped to the test that needs it
+def test_check_prereq():
+    from src.makefile_scaffold import _check_prereq_deps
+```
+
+**Why:** A module-level `ImportError` prevents pytest from collecting the file, silently destroying all passing tests in that module.

--- a/repo_wiki/T-rav/hydraflow/testing/0054-issue-synthesis-pin-function-signatures-in-the-source-file-before-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0054-issue-synthesis-pin-function-signatures-in-the-source-file-before-.md
@@ -1,0 +1,21 @@
+---
+id: 0054
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.213854+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Pin function signatures in the source file before writing tests or docs
+
+Decide the authoritative signature (argument order, return tuple shape) in the source file first; write docs and tests to match.
+
+1. Write the function stub
+2. Copy its exact signature into the docstring
+3. Then write the test
+
+**Why:** When docs and tests are authored before implementation, signature drift goes undetected until runtime — both artifacts can be wrong simultaneously.

--- a/repo_wiki/T-rav/hydraflow/testing/0055-issue-synthesis-specify-exact-logger-name-in-caplog-at-level-asser.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0055-issue-synthesis-specify-exact-logger-name-in-caplog-at-level-asser.md
@@ -1,0 +1,23 @@
+---
+id: 0055
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.214022+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Specify exact logger name in caplog.at_level() assertions
+
+Always pass the exact logger name to `caplog.at_level()` and clear caplog before the action under test.
+
+```python
+with caplog.at_level(logging.WARNING, logger="src.billing"):
+    trigger_action()
+assert "expected substring" in caplog.text
+```
+
+**Why:** Without the logger filter, unrelated log messages from other modules pollute captured output and produce false positives.

--- a/repo_wiki/T-rav/hydraflow/testing/0056-issue-synthesis-js-rendered-accessibility-attributes-require-playw.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0056-issue-synthesis-js-rendered-accessibility-attributes-require-playw.md
@@ -1,0 +1,17 @@
+---
+id: 0056
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.214191+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# JS-rendered accessibility attributes require Playwright, not TestClient
+
+Server-side `TestClient` (Django/FastAPI) returns only the initial HTML shell; `aria-labelledby` and other JS-rendered attributes are absent. Delete dead Python `TestClient` tests for these attributes and replace with Playwright tests.
+
+**Why:** TestClient assertions on JS-rendered attributes always pass vacuously — the attribute is missing from the initial render, so assertions check an empty string or missing key.

--- a/repo_wiki/T-rav/hydraflow/testing/0057-issue-synthesis-use-word-boundary-matching-in-name-coverage-checks.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0057-issue-synthesis-use-word-boundary-matching-in-name-coverage-checks.md
@@ -1,0 +1,20 @@
+---
+id: 0057
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.214380+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Use word-boundary matching in name-coverage checks to prevent collisions
+
+Substring matching in coverage or name checks produces false positives when short names appear inside longer ones.
+
+- Bad: `"Foo" in text` — also matches `FooBar`, `PrefixFoo`
+- Good: `re.search(r'\bFoo\b', text)` or full-name match
+
+**Why:** Short-name collisions silently mark unrelated targets as covered, hiding real gaps in coverage.

--- a/repo_wiki/T-rav/hydraflow/testing/0058-issue-synthesis-keep-test-label-stage-constants-synchronized-with-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0058-issue-synthesis-keep-test-label-stage-constants-synchronized-with-.md
@@ -1,0 +1,19 @@
+---
+id: 0058
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.214561+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Keep test label/stage constants synchronized with production definitions
+
+Test constants (`ALL_PIPELINE_LABELS`, `VALID_STAGES`, `VALID_TRANSITIONS`) must mirror production definitions. Add a sync test asserting set equality: `assert set(VALID_TRANSITIONS.keys()) == VALID_STAGES`.
+
+Direct-swap labels (`hitl-active`, `fixed`) are set via `swap_pipeline_labels()`, not transitions — test them on that separate path.
+
+**Why:** Stale test constants become false documentation and silently mask missing transition or label coverage.

--- a/repo_wiki/T-rav/hydraflow/testing/0059-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0059-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
@@ -1,0 +1,19 @@
+---
+id: 0059
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.214747+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Allow ±3 line drift in AST-based structure assertions
+
+For tests that verify code structure by parsing source ASTs (e.g., checking function length or nesting depth), allow ±3 line tolerance.
+
+Example: Assert `len(func.body) <= 53` rather than `<= 50` to account for blank lines and decorator variations.
+
+**Why:** Exact line-count assertions redden CI on whitespace-only diffs, creating maintenance noise without improving correctness.

--- a/repo_wiki/T-rav/hydraflow/testing/0060-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0060-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md
@@ -1,0 +1,19 @@
+---
+id: 0060
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.214924+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Existing tests cover private-method extractions; add only new-behavior tests
+
+When extracting a private method from a public one with an unchanged public API, the existing test suite provides full coverage — no new tests are needed for the extraction itself.
+
+When extracting prompt-building methods, run prompt-assertion tests in isolation immediately after extraction to verify parity.
+
+**Why:** Adding duplicate tests for unchanged behavior inflates the suite; the real regression risk is behavioral, which existing tests already guard.

--- a/repo_wiki/T-rav/hydraflow/testing/0061-issue-synthesis-enforce-50-line-handler-and-30-line-wiring-limits-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0061-issue-synthesis-enforce-50-line-handler-and-30-line-wiring-limits-.md
@@ -1,0 +1,19 @@
+---
+id: 0061
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.215098+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Enforce 50-line handler and 30-line wiring limits for testability
+
+Handler functions must stay under 50 lines; registration wiring under 30 lines. Extract nested closures into instance methods to flatten nesting to ≤3 levels.
+
+Enforce via AST-based tests with ±3 line tolerance (see: Allow ±3 line drift in AST-based structure assertions).
+
+**Why:** Deep nesting and long handlers are hard to unit-test in isolation; the limit forces decomposition that makes individual behaviors independently testable.

--- a/repo_wiki/T-rav/hydraflow/testing/0062-issue-synthesis-type-only-annotation-changes-require-no-new-tests.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0062-issue-synthesis-type-only-annotation-changes-require-no-new-tests.md
@@ -1,0 +1,19 @@
+---
+id: 0062
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T10:20:54.215274+00:00
+status: superseded
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033
+superseded_by: 0063
+---
+
+# Type-only annotation changes require no new tests
+
+Migrating from `dict[str, Any]` to a `TypedDict` return type, or narrowing a parameter from `Any` to a specific type, requires no new tests — `TypedDict` values are plain dicts at runtime and `Any` is compatible with all types in pyright.
+
+Verify via `make quality-lite` and `make test`; the existing suite suffices.
+
+**Why:** Runtime behavior is unchanged; only static validation improves. New tests for type-only changes create maintenance overhead without catching real bugs.

--- a/repo_wiki/T-rav/hydraflow/testing/0063-issue-synthesis-mock-at-definition-site-not-at-the-import-site.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0063-issue-synthesis-mock-at-definition-site-not-at-the-import-site.md
@@ -1,0 +1,22 @@
+---
+id: 0063
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.269004+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Mock at definition site, not at the import site
+
+Patch symbols at the module where they are defined, not where they are imported.
+
+- Bad: `patch('tests.test_foo.MyClass')`
+- Good: `patch('src.mymodule.MyClass')`
+
+For optional deps like `sentry_sdk`, use `patch.dict('sys.modules', {'sentry_sdk': mock, 'sentry_sdk.integrations': mock})`; patch sub-modules explicitly to prevent import leaks.
+
+**Why:** Usage-site patches intercept only that one import; other callers and subsequent imports still see the real object, producing inconsistent test behavior.

--- a/repo_wiki/T-rav/hydraflow/testing/0064-issue-synthesis-reserve-pytest-mark-integration-for-real-external-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0064-issue-synthesis-reserve-pytest-mark-integration-for-real-external-.md
@@ -1,0 +1,17 @@
+---
+id: 0064
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.269380+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Reserve @pytest.mark.integration for real external dependencies only
+
+Mark a test `@pytest.mark.integration` only when it exercises Docker, network, filesystem, real worktrees, or live service instances — not when all deps are `AsyncMock` or `MagicMock`. Use `pytest.mark.skipif(not shutil.which('cli'), ...)` for optional CLI tools.
+
+**Why:** Over-marking slows the fast suite and blurs the unit/integration boundary, making targeted test runs unreliable.

--- a/repo_wiki/T-rav/hydraflow/testing/0065-issue-synthesis-await-asyncio-sleep-0-before-asserting-on-create-t.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0065-issue-synthesis-await-asyncio-sleep-0-before-asserting-on-create-t.md
@@ -1,0 +1,23 @@
+---
+id: 0065
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.269705+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Await asyncio.sleep(0) before asserting on create_task() side effects
+
+After triggering fire-and-forget async tasks via `asyncio.create_task()`, yield the event loop before making assertions.
+
+```python
+task = asyncio.create_task(fn())
+await asyncio.sleep(0)
+mock.assert_called_once()
+```
+
+**Why:** Without yielding, the created task has not yet run; assertions on its side effects will fail spuriously and non-deterministically.

--- a/repo_wiki/T-rav/hydraflow/testing/0066-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0066-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
@@ -1,0 +1,22 @@
+---
+id: 0066
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.270028+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Test async context managers in three standard scenarios
+
+Test async context managers with three scenarios: (1) idempotent close — calling `close()` twice is safe, (2) context manager exit triggers `close()` exactly once, (3) `__aenter__` returns `self`.
+
+```python
+async with resource as r:
+    assert r is resource
+```
+
+**Why:** Missing any scenario leaves an incomplete behavioral contract, hiding bugs in external-connection or file-handle management.

--- a/repo_wiki/T-rav/hydraflow/testing/0067-issue-synthesis-use-python-script-stand-ins-to-test-subprocess-bou.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0067-issue-synthesis-use-python-script-stand-ins-to-test-subprocess-bou.md
@@ -1,0 +1,19 @@
+---
+id: 0067
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.270560+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Use Python script stand-ins to test subprocess boundaries
+
+Create small Python scripts that log invocations to JSON-lines files instead of mocking subprocess calls directly.
+
+Example: Pass `subprocess_runner = ['python3', 'fake_gh.py']` to the system under test; assert via `json.loads(log_path.read_text())`.
+
+**Why:** Real subprocess boundaries catch shell-quoting, PATH resolution, and argument-passing bugs that mock-based patches cannot detect.

--- a/repo_wiki/T-rav/hydraflow/testing/0068-issue-synthesis-reset-module-level-global-state-in-both-setup-and-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0068-issue-synthesis-reset-module-level-global-state-in-both-setup-and-.md
@@ -1,0 +1,24 @@
+---
+id: 0068
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.270848+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Reset module-level global state in both setup and teardown
+
+Global state (e.g., `_gh_semaphore`, `_rate_limit_until`) must be explicitly reset in both `setup_method` and `teardown_method`.
+
+```python
+def setup_method(self):
+    module._rate_limit_until = 0
+def teardown_method(self):
+    module._rate_limit_until = 0
+```
+
+**Why:** Omitting setup reset leaves stale state from a prior run; omitting teardown reset infects the next test — both produce non-deterministic failures.

--- a/repo_wiki/T-rav/hydraflow/testing/0069-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0069-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md
@@ -1,0 +1,22 @@
+---
+id: 0069
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.271146+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Use tmp_path with ConfigFactory for all file-based test I/O
+
+All tests that read or write files must use `tmp_path` combined with `ConfigFactory.create(base_path=tmp_path)` — never write to real project paths.
+
+```python
+def test_something(tmp_path):
+    config = ConfigFactory.create(base_path=tmp_path)
+```
+
+**Why:** Tests writing to real project paths corrupt the working directory and produce hard-to-reproduce cross-test pollution.

--- a/repo_wiki/T-rav/hydraflow/testing/0070-issue-synthesis-wire-real-business-logic-in-phase-runner-integrati.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0070-issue-synthesis-wire-real-business-logic-in-phase-runner-integrati.md
@@ -1,0 +1,17 @@
+---
+id: 0070
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.271434+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Wire real business logic in phase-runner integration tests
+
+Use real `StateTracker`, `EventBus`, and `VerificationJudge` instances in phase-runner integration tests; mock only the `_execute()` subprocess boundary. Provide configurable transcript strings for real runner parsing. Validate via `StateTracker` APIs and `EventBus.get_history()`, not mock call assertions.
+
+**Why:** Fully-mocked runners hide mismatches between transcript parsing logic and real output formats — exactly the bugs integration tests exist to catch.

--- a/repo_wiki/T-rav/hydraflow/testing/0071-issue-synthesis-test-protocol-compliance-with-structural-typing-an.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0071-issue-synthesis-test-protocol-compliance-with-structural-typing-an.md
@@ -1,0 +1,17 @@
+---
+id: 0071
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.271742+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Test protocol compliance with structural typing and duck-typing
+
+Verify protocol satisfaction with two complementary checks: (1) `isinstance(obj, Protocol)` with `@runtime_checkable`, and (2) `hasattr(obj, 'method_name')`. Add `inspect.signature()` comparison to detect parameter drift. Parametrize over each protocol method so failures are specific.
+
+**Why:** Either check alone misses a class of violations; structural typing catches missing methods, signature comparison catches arity and keyword drift.

--- a/repo_wiki/T-rav/hydraflow/testing/0072-issue-synthesis-test-fa-ade-getattr-routing-attributeerror-and-pro.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0072-issue-synthesis-test-fa-ade-getattr-routing-attributeerror-and-pro.md
@@ -1,0 +1,17 @@
+---
+id: 0072
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.272011+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Test façade __getattr__ routing, AttributeError, and protocol delegation
+
+When adding a façade over sub-clients, explicitly test: (1) `__getattr__` routes to the correct sub-client, (2) unknown attributes raise `AttributeError`, (3) the façade satisfies protocols via delegation, (4) existing mocks of the original class still pass. Assert sub-components receive mutable dict/set references — not copies — to shared state owned by the façade.
+
+**Why:** Façade delegation bugs pass all pre-existing tests because those tests mock the original class directly, not the façade.

--- a/repo_wiki/T-rav/hydraflow/testing/0073-issue-synthesis-assert-relative-event-id-ordering-never-absolute-v.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0073-issue-synthesis-assert-relative-event-id-ordering-never-absolute-v.md
@@ -1,0 +1,20 @@
+---
+id: 0073
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.272272+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Assert relative event ID ordering, never absolute values
+
+Tests for events backed by a global counter (`_event_counter`) must assert relative ordering and uniqueness within one test, never absolute ID values.
+
+- Good: `assert event_a.id < event_b.id`
+- Bad: `assert event_a.id == 1`
+
+**Why:** Global ID counters are shared across tests and imports; absolute assertions produce non-deterministic failures under parallel or reordered execution.

--- a/repo_wiki/T-rav/hydraflow/testing/0074-issue-synthesis-add-structural-tests-before-property-based-transit.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0074-issue-synthesis-add-structural-tests-before-property-based-transit.md
@@ -1,0 +1,19 @@
+---
+id: 0074
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.272533+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Add structural tests before property-based transition graph tests
+
+Before using hypothesis or similar tools to exercise a label/stage transition graph, add explicit structural assertions: every target is a valid stage, every stage has a transition entry, no dangling references.
+
+Example: `assert set(VALID_TRANSITIONS.keys()) == VALID_STAGES`
+
+**Why:** Property-based tests on a malformed graph surface as mysterious assertion failures rather than clear 'bad graph definition' errors.

--- a/repo_wiki/T-rav/hydraflow/testing/0075-issue-synthesis-grep-all-model-usages-before-committing-pydantic-o.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0075-issue-synthesis-grep-all-model-usages-before-committing-pydantic-o.md
@@ -1,0 +1,17 @@
+---
+id: 0075
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.272803+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Grep all model usages before committing Pydantic or TypedDict changes
+
+Before adding or removing a field, grep the test suite for the model name and update all affected assertions: model definition, factory defaults, `all_fields` tests, and round-trip serialization tests. For `NotRequired` fields, update exact-match assertions but not missing-key assertions.
+
+**Why:** Missed exact-match assertions silently pass when a field is optional, masking the coverage gap until a stricter test runs later.

--- a/repo_wiki/T-rav/hydraflow/testing/0076-issue-synthesis-feature-toggles-require-both-a-config-field-and-an.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0076-issue-synthesis-feature-toggles-require-both-a-config-field-and-an.md
@@ -1,0 +1,17 @@
+---
+id: 0076
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.273085+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Feature toggles require both a config field and an _ENV_INT_OVERRIDES entry
+
+Each new feature toggle needs a field in `src/config.py` AND an entry in `_ENV_INT_OVERRIDES`. Test both the default field value and the env-var override behavior. See also: architecture-state-persistence — `_ENV_INT_OVERRIDES` tuple default must equal the Field default or env override silently stops applying.
+
+**Why:** A config field alone makes the toggle code-only; without `_ENV_INT_OVERRIDES`, the environment variable silently has no effect.

--- a/repo_wiki/T-rav/hydraflow/testing/0077-issue-synthesis-test-concurrent-jsonl-appends-with-exact-counts-no.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0077-issue-synthesis-test-concurrent-jsonl-appends-with-exact-counts-no.md
@@ -1,0 +1,21 @@
+---
+id: 0077
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.273351+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Test concurrent JSONL appends with exact counts, not timing
+
+Use `ThreadPoolExecutor` with fixed thread and iteration counts; assert the exact expected line count after completion.
+
+Example: 10 threads × 20 events = 200 lines — assert `len(lines) == 200`.
+
+POSIX guarantees atomicity for writes under ~4 KB; validate empirically before relying on this.
+
+**Why:** Timing-based assertions are non-deterministic; exact counts reliably expose real data loss or line corruption.

--- a/repo_wiki/T-rav/hydraflow/testing/0078-issue-synthesis-use-identical-string-keys-across-memory-bank-dedup.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0078-issue-synthesis-use-identical-string-keys-across-memory-bank-dedup.md
@@ -1,0 +1,17 @@
+---
+id: 0078
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.273630+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Use identical string keys across memory bank deduplication and assembly
+
+The `bank_order` list and bank dict keys must use identical strings throughout (e.g., `'review_insights'` everywhere, never mixed with `'review-insights'`). Fallback recall functions should try multiple field names (`learning`, `text`, `content`, `display_text`) to extract the text payload.
+
+**Why:** Key mismatches silently skip entire banks during deduplication or assembly with no error or warning.

--- a/repo_wiki/T-rav/hydraflow/testing/0079-issue-synthesis-skill-definition-changes-must-update-all-4-backend.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0079-issue-synthesis-skill-definition-changes-must-update-all-4-backend.md
@@ -1,0 +1,17 @@
+---
+id: 0079
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.273902+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Skill definition changes must update all 4 backend copies
+
+HydraFlow skills are replicated across `.claude/commands/`, `.pi/skills/`, `.codex/skills/`, and `src/*.py`. Use a manual `SKILL_MARKERS` mapping (not regex introspection) to validate all copies contain matching output markers via substring search. A single skill change can require updates across 3+ test fixture files.
+
+**Why:** Missing updates in any one copy cause consistency test failures and silent runtime behavior divergence.

--- a/repo_wiki/T-rav/hydraflow/testing/0080-issue-synthesis-auto-generated-adr-tests-must-use-pytest-mark-skip.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0080-issue-synthesis-auto-generated-adr-tests-must-use-pytest-mark-skip.md
@@ -1,0 +1,17 @@
+---
+id: 0080
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.274182+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Auto-generated ADR tests must use @pytest.mark.skip by default
+
+When auto-generating tests from ADR Decision sections, emit all tests with `@pytest.mark.skip(reason='skeleton: requires human review')`. Extract only 4 high-confidence baseline patterns per ADR: uniqueness, usage, negative, coverage.
+
+**Why:** Automated pattern matching on ADR language is ambiguous; unskipped generated tests produce false-positive CI failures until a human validates each pattern.

--- a/repo_wiki/T-rav/hydraflow/testing/0081-issue-synthesis-every-adr-must-pass-structural-section-validation-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0081-issue-synthesis-every-adr-must-pass-structural-section-validation-.md
@@ -1,0 +1,17 @@
+---
+id: 0081
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.274459+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Every ADR must pass structural section validation before merge
+
+ADRs must pass `tests/test_adr_pre_validator.py`, which enforces required sections (Status, Context, Decision, Consequences) and valid status values: Proposed, Accepted, Deprecated, Superseded.
+
+**Why:** ADRs missing required sections are ambiguous to automated drift-detection tooling, causing false-positive or false-negative ADR drift reports.

--- a/repo_wiki/T-rav/hydraflow/testing/0082-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0082-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md
@@ -1,0 +1,26 @@
+---
+id: 0082
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.274748+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Never import private helpers at module level in test files
+
+Import private or internal functions (`_foo`) inside the test function or a `pytest.fixture`, never at the top of the test module.
+
+```python
+# bad — kills entire file if symbol doesn't exist
+from src.makefile_scaffold import _check_prereq_deps
+
+# good — failure scoped to the test
+def test_check_prereq():
+    from src.makefile_scaffold import _check_prereq_deps
+```
+
+**Why:** A module-level `ImportError` prevents pytest from collecting the file, silently destroying all passing tests in that module.

--- a/repo_wiki/T-rav/hydraflow/testing/0083-issue-synthesis-pin-function-signatures-in-the-source-file-before-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0083-issue-synthesis-pin-function-signatures-in-the-source-file-before-.md
@@ -1,0 +1,21 @@
+---
+id: 0083
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.275037+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Pin function signatures in the source file before writing tests or docs
+
+Decide the authoritative signature (argument order, return tuple shape) in the source file first; write docs and tests to match.
+
+1. Write the function stub
+2. Copy its exact signature into the docstring
+3. Then write the test
+
+**Why:** When docs and tests are authored before implementation, signature drift goes undetected until runtime — both artifacts can be wrong simultaneously.

--- a/repo_wiki/T-rav/hydraflow/testing/0084-issue-synthesis-specify-exact-logger-name-in-caplog-at-level-asser.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0084-issue-synthesis-specify-exact-logger-name-in-caplog-at-level-asser.md
@@ -1,0 +1,23 @@
+---
+id: 0084
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.275317+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Specify exact logger name in caplog.at_level() assertions
+
+Always pass the exact logger name to `caplog.at_level()` and clear caplog before the action under test.
+
+```python
+with caplog.at_level(logging.WARNING, logger='src.billing'):
+    trigger_action()
+assert 'expected substring' in caplog.text
+```
+
+**Why:** Without the logger filter, unrelated log messages from other modules pollute captured output and produce false positives.

--- a/repo_wiki/T-rav/hydraflow/testing/0085-issue-synthesis-js-rendered-accessibility-attributes-require-playw.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0085-issue-synthesis-js-rendered-accessibility-attributes-require-playw.md
@@ -1,0 +1,17 @@
+---
+id: 0085
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.275614+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# JS-rendered accessibility attributes require Playwright, not TestClient
+
+Server-side `TestClient` (Django/FastAPI) returns only the initial HTML shell; `aria-labelledby` and other JS-rendered attributes are absent. Delete dead Python `TestClient` tests for these attributes and replace with Playwright tests.
+
+**Why:** TestClient assertions on JS-rendered attributes always pass vacuously — the attribute is missing from the initial render, so assertions check an empty string or missing key.

--- a/repo_wiki/T-rav/hydraflow/testing/0086-issue-synthesis-use-word-boundary-matching-in-name-coverage-checks.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0086-issue-synthesis-use-word-boundary-matching-in-name-coverage-checks.md
@@ -1,0 +1,20 @@
+---
+id: 0086
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.275900+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Use word-boundary matching in name-coverage checks to prevent collisions
+
+Substring matching in coverage or name checks produces false positives when short names appear inside longer ones.
+
+- Bad: `'Foo' in text` — also matches `FooBar`, `PrefixFoo`
+- Good: `re.search(r'\bFoo\b', text)` or full-name match
+
+**Why:** Short-name collisions silently mark unrelated targets as covered, hiding real gaps in coverage.

--- a/repo_wiki/T-rav/hydraflow/testing/0087-issue-synthesis-keep-test-label-stage-constants-synchronized-with-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0087-issue-synthesis-keep-test-label-stage-constants-synchronized-with-.md
@@ -1,0 +1,17 @@
+---
+id: 0087
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.276183+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Keep test label/stage constants synchronized with production definitions
+
+Test constants (`ALL_PIPELINE_LABELS`, `VALID_STAGES`, `VALID_TRANSITIONS`) must mirror production definitions. Add a sync test asserting set equality: `assert set(VALID_TRANSITIONS.keys()) == VALID_STAGES`. See also: testing — Test direct-swap labels via swap_pipeline_labels(), not transitions.
+
+**Why:** Stale test constants become false documentation and silently mask missing transition or label coverage.

--- a/repo_wiki/T-rav/hydraflow/testing/0088-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels-n.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0088-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels-n.md
@@ -1,0 +1,17 @@
+---
+id: 0088
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.276463+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Test direct-swap labels via swap_pipeline_labels(), not transitions
+
+Labels set via atomic swap (`hitl-active`, `fixed`) bypass the transition graph and are applied by `swap_pipeline_labels()` — test them on that separate call path, not through `VALID_TRANSITIONS`. See also: testing — Keep test label/stage constants synchronized with production definitions.
+
+**Why:** Testing swap labels through the transition graph masks missing coverage; they have no transition entry by design.

--- a/repo_wiki/T-rav/hydraflow/testing/0089-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0089-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
@@ -1,0 +1,19 @@
+---
+id: 0089
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.276741+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Allow ±3 line drift in AST-based structure assertions
+
+For tests that verify code structure by parsing source ASTs (e.g., checking function length or nesting depth), allow ±3 line tolerance.
+
+Example: Assert `len(func.body) <= 53` rather than `<= 50` to account for blank lines and decorator variations. See also: testing — Enforce 50-line handler and 30-line wiring limits for testability.
+
+**Why:** Exact line-count assertions redden CI on whitespace-only diffs, creating maintenance noise without improving correctness.

--- a/repo_wiki/T-rav/hydraflow/testing/0090-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0090-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md
@@ -1,0 +1,17 @@
+---
+id: 0090
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.277019+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Existing tests cover private-method extractions; add only new-behavior tests
+
+When extracting a private method from a public one with an unchanged public API, the existing test suite provides full coverage — no new tests needed for the extraction itself. When extracting prompt-building methods, run prompt-assertion tests in isolation immediately after extraction to verify parity.
+
+**Why:** Adding duplicate tests for unchanged behavior inflates the suite; the real regression risk is behavioral, which existing tests already guard.

--- a/repo_wiki/T-rav/hydraflow/testing/0091-issue-synthesis-enforce-50-line-handler-and-30-line-wiring-limits-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0091-issue-synthesis-enforce-50-line-handler-and-30-line-wiring-limits-.md
@@ -1,0 +1,17 @@
+---
+id: 0091
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.277304+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Enforce 50-line handler and 30-line wiring limits for testability
+
+Handler functions must stay under 50 lines; registration wiring under 30 lines. Extract nested closures into instance methods to flatten nesting to ≤3 levels. Enforce via AST-based tests with ±3 line tolerance. See also: testing — Allow ±3 line drift in AST-based structure assertions.
+
+**Why:** Deep nesting and long handlers are hard to unit-test in isolation; the limit forces decomposition that makes individual behaviors independently testable.

--- a/repo_wiki/T-rav/hydraflow/testing/0092-issue-synthesis-type-only-annotation-changes-require-no-new-tests.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0092-issue-synthesis-type-only-annotation-changes-require-no-new-tests.md
@@ -1,0 +1,17 @@
+---
+id: 0092
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T14:41:04.277602+00:00
+status: superseded
+corroborations: 1
+supersedes: 0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049,0050,0051,0052,0053,0054,0055,0056,0057,0058,0059,0060,0061,0062
+superseded_by: 0093
+---
+
+# Type-only annotation changes require no new tests
+
+Migrating from `dict[str, Any]` to a `TypedDict` return type, or narrowing a parameter from `Any` to a specific type, requires no new tests — `TypedDict` values are plain dicts at runtime and `Any` is compatible with all types in pyright. Verify via `make quality-lite` and `make test`; the existing suite suffices.
+
+**Why:** Runtime behavior is unchanged; only static validation improves. New tests for type-only changes create maintenance overhead without catching real bugs.

--- a/repo_wiki/T-rav/hydraflow/testing/0093-issue-synthesis-mock-at-definition-site-not-at-the-import-site.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0093-issue-synthesis-mock-at-definition-site-not-at-the-import-site.md
@@ -1,0 +1,22 @@
+---
+id: 0093
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.079928+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Mock at definition site, not at the import site
+
+Patch symbols at the module where they are defined, not where they are imported.
+
+- Bad: `patch('tests.test_foo.MyClass')`
+- Good: `patch('src.mymodule.MyClass')`
+
+For optional deps like `sentry_sdk`, use `patch.dict('sys.modules', {'sentry_sdk': mock, 'sentry_sdk.integrations': mock})`; patch sub-modules explicitly to prevent import leaks.
+
+**Why:** Usage-site patches intercept only that one import; other callers and subsequent imports still see the real object, producing inconsistent test behavior.

--- a/repo_wiki/T-rav/hydraflow/testing/0094-issue-synthesis-reserve-pytest-mark-integration-for-real-external-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0094-issue-synthesis-reserve-pytest-mark-integration-for-real-external-.md
@@ -1,0 +1,17 @@
+---
+id: 0094
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.080208+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Reserve @pytest.mark.integration for real external dependencies only
+
+Mark a test `@pytest.mark.integration` only when it exercises Docker, network, filesystem, real worktrees, or live service instances — not when all deps are `AsyncMock` or `MagicMock`. Use `pytest.mark.skipif(not shutil.which('cli'), ...)` for optional CLI tools.
+
+**Why:** Over-marking slows the fast suite and blurs the unit/integration boundary, making targeted test runs unreliable.

--- a/repo_wiki/T-rav/hydraflow/testing/0095-issue-synthesis-await-asyncio-sleep-0-before-asserting-on-create-t.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0095-issue-synthesis-await-asyncio-sleep-0-before-asserting-on-create-t.md
@@ -1,0 +1,23 @@
+---
+id: 0095
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.080465+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Await asyncio.sleep(0) before asserting on create_task() side effects
+
+After triggering fire-and-forget async tasks via `asyncio.create_task()`, yield the event loop before making assertions.
+
+```python
+task = asyncio.create_task(fn())
+await asyncio.sleep(0)
+mock.assert_called_once()
+```
+
+**Why:** Without yielding, the created task has not yet run; assertions on its side effects will fail spuriously and non-deterministically.

--- a/repo_wiki/T-rav/hydraflow/testing/0096-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0096-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
@@ -1,0 +1,22 @@
+---
+id: 0096
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.080713+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Test async context managers in three standard scenarios
+
+Test async context managers with three scenarios: (1) idempotent close — calling `close()` twice is safe, (2) context manager exit triggers `close()` exactly once, (3) `__aenter__` returns `self`.
+
+```python
+async with resource as r:
+    assert r is resource
+```
+
+**Why:** Missing any scenario leaves an incomplete behavioral contract, hiding bugs in external-connection or file-handle management.

--- a/repo_wiki/T-rav/hydraflow/testing/0097-issue-synthesis-use-python-script-stand-ins-to-test-subprocess-bou.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0097-issue-synthesis-use-python-script-stand-ins-to-test-subprocess-bou.md
@@ -1,0 +1,19 @@
+---
+id: 0097
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.080953+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Use Python script stand-ins to test subprocess boundaries
+
+Create small Python scripts that log invocations to JSON-lines files instead of mocking subprocess calls directly.
+
+Example: Pass `subprocess_runner = ['python3', 'fake_gh.py']` to the system under test; assert via `json.loads(log_path.read_text())`.
+
+**Why:** Real subprocess boundaries catch shell-quoting, PATH resolution, and argument-passing bugs that mock-based patches cannot detect.

--- a/repo_wiki/T-rav/hydraflow/testing/0098-issue-synthesis-reset-module-level-global-state-in-both-setup-and-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0098-issue-synthesis-reset-module-level-global-state-in-both-setup-and-.md
@@ -1,0 +1,24 @@
+---
+id: 0098
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.081191+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Reset module-level global state in both setup and teardown
+
+Global state (e.g., `_gh_semaphore`, `_rate_limit_until`) must be explicitly reset in both `setup_method` and `teardown_method`.
+
+```python
+def setup_method(self):
+    module._rate_limit_until = 0
+def teardown_method(self):
+    module._rate_limit_until = 0
+```
+
+**Why:** Omitting setup reset leaves stale state from a prior run; omitting teardown reset infects the next test — both produce non-deterministic failures.

--- a/repo_wiki/T-rav/hydraflow/testing/0099-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0099-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md
@@ -1,0 +1,22 @@
+---
+id: 0099
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.081431+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Use tmp_path with ConfigFactory for all file-based test I/O
+
+All tests that read or write files must use `tmp_path` combined with `ConfigFactory.create(base_path=tmp_path)` — never write to real project paths.
+
+```python
+def test_something(tmp_path):
+    config = ConfigFactory.create(base_path=tmp_path)
+```
+
+**Why:** Tests writing to real project paths corrupt the working directory and produce hard-to-reproduce cross-test pollution.

--- a/repo_wiki/T-rav/hydraflow/testing/0100-issue-synthesis-wire-real-business-logic-in-phase-runner-integrati.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0100-issue-synthesis-wire-real-business-logic-in-phase-runner-integrati.md
@@ -1,0 +1,17 @@
+---
+id: 0100
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.081659+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Wire real business logic in phase-runner integration tests
+
+Use real `StateTracker`, `EventBus`, and `VerificationJudge` instances in phase-runner integration tests; mock only the `_execute()` subprocess boundary. Provide configurable transcript strings for real runner parsing. Validate via `StateTracker` APIs and `EventBus.get_history()`, not mock call assertions.
+
+**Why:** Fully-mocked runners hide mismatches between transcript parsing logic and real output formats — exactly the bugs integration tests exist to catch.

--- a/repo_wiki/T-rav/hydraflow/testing/0101-issue-synthesis-test-protocol-compliance-with-structural-typing-an.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0101-issue-synthesis-test-protocol-compliance-with-structural-typing-an.md
@@ -1,0 +1,17 @@
+---
+id: 0101
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.081892+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Test protocol compliance with structural typing and duck-typing
+
+Verify protocol satisfaction with two complementary checks: (1) `isinstance(obj, Protocol)` with `@runtime_checkable`, and (2) `hasattr(obj, 'method_name')`. Add `inspect.signature()` comparison to detect parameter drift. Parametrize over each protocol method so failures are specific.
+
+**Why:** Either check alone misses a class of violations; structural typing catches missing methods, signature comparison catches arity and keyword drift.

--- a/repo_wiki/T-rav/hydraflow/testing/0102-issue-synthesis-test-fa-ade-getattr-routing-attributeerror-and-pro.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0102-issue-synthesis-test-fa-ade-getattr-routing-attributeerror-and-pro.md
@@ -1,0 +1,17 @@
+---
+id: 0102
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.082128+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Test façade __getattr__ routing, AttributeError, and protocol delegation
+
+When adding a façade over sub-clients, explicitly test: (1) `__getattr__` routes to the correct sub-client, (2) unknown attributes raise `AttributeError`, (3) the façade satisfies protocols via delegation, (4) existing mocks of the original class still pass. Assert sub-components receive mutable dict/set references — not copies — to shared state owned by the façade.
+
+**Why:** Façade delegation bugs pass all pre-existing tests because those tests mock the original class directly, not the façade.

--- a/repo_wiki/T-rav/hydraflow/testing/0103-issue-synthesis-assert-relative-event-id-ordering-never-absolute-v.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0103-issue-synthesis-assert-relative-event-id-ordering-never-absolute-v.md
@@ -1,0 +1,20 @@
+---
+id: 0103
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.082364+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Assert relative event ID ordering, never absolute values
+
+Tests for events backed by a global counter (`_event_counter`) must assert relative ordering and uniqueness within one test, never absolute ID values.
+
+- Good: `assert event_a.id < event_b.id`
+- Bad: `assert event_a.id == 1`
+
+**Why:** Global ID counters are shared across tests and imports; absolute assertions produce non-deterministic failures under parallel or reordered execution.

--- a/repo_wiki/T-rav/hydraflow/testing/0104-issue-synthesis-add-structural-tests-before-property-based-transit.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0104-issue-synthesis-add-structural-tests-before-property-based-transit.md
@@ -1,0 +1,19 @@
+---
+id: 0104
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.082597+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Add structural tests before property-based transition graph tests
+
+Before using hypothesis or similar tools to exercise a label/stage transition graph, add explicit structural assertions: every target is a valid stage, every stage has a transition entry, no dangling references.
+
+Example: `assert set(VALID_TRANSITIONS.keys()) == VALID_STAGES`
+
+**Why:** Property-based tests on a malformed graph surface as mysterious assertion failures rather than clear 'bad graph definition' errors.

--- a/repo_wiki/T-rav/hydraflow/testing/0105-issue-synthesis-grep-all-model-usages-before-committing-pydantic-o.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0105-issue-synthesis-grep-all-model-usages-before-committing-pydantic-o.md
@@ -1,0 +1,19 @@
+---
+id: 0105
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.082823+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Grep all model usages before committing Pydantic or TypedDict changes
+
+Before adding or removing a field, grep the test suite for the model name and update all affected assertions: model definition, factory defaults, `all_fields` tests, and round-trip serialization tests. For `NotRequired` fields, update exact-match assertions but not missing-key assertions.
+
+See also: testing — Type-only annotation changes require no new tests.
+
+**Why:** Missed exact-match assertions silently pass when a field is optional, masking the coverage gap until a stricter test runs later.

--- a/repo_wiki/T-rav/hydraflow/testing/0106-issue-synthesis-feature-toggles-require-both-a-config-field-and-an.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0106-issue-synthesis-feature-toggles-require-both-a-config-field-and-an.md
@@ -1,0 +1,19 @@
+---
+id: 0106
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.083052+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Feature toggles require both a config field and an _ENV_INT_OVERRIDES entry
+
+Each new feature toggle needs a field in `src/config.py` AND an entry in `_ENV_INT_OVERRIDES`. Test both the default field value and the env-var override behavior. The `_ENV_INT_OVERRIDES` tuple default must equal the Field default or env override silently stops applying.
+
+See also: architecture-state-persistence — `_ENV_INT_OVERRIDES` default sync.
+
+**Why:** A config field alone makes the toggle code-only; without `_ENV_INT_OVERRIDES`, the environment variable silently has no effect.

--- a/repo_wiki/T-rav/hydraflow/testing/0107-issue-synthesis-test-concurrent-jsonl-appends-with-exact-counts-no.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0107-issue-synthesis-test-concurrent-jsonl-appends-with-exact-counts-no.md
@@ -1,0 +1,21 @@
+---
+id: 0107
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.083287+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Test concurrent JSONL appends with exact counts, not timing
+
+Use `ThreadPoolExecutor` with fixed thread and iteration counts; assert the exact expected line count after completion.
+
+Example: 10 threads × 20 events = 200 lines — assert `len(lines) == 200`.
+
+POSIX guarantees atomicity for writes under ~4 KB; validate empirically before relying on this.
+
+**Why:** Timing-based assertions are non-deterministic; exact counts reliably expose real data loss or line corruption.

--- a/repo_wiki/T-rav/hydraflow/testing/0108-issue-synthesis-use-identical-string-keys-across-memory-bank-dedup.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0108-issue-synthesis-use-identical-string-keys-across-memory-bank-dedup.md
@@ -1,0 +1,17 @@
+---
+id: 0108
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.083815+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Use identical string keys across memory bank deduplication and assembly
+
+The `bank_order` list and bank dict keys must use identical strings throughout (e.g., `'review_insights'` everywhere, never mixed with `'review-insights'`). Fallback recall functions should try multiple field names (`learning`, `text`, `content`, `display_text`) to extract the text payload.
+
+**Why:** Key mismatches silently skip entire banks during deduplication or assembly with no error or warning.

--- a/repo_wiki/T-rav/hydraflow/testing/0109-issue-synthesis-skill-definition-changes-must-update-all-4-backend.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0109-issue-synthesis-skill-definition-changes-must-update-all-4-backend.md
@@ -1,0 +1,17 @@
+---
+id: 0109
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.084087+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Skill definition changes must update all 4 backend copies
+
+HydraFlow skills are replicated across `.claude/commands/`, `.pi/skills/`, `.codex/skills/`, and `src/*.py`. Use a manual `SKILL_MARKERS` mapping (not regex introspection) to validate all copies contain matching output markers via substring search. A single skill change can require updates across 3+ test fixture files.
+
+**Why:** Missing updates in any one copy cause consistency test failures and silent runtime behavior divergence.

--- a/repo_wiki/T-rav/hydraflow/testing/0110-issue-synthesis-auto-generated-adr-tests-must-use-pytest-mark-skip.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0110-issue-synthesis-auto-generated-adr-tests-must-use-pytest-mark-skip.md
@@ -1,0 +1,17 @@
+---
+id: 0110
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.084342+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Auto-generated ADR tests must use @pytest.mark.skip by default
+
+When auto-generating tests from ADR Decision sections, emit all tests with `@pytest.mark.skip(reason='skeleton: requires human review')`. Extract only 4 high-confidence baseline patterns per ADR: uniqueness, usage, negative, coverage.
+
+**Why:** Automated pattern matching on ADR language is ambiguous; unskipped generated tests produce false-positive CI failures until a human validates each pattern.

--- a/repo_wiki/T-rav/hydraflow/testing/0111-issue-synthesis-every-adr-must-pass-structural-section-validation-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0111-issue-synthesis-every-adr-must-pass-structural-section-validation-.md
@@ -1,0 +1,19 @@
+---
+id: 0111
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.084594+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Every ADR must pass structural section validation before merge
+
+ADRs must pass `tests/test_adr_pre_validator.py`, which enforces required sections (Status, Context, Decision, Consequences) and valid status values: Proposed, Accepted, Deprecated, Superseded.
+
+See also: architecture — ADR number collision and README guards.
+
+**Why:** ADRs missing required sections are ambiguous to automated drift-detection tooling, causing false-positive or false-negative ADR drift reports.

--- a/repo_wiki/T-rav/hydraflow/testing/0112-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0112-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md
@@ -1,0 +1,26 @@
+---
+id: 0112
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.084968+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Never import private helpers at module level in test files
+
+Import private or internal functions (`_foo`) inside the test function or a `pytest.fixture`, never at the top of the test module.
+
+```python
+# bad — kills entire file if symbol doesn't exist
+from src.makefile_scaffold import _check_prereq_deps
+
+# good — failure scoped to the test
+def test_check_prereq():
+    from src.makefile_scaffold import _check_prereq_deps
+```
+
+**Why:** A module-level `ImportError` prevents pytest from collecting the file, silently destroying all passing tests in that module.

--- a/repo_wiki/T-rav/hydraflow/testing/0113-issue-synthesis-pin-function-signatures-in-the-source-file-before-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0113-issue-synthesis-pin-function-signatures-in-the-source-file-before-.md
@@ -1,0 +1,21 @@
+---
+id: 0113
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.085270+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Pin function signatures in the source file before writing tests or docs
+
+Decide the authoritative signature (argument order, return tuple shape) in the source file first; write docs and tests to match.
+
+1. Write the function stub
+2. Copy its exact signature into the docstring
+3. Then write the test
+
+**Why:** When docs and tests are authored before implementation, signature drift goes undetected until runtime — both artifacts can be wrong simultaneously.

--- a/repo_wiki/T-rav/hydraflow/testing/0114-issue-synthesis-specify-exact-logger-name-in-caplog-at-level-asser.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0114-issue-synthesis-specify-exact-logger-name-in-caplog-at-level-asser.md
@@ -1,0 +1,23 @@
+---
+id: 0114
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.085530+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Specify exact logger name in caplog.at_level() assertions
+
+Always pass the exact logger name to `caplog.at_level()` and clear caplog before the action under test.
+
+```python
+with caplog.at_level(logging.WARNING, logger='src.billing'):
+    trigger_action()
+assert 'expected substring' in caplog.text
+```
+
+**Why:** Without the logger filter, unrelated log messages from other modules pollute captured output and produce false positives.

--- a/repo_wiki/T-rav/hydraflow/testing/0115-issue-synthesis-js-rendered-accessibility-attributes-require-playw.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0115-issue-synthesis-js-rendered-accessibility-attributes-require-playw.md
@@ -1,0 +1,17 @@
+---
+id: 0115
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.085896+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# JS-rendered accessibility attributes require Playwright, not TestClient
+
+Server-side `TestClient` (Django/FastAPI) returns only the initial HTML shell; `aria-labelledby` and other JS-rendered attributes are absent. Delete dead Python `TestClient` tests for these attributes and replace with Playwright tests.
+
+**Why:** TestClient assertions on JS-rendered attributes always pass vacuously — the attribute is missing from the initial render, so assertions check an empty string or missing key.

--- a/repo_wiki/T-rav/hydraflow/testing/0116-issue-synthesis-use-word-boundary-matching-in-name-coverage-checks.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0116-issue-synthesis-use-word-boundary-matching-in-name-coverage-checks.md
@@ -1,0 +1,20 @@
+---
+id: 0116
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.086241+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Use word-boundary matching in name-coverage checks to prevent collisions
+
+Substring matching in coverage or name checks produces false positives when short names appear inside longer ones.
+
+- Bad: `'Foo' in text` — also matches `FooBar`, `PrefixFoo`
+- Good: `re.search(r'\bFoo\b', text)` or full-name match
+
+**Why:** Short-name collisions silently mark unrelated targets as covered, hiding real gaps in coverage.

--- a/repo_wiki/T-rav/hydraflow/testing/0117-issue-synthesis-keep-test-label-stage-constants-synchronized-with-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0117-issue-synthesis-keep-test-label-stage-constants-synchronized-with-.md
@@ -1,0 +1,19 @@
+---
+id: 0117
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.086572+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Keep test label/stage constants synchronized with production definitions
+
+Test constants (`ALL_PIPELINE_LABELS`, `VALID_STAGES`, `VALID_TRANSITIONS`) must mirror production definitions. Add a sync test asserting set equality: `assert set(VALID_TRANSITIONS.keys()) == VALID_STAGES`.
+
+See also: testing — Test direct-swap labels via swap_pipeline_labels(), not transitions.
+
+**Why:** Stale test constants become false documentation and silently mask missing transition or label coverage.

--- a/repo_wiki/T-rav/hydraflow/testing/0118-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels-n.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0118-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels-n.md
@@ -1,0 +1,19 @@
+---
+id: 0118
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.086888+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Test direct-swap labels via swap_pipeline_labels(), not transitions
+
+Labels set via atomic swap (`hitl-active`, `fixed`) bypass the transition graph and are applied by `swap_pipeline_labels()` — test them on that separate call path, not through `VALID_TRANSITIONS`.
+
+See also: testing — Keep test label/stage constants synchronized with production definitions.
+
+**Why:** Testing swap labels through the transition graph masks missing coverage; they have no transition entry by design.

--- a/repo_wiki/T-rav/hydraflow/testing/0119-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0119-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
@@ -1,0 +1,21 @@
+---
+id: 0119
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.087267+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Allow ±3 line drift in AST-based structure assertions
+
+For tests that verify code structure by parsing source ASTs (e.g., checking function length or nesting depth), allow ±3 line tolerance.
+
+Example: Assert `len(func.body) <= 53` rather than `<= 50` to account for blank lines and decorator variations.
+
+See also: testing — Enforce 50-line handler and 30-line wiring limits for testability.
+
+**Why:** Exact line-count assertions redden CI on whitespace-only diffs, creating maintenance noise without improving correctness.

--- a/repo_wiki/T-rav/hydraflow/testing/0120-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0120-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md
@@ -1,0 +1,17 @@
+---
+id: 0120
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.087627+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Existing tests cover private-method extractions; add only new-behavior tests
+
+When extracting a private method from a public one with an unchanged public API, the existing test suite provides full coverage — no new tests needed for the extraction itself. When extracting prompt-building methods, run prompt-assertion tests in isolation immediately after extraction to verify parity.
+
+**Why:** Adding duplicate tests for unchanged behavior inflates the suite; the real regression risk is behavioral, which existing tests already guard.

--- a/repo_wiki/T-rav/hydraflow/testing/0121-issue-synthesis-enforce-50-line-handler-and-30-line-wiring-limits-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0121-issue-synthesis-enforce-50-line-handler-and-30-line-wiring-limits-.md
@@ -1,0 +1,19 @@
+---
+id: 0121
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.087982+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Enforce 50-line handler and 30-line wiring limits for testability
+
+Handler functions must stay under 50 lines; registration wiring under 30 lines. Extract nested closures into instance methods to flatten nesting to ≤3 levels. Enforce via AST-based tests with ±3 line tolerance.
+
+See also: testing — Allow ±3 line drift in AST-based structure assertions.
+
+**Why:** Deep nesting and long handlers are hard to unit-test in isolation; the limit forces decomposition that makes individual behaviors independently testable.

--- a/repo_wiki/T-rav/hydraflow/testing/0122-issue-synthesis-type-only-annotation-changes-require-no-new-tests.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0122-issue-synthesis-type-only-annotation-changes-require-no-new-tests.md
@@ -1,0 +1,19 @@
+---
+id: 0122
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-14T15:18:41.088348+00:00
+status: superseded
+corroborations: 1
+supersedes: 0063,0064,0065,0066,0067,0068,0069,0070,0071,0072,0073,0074,0075,0076,0077,0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092
+superseded_by: 0123
+---
+
+# Type-only annotation changes require no new tests
+
+Migrating from `dict[str, Any]` to a `TypedDict` return type, or narrowing a parameter from `Any` to a specific type, requires no new tests — `TypedDict` values are plain dicts at runtime and `Any` is compatible with all types in pyright. Verify via `make quality-lite` and `make test`; the existing suite suffices.
+
+See also: testing — Grep all model usages before committing Pydantic or TypedDict changes.
+
+**Why:** Runtime behavior is unchanged; only static validation improves. New tests for type-only changes create maintenance overhead without catching real bugs.

--- a/repo_wiki/T-rav/hydraflow/testing/0123-issue-synthesis-mock-at-definition-site-not-at-the-import-site.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0123-issue-synthesis-mock-at-definition-site-not-at-the-import-site.md
@@ -1,0 +1,22 @@
+---
+id: 0123
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.431701+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Mock at definition site, not at the import site
+
+Patch symbols at the module where they are defined, not where they are imported.
+
+- Bad: `patch('tests.test_foo.MyClass')`
+- Good: `patch('src.mymodule.MyClass')`
+
+For optional deps like `sentry_sdk`, use `patch.dict('sys.modules', {'sentry_sdk': mock, 'sentry_sdk.integrations': mock})`; patch sub-modules explicitly to prevent import leaks.
+
+**Why:** Usage-site patches intercept only that one import; other callers and subsequent imports still see the real object, producing inconsistent test behavior.

--- a/repo_wiki/T-rav/hydraflow/testing/0124-issue-synthesis-reserve-pytest-mark-integration-for-real-external-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0124-issue-synthesis-reserve-pytest-mark-integration-for-real-external-.md
@@ -1,0 +1,17 @@
+---
+id: 0124
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.432106+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Reserve @pytest.mark.integration for real external dependencies only
+
+Mark a test `@pytest.mark.integration` only when it exercises Docker, network, filesystem, real worktrees, or live service instances — not when all deps are `AsyncMock` or `MagicMock`. Use `pytest.mark.skipif(not shutil.which('cli'), ...)` for optional CLI tools.
+
+**Why:** Over-marking slows the fast suite and blurs the unit/integration boundary, making targeted test runs unreliable.

--- a/repo_wiki/T-rav/hydraflow/testing/0125-issue-synthesis-await-asyncio-sleep-0-before-asserting-on-create-t.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0125-issue-synthesis-await-asyncio-sleep-0-before-asserting-on-create-t.md
@@ -1,0 +1,23 @@
+---
+id: 0125
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.432442+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Await asyncio.sleep(0) before asserting on create_task() side effects
+
+After triggering fire-and-forget async tasks via `asyncio.create_task()`, yield the event loop before making assertions.
+
+```python
+task = asyncio.create_task(fn())
+await asyncio.sleep(0)
+mock.assert_called_once()
+```
+
+**Why:** Without yielding, the created task has not yet run; assertions on its side effects will fail spuriously and non-deterministically.

--- a/repo_wiki/T-rav/hydraflow/testing/0126-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0126-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
@@ -1,0 +1,22 @@
+---
+id: 0126
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.432750+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Test async context managers in three standard scenarios
+
+Test async context managers with three scenarios: (1) idempotent close — calling `close()` twice is safe, (2) context manager exit triggers `close()` exactly once, (3) `__aenter__` returns `self`.
+
+```python
+async with resource as r:
+    assert r is resource
+```
+
+**Why:** Missing any scenario leaves an incomplete behavioral contract, hiding bugs in external-connection or file-handle management.

--- a/repo_wiki/T-rav/hydraflow/testing/0127-issue-synthesis-use-python-script-stand-ins-to-test-subprocess-bou.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0127-issue-synthesis-use-python-script-stand-ins-to-test-subprocess-bou.md
@@ -1,0 +1,19 @@
+---
+id: 0127
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.433073+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Use Python script stand-ins to test subprocess boundaries
+
+Create small Python scripts that log invocations to JSON-lines files instead of mocking subprocess calls directly.
+
+Example: Pass `subprocess_runner = ['python3', 'fake_gh.py']` to the system under test; assert via `json.loads(log_path.read_text())`.
+
+**Why:** Real subprocess boundaries catch shell-quoting, PATH resolution, and argument-passing bugs that mock-based patches cannot detect.

--- a/repo_wiki/T-rav/hydraflow/testing/0128-issue-synthesis-reset-module-level-global-state-in-both-setup-and-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0128-issue-synthesis-reset-module-level-global-state-in-both-setup-and-.md
@@ -1,0 +1,24 @@
+---
+id: 0128
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.433368+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Reset module-level global state in both setup and teardown
+
+Global state (e.g., `_gh_semaphore`, `_rate_limit_until`) must be explicitly reset in both `setup_method` and `teardown_method`.
+
+```python
+def setup_method(self):
+    module._rate_limit_until = 0
+def teardown_method(self):
+    module._rate_limit_until = 0
+```
+
+**Why:** Omitting setup reset leaves stale state from a prior run; omitting teardown reset infects the next test — both produce non-deterministic failures.

--- a/repo_wiki/T-rav/hydraflow/testing/0129-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0129-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md
@@ -1,0 +1,22 @@
+---
+id: 0129
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.433647+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Use tmp_path with ConfigFactory for all file-based test I/O
+
+All tests that read or write files must use `tmp_path` combined with `ConfigFactory.create(base_path=tmp_path)` — never write to real project paths.
+
+```python
+def test_something(tmp_path):
+    config = ConfigFactory.create(base_path=tmp_path)
+```
+
+**Why:** Tests writing to real project paths corrupt the working directory and produce hard-to-reproduce cross-test pollution.

--- a/repo_wiki/T-rav/hydraflow/testing/0130-issue-synthesis-wire-real-business-logic-in-phase-runner-integrati.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0130-issue-synthesis-wire-real-business-logic-in-phase-runner-integrati.md
@@ -1,0 +1,17 @@
+---
+id: 0130
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.433929+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Wire real business logic in phase-runner integration tests
+
+Use real `StateTracker`, `EventBus`, and `VerificationJudge` instances in phase-runner integration tests; mock only the `_execute()` subprocess boundary. Provide configurable transcript strings for real runner parsing. Validate via `StateTracker` APIs and `EventBus.get_history()`, not mock call assertions.
+
+**Why:** Fully-mocked runners hide mismatches between transcript parsing logic and real output formats — exactly the bugs integration tests exist to catch.

--- a/repo_wiki/T-rav/hydraflow/testing/0131-issue-synthesis-test-protocol-compliance-with-structural-typing-an.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0131-issue-synthesis-test-protocol-compliance-with-structural-typing-an.md
@@ -1,0 +1,17 @@
+---
+id: 0131
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.434209+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Test protocol compliance with structural typing and duck-typing
+
+Verify protocol satisfaction with two complementary checks: (1) `isinstance(obj, Protocol)` with `@runtime_checkable`, and (2) `hasattr(obj, 'method_name')`. Add `inspect.signature()` comparison to detect parameter drift. Parametrize over each protocol method so failures are specific.
+
+**Why:** Either check alone misses a class of violations; structural typing catches missing methods, signature comparison catches arity and keyword drift.

--- a/repo_wiki/T-rav/hydraflow/testing/0132-issue-synthesis-test-fa-ade-getattr-routing-attributeerror-and-pro.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0132-issue-synthesis-test-fa-ade-getattr-routing-attributeerror-and-pro.md
@@ -1,0 +1,17 @@
+---
+id: 0132
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.434500+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Test façade __getattr__ routing, AttributeError, and protocol delegation
+
+When adding a façade over sub-clients, explicitly test: (1) `__getattr__` routes to the correct sub-client, (2) unknown attributes raise `AttributeError`, (3) the façade satisfies protocols via delegation, (4) existing mocks of the original class still pass. Assert sub-components receive mutable dict/set references — not copies — to shared state owned by the façade.
+
+**Why:** Façade delegation bugs pass all pre-existing tests because those tests mock the original class directly, not the façade.

--- a/repo_wiki/T-rav/hydraflow/testing/0133-issue-synthesis-assert-relative-event-id-ordering-never-absolute-v.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0133-issue-synthesis-assert-relative-event-id-ordering-never-absolute-v.md
@@ -1,0 +1,20 @@
+---
+id: 0133
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.434788+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Assert relative event ID ordering, never absolute values
+
+Tests for events backed by a global counter (`_event_counter`) must assert relative ordering and uniqueness within one test, never absolute ID values.
+
+- Good: `assert event_a.id < event_b.id`
+- Bad: `assert event_a.id == 1`
+
+**Why:** Global ID counters are shared across tests and imports; absolute assertions produce non-deterministic failures under parallel or reordered execution.

--- a/repo_wiki/T-rav/hydraflow/testing/0134-issue-synthesis-add-structural-tests-before-property-based-transit.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0134-issue-synthesis-add-structural-tests-before-property-based-transit.md
@@ -1,0 +1,19 @@
+---
+id: 0134
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.435075+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Add structural tests before property-based transition graph tests
+
+Before using hypothesis or similar tools to exercise a label/stage transition graph, add explicit structural assertions: every target is a valid stage, every stage has a transition entry, no dangling references.
+
+Example: `assert set(VALID_TRANSITIONS.keys()) == VALID_STAGES`
+
+**Why:** Property-based tests on a malformed graph surface as mysterious assertion failures rather than clear 'bad graph definition' errors.

--- a/repo_wiki/T-rav/hydraflow/testing/0135-issue-synthesis-grep-all-model-usages-before-committing-pydantic-o.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0135-issue-synthesis-grep-all-model-usages-before-committing-pydantic-o.md
@@ -1,0 +1,19 @@
+---
+id: 0135
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.435372+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Grep all model usages before committing Pydantic or TypedDict changes
+
+Before adding or removing a field, grep the test suite for the model name and update all affected assertions: model definition, factory defaults, `all_fields` tests, and round-trip serialization tests. For `NotRequired` fields, update exact-match assertions but not missing-key assertions.
+
+See also: testing — Type-only annotation changes require no new tests.
+
+**Why:** Missed exact-match assertions silently pass when a field is optional, masking the coverage gap until a stricter test runs later.

--- a/repo_wiki/T-rav/hydraflow/testing/0136-issue-synthesis-feature-toggles-require-both-a-config-field-and-an.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0136-issue-synthesis-feature-toggles-require-both-a-config-field-and-an.md
@@ -1,0 +1,19 @@
+---
+id: 0136
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.435662+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Feature toggles require both a config field and an _ENV_INT_OVERRIDES entry
+
+Each new feature toggle needs a field in `src/config.py` AND an entry in `_ENV_INT_OVERRIDES`. Test both the default field value and the env-var override behavior. The `_ENV_INT_OVERRIDES` tuple default must equal the Field default or env override silently stops applying.
+
+See also: architecture-state-persistence — `_ENV_INT_OVERRIDES` default sync.
+
+**Why:** A config field alone makes the toggle code-only; without `_ENV_INT_OVERRIDES`, the environment variable silently has no effect.

--- a/repo_wiki/T-rav/hydraflow/testing/0137-issue-synthesis-test-concurrent-jsonl-appends-with-exact-counts-no.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0137-issue-synthesis-test-concurrent-jsonl-appends-with-exact-counts-no.md
@@ -1,0 +1,21 @@
+---
+id: 0137
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.435950+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Test concurrent JSONL appends with exact counts, not timing
+
+Use `ThreadPoolExecutor` with fixed thread and iteration counts; assert the exact expected line count after completion.
+
+Example: 10 threads × 20 events = 200 lines — assert `len(lines) == 200`.
+
+POSIX guarantees atomicity for writes under ~4 KB; validate empirically before relying on this.
+
+**Why:** Timing-based assertions are non-deterministic; exact counts reliably expose real data loss or line corruption.

--- a/repo_wiki/T-rav/hydraflow/testing/0138-issue-synthesis-use-identical-string-keys-across-memory-bank-dedup.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0138-issue-synthesis-use-identical-string-keys-across-memory-bank-dedup.md
@@ -1,0 +1,17 @@
+---
+id: 0138
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.436245+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Use identical string keys across memory bank deduplication and assembly
+
+The `bank_order` list and bank dict keys must use identical strings throughout (e.g., `'review_insights'` everywhere, never mixed with `'review-insights'`). Fallback recall functions should try multiple field names (`learning`, `text`, `content`, `display_text`) to extract the text payload.
+
+**Why:** Key mismatches silently skip entire banks during deduplication or assembly with no error or warning.

--- a/repo_wiki/T-rav/hydraflow/testing/0139-issue-synthesis-skill-definition-changes-must-update-all-4-backend.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0139-issue-synthesis-skill-definition-changes-must-update-all-4-backend.md
@@ -1,0 +1,17 @@
+---
+id: 0139
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.436537+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Skill definition changes must update all 4 backend copies
+
+HydraFlow skills are replicated across `.claude/commands/`, `.pi/skills/`, `.codex/skills/`, and `src/*.py`. Use a manual `SKILL_MARKERS` mapping (not regex introspection) to validate all copies contain matching output markers via substring search. A single skill change can require updates across 3+ test fixture files.
+
+**Why:** Missing updates in any one copy cause consistency test failures and silent runtime behavior divergence.

--- a/repo_wiki/T-rav/hydraflow/testing/0140-issue-synthesis-auto-generated-adr-tests-must-use-pytest-mark-skip.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0140-issue-synthesis-auto-generated-adr-tests-must-use-pytest-mark-skip.md
@@ -1,0 +1,17 @@
+---
+id: 0140
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.436854+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Auto-generated ADR tests must use @pytest.mark.skip by default
+
+When auto-generating tests from ADR Decision sections, emit all tests with `@pytest.mark.skip(reason='skeleton: requires human review')`. Extract only 4 high-confidence baseline patterns per ADR: uniqueness, usage, negative, coverage.
+
+**Why:** Automated pattern matching on ADR language is ambiguous; unskipped generated tests produce false-positive CI failures until a human validates each pattern.

--- a/repo_wiki/T-rav/hydraflow/testing/0141-issue-synthesis-every-adr-must-pass-structural-section-validation-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0141-issue-synthesis-every-adr-must-pass-structural-section-validation-.md
@@ -1,0 +1,19 @@
+---
+id: 0141
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.437156+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Every ADR must pass structural section validation before merge
+
+ADRs must pass `tests/test_adr_pre_validator.py`, which enforces required sections (Status, Context, Decision, Consequences) and valid status values: Proposed, Accepted, Deprecated, Superseded.
+
+See also: architecture — ADR number collision and README guards.
+
+**Why:** ADRs missing required sections are ambiguous to automated drift-detection tooling, causing false-positive or false-negative ADR drift reports.

--- a/repo_wiki/T-rav/hydraflow/testing/0142-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0142-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md
@@ -1,0 +1,23 @@
+---
+id: 0142
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.437452+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Never import private helpers at module level in test files
+
+Import private or internal functions (`_foo`) inside the test function or a `pytest.fixture`, never at the top of the test module.
+
+```python
+# good — failure scoped to the test
+def test_check_prereq():
+    from src.makefile_scaffold import _check_prereq_deps
+```
+
+**Why:** A module-level `ImportError` prevents pytest from collecting the file, silently destroying all passing tests in that module.

--- a/repo_wiki/T-rav/hydraflow/testing/0143-issue-synthesis-pin-function-signatures-in-the-source-file-before-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0143-issue-synthesis-pin-function-signatures-in-the-source-file-before-.md
@@ -1,0 +1,21 @@
+---
+id: 0143
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.437778+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Pin function signatures in the source file before writing tests or docs
+
+Decide the authoritative signature (argument order, return tuple shape) in the source file first; write docs and tests to match.
+
+1. Write the function stub
+2. Copy its exact signature into the docstring
+3. Then write the test
+
+**Why:** When docs and tests are authored before implementation, signature drift goes undetected until runtime — both artifacts can be wrong simultaneously.

--- a/repo_wiki/T-rav/hydraflow/testing/0144-issue-synthesis-specify-exact-logger-name-in-caplog-at-level-asser.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0144-issue-synthesis-specify-exact-logger-name-in-caplog-at-level-asser.md
@@ -1,0 +1,23 @@
+---
+id: 0144
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.438067+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Specify exact logger name in caplog.at_level() assertions
+
+Always pass the exact logger name to `caplog.at_level()` and clear caplog before the action under test.
+
+```python
+with caplog.at_level(logging.WARNING, logger='src.billing'):
+    trigger_action()
+assert 'expected substring' in caplog.text
+```
+
+**Why:** Without the logger filter, unrelated log messages from other modules pollute captured output and produce false positives.

--- a/repo_wiki/T-rav/hydraflow/testing/0145-issue-synthesis-js-rendered-accessibility-attributes-require-playw.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0145-issue-synthesis-js-rendered-accessibility-attributes-require-playw.md
@@ -1,0 +1,17 @@
+---
+id: 0145
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.438376+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# JS-rendered accessibility attributes require Playwright, not TestClient
+
+Server-side `TestClient` (Django/FastAPI) returns only the initial HTML shell; `aria-labelledby` and other JS-rendered attributes are absent. Delete dead Python `TestClient` tests for these attributes and replace with Playwright tests.
+
+**Why:** TestClient assertions on JS-rendered attributes always pass vacuously — the attribute is missing from the initial render, so assertions check an empty string or missing key.

--- a/repo_wiki/T-rav/hydraflow/testing/0146-issue-synthesis-use-word-boundary-matching-in-name-coverage-checks.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0146-issue-synthesis-use-word-boundary-matching-in-name-coverage-checks.md
@@ -1,0 +1,20 @@
+---
+id: 0146
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.438696+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Use word-boundary matching in name-coverage checks to prevent collisions
+
+Substring matching in coverage or name checks produces false positives when short names appear inside longer ones.
+
+- Bad: `'Foo' in text` — also matches `FooBar`, `PrefixFoo`
+- Good: `re.search(r'\bFoo\b', text)` or full-name match
+
+**Why:** Short-name collisions silently mark unrelated targets as covered, hiding real gaps in coverage.

--- a/repo_wiki/T-rav/hydraflow/testing/0147-issue-synthesis-keep-test-label-stage-constants-synchronized-with-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0147-issue-synthesis-keep-test-label-stage-constants-synchronized-with-.md
@@ -1,0 +1,19 @@
+---
+id: 0147
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.438993+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Keep test label/stage constants synchronized with production definitions
+
+Test constants (`ALL_PIPELINE_LABELS`, `VALID_STAGES`, `VALID_TRANSITIONS`) must mirror production definitions. Add a sync test asserting set equality: `assert set(VALID_TRANSITIONS.keys()) == VALID_STAGES`.
+
+See also: testing — Test direct-swap labels via swap_pipeline_labels(), not transitions.
+
+**Why:** Stale test constants become false documentation and silently mask missing transition or label coverage.

--- a/repo_wiki/T-rav/hydraflow/testing/0148-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels-n.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0148-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels-n.md
@@ -1,0 +1,19 @@
+---
+id: 0148
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.439290+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Test direct-swap labels via swap_pipeline_labels(), not transitions
+
+Labels set via atomic swap (`hitl-active`, `fixed`) bypass the transition graph and are applied by `swap_pipeline_labels()` — test them on that separate call path, not through `VALID_TRANSITIONS`.
+
+See also: testing — Keep test label/stage constants synchronized with production definitions.
+
+**Why:** Testing swap labels through the transition graph masks missing coverage; they have no transition entry by design.

--- a/repo_wiki/T-rav/hydraflow/testing/0149-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0149-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
@@ -1,0 +1,21 @@
+---
+id: 0149
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.439589+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Allow ±3 line drift in AST-based structure assertions
+
+For tests that verify code structure by parsing source ASTs (e.g., checking function length or nesting depth), allow ±3 line tolerance.
+
+Example: Assert `len(func.body) <= 53` rather than `<= 50` to account for blank lines and decorator variations.
+
+See also: testing — Enforce 50-line handler and 30-line wiring limits for testability.
+
+**Why:** Exact line-count assertions redden CI on whitespace-only diffs, creating maintenance noise without improving correctness.

--- a/repo_wiki/T-rav/hydraflow/testing/0150-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0150-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md
@@ -1,0 +1,17 @@
+---
+id: 0150
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.439886+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Existing tests cover private-method extractions; add only new-behavior tests
+
+When extracting a private method from a public one with an unchanged public API, the existing test suite provides full coverage — no new tests needed for the extraction itself. When extracting prompt-building methods, run prompt-assertion tests in isolation immediately after extraction to verify parity.
+
+**Why:** Adding duplicate tests for unchanged behavior inflates the suite; the real regression risk is behavioral, which existing tests already guard.

--- a/repo_wiki/T-rav/hydraflow/testing/0151-issue-synthesis-enforce-50-line-handler-and-30-line-wiring-limits-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0151-issue-synthesis-enforce-50-line-handler-and-30-line-wiring-limits-.md
@@ -1,0 +1,19 @@
+---
+id: 0151
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.440177+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Enforce 50-line handler and 30-line wiring limits for testability
+
+Handler functions must stay under 50 lines; registration wiring under 30 lines. Extract nested closures into instance methods to flatten nesting to ≤3 levels. Enforce via AST-based tests with ±3 line tolerance.
+
+See also: testing — Allow ±3 line drift in AST-based structure assertions.
+
+**Why:** Deep nesting and long handlers are hard to unit-test in isolation; the limit forces decomposition that makes individual behaviors independently testable.

--- a/repo_wiki/T-rav/hydraflow/testing/0152-issue-synthesis-type-only-annotation-changes-require-no-new-tests.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0152-issue-synthesis-type-only-annotation-changes-require-no-new-tests.md
@@ -1,0 +1,19 @@
+---
+id: 0152
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T05:57:54.440475+00:00
+status: superseded
+corroborations: 1
+supersedes: 0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122
+superseded_by: 0153
+---
+
+# Type-only annotation changes require no new tests
+
+Migrating from `dict[str, Any]` to a `TypedDict` return type, or narrowing a parameter from `Any` to a specific type, requires no new tests — `TypedDict` values are plain dicts at runtime and `Any` is compatible with all types in pyright. Verify via `make quality-lite` and `make test`; the existing suite suffices.
+
+See also: testing — Grep all model usages before committing Pydantic or TypedDict changes.
+
+**Why:** Runtime behavior is unchanged; only static validation improves. New tests for type-only changes create maintenance overhead without catching real bugs.

--- a/repo_wiki/T-rav/hydraflow/testing/0153-issue-synthesis-mock-at-definition-site-not-at-the-import-site.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0153-issue-synthesis-mock-at-definition-site-not-at-the-import-site.md
@@ -1,0 +1,21 @@
+---
+id: 0153
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.574285+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Mock at definition site, not at the import site
+
+Patch symbols at the module where they are defined, not where they are imported.
+
+- Bad: `patch('tests.test_foo.MyClass')`
+- Good: `patch('src.mymodule.MyClass')`
+
+For optional deps like `sentry_sdk`, use `patch.dict('sys.modules', {'sentry_sdk': mock, 'sentry_sdk.integrations': mock})`; patch sub-modules explicitly to prevent import leaks.
+
+**Why:** Usage-site patches intercept only that one import; other callers and subsequent imports still see the real object, producing inconsistent test behavior.

--- a/repo_wiki/T-rav/hydraflow/testing/0154-issue-synthesis-reserve-pytest-mark-integration-for-real-external-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0154-issue-synthesis-reserve-pytest-mark-integration-for-real-external-.md
@@ -1,0 +1,16 @@
+---
+id: 0154
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.574648+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Reserve @pytest.mark.integration for real external dependencies only
+
+Mark a test `@pytest.mark.integration` only when it exercises Docker, network, filesystem, real worktrees, or live service instances — not when all deps are `AsyncMock` or `MagicMock`. Use `pytest.mark.skipif(not shutil.which('cli'), ...)` for optional CLI tools.
+
+**Why:** Over-marking slows the fast suite and blurs the unit/integration boundary, making targeted test runs unreliable.

--- a/repo_wiki/T-rav/hydraflow/testing/0155-issue-synthesis-await-asyncio-sleep-0-before-asserting-on-create-t.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0155-issue-synthesis-await-asyncio-sleep-0-before-asserting-on-create-t.md
@@ -1,0 +1,22 @@
+---
+id: 0155
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.574983+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Await asyncio.sleep(0) before asserting on create_task() side effects
+
+After triggering fire-and-forget async tasks via `asyncio.create_task()`, yield the event loop before making assertions.
+
+```python
+task = asyncio.create_task(fn())
+await asyncio.sleep(0)
+mock.assert_called_once()
+```
+
+**Why:** Without yielding, the created task has not yet run; assertions on its side effects will fail spuriously and non-deterministically.

--- a/repo_wiki/T-rav/hydraflow/testing/0156-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0156-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
@@ -1,0 +1,21 @@
+---
+id: 0156
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.575316+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Test async context managers in three standard scenarios
+
+Test async context managers with three scenarios: (1) idempotent close — calling `close()` twice is safe, (2) context manager exit triggers `close()` exactly once, (3) `__aenter__` returns `self`.
+
+```python
+async with resource as r:
+    assert r is resource
+```
+
+**Why:** Missing any scenario leaves an incomplete behavioral contract, hiding bugs in external-connection or file-handle management.

--- a/repo_wiki/T-rav/hydraflow/testing/0157-issue-synthesis-use-python-script-stand-ins-to-test-subprocess-bou.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0157-issue-synthesis-use-python-script-stand-ins-to-test-subprocess-bou.md
@@ -1,0 +1,18 @@
+---
+id: 0157
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.575641+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Use Python script stand-ins to test subprocess boundaries
+
+Create small Python scripts that log invocations to JSON-lines files instead of mocking subprocess calls directly.
+
+Example: Pass `subprocess_runner = ['python3', 'fake_gh.py']` to the system under test; assert via `json.loads(log_path.read_text())`.
+
+**Why:** Real subprocess boundaries catch shell-quoting, PATH resolution, and argument-passing bugs that mock-based patches cannot detect.

--- a/repo_wiki/T-rav/hydraflow/testing/0158-issue-synthesis-reset-module-level-global-state-in-both-setup-and-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0158-issue-synthesis-reset-module-level-global-state-in-both-setup-and-.md
@@ -1,0 +1,23 @@
+---
+id: 0158
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.575951+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Reset module-level global state in both setup and teardown
+
+Global state (e.g., `_gh_semaphore`, `_rate_limit_until`) must be explicitly reset in both `setup_method` and `teardown_method`.
+
+```python
+def setup_method(self):
+    module._rate_limit_until = 0
+def teardown_method(self):
+    module._rate_limit_until = 0
+```
+
+**Why:** Omitting setup reset leaves stale state from a prior run; omitting teardown reset infects the next test — both produce non-deterministic failures.

--- a/repo_wiki/T-rav/hydraflow/testing/0159-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0159-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md
@@ -1,0 +1,21 @@
+---
+id: 0159
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.576265+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Use tmp_path with ConfigFactory for all file-based test I/O
+
+All tests that read or write files must use `tmp_path` combined with `ConfigFactory.create(base_path=tmp_path)` — never write to real project paths.
+
+```python
+def test_something(tmp_path):
+    config = ConfigFactory.create(base_path=tmp_path)
+```
+
+**Why:** Tests writing to real project paths corrupt the working directory and produce hard-to-reproduce cross-test pollution.

--- a/repo_wiki/T-rav/hydraflow/testing/0160-issue-synthesis-wire-real-business-logic-in-phase-runner-integrati.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0160-issue-synthesis-wire-real-business-logic-in-phase-runner-integrati.md
@@ -1,0 +1,16 @@
+---
+id: 0160
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.576577+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Wire real business logic in phase-runner integration tests
+
+Use real `StateTracker`, `EventBus`, and `VerificationJudge` instances in phase-runner integration tests; mock only the `_execute()` subprocess boundary. Provide configurable transcript strings for real runner parsing. Validate via `StateTracker` APIs and `EventBus.get_history()`, not mock call assertions.
+
+**Why:** Fully-mocked runners hide mismatches between transcript parsing logic and real output formats — exactly the bugs integration tests exist to catch.

--- a/repo_wiki/T-rav/hydraflow/testing/0161-issue-synthesis-test-protocol-compliance-with-structural-typing-an.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0161-issue-synthesis-test-protocol-compliance-with-structural-typing-an.md
@@ -1,0 +1,16 @@
+---
+id: 0161
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.576876+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Test protocol compliance with structural typing and duck-typing
+
+Verify protocol satisfaction with two complementary checks: (1) `isinstance(obj, Protocol)` with `@runtime_checkable`, and (2) `hasattr(obj, 'method_name')`. Add `inspect.signature()` comparison to detect parameter drift. Parametrize over each protocol method so failures are specific.
+
+**Why:** Either check alone misses a class of violations; structural typing catches missing methods, signature comparison catches arity and keyword drift.

--- a/repo_wiki/T-rav/hydraflow/testing/0162-issue-synthesis-test-fa-ade-getattr-routing-attributeerror-and-pro.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0162-issue-synthesis-test-fa-ade-getattr-routing-attributeerror-and-pro.md
@@ -1,0 +1,16 @@
+---
+id: 0162
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.577187+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Test façade __getattr__ routing, AttributeError, and protocol delegation
+
+When adding a façade over sub-clients, explicitly test: (1) `__getattr__` routes to the correct sub-client, (2) unknown attributes raise `AttributeError`, (3) the façade satisfies protocols via delegation, (4) existing mocks of the original class still pass. Assert sub-components receive mutable dict/set references — not copies — to shared state owned by the façade.
+
+**Why:** Façade delegation bugs pass all pre-existing tests because those tests mock the original class directly, not the façade.

--- a/repo_wiki/T-rav/hydraflow/testing/0163-issue-synthesis-assert-relative-event-id-ordering-never-absolute-v.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0163-issue-synthesis-assert-relative-event-id-ordering-never-absolute-v.md
@@ -1,0 +1,19 @@
+---
+id: 0163
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.577494+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Assert relative event ID ordering, never absolute values
+
+Tests for events backed by a global counter must assert relative ordering and uniqueness within one test, never absolute ID values.
+
+- Good: `assert event_a.id < event_b.id`
+- Bad: `assert event_a.id == 1`
+
+**Why:** Global ID counters are shared across tests and imports; absolute assertions produce non-deterministic failures under parallel or reordered execution.

--- a/repo_wiki/T-rav/hydraflow/testing/0164-issue-synthesis-add-structural-tests-before-property-based-transit.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0164-issue-synthesis-add-structural-tests-before-property-based-transit.md
@@ -1,0 +1,18 @@
+---
+id: 0164
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.577810+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Add structural tests before property-based transition graph tests
+
+Before using hypothesis or similar tools to exercise a label/stage transition graph, add explicit structural assertions: every target is a valid stage, every stage has a transition entry, no dangling references.
+
+Example: `assert set(VALID_TRANSITIONS.keys()) == VALID_STAGES`
+
+**Why:** Property-based tests on a malformed graph surface as mysterious assertion failures rather than clear 'bad graph definition' errors.

--- a/repo_wiki/T-rav/hydraflow/testing/0165-issue-synthesis-grep-all-model-usages-before-committing-pydantic-o.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0165-issue-synthesis-grep-all-model-usages-before-committing-pydantic-o.md
@@ -1,0 +1,18 @@
+---
+id: 0165
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.578130+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Grep all model usages before committing Pydantic or TypedDict changes
+
+Before adding or removing a field, grep the test suite for the model name and update all affected assertions: model definition, factory defaults, `all_fields` tests, and round-trip serialization tests. For `NotRequired` fields, update exact-match assertions but not missing-key assertions.
+
+See also: testing — Type-only annotation changes require no new tests.
+
+**Why:** Missed exact-match assertions silently pass when a field is optional, masking the coverage gap until a stricter test runs later.

--- a/repo_wiki/T-rav/hydraflow/testing/0166-issue-synthesis-feature-toggles-require-both-a-config-field-and-an.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0166-issue-synthesis-feature-toggles-require-both-a-config-field-and-an.md
@@ -1,0 +1,18 @@
+---
+id: 0166
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.578470+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Feature toggles require both a config field and an _ENV_INT_OVERRIDES entry
+
+Each new feature toggle needs a field in `src/config.py` AND an entry in `_ENV_INT_OVERRIDES`. Test both the default field value and the env-var override behavior. The `_ENV_INT_OVERRIDES` tuple default must equal the Field default or env override silently stops applying.
+
+See also: architecture-state-persistence — `_ENV_INT_OVERRIDES` default sync.
+
+**Why:** A config field alone makes the toggle code-only; without `_ENV_INT_OVERRIDES`, the environment variable silently has no effect.

--- a/repo_wiki/T-rav/hydraflow/testing/0167-issue-synthesis-test-concurrent-jsonl-appends-with-exact-counts-no.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0167-issue-synthesis-test-concurrent-jsonl-appends-with-exact-counts-no.md
@@ -1,0 +1,20 @@
+---
+id: 0167
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.578787+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Test concurrent JSONL appends with exact counts, not timing
+
+Use `ThreadPoolExecutor` with fixed thread and iteration counts; assert the exact expected line count after completion.
+
+Example: 10 threads × 20 events = 200 lines — assert `len(lines) == 200`.
+
+POSIX guarantees atomicity for writes under ~4 KB; validate empirically before relying on this.
+
+**Why:** Timing-based assertions are non-deterministic; exact counts reliably expose real data loss or line corruption.

--- a/repo_wiki/T-rav/hydraflow/testing/0168-issue-synthesis-use-identical-string-keys-across-memory-bank-dedup.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0168-issue-synthesis-use-identical-string-keys-across-memory-bank-dedup.md
@@ -1,0 +1,16 @@
+---
+id: 0168
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.579096+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Use identical string keys across memory bank deduplication and assembly
+
+The `bank_order` list and bank dict keys must use identical strings throughout (e.g., `'review_insights'` everywhere, never mixed with `'review-insights'`). Fallback recall functions should try multiple field names (`learning`, `text`, `content`, `display_text`) to extract the text payload.
+
+**Why:** Key mismatches silently skip entire banks during deduplication or assembly with no error or warning.

--- a/repo_wiki/T-rav/hydraflow/testing/0169-issue-synthesis-skill-definition-changes-must-update-all-4-backend.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0169-issue-synthesis-skill-definition-changes-must-update-all-4-backend.md
@@ -1,0 +1,16 @@
+---
+id: 0169
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.579421+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Skill definition changes must update all 4 backend copies
+
+HydraFlow skills are replicated across `.claude/commands/`, `.pi/skills/`, `.codex/skills/`, and `src/*.py`. Use a manual `SKILL_MARKERS` mapping (not regex introspection) to validate all copies contain matching output markers via substring search. A single skill change can require updates across 3+ test fixture files.
+
+**Why:** Missing updates in any one copy cause consistency test failures and silent runtime behavior divergence.

--- a/repo_wiki/T-rav/hydraflow/testing/0170-issue-synthesis-auto-generated-adr-tests-must-use-pytest-mark-skip.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0170-issue-synthesis-auto-generated-adr-tests-must-use-pytest-mark-skip.md
@@ -1,0 +1,16 @@
+---
+id: 0170
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.579759+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Auto-generated ADR tests must use @pytest.mark.skip by default
+
+When auto-generating tests from ADR Decision sections, emit all tests with `@pytest.mark.skip(reason='skeleton: requires human review')`. Extract only 4 high-confidence baseline patterns per ADR: uniqueness, usage, negative, coverage.
+
+**Why:** Automated pattern matching on ADR language is ambiguous; unskipped generated tests produce false-positive CI failures until a human validates each pattern.

--- a/repo_wiki/T-rav/hydraflow/testing/0171-issue-synthesis-every-adr-must-pass-structural-section-validation-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0171-issue-synthesis-every-adr-must-pass-structural-section-validation-.md
@@ -1,0 +1,18 @@
+---
+id: 0171
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.580071+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Every ADR must pass structural section validation before merge
+
+ADRs must pass `tests/test_adr_pre_validator.py`, which enforces required sections (Status, Context, Decision, Consequences) and valid status values: Proposed, Accepted, Deprecated, Superseded.
+
+See also: architecture — ADR number collision and README guards.
+
+**Why:** ADRs missing required sections are ambiguous to automated drift-detection tooling, causing false-positive or false-negative ADR drift reports.

--- a/repo_wiki/T-rav/hydraflow/testing/0172-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0172-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md
@@ -1,0 +1,22 @@
+---
+id: 0172
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.580387+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Never import private helpers at module level in test files
+
+Import private or internal functions (`_foo`) inside the test function or a `pytest.fixture`, never at the top of the test module.
+
+```python
+# good — failure scoped to the test
+def test_check_prereq():
+    from src.makefile_scaffold import _check_prereq_deps
+```
+
+**Why:** A module-level `ImportError` prevents pytest from collecting the file, silently destroying all passing tests in that module.

--- a/repo_wiki/T-rav/hydraflow/testing/0173-issue-synthesis-pin-function-signatures-in-the-source-file-before-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0173-issue-synthesis-pin-function-signatures-in-the-source-file-before-.md
@@ -1,0 +1,20 @@
+---
+id: 0173
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.580702+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Pin function signatures in the source file before writing tests or docs
+
+Decide the authoritative signature (argument order, return tuple shape) in the source file first; write docs and tests to match.
+
+1. Write the function stub
+2. Copy its exact signature into the docstring
+3. Then write the test
+
+**Why:** When docs and tests are authored before implementation, signature drift goes undetected until runtime — both artifacts can be wrong simultaneously.

--- a/repo_wiki/T-rav/hydraflow/testing/0174-issue-synthesis-specify-exact-logger-name-in-caplog-at-level-asser.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0174-issue-synthesis-specify-exact-logger-name-in-caplog-at-level-asser.md
@@ -1,0 +1,22 @@
+---
+id: 0174
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.581029+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Specify exact logger name in caplog.at_level() assertions
+
+Always pass the exact logger name to `caplog.at_level()` and clear caplog before the action under test.
+
+```python
+with caplog.at_level(logging.WARNING, logger='src.billing'):
+    trigger_action()
+assert 'expected substring' in caplog.text
+```
+
+**Why:** Without the logger filter, unrelated log messages from other modules pollute captured output and produce false positives.

--- a/repo_wiki/T-rav/hydraflow/testing/0175-issue-synthesis-js-rendered-accessibility-attributes-require-playw.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0175-issue-synthesis-js-rendered-accessibility-attributes-require-playw.md
@@ -1,0 +1,16 @@
+---
+id: 0175
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.581376+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# JS-rendered accessibility attributes require Playwright, not TestClient
+
+Server-side `TestClient` (Django/FastAPI) returns only the initial HTML shell; `aria-labelledby` and other JS-rendered attributes are absent. Delete dead Python `TestClient` tests for these attributes and replace with Playwright tests.
+
+**Why:** TestClient assertions on JS-rendered attributes always pass vacuously — the attribute is missing from the initial render, so assertions check an empty string or missing key.

--- a/repo_wiki/T-rav/hydraflow/testing/0176-issue-synthesis-use-word-boundary-matching-in-name-coverage-checks.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0176-issue-synthesis-use-word-boundary-matching-in-name-coverage-checks.md
@@ -1,0 +1,19 @@
+---
+id: 0176
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.581718+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Use word-boundary matching in name-coverage checks to prevent collisions
+
+Substring matching in coverage or name checks produces false positives when short names appear inside longer ones.
+
+- Bad: `'Foo' in text` — also matches `FooBar`, `PrefixFoo`
+- Good: `re.search(r'\bFoo\b', text)` or full-name match
+
+**Why:** Short-name collisions silently mark unrelated targets as covered, hiding real gaps in coverage.

--- a/repo_wiki/T-rav/hydraflow/testing/0177-issue-synthesis-keep-test-label-stage-constants-synchronized-with-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0177-issue-synthesis-keep-test-label-stage-constants-synchronized-with-.md
@@ -1,0 +1,18 @@
+---
+id: 0177
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.582062+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Keep test label/stage constants synchronized with production definitions
+
+Test constants (`ALL_PIPELINE_LABELS`, `VALID_STAGES`, `VALID_TRANSITIONS`) must mirror production definitions. Add a sync test asserting set equality: `assert set(VALID_TRANSITIONS.keys()) == VALID_STAGES`.
+
+See also: testing — Test direct-swap labels via swap_pipeline_labels(), not transitions.
+
+**Why:** Stale test constants become false documentation and silently mask missing transition or label coverage.

--- a/repo_wiki/T-rav/hydraflow/testing/0178-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels-n.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0178-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels-n.md
@@ -1,0 +1,18 @@
+---
+id: 0178
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.582440+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Test direct-swap labels via swap_pipeline_labels(), not transitions
+
+Labels set via atomic swap (`hitl-active`, `fixed`) bypass the transition graph and are applied by `swap_pipeline_labels()` — test them on that separate call path, not through `VALID_TRANSITIONS`.
+
+See also: testing — Keep test label/stage constants synchronized with production definitions.
+
+**Why:** Testing swap labels through the transition graph masks missing coverage; they have no transition entry by design.

--- a/repo_wiki/T-rav/hydraflow/testing/0179-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0179-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
@@ -1,0 +1,20 @@
+---
+id: 0179
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.582809+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Allow ±3 line drift in AST-based structure assertions
+
+For tests that verify code structure by parsing source ASTs (e.g., checking function length or nesting depth), allow ±3 line tolerance.
+
+Example: Assert `len(func.body) <= 53` rather than `<= 50` to account for blank lines and decorator variations.
+
+See also: testing — Enforce 50-line handler and 30-line wiring limits for testability.
+
+**Why:** Exact line-count assertions redden CI on whitespace-only diffs, creating maintenance noise without improving correctness.

--- a/repo_wiki/T-rav/hydraflow/testing/0180-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0180-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md
@@ -1,0 +1,16 @@
+---
+id: 0180
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.583171+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Existing tests cover private-method extractions; add only new-behavior tests
+
+When extracting a private method from a public one with an unchanged public API, the existing test suite provides full coverage — no new tests needed for the extraction itself. When extracting prompt-building methods, run prompt-assertion tests in isolation immediately after extraction to verify parity.
+
+**Why:** Adding duplicate tests for unchanged behavior inflates the suite; the real regression risk is behavioral, which existing tests already guard.

--- a/repo_wiki/T-rav/hydraflow/testing/0181-issue-synthesis-enforce-50-line-handler-and-30-line-wiring-limits-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0181-issue-synthesis-enforce-50-line-handler-and-30-line-wiring-limits-.md
@@ -1,0 +1,18 @@
+---
+id: 0181
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.583532+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Enforce 50-line handler and 30-line wiring limits for testability
+
+Handler functions must stay under 50 lines; registration wiring under 30 lines. Extract nested closures into instance methods to flatten nesting to ≤3 levels. Enforce via AST-based tests with ±3 line tolerance.
+
+See also: testing — Allow ±3 line drift in AST-based structure assertions.
+
+**Why:** Deep nesting and long handlers are hard to unit-test in isolation; the limit forces decomposition that makes individual behaviors independently testable.

--- a/repo_wiki/T-rav/hydraflow/testing/0182-issue-synthesis-type-only-annotation-changes-require-no-new-tests.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0182-issue-synthesis-type-only-annotation-changes-require-no-new-tests.md
@@ -1,0 +1,18 @@
+---
+id: 0182
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-15T06:37:30.583920+00:00
+status: active
+corroborations: 1
+supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+---
+
+# Type-only annotation changes require no new tests
+
+Migrating from `dict[str, Any]` to a `TypedDict` return type, or narrowing a parameter from `Any` to a specific type, requires no new tests — `TypedDict` values are plain dicts at runtime. Verify via `make quality-lite` and `make test`; the existing suite suffices.
+
+See also: testing — Grep all model usages before committing Pydantic or TypedDict changes.
+
+**Why:** Runtime behavior is unchanged; only static validation improves. New tests for type-only changes create maintenance overhead without catching real bugs.

--- a/src/subprocess_util.py
+++ b/src/subprocess_util.py
@@ -339,6 +339,15 @@ _CREDIT_PATTERNS = (
     # (2026-06-13 incident; see tests/regressions/test_session_limit_credit_pause.py.)
     "hit your session limit",
     "session limit reached",
+    # Claude Code subscription *weekly*-cap message
+    # ("You've hit your weekly limit · resets Jun 18 at 5pm"). Same failure
+    # class as the session cap (2026-06-17 incident): "weekly" sits between
+    # "hit your" and "limit", so it slipped past every substring and the factory
+    # burned its whole attempt budget into HITL. The _LIMIT_HIT_RE regex below
+    # now catches the entire "hit your <period> limit" family so a new cap
+    # wording (daily/monthly/…) cannot recur this.
+    # See tests/regressions/test_weekly_limit_credit_pause.py.
+    "weekly limit reached",
     # Anthropic API spend-cap rejection (HTTP 400 invalid_request_error).
     # Full phrase — narrower patterns would false-match conversational
     # transcript text like "reached your specified goals" and trigger a
@@ -346,6 +355,14 @@ _CREDIT_PATTERNS = (
     "reached your specified api usage limits",
     "reached your specified usage limits",
 )
+
+# Catches the whole "You've hit your <usage|session|weekly|daily|…> limit"
+# family in one shot, so a new subscription-cap wording can't slip past the
+# substring list and burn the attempt budget — the failure mode behind both the
+# 2026-06-13 (session) and 2026-06-17 (weekly) HITL pile-ups. Allows 0–2 words
+# between "your" and "limit"; word-boundary anchored so it does not match prose
+# like "hit your stride, no limit".
+_LIMIT_HIT_RE = re.compile(r"\bhit your(?:\s+\w+){0,2}\s+limit\b", re.IGNORECASE)
 
 # Matches e.g. "reset at 3pm (America/New_York)", "reset at 3am",
 # "resets 5am (America/Denver)", "resets at 5am", "resets 5:50am (America/Denver)".
@@ -356,6 +373,37 @@ _RESET_TIME_RE = re.compile(
     r"(?:\s*\(([^)]+)\))?",
     re.IGNORECASE,
 )
+
+# Weekly-cap resume formats. Claude Code renders the weekly reset as an absolute
+# day, usually WITHOUT a timezone — assume local time (the message is shown in
+# the user's locale). Both forms optionally accept a trailing "(Area/City)".
+#   "resets Jun 18 at 5pm"      → month abbrev + day + time
+#   "resets Wednesday at 5pm"   → weekday name + time (next occurrence)
+_WEEKLY_DATE_RE = re.compile(
+    r"resets?\s+(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\s+(\d{1,2})"
+    r"\s+at\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)(?:\s*\(([^)]+)\))?",
+    re.IGNORECASE,
+)
+_WEEKLY_DAY_RE = re.compile(
+    r"resets?\s+(mon|tue|wed|thu|fri|sat|sun)[a-z]*\s+at\s+"
+    r"(\d{1,2})(?::(\d{2}))?\s*(am|pm)(?:\s*\(([^)]+)\))?",
+    re.IGNORECASE,
+)
+_MONTH_ABBR = {
+    "jan": 1,
+    "feb": 2,
+    "mar": 3,
+    "apr": 4,
+    "may": 5,
+    "jun": 6,
+    "jul": 7,
+    "aug": 8,
+    "sep": 9,
+    "oct": 10,
+    "nov": 11,
+    "dec": 12,
+}
+_WEEKDAY_ABBR = {"mon": 0, "tue": 1, "wed": 2, "thu": 3, "fri": 4, "sat": 5, "sun": 6}
 
 # Matches Anthropic's ISO-style spend-cap resume format:
 # "regain access on 2026-05-01 at 00:00 UTC"
@@ -402,7 +450,103 @@ _DOCKER_ENV_PASSTHROUGH_KEYS = (
 def is_credit_exhaustion(text: str) -> bool:
     """Check if *text* indicates an API credit exhaustion condition."""
     text_lower = text.lower()
-    return any(p in text_lower for p in _CREDIT_PATTERNS)
+    if any(p in text_lower for p in _CREDIT_PATTERNS):
+        return True
+    # Future-proof catch-all for the "hit your <period> limit" family.
+    return _LIMIT_HIT_RE.search(text) is not None
+
+
+def _to_24h(hour: int, minute: int, ampm: str) -> tuple[int, int] | None:
+    """Convert a validated 12-hour clock reading to (hour24, minute), or None.
+
+    Rejects out-of-range hours (1–12) and minutes (0–59) so a bogus value
+    ("5:99am") fails to parse rather than rolling over.
+    """
+    if hour < 1 or hour > 12 or minute > 59:
+        return None
+    if ampm.lower() == "am":
+        hour_24 = 0 if hour == 12 else hour
+    else:
+        hour_24 = hour if hour == 12 else hour + 12
+    return hour_24, minute
+
+
+def _resolve_tz(tz_name: str | None, *, default_utc: bool):
+    """Resolve a parenthesised tz name to a tzinfo.
+
+    ``default_utc`` picks the fallback when no tz is present: the legacy
+    hour-only format defaults to UTC; the weekly formats (rendered in the user's
+    locale without a tz) default to local time.
+    """
+    if tz_name:
+        try:
+            return ZoneInfo(tz_name.strip())
+        except (KeyError, ValueError):
+            logger.warning(
+                "Could not parse timezone %r — falling back to local time", tz_name
+            )
+            return datetime.now().astimezone().tzinfo or UTC
+    if default_utc:
+        return UTC
+    return datetime.now().astimezone().tzinfo or UTC
+
+
+def _parse_weekly_month_day(text: str) -> datetime | None:
+    """Parse ``"resets Jun 18 at 5pm"`` (month abbrev + day) → UTC datetime."""
+    md = _WEEKLY_DATE_RE.search(text)
+    if md is None:
+        return None
+    hm = _to_24h(int(md.group(3)), int(md.group(4) or 0), md.group(5))
+    if hm is None:
+        return None
+    tz = _resolve_tz(md.group(6), default_utc=False)
+    now = datetime.now(tz=tz)
+    try:
+        reset = now.replace(
+            month=_MONTH_ABBR[md.group(1).lower()[:3]],
+            day=int(md.group(2)),
+            hour=hm[0],
+            minute=hm[1],
+            second=0,
+            microsecond=0,
+        )
+    except ValueError:
+        return None  # e.g. "Feb 30"
+    # A weekly reset is always within ~7 days, so a clearly-past month/day is a
+    # stale message — NOT next year. Return None so the caller falls back to its
+    # short default pause and re-evaluates, rather than idling for a year. (1h
+    # slack absorbs clock skew.)
+    if reset < now - timedelta(hours=1):
+        return None
+    return reset.astimezone(UTC)
+
+
+def _parse_weekly_weekday(text: str) -> datetime | None:
+    """Parse ``"resets Wednesday at 5pm"`` (weekday → next occurrence) → UTC."""
+    wd = _WEEKLY_DAY_RE.search(text)
+    if wd is None:
+        return None
+    hm = _to_24h(int(wd.group(2)), int(wd.group(3) or 0), wd.group(4))
+    if hm is None:
+        return None
+    tz = _resolve_tz(wd.group(5), default_utc=False)
+    now = datetime.now(tz=tz)
+    days_ahead = (_WEEKDAY_ABBR[wd.group(1).lower()[:3]] - now.weekday()) % 7
+    reset = (now + timedelta(days=days_ahead)).replace(
+        hour=hm[0], minute=hm[1], second=0, microsecond=0
+    )
+    if reset <= now:
+        reset += timedelta(days=7)
+    return reset.astimezone(UTC)
+
+
+def _parse_weekly_resume_time(text: str) -> datetime | None:
+    """Parse Claude Code's weekly-cap resume formats to a UTC datetime.
+
+    ``"resets Jun 18 at 5pm"`` (month + day) and ``"resets Wednesday at 5pm"``
+    (weekday → next occurrence). Returns None if neither matches.
+    """
+    return _parse_weekly_month_day(text) or _parse_weekly_weekday(text)
 
 
 async def probe_credit_availability() -> bool:
@@ -476,6 +620,13 @@ def parse_credit_resume_time(text: str) -> datetime | None:
             return datetime(year, month, day, hour, minute, tzinfo=UTC)
         except ValueError:
             return None
+
+    # Weekly-cap formats ("resets Jun 18 at 5pm" / "resets Wednesday at 5pm").
+    # Checked before the bare hour format so the "5pm" tail isn't parsed as a
+    # same-day reset (which would resume days early during a weekly pause).
+    weekly = _parse_weekly_resume_time(text)
+    if weekly is not None:
+        return weekly
 
     match = _RESET_TIME_RE.search(text)
     if not match:

--- a/src/trace_collector.py
+++ b/src/trace_collector.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 import logging
 import time
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from models import (
@@ -443,8 +443,14 @@ def emit_loop_subprocess_trace(
             return
 
         stderr = stderr_excerpt[-_STDERR_TRUNC_CAP:] if stderr_excerpt else None
-        started_at = datetime.now(UTC).isoformat()
-        slug_ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+        # The helper is invoked after the subprocess finishes (duration_ms is
+        # already elapsed), so ``emitted`` is ~the work's END. Back-date to the
+        # true start so a consumer's [started_at, started_at + duration_ms]
+        # window brackets the work instead of landing one full duration in the
+        # future. The filename keeps emit-time for uniqueness/ordering.
+        emitted = datetime.now(UTC)
+        started_at = (emitted - timedelta(milliseconds=int(duration_ms))).isoformat()
+        slug_ts = emitted.strftime("%Y%m%dT%H%M%S%fZ")
 
         payload = {
             "kind": "loop",

--- a/tests/regressions/test_weekly_limit_credit_pause.py
+++ b/tests/regressions/test_weekly_limit_credit_pause.py
@@ -1,0 +1,73 @@
+"""Regression: Claude Code's *weekly*-cap message must drive the credit-pause
+path, not be mistaken for an ordinary agent failure.
+
+Incident — 2026-06-17. The factory hit its Claude subscription WEEKLY limit.
+Agents printed::
+
+    You've hit your weekly limit · resets Jun 18 at 5pm
+
+This is the same failure class as the 2026-06-13 session-limit incident
+(see test_session_limit_credit_pause.py / PR #9529): the word "weekly" sits
+between "hit your" and "limit", so it slipped past every substring in
+``_CREDIT_PATTERNS``. ``is_credit_exhaustion`` returned False, no
+``CreditExhaustedError`` was raised, the orchestrator never paused, and the
+factory burned its whole attempt budget into HITL (one issue accumulated 492
+billing-message comments).
+
+This pins the fix: a future-proof "hit your <period> limit" detector plus
+weekly resume-time parsing, asserted through the lightweight runner classifier
+that every ``run_simple``-based runner uses.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from runner_utils import raise_if_credit_exhausted
+from subprocess_util import (
+    CreditExhaustedError,
+    is_credit_exhaustion,
+    parse_credit_resume_time,
+)
+
+WEEKLY_MSG = "You've hit your weekly limit · resets Jun 18 at 5pm"
+WEEKLY_WEEKDAY_MSG = "You've hit your weekly limit · resets Wednesday at 5pm"
+
+
+def test_weekly_limit_is_classified_as_credit_exhaustion() -> None:
+    assert is_credit_exhaustion(WEEKLY_MSG)
+    assert is_credit_exhaustion(WEEKLY_WEEKDAY_MSG)
+
+
+def test_lightweight_runner_raises_on_weekly_limit() -> None:
+    """The path every run_simple-based runner uses must raise so the orchestrator
+    pauses + refunds the attempt instead of failing it.
+    """
+    with pytest.raises(CreditExhaustedError):
+        raise_if_credit_exhausted(WEEKLY_MSG, "", tool="claude")
+    with pytest.raises(CreditExhaustedError):
+        raise_if_credit_exhausted("", WEEKLY_WEEKDAY_MSG, tool="claude")
+
+
+def test_weekly_weekday_reset_populates_resume_time() -> None:
+    """The weekday form yields a concrete resume time so the pause lasts the
+    right duration rather than waking every 5h on the default fallback.
+    """
+    with pytest.raises(CreditExhaustedError) as excinfo:
+        raise_if_credit_exhausted(WEEKLY_WEEKDAY_MSG, "", tool="claude")
+    assert excinfo.value.resume_at is not None
+
+
+def test_future_proof_period_family_detected() -> None:
+    """A new single-word cap wording (daily/monthly) must not recur the burn."""
+    for period in ("daily", "monthly", "hourly"):
+        assert is_credit_exhaustion(f"You've hit your {period} limit")
+
+
+def test_weekly_with_unparseable_reset_still_raises() -> None:
+    """Even when the reset clause can't be parsed, detection must fire (the
+    orchestrator falls back to its default pause window).
+    """
+    assert parse_credit_resume_time("You've hit your weekly limit") is None
+    with pytest.raises(CreditExhaustedError):
+        raise_if_credit_exhausted("You've hit your weekly limit", "", tool="claude")

--- a/tests/test_subprocess_util.py
+++ b/tests/test_subprocess_util.py
@@ -1251,6 +1251,53 @@ class TestIsCreditExhaustion:
             "The session limit is configured to 10 sessions per repo."
         )
 
+    def test_matches_claude_code_weekly_limit(self) -> None:
+        """Claude Code subscription *weekly*-cap message (2026-06-17 incident).
+
+        'weekly' sits between 'hit your' and 'limit', so it slipped past every
+        substring and the factory burned its whole attempt budget into HITL.
+        """
+        assert is_credit_exhaustion(
+            "You've hit your weekly limit · resets Jun 18 at 5pm"
+        )
+
+    def test_matches_weekly_limit_reached_phrasing(self) -> None:
+        assert is_credit_exhaustion("Weekly limit reached. Try again later.")
+
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "You've hit your limit",
+            "You've hit your usage limit",
+            "You've hit your session limit",
+            "You've hit your weekly limit",
+            "You've hit your daily limit",
+            "You've hit your monthly limit",
+            "you have hit your weekly usage limit",
+        ],
+    )
+    def test_limit_hit_regex_covers_the_whole_period_family(self, msg: str) -> None:
+        """Future-proofing: any 'hit your <period> limit' wording must match so a
+        new cap type can't recur the 2026-06-13/2026-06-17 attempt-burn.
+        """
+        assert is_credit_exhaustion(msg)
+
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "you hit your stride, no limit today",
+            "the rate limit is configured to 100 requests",
+            "we hit your target under the limit",
+            "All tests passed.",
+            "",
+        ],
+    )
+    def test_does_not_false_match_benign_limit_prose(self, msg: str) -> None:
+        """The catch-all regex must not fire on conversational text — a false
+        positive halts all work (non-retryable).
+        """
+        assert not is_credit_exhaustion(msg)
+
 
 class TestParseCreditResumeTime:
     """parse_credit_resume_time must recognize Anthropic's ISO-style resume format."""
@@ -1316,3 +1363,95 @@ class TestParseCreditResumeTime:
         assert (
             parse_credit_resume_time("regain access on 2026-05-01 at 00:00 PST") is None
         )
+
+    # ---- Weekly-cap resume formats (2026-06-17 incident) ----
+
+    def test_parses_weekly_weekday_format(self) -> None:
+        """'resets Wednesday at 5pm' → next Wednesday 17:00 in local time."""
+        from datetime import UTC, datetime, timedelta
+
+        resume = parse_credit_resume_time(
+            "You've hit your weekly limit · resets Wednesday at 5pm"
+        )
+        assert resume is not None
+        now = datetime.now(UTC)
+        assert now < resume <= now + timedelta(days=7)
+        local = datetime.now().astimezone().tzinfo
+        local_reset = resume.astimezone(local)
+        assert local_reset.weekday() == 2  # Wednesday
+        assert (local_reset.hour, local_reset.minute) == (17, 0)
+
+    def test_parses_weekly_weekday_with_minutes(self) -> None:
+        from datetime import datetime
+
+        resume = parse_credit_resume_time("resets Wednesday at 5:30pm")
+        assert resume is not None
+        local = datetime.now().astimezone().tzinfo
+        assert resume.astimezone(local).minute == 30
+
+    def test_parses_weekly_month_day_future(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """'resets Jun 18 at 5pm' with now=Jun 15 → ~3 days out (tz-robust)."""
+        from datetime import UTC, timedelta
+        from datetime import datetime as _dt
+
+        import subprocess_util as su
+
+        frozen = _dt(2026, 6, 15, 12, 0, tzinfo=UTC)
+
+        class _Frozen(_dt):
+            @classmethod
+            def now(cls, tz=None):  # type: ignore[override]
+                return (
+                    frozen.astimezone(tz)
+                    if tz is not None
+                    else frozen.replace(tzinfo=None)
+                )
+
+        monkeypatch.setattr(su, "datetime", _Frozen)
+        resume = su.parse_credit_resume_time(
+            "You've hit your weekly limit · resets Jun 18 at 5pm"
+        )
+        assert resume is not None
+        delta = resume - frozen
+        assert timedelta(days=2) < delta < timedelta(days=4)  # ~3d, any tz
+
+    def test_weekly_month_day_in_past_returns_none_not_next_year(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A clearly-past month/day is a stale message — must return None (short
+        default pause), NOT roll a full year and idle the factory.
+        """
+        from datetime import UTC
+        from datetime import datetime as _dt
+
+        import subprocess_util as su
+
+        frozen = _dt(2026, 6, 20, 12, 0, tzinfo=UTC)
+
+        class _Frozen(_dt):
+            @classmethod
+            def now(cls, tz=None):  # type: ignore[override]
+                return (
+                    frozen.astimezone(tz)
+                    if tz is not None
+                    else frozen.replace(tzinfo=None)
+                )
+
+        monkeypatch.setattr(su, "datetime", _Frozen)
+        assert (
+            su.parse_credit_resume_time(
+                "You've hit your weekly limit · resets Jun 18 at 5pm"
+            )
+            is None
+        )
+
+    def test_weekly_invalid_month_day_returns_none(self) -> None:
+        assert parse_credit_resume_time("resets Feb 30 at 5pm") is None
+
+    def test_weekly_detected_but_no_reset_clause_returns_none(self) -> None:
+        """Detection still fires (tested elsewhere); with no parseable reset the
+        caller falls back to its default pause, so parse returns None.
+        """
+        assert parse_credit_resume_time("You've hit your weekly limit") is None

--- a/tests/test_trace_collector_loop_helper.py
+++ b/tests/test_trace_collector_loop_helper.py
@@ -58,6 +58,31 @@ def test_emit_writes_trace_entry_with_required_shape(data_root: Path) -> None:
     assert "started_at" in payload  # ISO 8601
 
 
+def test_emit_started_at_is_work_start_not_emit_time(data_root: Path) -> None:
+    """started_at marks when the work began, not when the trace was emitted.
+
+    The helper is called after the subprocess completes (it receives the
+    already-elapsed duration_ms), so it back-dates started_at by duration_ms.
+    A consumer computing [started_at, started_at + duration_ms] then brackets
+    the real work interval instead of a window one full duration in the future.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    duration_ms = 60_000
+    before = datetime.now(UTC)
+    emit_loop_subprocess_trace(
+        loop="X", command=["x"], exit_code=0, duration_ms=duration_ms
+    )
+    after = datetime.now(UTC)
+
+    files = list((data_root / "traces" / "_loops" / "x").glob("run-*.json"))
+    payload = json.loads(files[0].read_text(encoding="utf-8"))
+    started = datetime.fromisoformat(payload["started_at"])
+
+    # started_at + duration lands at ~emit time (now), not one duration ahead.
+    assert before <= started + timedelta(milliseconds=duration_ms) <= after
+
+
 def test_emit_truncates_stderr_tail_preserving(data_root: Path) -> None:
     big = "A" * 4096 + "TAIL_MARKER"
     emit_loop_subprocess_trace(


### PR DESCRIPTION
Manual RC promotion (staging → main) — cut by hand because the factory's `StagingPromotionLoop` is currently stopped, so no automated RC was in flight.

Promotes the 4 staging-ahead commits to main, including the critical **#9589 — weekly subscription-cap detection** (without this on main, the running factory burns its attempt budget into HITL on the weekly limit). Also #9590 (wiki backlog), #9591 (dark-factory lessons), #9588 (loop-trace timing).

Runs the full RC promotion test suite. Will merge on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)