### PR TITLE
feat(cost): activate the >2x cost-spike highlight (populate prev-period avg)

### DIFF
--- a/src/dashboard_routes/_cost_rollups.py
+++ b/src/dashboard_routes/_cost_rollups.py
@@ -397,6 +397,37 @@ def _tally_worker_events(events: list[Any]) -> dict[str, dict[str, Any]]:
     return out
 
 
+def _event_timestamp(ev: Any) -> datetime | None:
+    """Best-effort parse of a worker-status event's wall-clock time."""
+    data = getattr(ev, "data", None)
+    if data is None and isinstance(ev, dict):
+        data = ev.get("data")
+    data = data if isinstance(data, dict) else {}
+    raw = data.get("last_run")
+    if not raw:
+        raw = getattr(ev, "timestamp", None)
+        if raw is None and isinstance(ev, dict):
+            raw = ev.get("timestamp")
+    return _parse_iso(raw) if isinstance(raw, str) else None
+
+
+def _split_events_on(
+    events: list[Any], *, boundary: datetime
+) -> tuple[list[Any], list[Any]]:
+    """Partition events into ``(current, prior)`` on a timestamp boundary.
+
+    An event strictly before ``boundary`` is prior; one at/after it — or whose
+    timestamp can't be parsed (preserving the old ``load_events_since(since)``
+    behavior, where every returned event was current) — is current.
+    """
+    current: list[Any] = []
+    prior: list[Any] = []
+    for ev in events:
+        ts = _event_timestamp(ev)
+        (prior if ts is not None and ts < boundary else current).append(ev)
+    return current, prior
+
+
 # Inference ``source`` values that name no loop: char-estimate token-source
 # markers, the design-time onboarding agent, synchronous post-merge hooks, and
 # empty sources. These never represent a background-worker/pipeline loop, so
@@ -507,16 +538,40 @@ def build_per_loop_cost(
             rec.get("cache_creation_input_tokens", 0) or 0
         )
 
-    # Event-based counters (filed / closed / escalations / errored ticks).
+    # Prior-period window of equal length immediately before ``since``. Used
+    # to populate ``tick_cost_avg_usd_prev_period`` so the client's >2x cost
+    # spike highlight (PerLoopCostTable.isSpike, gated on prev > 0) can fire.
+    prev_since = since - (until - since)
+
+    prev_loop_cost: dict[str, float] = defaultdict(float)
+    for rec in iter_priced_inferences(
+        config, since=prev_since, until=since, pricing=pricing
+    ):
+        worker = _worker_for_cost_source(str(rec.get("source", "")))
+        if worker is None:
+            continue
+        prev_loop_cost[worker] += rec["cost_usd"]
+
+    prev_loop_ticks: dict[str, int] = defaultdict(int)
+    for tr in iter_loop_traces(config, since=prev_since, until=since):
+        prev_loop_ticks[_slug_for_loop(str(tr.get("loop", "?")))] += 1
+
+    # Event-based counters (filed / closed / escalations / errored ticks). Load
+    # across both windows so prior-period tick counts are available, then split
+    # on the ``since`` boundary — the current half preserves the previous
+    # ``load_events_since(since)`` semantics exactly.
     worker_stats: dict[str, dict[str, Any]] = {}
+    prev_worker_stats: dict[str, dict[str, Any]] = {}
     if event_bus is not None:
         try:
-            events = asyncio.run(event_bus.load_events_since(since))
+            events = asyncio.run(event_bus.load_events_since(prev_since))
         except RuntimeError:
             # Called from an already-running event loop — fall back.
             logger.debug("build_per_loop_cost: nested event loop; skipping events")
             events = []
-        worker_stats = _tally_worker_events(events or [])
+        cur_events, prev_events = _split_events_on(events or [], boundary=since)
+        worker_stats = _tally_worker_events(cur_events)
+        prev_worker_stats = _tally_worker_events(prev_events)
 
     # Union of every worker seen via traces, inferences, or events. All three
     # key spaces are worker_name, so they merge into one row per worker.
@@ -528,6 +583,12 @@ def build_per_loop_cost(
         ticks = int(stats.get("ticks", 0) or per_loop_ticks.get(worker, 0))
         cost = per_loop_cost.get(worker, 0.0)
         avg_cost = round(cost / ticks, 6) if ticks else 0.0
+        prev_ticks = int(
+            prev_worker_stats.get(worker, {}).get("ticks", 0)
+            or prev_loop_ticks.get(worker, 0)
+        )
+        prev_cost = prev_loop_cost.get(worker, 0.0)
+        prev_avg = round(prev_cost / prev_ticks, 6) if prev_ticks else 0.0
         breakdown_raw = per_loop_model.get(worker, {})
         model_breakdown = {
             model: {
@@ -555,10 +616,9 @@ def build_per_loop_cost(
                 "tick_cost_avg_usd": avg_cost,
                 "wall_clock_seconds": per_loop_wall.get(worker, 0),
                 "last_tick_at": stats.get("last_tick_at", "") or None,
-                # Reserved 0.0 stub: the client-side spike highlight is gated on
-                # ``prev > 0`` (PerLoopCostTable.isSpike), so a future change can
-                # populate this from the prior window without a UI change.
-                "tick_cost_avg_usd_prev_period": 0.0,
+                # Prior-period avg $/tick — drives the client >2x spike
+                # highlight (PerLoopCostTable.isSpike, gated on prev > 0).
+                "tick_cost_avg_usd_prev_period": prev_avg,
                 "model_breakdown": model_breakdown,
             }
         )

--- a/tests/test_cost_rollups_helpers.py
+++ b/tests/test_cost_rollups_helpers.py
@@ -808,3 +808,73 @@ def test_per_loop_cost_excludes_non_loop_sources(config) -> None:
     assert "estimated" not in loops
     assert "claude" not in loops
     assert "" not in loops
+
+
+def test_per_loop_cost_populates_prev_period_avg_for_spike_highlight(config) -> None:
+    """tick_cost_avg_usd_prev_period reflects the prior window's avg $/tick.
+
+    A worker that ticks (via BACKGROUND_WORKER_STATUS events) and spends in
+    BOTH the current and the immediately-prior window gets a non-zero
+    prev-period average, so the client-side >2x spike highlight can fire.
+    """
+    now = datetime(2026, 4, 22, 12, tzinfo=UTC)
+    since = now - timedelta(hours=1)
+    prev_since = since - timedelta(hours=1)
+    cur_ts = (since + timedelta(minutes=10)).isoformat()
+    prev_ts = (prev_since + timedelta(minutes=10)).isoformat()
+
+    # source "wiki_compilation" folds to worker "repo_wiki".
+    _write_inference(
+        config,
+        timestamp=cur_ts,
+        source="wiki_compilation",
+        model="claude-sonnet-4-6",
+        input_tokens=0,
+        output_tokens=0,
+        estimated_cost_usd=0.10,
+    )
+    _write_inference(
+        config,
+        timestamp=prev_ts,
+        source="wiki_compilation",
+        model="claude-sonnet-4-6",
+        input_tokens=0,
+        output_tokens=0,
+        estimated_cost_usd=0.02,
+    )
+
+    def _evt(ts: str):
+        ev = MagicMock()
+        ev.type = "background_worker_status"
+        ev.timestamp = ts
+        ev.data = {"worker": "repo_wiki", "status": "success", "last_run": ts}
+        return ev
+
+    cur_ev, prev_ev = _evt(cur_ts), _evt(prev_ts)
+    bus = MagicMock()
+
+    async def _load(s):
+        # Mirror the real EventBus contract: return events at-or-after `s`.
+        out = []
+        for ev, ts in ((cur_ev, cur_ts), (prev_ev, prev_ts)):
+            if datetime.fromisoformat(ts) >= s:
+                out.append(ev)
+        return out
+
+    bus.load_events_since = _load
+
+    # token_source=estimated path: priced 0 from tokens → falls back to
+    # estimated_cost_usd, so cost is deterministic regardless of the table.
+    pricing = MagicMock()
+    pricing.estimate_cost.return_value = 0.0
+
+    rows = build_per_loop_cost(
+        config, since=since, until=now, pricing=pricing, event_bus=bus
+    )
+    row = next(r for r in rows if r["loop"] == "repo_wiki")
+
+    assert row["cost_usd"] == pytest.approx(0.10)
+    assert row["ticks"] == 1  # one current-window event
+    assert row["tick_cost_avg_usd"] == pytest.approx(0.10)
+    # Prior window: $0.02 over 1 tick.
+    assert row["tick_cost_avg_usd_prev_period"] == pytest.approx(0.02)


### PR DESCRIPTION
## What

Activates the Per-Loop Cost table's **>2× cost-spike red-highlight**, which has been dormant since the table shipped.

`build_per_loop_cost` left `tick_cost_avg_usd_prev_period` a hardcoded `0.0` stub, and the frontend `PerLoopCostTable.isSpike` gates on `prev > 0` — so the highlight could never fire.

## Fix

Populate `tick_cost_avg_usd_prev_period` from the equal-length window immediately before `since`:
- **prior cost** is source-attributed with the same `_worker_for_cost_source` mapping as the current window (consistent with #9550);
- **prior ticks** come from prior-window loop traces + `BACKGROUND_WORKER_STATUS` events.

Events are now loaded across both windows and split on the `since` boundary; the **current half preserves the previous `load_events_since(since)` semantics exactly** (the unchanged route/field tests confirm it). This makes the highlight work for the bg/caretaker workers that emit ticks via events — the ones whose per-tick cost actually varies — not just trace-emitting loops.

Row schema unchanged (the field already existed); frontend untouched.

## Tests

- New unit test `test_per_loop_cost_populates_prev_period_avg_for_spike_highlight` — a worker spending in *both* windows gets a non-zero prior avg. Verified to **fail** when the wiring is reverted to the `0.0` stub.
- Full `pytest tests/` green; the existing `/loops/cost` route, multi-repo merge, and the per-loop-cost scenario (#9595) are unaffected.

## Scope

Completes a designed-but-dead feature (the field + `isSpike` already existed). No sandbox e2e — read-only calculation refinement, per `docs/standards/testing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
