### PR TITLE
feat(factory): generate-in-worktree foundation + DiagramLoop migration (#9539 pt1)

### DIFF
--- a/src/arch/runner.py
+++ b/src/arch/runner.py
@@ -61,7 +61,7 @@ _ARTIFACT_FILES = [
 
 def _run(cmd: list[str], cwd: Path) -> str:
     # Timeout guards against thread-pool exhaustion when ``emit`` is
-    # called from ``DiagramLoop._regen_and_detect_drift`` via
+    # called from ``DiagramLoop._regen_pr``'s generate callback via
     # ``asyncio.to_thread``. Same deadlock class as PR #8454.
     # 60s covers the heaviest call here (``git log --since=90.days.ago``
     # with several pathspecs).

--- a/src/auto_pr.py
+++ b/src/auto_pr.py
@@ -23,6 +23,7 @@ import logging
 import re
 import shutil
 import subprocess
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -427,6 +428,108 @@ async def _ensure_labels_async(
     return ensured
 
 
+async def _finalize_pr_from_worktree(
+    *,
+    worktree_path: Path,
+    branch: str,
+    pr_title: str,
+    pr_body: str,
+    commit_message: str,
+    base: str,
+    auto_merge: bool,
+    gh_token: str,
+    labels: list[str] | None,
+    commit_author_name: str,
+    commit_author_email: str,
+    fail: Callable[[str], AutoPrResult],
+) -> AutoPrResult:
+    """Commit already-staged worktree changes, push, open the PR, auto-merge.
+
+    Shared tail for ``open_automated_pr_async`` (which stages by copying files
+    from ``repo_root``) and ``generate_and_open_pr_async`` (which stages content
+    generated directly in the worktree). The caller owns worktree creation,
+    staging (``git add``), and teardown (``finally``); this only runs the
+    commit → push → label → pr-create → auto-merge tail.
+    """
+    from subprocess_util import run_subprocess  # noqa: PLC0415
+
+    # Empty staged diff → nothing to PR.
+    try:
+        await run_subprocess(
+            "git", "diff", "--cached", "--quiet", cwd=worktree_path, gh_token=gh_token
+        )
+        logger.info("auto_pr: empty staged diff for %s", branch)
+        return AutoPrResult(status="no-diff", pr_url=None, branch=branch)
+    except RuntimeError:
+        pass  # non-zero → there IS a diff; proceed.
+
+    commit_args = _build_commit_args(
+        commit_author_name, commit_author_email, commit_message
+    )
+    try:
+        await run_subprocess("git", *commit_args, cwd=worktree_path, gh_token=gh_token)
+    except RuntimeError as exc:
+        return fail(f"git commit failed: {exc}")
+
+    try:
+        await run_subprocess(
+            "git", "push", "-u", "origin", branch, cwd=worktree_path, gh_token=gh_token
+        )
+    except RuntimeError as exc:
+        return fail(f"git push failed for {branch!r}: {exc}")
+
+    ensured_labels = (
+        await _ensure_labels_async(labels or [], cwd=worktree_path, gh_token=gh_token)
+        if labels
+        else []
+    )
+
+    create_args: list[str] = [
+        "gh",
+        "pr",
+        "create",
+        "--title",
+        pr_title,
+        "--body",
+        pr_body,
+        "--base",
+        base,
+        "--head",
+        branch,
+    ]
+    for label in ensured_labels:
+        create_args.extend(["--label", label])
+    try:
+        create_stdout = await run_subprocess(
+            *create_args, cwd=worktree_path, gh_token=gh_token
+        )
+    except RuntimeError as exc:
+        return fail(f"gh pr create failed for {branch!r}: {exc}")
+
+    pr_url = _extract_pr_url(create_stdout)
+    if pr_url is None:
+        logger.warning(
+            "gh pr create succeeded for %s but no URL parsed: %r", branch, create_stdout
+        )
+
+    if auto_merge and pr_url is not None:
+        try:
+            await run_subprocess(
+                "gh",
+                "pr",
+                "merge",
+                pr_url,
+                "--auto",
+                "--squash",
+                cwd=worktree_path,
+                gh_token=gh_token,
+            )
+        except RuntimeError as exc:
+            logger.warning("gh pr merge --auto failed for %s: %s", pr_url, exc)
+
+    return AutoPrResult(status="opened", pr_url=pr_url, branch=branch)
+
+
 async def open_automated_pr_async(  # noqa: PLR0911 — linear step-by-step guards, each with its own fail path
     *,
     repo_root: Path,
@@ -574,108 +677,145 @@ async def open_automated_pr_async(  # noqa: PLR0911 — linear step-by-step guar
         except (RuntimeError, OSError, ValueError) as exc:
             return _fail(f"failed to stage files for {branch!r}: {exc}")
 
-        # Detect empty staged diff.
-        try:
-            await run_subprocess(
-                "git",
-                "diff",
-                "--cached",
-                "--quiet",
-                cwd=worktree_path,
-                gh_token=gh_token,
-            )
-            # exit 0 → no staged diff
-            logger.info("open_automated_pr_async: empty staged diff for %s", branch)
-            return AutoPrResult(status="no-diff", pr_url=None, branch=branch)
-        except RuntimeError:
-            # Non-zero exit means there IS a diff. Proceed.
-            pass
-
-        # Commit with the caller-supplied identity when provided; when either
-        # value is empty, omit the `-c user.*` overrides so git falls back to
-        # ambient config per the `HydraFlowConfig.git_user_name/email`
-        # contract.
-        commit_args = _build_commit_args(commit_author_name, commit_author_email, msg)
-        try:
-            await run_subprocess(
-                "git", *commit_args, cwd=worktree_path, gh_token=gh_token
-            )
-        except RuntimeError as exc:
-            return _fail(f"git commit failed: {exc}")
-
-        try:
-            await run_subprocess(
-                "git",
-                "push",
-                "-u",
-                "origin",
-                branch,
-                cwd=worktree_path,
-                gh_token=gh_token,
-            )
-        except RuntimeError as exc:
-            return _fail(f"git push failed for {branch!r}: {exc}")
-
-        # Ensure each requested label exists on the repo before pr-create —
-        # otherwise a missing label crashes the whole PR (#6643 / EdgeProposer).
-        ensured_labels = (
-            await _ensure_labels_async(
-                labels or [], cwd=worktree_path, gh_token=gh_token
-            )
-            if labels
-            else []
+        return await _finalize_pr_from_worktree(
+            worktree_path=worktree_path,
+            branch=branch,
+            pr_title=pr_title,
+            pr_body=pr_body,
+            commit_message=msg,
+            base=base,
+            auto_merge=auto_merge,
+            gh_token=gh_token,
+            labels=labels,
+            commit_author_name=commit_author_name,
+            commit_author_email=commit_author_email,
+            fail=_fail,
         )
 
-        # Create the PR.
-        create_args: list[str] = [
-            "gh",
-            "pr",
-            "create",
-            "--title",
-            pr_title,
-            "--body",
-            pr_body,
-            "--base",
+    finally:
+        await _remove_worktree_async(repo_root, worktree_path, branch, gh_token)
+
+
+async def generate_and_open_pr_async(
+    *,
+    repo_root: Path,
+    branch: str,
+    generate: Callable[[Path], Awaitable[None]],
+    path_specs: list[str],
+    pr_title: str,
+    pr_body: str,
+    commit_message: str | None = None,
+    base: str = "main",
+    auto_merge: bool = True,
+    gh_token: str = "",
+    raise_on_failure: bool = True,
+    worktree_parent: Path | None = None,
+    commit_author_name: str = BOT_NAME,
+    commit_author_email: str = BOT_EMAIL,
+    labels: list[str] | None = None,
+) -> AutoPrResult:
+    """Open a PR for content GENERATED inside the worktree — never touching repo_root.
+
+    The generate-in-worktree counterpart to :func:`open_automated_pr_async`.
+    Instead of the caller pre-writing files under ``repo_root`` (which leaves the
+    factory's checkout perpetually dirty — see #9539 /
+    ``docs/proposals/factory-tree-self-clean.md``), the caller supplies a
+    ``generate`` coroutine that writes into the freshly-created worktree (branched
+    off ``origin/{base}``). The worktree is the only thing mutated, and it is torn
+    down in ``finally`` — so ``repo_root`` stays clean.
+
+    Args:
+        generate: ``async (worktree_path) -> None`` — produce the desired file
+            state inside ``worktree_path`` (e.g. run an arch/diagram regen with
+            ``out_dir`` under the worktree). Credit/auth/bug exceptions propagate
+            via ``reraise_on_credit_or_bug``; other errors become a ``failed``
+            result (or raise when ``raise_on_failure``).
+        path_specs: repo-relative paths/dirs to ``git add`` after generation
+            (e.g. ``["docs/arch/generated", "docs/arch/.meta.json"]``). An empty
+            staged diff short-circuits to ``no-diff``.
+
+    All other args mirror :func:`open_automated_pr_async`.
+    """
+    from exception_classify import reraise_on_credit_or_bug  # noqa: PLC0415
+    from subprocess_util import run_subprocess  # noqa: PLC0415
+
+    repo_root = repo_root.resolve()
+    timestamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
+    wt_name = f"genpr-{_sanitize_branch_for_path(branch)}-{timestamp}"
+    wt_parent = (worktree_parent or repo_root.parent).resolve()
+    wt_parent.mkdir(parents=True, exist_ok=True)
+    worktree_path = wt_parent / wt_name
+    msg = commit_message if commit_message is not None else pr_title
+
+    def _fail(err: str) -> AutoPrResult:
+        if raise_on_failure:
+            raise AutoPrError(err)
+        logger.warning("generate_and_open_pr_async failed for %s: %s", branch, err)
+        return AutoPrResult(status="failed", pr_url=None, branch=branch, error=err)
+
+    try:
+        await run_subprocess(
+            "git", "fetch", "origin", base, "--quiet", cwd=repo_root, gh_token=gh_token
+        )
+    except RuntimeError as exc:
+        logger.warning(
+            "git fetch origin %s failed for %s; continuing with cached ref: %s",
             base,
-            "--head",
             branch,
-        ]
-        for label in ensured_labels:
-            create_args.extend(["--label", label])
+            exc,
+        )
+
+    try:
         try:
-            create_stdout = await run_subprocess(
-                *create_args,
-                cwd=worktree_path,
+            await run_subprocess(
+                "git",
+                "worktree",
+                "add",
+                "-b",
+                branch,
+                str(worktree_path),
+                f"origin/{base}",
+                cwd=repo_root,
                 gh_token=gh_token,
             )
         except RuntimeError as exc:
-            return _fail(f"gh pr create failed for {branch!r}: {exc}")
+            return _fail(f"git worktree add failed for {branch!r}: {exc}")
 
-        pr_url = _extract_pr_url(create_stdout)
-        if pr_url is None:
-            logger.warning(
-                "gh pr create succeeded for %s but no URL parsed: %r",
-                branch,
-                create_stdout,
-            )
+        # Generate the desired file state INSIDE the worktree (never repo_root).
+        try:
+            await generate(worktree_path)
+        except Exception as exc:  # noqa: BLE001 — classify then convert to a result
+            reraise_on_credit_or_bug(exc)
+            return _fail(f"generate callback failed for {branch!r}: {exc}")
 
-        if auto_merge and pr_url is not None:
-            try:
+        # Stage the generated paths (targeted; mirrors the no-`git add -A` rule).
+        # Skip specs the generator didn't materialise — `git add` errors on a
+        # pathspec that matches nothing, and "the generator produced none of
+        # this path" is a legitimate no-op (→ empty staged diff → no-diff).
+        try:
+            for spec in path_specs:
+                if not (worktree_path / spec).exists():
+                    continue
                 await run_subprocess(
-                    "gh",
-                    "pr",
-                    "merge",
-                    pr_url,
-                    "--auto",
-                    "--squash",
-                    cwd=worktree_path,
-                    gh_token=gh_token,
+                    "git", "add", "--", spec, cwd=worktree_path, gh_token=gh_token
                 )
-            except RuntimeError as exc:
-                logger.warning("gh pr merge --auto failed for %s: %s", pr_url, exc)
+        except RuntimeError as exc:
+            return _fail(f"failed to stage generated paths for {branch!r}: {exc}")
 
-        return AutoPrResult(status="opened", pr_url=pr_url, branch=branch)
-
+        return await _finalize_pr_from_worktree(
+            worktree_path=worktree_path,
+            branch=branch,
+            pr_title=pr_title,
+            pr_body=pr_body,
+            commit_message=msg,
+            base=base,
+            auto_merge=auto_merge,
+            gh_token=gh_token,
+            labels=labels,
+            commit_author_name=commit_author_name,
+            commit_author_email=commit_author_email,
+            fail=_fail,
+        )
     finally:
         await _remove_worktree_async(repo_root, worktree_path, branch, gh_token)
 

--- a/src/diagram_loop.py
+++ b/src/diagram_loop.py
@@ -23,13 +23,15 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import subprocess
-from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import HydraFlowConfig
 from models import WorkCycleResult
+
+if TYPE_CHECKING:
+    from auto_pr import AutoPrResult
 
 logger = logging.getLogger(__name__)
 
@@ -37,12 +39,6 @@ _KILL_SWITCH_ENV = "HYDRAFLOW_DISABLE_DIAGRAM_LOOP"
 _REGEN_BRANCH = "arch-regen-auto"
 _PR_TITLE_PREFIX = "chore(arch): regenerate architecture knowledge"
 _COVERAGE_ISSUE_TITLE = "chore(arch): unassigned functional area"
-
-
-@dataclass
-class _DriftResult:
-    has_drift: bool
-    changed_files: list[str]
 
 
 class DiagramLoop(BaseBackgroundLoop):
@@ -84,104 +80,68 @@ class DiagramLoop(BaseBackgroundLoop):
         if os.environ.get(_KILL_SWITCH_ENV) == "1":
             return {"skipped": "kill_switch"}
 
-        drift = await asyncio.to_thread(self._regen_and_detect_drift)
-        if not drift.has_drift:
+        result = await self._regen_pr()
+        if result is None:
+            return {"drift": None}
+        if result.status == "no-diff":
             return {"drift": False}
-
-        pr_url = await self._open_or_update_regen_pr(drift.changed_files)
+        # A PR opened → the committed arch drifted from source. Also run the
+        # functional-area coverage check (separate issue, not the regen PR).
         await self._ensure_coverage_issue()
+        return {"drift": True, "pr_url": result.pr_url}
 
-        return {
-            "drift": True,
-            "changed_files": len(drift.changed_files),
-            "pr_url": pr_url,
-        }
-
-    def _regen_and_detect_drift(self) -> _DriftResult:
-        # Lazy import — avoids loading arch.* at module import time.
-        from arch.runner import emit  # noqa: PLC0415
-
-        out_dir = self._repo_root / "docs/arch/generated"
-        emit(repo_root=self._repo_root, out_dir=out_dir)
-        res = subprocess.run(
-            [
-                "git",
-                "status",
-                "--porcelain",
-                "docs/arch/generated",
-                "docs/arch/.meta.json",
-            ],
-            cwd=self._repo_root,
-            capture_output=True,
-            text=True,
-            check=False,
-            # Hard cap to prevent thread-pool exhaustion on a hung git
-            # process. Same deadlock class as PR #8454 — even though the
-            # caller wraps this in ``asyncio.to_thread`` (line 82), an
-            # unbounded subprocess can leak the worker thread forever.
-            timeout=30,
-        )
-        if res.returncode != 0:
-            return _DriftResult(has_drift=False, changed_files=[])
-        lines = [line for line in res.stdout.splitlines() if line.strip()]
-        return _DriftResult(has_drift=bool(lines), changed_files=lines)
-
-    async def _open_or_update_regen_pr(self, changed_files: list[str]) -> str | None:
-        """Open a regen PR via auto_pr.open_automated_pr_async.
-
-        Branch is fixed (`arch-regen-auto`); auto_pr handles the
-        idempotent open-or-update behavior at the branch level.
+    async def _regen_pr(self) -> AutoPrResult | None:
+        """Regenerate the arch artifacts INSIDE an ephemeral worktree (branched
+        off the base) and open/update the regen PR — ``repo_root`` is never
+        mutated (#9539). Branch is fixed (``arch-regen-auto``); gh handles
+        open-or-update idempotence at the branch level. Returns the
+        ``AutoPrResult`` (``opened``/``no-diff``), or ``None`` on failure.
         """
-        # Lazy import to avoid a top-level dependency cycle.
         from datetime import UTC, datetime  # noqa: PLC0415
 
-        from auto_pr import open_automated_pr_async  # noqa: PLC0415
+        from auto_pr import generate_and_open_pr_async  # noqa: PLC0415
 
         today = datetime.now(UTC).strftime("%Y-%m-%d")
-        pr_title = f"{_PR_TITLE_PREFIX} — {today}"
-        pr_body = self._build_pr_body(changed_files)
 
-        files_to_commit = [
-            self._repo_root / "docs" / "arch" / "generated",
-            self._repo_root / "docs" / "arch" / ".meta.json",
-        ]
+        async def _generate(worktree: Path) -> None:
+            # Re-extract arch artifacts from the worktree's (base) source into
+            # the worktree's out_dir — never the host checkout. Wrapped in a
+            # thread: emit() is sync CPU/IO work.
+            from arch.runner import emit  # noqa: PLC0415
 
-        result = await open_automated_pr_async(
+            await asyncio.to_thread(
+                emit, repo_root=worktree, out_dir=worktree / "docs/arch/generated"
+            )
+
+        result = await generate_and_open_pr_async(
             repo_root=self._repo_root,
             branch=_REGEN_BRANCH,
-            files=files_to_commit,
-            pr_title=pr_title,
-            pr_body=pr_body,
+            generate=_generate,
+            path_specs=["docs/arch/generated", "docs/arch/.meta.json"],
+            pr_title=f"{_PR_TITLE_PREFIX} — {today}",
+            pr_body=self._build_pr_body(),
             base=self._config.base_branch(),
             auto_merge=True,
             labels=["hydraflow-ready", "arch-regen"],
             raise_on_failure=False,
         )
-        if result.status in {"opened", "no-diff"}:
-            return result.pr_url
-        logger.warning("DiagramLoop PR creation failed: %s", result.error)
-        return None
+        if result.status == "failed":
+            logger.warning("DiagramLoop regen PR failed: %s", result.error)
+            return None
+        return result
 
-    def _build_pr_body(self, changed_files: list[str]) -> str:
-        lines = [
-            "Auto-generated by `DiagramLoop` (L24). The architecture knowledge",
-            "artifacts in `docs/arch/generated/` were re-extracted from source",
-            "and the diff is included in this PR.",
-            "",
-            f"**Changed files** ({len(changed_files)}):",
-            "",
-        ]
-        lines.extend(f"- `{path}`" for path in changed_files[:30])
-        if len(changed_files) > 30:
-            lines.append(f"- _(...and {len(changed_files) - 30} more)_")
-        lines.extend(
+    def _build_pr_body(self) -> str:
+        return "\n".join(
             [
+                "Auto-generated by `DiagramLoop` (L24). The architecture knowledge",
+                "artifacts in `docs/arch/generated/` were re-extracted from source",
+                "inside an ephemeral worktree off the base branch — the factory's",
+                "checkout is never touched (#9539) — and the diff is in this PR.",
                 "",
                 "Per ADR-0029 caretaker pattern. Auto-merges once CI passes",
                 "(arch-regen guard, quality, scenario tests).",
             ]
         )
-        return "\n".join(lines)
 
     async def _unassigned_items(self) -> dict[str, list[str]]:
         """Return {'loops': [...], 'ports': [...]} of items in code but not in YAML."""

--- a/tests/regressions/test_async_subprocess_timeouts.py
+++ b/tests/regressions/test_async_subprocess_timeouts.py
@@ -30,7 +30,10 @@ _REPO = Path(__file__).resolve().parent.parent.parent
 # alone is not enough; an unbounded subprocess will leak the worker
 # thread and exhaust the pool.
 _ASYNC_SUBPROCESS_MODULES = [
-    "src/diagram_loop.py",
+    # NOTE: src/diagram_loop.py was removed from this list in #9539 — it no
+    # longer runs subprocess.run directly (arch regen now happens inside an
+    # ephemeral worktree via auto_pr.generate_and_open_pr_async, whose git
+    # calls are timeout-bounded in src/auto_pr.py, audited below).
     "src/repo_wiki.py",
     "src/repo_wiki_loop.py",
     "src/arch/runner.py",

--- a/tests/scenarios/test_diagram_loop_mockworld.py
+++ b/tests/scenarios/test_diagram_loop_mockworld.py
@@ -10,7 +10,7 @@ Companion to ``tests/scenarios/test_diagram_loop_scenario.py`` (which calls
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -23,56 +23,59 @@ pytestmark = pytest.mark.scenario_loops
 class TestL24DiagramLoop:
     """L24: DiagramLoop regenerates docs/arch/generated/, opens PR on drift."""
 
-    async def test_no_drift_runs_emit_and_skips_pr(self, tmp_path) -> None:
-        """Clean source → emit() runs, git status empty, no PR opened."""
+    async def test_no_drift_skips_pr(self, tmp_path) -> None:
+        """No arch drift → generate-in-worktree returns no-diff; no PR, no issue.
+
+        The regen now runs inside the ephemeral worktree, so the loop routes
+        through ``generate_and_open_pr_async``; a no-diff result means no PR.
+        """
         world = MockWorld(tmp_path)
 
         _seed_ports(world, github=world.github)
 
-        pr_helper = AsyncMock()
-        with (
-            patch("arch.runner.emit") as mock_emit,
-            patch("diagram_loop.subprocess.run") as mock_run,
-            patch("auto_pr.open_automated_pr_async", pr_helper),
-        ):
-            mock_run.return_value = MagicMock(returncode=0, stdout="")
+        from auto_pr import AutoPrResult
+
+        pr_helper = AsyncMock(
+            return_value=AutoPrResult(
+                status="no-diff", pr_url=None, branch="arch-regen-auto"
+            )
+        )
+        with patch("auto_pr.generate_and_open_pr_async", pr_helper):
             stats = await world.run_with_loops(["diagram_loop"], cycles=1)
 
-        result = stats["diagram_loop"]
-        assert result == {"drift": False}
-        mock_emit.assert_called_once()
-        pr_helper.assert_not_awaited()
+        assert stats["diagram_loop"] == {"drift": False}
+        pr_helper.assert_awaited_once()
         assert world.github._issues == {}
 
     async def test_drift_opens_regen_pr_via_auto_pr(self, tmp_path) -> None:
-        """Source drifted → auto_pr opens PR with arch-regen-auto branch."""
+        """Source drifted → generate_and_open_pr_async opens the regen PR."""
         world = MockWorld(tmp_path)
 
         _seed_ports(world, github=world.github)
 
-        pr_result = MagicMock(status="opened", pr_url="https://github.com/x/y/pull/1")
-        pr_helper = AsyncMock(return_value=pr_result)
+        from auto_pr import AutoPrResult
+
+        pr_helper = AsyncMock(
+            return_value=AutoPrResult(
+                status="opened",
+                pr_url="https://github.com/x/y/pull/1",
+                branch="arch-regen-auto",
+            )
+        )
 
         with (
-            patch("arch.runner.emit"),
-            patch("diagram_loop.subprocess.run") as mock_run,
-            patch("auto_pr.open_automated_pr_async", pr_helper),
+            patch("auto_pr.generate_and_open_pr_async", pr_helper),
             # Stub _unassigned_items to focus on the PR path.
             patch(
                 "diagram_loop.DiagramLoop._unassigned_items",
                 AsyncMock(return_value={"loops": [], "ports": []}),
             ),
         ):
-            mock_run.return_value = MagicMock(
-                returncode=0,
-                stdout=" M docs/arch/generated/loops.md\n M docs/arch/generated/ports.md\n",
-            )
             stats = await world.run_with_loops(["diagram_loop"], cycles=1)
 
         result = stats["diagram_loop"]
         assert result["drift"] is True
         assert result["pr_url"] == "https://github.com/x/y/pull/1"
-        assert result["changed_files"] == 2
 
         pr_helper.assert_awaited_once()
         kwargs = pr_helper.await_args.kwargs
@@ -81,3 +84,4 @@ class TestL24DiagramLoop:
         assert kwargs["pr_title"].startswith(
             "chore(arch): regenerate architecture knowledge"
         )
+        assert kwargs["path_specs"] == ["docs/arch/generated", "docs/arch/.meta.json"]

--- a/tests/scenarios/test_diagram_loop_scenario.py
+++ b/tests/scenarios/test_diagram_loop_scenario.py
@@ -48,15 +48,20 @@ def _make_loop(tmp_path: Path) -> tuple[DiagramLoop, MagicMock]:
 @pytest.mark.asyncio
 async def test_no_drift_returns_drift_false_and_skips_pr(tmp_path: Path) -> None:
     loop, pr_manager = _make_loop(tmp_path)
-    # arch.runner.emit is a no-op; git status returns nothing.
-    with (
-        patch("arch.runner.emit") as mock_emit,
-        patch("diagram_loop.subprocess.run") as mock_run,
-    ):
-        mock_run.return_value = MagicMock(returncode=0, stdout="")
+    from auto_pr import AutoPrResult
+
+    # Generation-in-worktree finds no drift → no-diff result; coverage skipped.
+    with patch(
+        "auto_pr.generate_and_open_pr_async",
+        AsyncMock(
+            return_value=AutoPrResult(
+                status="no-diff", pr_url=None, branch="arch-regen-auto"
+            )
+        ),
+    ) as mock_pr:
         result = await loop._do_work()
     assert result == {"drift": False}
-    mock_emit.assert_called_once()
+    mock_pr.assert_awaited_once()
     pr_manager.find_existing_issue.assert_not_awaited()
     pr_manager.create_issue.assert_not_awaited()
 
@@ -69,25 +74,23 @@ async def test_drift_opens_pr_with_correct_labels(tmp_path: Path, monkeypatch) -
         loop, "_unassigned_items", AsyncMock(return_value={"loops": [], "ports": []})
     )
 
-    pr_result = MagicMock(status="opened", pr_url="https://github.com/x/y/pull/1")
-    with (
-        patch("arch.runner.emit") as mock_emit,
-        patch("diagram_loop.subprocess.run") as mock_run,
-        patch(
-            "auto_pr.open_automated_pr_async", AsyncMock(return_value=pr_result)
-        ) as mock_pr,
-    ):
-        mock_run.return_value = MagicMock(
-            returncode=0, stdout=" M docs/arch/generated/loops.md\n"
-        )
+    from auto_pr import AutoPrResult
+
+    pr_result = AutoPrResult(
+        status="opened",
+        pr_url="https://github.com/x/y/pull/1",
+        branch="arch-regen-auto",
+    )
+    with patch(
+        "auto_pr.generate_and_open_pr_async", AsyncMock(return_value=pr_result)
+    ) as mock_pr:
         result = await loop._do_work()
 
     assert result["drift"] is True
     assert result["pr_url"] == "https://github.com/x/y/pull/1"
-    assert result["changed_files"] == 1
 
-    # PR opened with the regen branch and expected labels
-    mock_emit.assert_called_once()
+    # PR opened with the regen branch, expected labels, and worktree-generated
+    # path specs (the loop never stages files from repo_root).
     call_kwargs = mock_pr.await_args.kwargs
     assert call_kwargs["branch"] == "arch-regen-auto"
     assert call_kwargs["pr_title"].startswith(
@@ -95,6 +98,8 @@ async def test_drift_opens_pr_with_correct_labels(tmp_path: Path, monkeypatch) -
     )
     assert "hydraflow-ready" in call_kwargs["labels"]
     assert "arch-regen" in call_kwargs["labels"]
+    assert call_kwargs["path_specs"] == ["docs/arch/generated", "docs/arch/.meta.json"]
+    assert callable(call_kwargs["generate"])
 
 
 @pytest.mark.asyncio

--- a/tests/test_auto_pr.py
+++ b/tests/test_auto_pr.py
@@ -836,3 +836,94 @@ async def test_refresh_real_conflict_aborts_no_push(
         check=True,
     ).stdout.strip()
     assert before == after
+
+
+# ---------------------------------------------------------------------------
+# generate_and_open_pr_async — generate-in-worktree (#9539)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_and_open_pr_leaves_repo_root_clean(
+    local_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#9539: the generate callback writes INTO the worktree; repo_root is never
+    mutated, so the factory's checkout stays clean after the PR opens."""
+    from auto_pr import generate_and_open_pr_async
+
+    def gh_handler(cmd: tuple[str, ...]) -> str:
+        return "https://github.com/x/y/pull/7\n" if cmd[2] == "create" else ""
+
+    monkeypatch.setattr(
+        "subprocess_util.run_subprocess",
+        _real_run_subprocess_stub(gh_handler=gh_handler),
+    )
+
+    seen: list[Path] = []
+
+    async def generate(worktree: Path) -> None:
+        seen.append(worktree)
+        gen_dir = worktree / "docs" / "arch" / "generated"
+        gen_dir.mkdir(parents=True, exist_ok=True)
+        (gen_dir / "loops.md").write_text("# loops\n")
+
+    result = await generate_and_open_pr_async(
+        repo_root=local_repo,
+        branch="arch-regen-auto",
+        generate=generate,
+        path_specs=["docs/arch/generated"],
+        pr_title="chore(arch): regen",
+        pr_body="b",
+        auto_merge=False,
+    )
+
+    assert result.status == "opened"
+    assert result.pr_url == "https://github.com/x/y/pull/7"
+    # The generate callback ran in a worktree OUTSIDE the host checkout.
+    assert seen and seen[0].resolve() != local_repo.resolve()
+    # KEY PROPERTY: repo_root's working tree is CLEAN — the generated file is
+    # NOT in the host checkout, and `git status` reports nothing.
+    assert not (local_repo / "docs" / "arch" / "generated" / "loops.md").exists()
+    porcelain = subprocess.run(
+        ["git", "-C", str(local_repo), "status", "--porcelain"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert porcelain == ""
+
+
+@pytest.mark.asyncio
+async def test_generate_and_open_pr_no_diff_when_generate_writes_nothing(
+    local_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A generate callback that produces no change short-circuits to no-diff —
+    no commit, no PR (so a quiescent loop tick is a cheap no-op)."""
+    from auto_pr import generate_and_open_pr_async
+
+    gh_calls: list[tuple[str, ...]] = []
+
+    def gh_handler(cmd: tuple[str, ...]) -> str:
+        gh_calls.append(cmd)
+        return "https://github.com/x/y/pull/8\n" if cmd[2] == "create" else ""
+
+    monkeypatch.setattr(
+        "subprocess_util.run_subprocess",
+        _real_run_subprocess_stub(gh_handler=gh_handler),
+    )
+
+    async def generate(_worktree: Path) -> None:
+        return  # writes nothing
+
+    result = await generate_and_open_pr_async(
+        repo_root=local_repo,
+        branch="noop-regen",
+        generate=generate,
+        path_specs=["docs/arch/generated"],
+        pr_title="t",
+        pr_body="b",
+        auto_merge=False,
+    )
+
+    assert result.status == "no-diff"
+    assert not any(c[:3] == ("gh", "pr", "create") for c in gh_calls)

--- a/tests/test_diagram_loop.py
+++ b/tests/test_diagram_loop.py
@@ -38,18 +38,20 @@ def test_default_interval_is_four_hours(loop_deps):
 
 @pytest.mark.asyncio
 async def test_no_drift_returns_drift_false(loop_deps, tmp_path, monkeypatch):
-    pr_manager = MagicMock()
-    pr_manager.find_existing_issue = AsyncMock(return_value=0)
-    pr_manager.create_issue = AsyncMock(return_value=42)
-    loop = DiagramLoop(config=MagicMock(), pr_manager=pr_manager, deps=loop_deps)
+    loop = DiagramLoop(config=MagicMock(), pr_manager=MagicMock(), deps=loop_deps)
     loop._set_repo_root(tmp_path)
 
-    from diagram_loop import _DriftResult
+    from auto_pr import AutoPrResult
 
+    # _regen_pr returns a no-diff result → no drift, coverage check skipped.
     monkeypatch.setattr(
         loop,
-        "_regen_and_detect_drift",
-        lambda: _DriftResult(has_drift=False, changed_files=[]),
+        "_regen_pr",
+        AsyncMock(
+            return_value=AutoPrResult(
+                status="no-diff", pr_url=None, branch="arch-regen-auto"
+            )
+        ),
     )
     result = await loop._do_work()
     assert result == {"drift": False}
@@ -57,35 +59,31 @@ async def test_no_drift_returns_drift_false(loop_deps, tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_drift_opens_pr_and_runs_coverage(loop_deps, tmp_path, monkeypatch):
-    pr_manager = MagicMock()
-    pr_manager.find_existing_issue = AsyncMock(return_value=0)
-    loop = DiagramLoop(config=MagicMock(), pr_manager=pr_manager, deps=loop_deps)
+    loop = DiagramLoop(config=MagicMock(), pr_manager=MagicMock(), deps=loop_deps)
     loop._set_repo_root(tmp_path)
 
-    from diagram_loop import _DriftResult
+    from auto_pr import AutoPrResult
 
     monkeypatch.setattr(
         loop,
-        "_regen_and_detect_drift",
-        lambda: _DriftResult(
-            has_drift=True, changed_files=["M docs/arch/generated/loops.md"]
+        "_regen_pr",
+        AsyncMock(
+            return_value=AutoPrResult(
+                status="opened", pr_url="https://pr/1", branch="arch-regen-auto"
+            )
         ),
     )
-
-    open_pr_mock = AsyncMock(return_value="https://pr/1")
-    monkeypatch.setattr(loop, "_open_or_update_regen_pr", open_pr_mock)
     coverage_mock = AsyncMock()
     monkeypatch.setattr(loop, "_ensure_coverage_issue", coverage_mock)
 
     result = await loop._do_work()
     assert result["drift"] is True
     assert result["pr_url"] == "https://pr/1"
-    open_pr_mock.assert_awaited_once()
     coverage_mock.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_regen_pr_uses_config_base_branch_staging(
+async def test_regen_pr_uses_config_base_branch_and_worktree_path_specs(
     loop_deps, tmp_path, monkeypatch
 ):
     config = MagicMock()
@@ -97,21 +95,24 @@ async def test_regen_pr_uses_config_base_branch_staging(
     captured = {}
 
     import auto_pr as _auto_pr_mod
+    from auto_pr import AutoPrResult
 
     async def intercept(**kw):
-        captured["base"] = kw["base"]
-        from auto_pr import AutoPrResult
-
+        captured.update(kw)
         return AutoPrResult(
-            status="opened",
-            pr_url="https://pr/2",
-            branch=kw["branch"],
-            error=None,
+            status="opened", pr_url="https://pr/2", branch=kw["branch"], error=None
         )
 
-    monkeypatch.setattr(_auto_pr_mod, "open_automated_pr_async", intercept)
-    await loop._open_or_update_regen_pr(["M docs/arch/generated/loops.md"])
+    # _regen_pr must route through generate_and_open_pr_async (worktree), not
+    # open_automated_pr_async (repo_root copy).
+    monkeypatch.setattr(_auto_pr_mod, "generate_and_open_pr_async", intercept)
+    result = await loop._regen_pr()
+
+    assert result.pr_url == "https://pr/2"
     assert captured["base"] == "staging"
+    assert captured["branch"] == "arch-regen-auto"
+    assert captured["path_specs"] == ["docs/arch/generated", "docs/arch/.meta.json"]
+    assert callable(captured["generate"])
 
 
 @pytest.mark.asyncio

--- a/tests/test_diagram_loop_kill_switch.py
+++ b/tests/test_diagram_loop_kill_switch.py
@@ -42,12 +42,16 @@ async def test_kill_switch_unset_runs_normally(loop_deps, monkeypatch):
     loop = DiagramLoop(config=MagicMock(), pr_manager=pr_manager, deps=loop_deps)
 
     monkeypatch.delenv("HYDRAFLOW_DISABLE_DIAGRAM_LOOP", raising=False)
-    from diagram_loop import _DriftResult
+    from auto_pr import AutoPrResult
 
     monkeypatch.setattr(
         loop,
-        "_regen_and_detect_drift",
-        lambda: _DriftResult(has_drift=False, changed_files=[]),
+        "_regen_pr",
+        AsyncMock(
+            return_value=AutoPrResult(
+                status="no-diff", pr_url=None, branch="arch-regen-auto"
+            )
+        ),
     )
     result = await loop._do_work()
     assert result.get("drift") is False


### PR DESCRIPTION
Implements proposal **#9539** (`docs/proposals/factory-tree-self-clean.md`) — stop loops mutating the checkout they run from. Root cause: `auto_pr.open_automated_pr_async` reads file contents *from `repo_root`*, so the originals are left dirty after the ephemeral worktree is torn down.

## auto_pr (foundation)
- Extract the shared commit→push→pr-create→auto-merge tail into `_finalize_pr_from_worktree`; `open_automated_pr_async` now uses it — **behavior-preserving** (27 existing auto_pr tests pass unchanged).
- Add **`generate_and_open_pr_async(generate, path_specs, …)`**: the caller's async `generate(worktree_path)` produces content *inside* the ephemeral worktree (off `origin/base`); **`repo_root` is never touched**. Staging skips specs the generator didn't materialise (→ no-diff). Generate-callback credit/auth/bug exceptions propagate via `reraise_on_credit_or_bug`.

## DiagramLoop (first migration — highest value)
It was the source of the recurring `docs/arch/generated` + `.meta.json` churn tax. Regen now runs `arch.runner.emit` into the worktree via `generate_and_open_pr_async`; drift = the `opened`/`no-diff` result. The loop no longer writes `docs/arch` into `repo_root` or runs `subprocess.run` directly (dropped from the async-timeout audit list).

## Tests
- **Real-git integration test** proving `repo_root` stays clean (`git status --porcelain == ""`) after a regen PR opens, plus a no-diff test.
- DiagramLoop unit/scenario/kill-switch tests updated to the worktree flow.
- **715 tests pass** across all `auto_pr` callers; ruff + pyright + lint-check + arch-check clean.

## Sequencing (per the proposal)
This is part 1 (foundation + first loop). Remaining: pricing/term/corpus = EASY, contract/adr = MEDIUM (same `generate_and_open_pr_async` pattern), and **repo_wiki = HARD** (its cross-tick coalesce uses dirty `repo_root` as an accumulation buffer — needs the persistent-worktree redesign sketched in the proposal). Each follows in its own TDD'd PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)