### PR TITLE
fix(ui): Header arrow-count test for terminal-fork topology (#9224)

### DIFF
--- a/src/ui/src/components/__tests__/Header.test.jsx
+++ b/src/ui/src/components/__tests__/Header.test.jsx
@@ -287,9 +287,13 @@ describe('Header component', () => {
       })
 
       const arrows = screen.getAllByText('\u2192')
-      // 4 arrows in main track (plan, implement, review, merged) +
-      // 1 arrow between product track stages (discover → shape) = 5
-      const mainTrackArrows = PIPELINE_STAGES.filter(s => s.track !== 'product').length - 1
+      // Linear arrows = 3 main (plan, implement, review) + 1 product-internal.
+      // Terminal stages (hitl, merged: role/configKey null) fork off review
+      // with diagonal fork arrows instead of chaining linearly, so they no
+      // longer contribute a linear arrow to the main track (#9224).
+      const terminalStages = PIPELINE_STAGES.filter(s => !s.role && !s.configKey)
+      const mainTrackArrows =
+        PIPELINE_STAGES.filter(s => s.track !== 'product').length - 1 - terminalStages.length
       const productTrackArrows = Math.max(0, PIPELINE_STAGES.filter(s => s.track === 'product').length - 1)
       expect(arrows.length).toBe(mainTrackArrows + productTrackArrows)
     })


### PR DESCRIPTION
## What
`#9592`'s Header.jsx change (#9224) moved the terminal stages (`hitl`, `merged`) out of the linear pipeline chain — they now fork off `review` with diagonal arrows (`↗`/`↘`) instead of contributing a linear `→`. But `Header.test.jsx`'s arrow-count assertion still expected the old linear count, so it failed: **`expected 4 to be 6`**.

## Why it slipped through
The vitest gate (`Dashboard Build`) runs on **promotion PRs to `main`**, not on staging-targeted PRs — so #9592 went green on staging and the regression only surfaced on RC **#9608** (`rc/2026-06-20-0218 → main`), blocking promotion.

## Fix
Subtract the terminal stages (`role`/`configKey` null — matching the component's `TERMINAL_STAGE_KEYS`) from the main-track arrow count: `(6 − 1) − 2 + 1 = 4`. One-line logic change in the test; the component is correct as-is.

Verified: full UI vitest suite green (**62 files**).

## Unblocks
Once this lands on staging, a fresh RC will promote cleanly to `main`. (RC #9608 is built from pre-fix staging and can't merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)