### PR TITLE
fix(pr-manager): guard list_issues_by_label against empty gh stdout (closes #9602)

### DIFF
--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -1469,7 +1469,7 @@ class PRManager:
         )
         from contracts.boundary import field_or  # noqa: PLC0415
 
-        results = parse_list_with_shape(output, GhIssueListItem)
+        results = parse_list_with_shape(output or "[]", GhIssueListItem)
         return [
             {
                 "number": field_or(r, "number", 0),
@@ -1509,7 +1509,7 @@ class PRManager:
         )
         from contracts.boundary import field_or  # noqa: PLC0415
 
-        results = parse_list_with_shape(output, GhIssueListItem)
+        results = parse_list_with_shape(output or "[]", GhIssueListItem)
         return [
             {
                 "number": field_or(r, "number", 0),

--- a/tests/regressions/test_pr_manager_empty_gh_output.py
+++ b/tests/regressions/test_pr_manager_empty_gh_output.py
@@ -1,0 +1,54 @@
+"""Regression #9602: list_issues_by_label and list_closed_issues_by_label must not raise
+ValueError when gh returns empty stdout.
+
+Root cause: `parse_list_with_shape("")` raises ValueError for empty input, which
+`reraise_on_credit_or_bug` re-raises (ValueError is in LIKELY_BUG_EXCEPTIONS).
+In `_reconcile_closed_escalations`, this propagated uncaught to `_execute_cycle`,
+which reported the tick as an error (tick_error_ratio breach).
+
+Fix: use `output or "[]"` before passing to `parse_list_with_shape`, matching the
+pattern already used by other callers in pr_manager.py (line 2713).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from config import HydraFlowConfig
+from events import EventBus
+from pr_manager import PRManager
+
+
+def _make_pr_manager(tmp_path: Path) -> PRManager:
+    cfg = HydraFlowConfig(data_root=tmp_path, repo="hydra/hydraflow")
+    creds = MagicMock()
+    creds.gh_token = "tok"
+    return PRManager(config=cfg, event_bus=EventBus(), credentials=creds)
+
+
+@pytest.mark.asyncio
+async def test_list_closed_issues_by_label_empty_gh_output(tmp_path: Path) -> None:
+    """Empty stdout from gh must return [] rather than raising ValueError."""
+    pr = _make_pr_manager(tmp_path)
+
+    with patch.object(pr, "_run_gh", new=AsyncMock(return_value="")):
+        result = await pr.list_closed_issues_by_label("principles-stuck", limit=100)
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_list_issues_by_label_empty_gh_output(tmp_path: Path) -> None:
+    """Empty stdout from gh must return [] rather than raising ValueError."""
+    pr = _make_pr_manager(tmp_path)
+
+    with patch.object(pr, "_run_gh", new=AsyncMock(return_value="")):
+        result = await pr.list_issues_by_label("principles-drift")
+
+    assert result == []


### PR DESCRIPTION
## Summary

- `parse_list_with_shape("")` raises `ValueError` for empty input; `ValueError` is in `LIKELY_BUG_EXCEPTIONS`, so `reraise_on_credit_or_bug` re-raises it inside `_reconcile_closed_escalations`
- This propagated uncaught to `_execute_cycle`, recording a tick error and triggering the `tick_error_ratio` alert that filed #9602
- `list_issues_by_label` and `list_closed_issues_by_label` were passing `output` directly to `parse_list_with_shape`, unlike other callers in the same file that already use `raw or "[]"` (see line 2713)

Fix: use `output or "[]"` in both methods. Regression tests guard both call sites.

## Test plan
- [x] `tests/regressions/test_pr_manager_empty_gh_output.py` — two new regression tests, both green
- [x] `make lint-check` clean
- [x] `make quality-lite` clean (pre-push gate)
- [x] Closes #9602

🤖 Generated with [Claude Code](https://claude.com/claude-code)