### PR TITLE
chore(wiki): maintenance 2026-06-20

### DIFF
--- a/repo_wiki/T-rav/hydraflow/testing/0001-issue-unknown-core-testing-strategy-and-design-for-testability.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0001-issue-unknown-core-testing-strategy-and-design-for-testability.md
@@ -4,7 +4,8 @@ topic: testing
 source_issue: unknown
 source_phase: synthesis
 created_at: 2026-04-18T14:53:08.908932+00:00
-status: active
+status: superseded
+superseded_by: 0183
 ---
 
 # Core Testing Strategy and Design for Testability

--- a/repo_wiki/T-rav/hydraflow/testing/0002-issue-unknown-type-system-and-data-model-consistency-testing.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0002-issue-unknown-type-system-and-data-model-consistency-testing.md
@@ -4,7 +4,8 @@ topic: testing
 source_issue: unknown
 source_phase: synthesis
 created_at: 2026-04-18T14:53:08.908950+00:00
-status: active
+status: superseded
+superseded_by: 0183
 ---
 
 # Type System and Data Model Consistency Testing

--- a/repo_wiki/T-rav/hydraflow/testing/0003-issue-unknown-multi-location-consistency-and-concurrent-file-i-o.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0003-issue-unknown-multi-location-consistency-and-concurrent-file-i-o.md
@@ -4,7 +4,8 @@ topic: testing
 source_issue: unknown
 source_phase: synthesis
 created_at: 2026-04-18T14:53:08.908953+00:00
-status: active
+status: superseded
+superseded_by: 0183
 ---
 
 # Multi-Location Consistency and Concurrent File I/O Testing

--- a/repo_wiki/T-rav/hydraflow/testing/0004-issue-unknown-adr-testing-patterns-conservative-pattern-matching.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0004-issue-unknown-adr-testing-patterns-conservative-pattern-matching.md
@@ -4,7 +4,8 @@ topic: testing
 source_issue: unknown
 source_phase: synthesis
 created_at: 2026-04-18T14:53:08.908957+00:00
-status: active
+status: superseded
+superseded_by: 0183
 ---
 
 # ADR Testing Patterns: Conservative Pattern Matching and Validation

--- a/repo_wiki/T-rav/hydraflow/testing/0005-issue-7644-never-import-private-helpers-at-module-level-in-te.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0005-issue-7644-never-import-private-helpers-at-module-level-in-te.md
@@ -4,8 +4,9 @@ topic: testing
 source_issue: 7644
 source_phase: review
 created_at: 2026-05-07T07:44:17.831320+00:00
-status: active
+status: superseded
 corroborations: 1
+superseded_by: 0183
 ---
 
 # Never import private helpers at module level in test files

--- a/repo_wiki/T-rav/hydraflow/testing/0006-issue-7644-pin-function-signatures-in-one-canonical-location-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0006-issue-7644-pin-function-signatures-in-one-canonical-location-.md
@@ -4,8 +4,9 @@ topic: testing
 source_issue: 7644
 source_phase: review
 created_at: 2026-05-07T07:44:17.831331+00:00
-status: active
+status: superseded
 corroborations: 1
+superseded_by: 0183
 ---
 
 # Pin function signatures in one canonical location before writing any callers

--- a/repo_wiki/T-rav/hydraflow/testing/0007-issue-9442-use-public-fakegithub-api-in-scenario-tests-never-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0007-issue-9442-use-public-fakegithub-api-in-scenario-tests-never-.md
@@ -4,8 +4,9 @@ topic: testing
 source_issue: 9442
 source_phase: review
 created_at: 2026-06-13T07:10:55.323905+00:00
-status: active
+status: superseded
 corroborations: 1
+superseded_by: 0183
 ---
 
 # Use public FakeGitHub API in scenario tests — never mutate _issues directly

--- a/repo_wiki/T-rav/hydraflow/testing/0153-issue-synthesis-mock-at-definition-site-not-at-the-import-site.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0153-issue-synthesis-mock-at-definition-site-not-at-the-import-site.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.574285+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Mock at definition site, not at the import site

--- a/repo_wiki/T-rav/hydraflow/testing/0154-issue-synthesis-reserve-pytest-mark-integration-for-real-external-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0154-issue-synthesis-reserve-pytest-mark-integration-for-real-external-.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.574648+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Reserve @pytest.mark.integration for real external dependencies only

--- a/repo_wiki/T-rav/hydraflow/testing/0155-issue-synthesis-await-asyncio-sleep-0-before-asserting-on-create-t.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0155-issue-synthesis-await-asyncio-sleep-0-before-asserting-on-create-t.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.574983+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Await asyncio.sleep(0) before asserting on create_task() side effects

--- a/repo_wiki/T-rav/hydraflow/testing/0156-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0156-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.575316+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Test async context managers in three standard scenarios

--- a/repo_wiki/T-rav/hydraflow/testing/0157-issue-synthesis-use-python-script-stand-ins-to-test-subprocess-bou.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0157-issue-synthesis-use-python-script-stand-ins-to-test-subprocess-bou.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.575641+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Use Python script stand-ins to test subprocess boundaries

--- a/repo_wiki/T-rav/hydraflow/testing/0158-issue-synthesis-reset-module-level-global-state-in-both-setup-and-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0158-issue-synthesis-reset-module-level-global-state-in-both-setup-and-.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.575951+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Reset module-level global state in both setup and teardown

--- a/repo_wiki/T-rav/hydraflow/testing/0159-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0159-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.576265+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Use tmp_path with ConfigFactory for all file-based test I/O

--- a/repo_wiki/T-rav/hydraflow/testing/0160-issue-synthesis-wire-real-business-logic-in-phase-runner-integrati.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0160-issue-synthesis-wire-real-business-logic-in-phase-runner-integrati.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.576577+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Wire real business logic in phase-runner integration tests

--- a/repo_wiki/T-rav/hydraflow/testing/0161-issue-synthesis-test-protocol-compliance-with-structural-typing-an.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0161-issue-synthesis-test-protocol-compliance-with-structural-typing-an.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.576876+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Test protocol compliance with structural typing and duck-typing

--- a/repo_wiki/T-rav/hydraflow/testing/0162-issue-synthesis-test-fa-ade-getattr-routing-attributeerror-and-pro.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0162-issue-synthesis-test-fa-ade-getattr-routing-attributeerror-and-pro.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.577187+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Test façade __getattr__ routing, AttributeError, and protocol delegation

--- a/repo_wiki/T-rav/hydraflow/testing/0163-issue-synthesis-assert-relative-event-id-ordering-never-absolute-v.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0163-issue-synthesis-assert-relative-event-id-ordering-never-absolute-v.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.577494+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Assert relative event ID ordering, never absolute values

--- a/repo_wiki/T-rav/hydraflow/testing/0164-issue-synthesis-add-structural-tests-before-property-based-transit.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0164-issue-synthesis-add-structural-tests-before-property-based-transit.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.577810+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Add structural tests before property-based transition graph tests

--- a/repo_wiki/T-rav/hydraflow/testing/0165-issue-synthesis-grep-all-model-usages-before-committing-pydantic-o.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0165-issue-synthesis-grep-all-model-usages-before-committing-pydantic-o.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.578130+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Grep all model usages before committing Pydantic or TypedDict changes

--- a/repo_wiki/T-rav/hydraflow/testing/0166-issue-synthesis-feature-toggles-require-both-a-config-field-and-an.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0166-issue-synthesis-feature-toggles-require-both-a-config-field-and-an.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.578470+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Feature toggles require both a config field and an _ENV_INT_OVERRIDES entry

--- a/repo_wiki/T-rav/hydraflow/testing/0167-issue-synthesis-test-concurrent-jsonl-appends-with-exact-counts-no.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0167-issue-synthesis-test-concurrent-jsonl-appends-with-exact-counts-no.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.578787+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Test concurrent JSONL appends with exact counts, not timing

--- a/repo_wiki/T-rav/hydraflow/testing/0168-issue-synthesis-use-identical-string-keys-across-memory-bank-dedup.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0168-issue-synthesis-use-identical-string-keys-across-memory-bank-dedup.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.579096+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Use identical string keys across memory bank deduplication and assembly

--- a/repo_wiki/T-rav/hydraflow/testing/0169-issue-synthesis-skill-definition-changes-must-update-all-4-backend.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0169-issue-synthesis-skill-definition-changes-must-update-all-4-backend.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.579421+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Skill definition changes must update all 4 backend copies

--- a/repo_wiki/T-rav/hydraflow/testing/0170-issue-synthesis-auto-generated-adr-tests-must-use-pytest-mark-skip.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0170-issue-synthesis-auto-generated-adr-tests-must-use-pytest-mark-skip.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.579759+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Auto-generated ADR tests must use @pytest.mark.skip by default

--- a/repo_wiki/T-rav/hydraflow/testing/0171-issue-synthesis-every-adr-must-pass-structural-section-validation-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0171-issue-synthesis-every-adr-must-pass-structural-section-validation-.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.580071+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Every ADR must pass structural section validation before merge

--- a/repo_wiki/T-rav/hydraflow/testing/0172-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0172-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.580387+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Never import private helpers at module level in test files

--- a/repo_wiki/T-rav/hydraflow/testing/0173-issue-synthesis-pin-function-signatures-in-the-source-file-before-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0173-issue-synthesis-pin-function-signatures-in-the-source-file-before-.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.580702+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Pin function signatures in the source file before writing tests or docs

--- a/repo_wiki/T-rav/hydraflow/testing/0174-issue-synthesis-specify-exact-logger-name-in-caplog-at-level-asser.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0174-issue-synthesis-specify-exact-logger-name-in-caplog-at-level-asser.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.581029+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Specify exact logger name in caplog.at_level() assertions

--- a/repo_wiki/T-rav/hydraflow/testing/0175-issue-synthesis-js-rendered-accessibility-attributes-require-playw.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0175-issue-synthesis-js-rendered-accessibility-attributes-require-playw.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.581376+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # JS-rendered accessibility attributes require Playwright, not TestClient

--- a/repo_wiki/T-rav/hydraflow/testing/0176-issue-synthesis-use-word-boundary-matching-in-name-coverage-checks.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0176-issue-synthesis-use-word-boundary-matching-in-name-coverage-checks.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.581718+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Use word-boundary matching in name-coverage checks to prevent collisions

--- a/repo_wiki/T-rav/hydraflow/testing/0177-issue-synthesis-keep-test-label-stage-constants-synchronized-with-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0177-issue-synthesis-keep-test-label-stage-constants-synchronized-with-.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.582062+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Keep test label/stage constants synchronized with production definitions

--- a/repo_wiki/T-rav/hydraflow/testing/0178-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels-n.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0178-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels-n.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.582440+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Test direct-swap labels via swap_pipeline_labels(), not transitions

--- a/repo_wiki/T-rav/hydraflow/testing/0179-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0179-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.582809+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Allow ±3 line drift in AST-based structure assertions

--- a/repo_wiki/T-rav/hydraflow/testing/0180-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0180-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.583171+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Existing tests cover private-method extractions; add only new-behavior tests

--- a/repo_wiki/T-rav/hydraflow/testing/0181-issue-synthesis-enforce-50-line-handler-and-30-line-wiring-limits-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0181-issue-synthesis-enforce-50-line-handler-and-30-line-wiring-limits-.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.583532+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Enforce 50-line handler and 30-line wiring limits for testability

--- a/repo_wiki/T-rav/hydraflow/testing/0182-issue-synthesis-type-only-annotation-changes-require-no-new-tests.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0182-issue-synthesis-type-only-annotation-changes-require-no-new-tests.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-15T06:37:30.583920+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152
+superseded_by: 0183
 ---
 
 # Type-only annotation changes require no new tests

--- a/repo_wiki/T-rav/hydraflow/testing/0183-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0183-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md
@@ -1,0 +1,22 @@
+---
+id: 0183
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.782918+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Never import private helpers at module level in test files
+
+Import private or internal functions (`_foo`) inside the test function or a `pytest.fixture`, never at module top level.
+
+```python
+# good — failure scoped to the test
+def test_check_prereq():
+    from src.makefile_scaffold import _check_prereq_deps
+```
+
+**Why:** A module-level `ImportError` prevents pytest from collecting the file, silently destroying all passing tests in that module.

--- a/repo_wiki/T-rav/hydraflow/testing/0184-issue-synthesis-pin-function-signatures-in-the-source-file-before-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0184-issue-synthesis-pin-function-signatures-in-the-source-file-before-.md
@@ -1,0 +1,20 @@
+---
+id: 0184
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.783288+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Pin function signatures in the source file before writing tests or docs
+
+Decide the authoritative signature (argument order, return tuple shape) in the source file first; then write docs and tests to match.
+
+1. Write the function stub
+2. Copy its exact signature into the docstring
+3. Write the test
+
+**Why:** When docs and tests are authored before implementation, signature drift goes undetected until runtime — both artifacts can be wrong simultaneously.

--- a/repo_wiki/T-rav/hydraflow/testing/0185-issue-synthesis-use-public-fakegithub-api-in-scenario-tests-never-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0185-issue-synthesis-use-public-fakegithub-api-in-scenario-tests-never-.md
@@ -1,0 +1,19 @@
+---
+id: 0185
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.783632+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Use public FakeGitHub API in scenario tests — never mutate _issues directly
+
+Always use the public API to mutate `FakeGitHub` state in scenario tests; never write to private attributes directly.
+
+- Bad: `world.github._issues[901].state = "closed"`
+- Good: `await world.github.close_issue(901)`
+
+**Why:** If `FakeIssue` internals change, direct attribute writes silently remain valid Python while the fake's behavior drifts — the public API is the compatibility boundary that signals breakage.

--- a/repo_wiki/T-rav/hydraflow/testing/0186-issue-synthesis-mock-at-definition-site-not-at-the-import-site.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0186-issue-synthesis-mock-at-definition-site-not-at-the-import-site.md
@@ -1,0 +1,21 @@
+---
+id: 0186
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.783966+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Mock at definition site, not at the import site
+
+Patch symbols at the module where they are defined, not where they are imported.
+
+- Bad: `patch('tests.test_foo.MyClass')`
+- Good: `patch('src.mymodule.MyClass')`
+
+For optional deps like `sentry_sdk`, use `patch.dict('sys.modules', {'sentry_sdk': mock, 'sentry_sdk.integrations': mock})`; patch sub-modules explicitly to prevent import leaks.
+
+**Why:** Usage-site patches intercept only that one import; other callers and subsequent imports still see the real object, producing inconsistent test behavior.

--- a/repo_wiki/T-rav/hydraflow/testing/0187-issue-synthesis-reserve-pytest-mark-integration-for-real-external-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0187-issue-synthesis-reserve-pytest-mark-integration-for-real-external-.md
@@ -1,0 +1,16 @@
+---
+id: 0187
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.784311+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Reserve @pytest.mark.integration for real external dependencies only
+
+Mark a test `@pytest.mark.integration` only when it exercises Docker, network, filesystem, real worktrees, or live service instances — not when all deps are `AsyncMock` or `MagicMock`. Use `pytest.mark.skipif(not shutil.which('cli'), ...)` for optional CLI tools.
+
+**Why:** Over-marking slows the fast suite and blurs the unit/integration boundary, making targeted test runs unreliable.

--- a/repo_wiki/T-rav/hydraflow/testing/0188-issue-synthesis-await-asyncio-sleep-0-before-asserting-on-create-t.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0188-issue-synthesis-await-asyncio-sleep-0-before-asserting-on-create-t.md
@@ -1,0 +1,22 @@
+---
+id: 0188
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.784644+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Await asyncio.sleep(0) before asserting on create_task() side effects
+
+After triggering fire-and-forget tasks via `asyncio.create_task()`, yield the event loop before making assertions.
+
+```python
+task = asyncio.create_task(fn())
+await asyncio.sleep(0)
+mock.assert_called_once()
+```
+
+**Why:** Without yielding, the created task has not yet run; assertions on its side effects will fail spuriously and non-deterministically.

--- a/repo_wiki/T-rav/hydraflow/testing/0189-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0189-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
@@ -1,0 +1,21 @@
+---
+id: 0189
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.784968+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Test async context managers in three standard scenarios
+
+Cover async context managers with three scenarios: (1) idempotent close — calling `close()` twice is safe; (2) `__aexit__` triggers `close()` exactly once; (3) `__aenter__` returns `self`.
+
+```python
+async with resource as r:
+    assert r is resource
+```
+
+**Why:** Missing any scenario leaves an incomplete behavioral contract, hiding bugs in external-connection or file-handle management.

--- a/repo_wiki/T-rav/hydraflow/testing/0190-issue-synthesis-use-python-script-stand-ins-to-test-subprocess-bou.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0190-issue-synthesis-use-python-script-stand-ins-to-test-subprocess-bou.md
@@ -1,0 +1,18 @@
+---
+id: 0190
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.785304+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Use Python script stand-ins to test subprocess boundaries
+
+Create small Python scripts that log invocations to JSON-lines files instead of mocking subprocess calls directly.
+
+Example: Pass `subprocess_runner = ['python3', 'fake_gh.py']` to the system under test; assert via `json.loads(log_path.read_text())`.
+
+**Why:** Real subprocess boundaries catch shell-quoting, PATH resolution, and argument-passing bugs that mock-based patches cannot detect.

--- a/repo_wiki/T-rav/hydraflow/testing/0191-issue-synthesis-reset-module-level-global-state-in-both-setup-and-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0191-issue-synthesis-reset-module-level-global-state-in-both-setup-and-.md
@@ -1,0 +1,23 @@
+---
+id: 0191
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.785638+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Reset module-level global state in both setup and teardown
+
+Explicitly reset globals (e.g., `_gh_semaphore`, `_rate_limit_until`) in both `setup_method` and `teardown_method`.
+
+```python
+def setup_method(self):
+    module._rate_limit_until = 0
+def teardown_method(self):
+    module._rate_limit_until = 0
+```
+
+**Why:** Omitting setup reset leaves stale state from a prior run; omitting teardown reset infects the next test — both produce non-deterministic failures.

--- a/repo_wiki/T-rav/hydraflow/testing/0192-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0192-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md
@@ -1,0 +1,21 @@
+---
+id: 0192
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.785994+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Use tmp_path with ConfigFactory for all file-based test I/O
+
+All tests that read or write files must use `tmp_path` combined with `ConfigFactory.create(base_path=tmp_path)` — never write to real project paths.
+
+```python
+def test_something(tmp_path):
+    config = ConfigFactory.create(base_path=tmp_path)
+```
+
+**Why:** Tests writing to real project paths corrupt the working directory and produce hard-to-reproduce cross-test pollution.

--- a/repo_wiki/T-rav/hydraflow/testing/0193-issue-synthesis-wire-real-business-logic-in-phase-runner-integrati.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0193-issue-synthesis-wire-real-business-logic-in-phase-runner-integrati.md
@@ -1,0 +1,16 @@
+---
+id: 0193
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.786329+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Wire real business logic in phase-runner integration tests
+
+Use real `StateTracker`, `EventBus`, and `VerificationJudge` instances in phase-runner integration tests; mock only the `_execute()` subprocess boundary. Provide configurable transcript strings for real runner parsing. Validate via `StateTracker` APIs and `EventBus.get_history()`, not mock call assertions.
+
+**Why:** Fully-mocked runners hide mismatches between transcript parsing logic and real output formats — exactly the bugs integration tests exist to catch.

--- a/repo_wiki/T-rav/hydraflow/testing/0194-issue-synthesis-test-protocol-compliance-with-structural-typing-an.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0194-issue-synthesis-test-protocol-compliance-with-structural-typing-an.md
@@ -1,0 +1,16 @@
+---
+id: 0194
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.786664+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Test protocol compliance with structural typing and duck-typing
+
+Verify protocol satisfaction with two complementary checks: (1) `isinstance(obj, Protocol)` with `@runtime_checkable`, and (2) `hasattr(obj, 'method_name')`. Add `inspect.signature()` comparison to detect parameter drift. Parametrize over each protocol method so failures are specific.
+
+**Why:** Either check alone misses a class of violations; structural typing catches missing methods, signature comparison catches arity and keyword drift.

--- a/repo_wiki/T-rav/hydraflow/testing/0195-issue-synthesis-test-fa-ade-getattr-routing-attributeerror-and-pro.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0195-issue-synthesis-test-fa-ade-getattr-routing-attributeerror-and-pro.md
@@ -1,0 +1,16 @@
+---
+id: 0195
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.787002+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Test façade __getattr__ routing, AttributeError, and protocol delegation
+
+When adding a façade, explicitly test: (1) `__getattr__` routes to the correct sub-client; (2) unknown attributes raise `AttributeError`; (3) the façade satisfies protocols via delegation; (4) existing mocks of the original class still pass. Assert sub-components receive mutable references — not copies — to shared state owned by the façade.
+
+**Why:** Façade delegation bugs pass all pre-existing tests because those tests mock the original class directly, not the façade.

--- a/repo_wiki/T-rav/hydraflow/testing/0196-issue-synthesis-assert-relative-event-id-ordering-never-absolute-v.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0196-issue-synthesis-assert-relative-event-id-ordering-never-absolute-v.md
@@ -1,0 +1,19 @@
+---
+id: 0196
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.787334+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Assert relative event ID ordering, never absolute values
+
+Tests for events backed by a global counter must assert relative ordering and uniqueness within one test, never absolute ID values.
+
+- Good: `assert event_a.id < event_b.id`
+- Bad: `assert event_a.id == 1`
+
+**Why:** Global ID counters are shared across tests and imports; absolute assertions produce non-deterministic failures under parallel or reordered execution.

--- a/repo_wiki/T-rav/hydraflow/testing/0197-issue-synthesis-add-structural-tests-before-property-based-transit.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0197-issue-synthesis-add-structural-tests-before-property-based-transit.md
@@ -1,0 +1,18 @@
+---
+id: 0197
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.787682+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Add structural tests before property-based transition graph tests
+
+Before using hypothesis or similar tools to exercise a label/stage transition graph, add explicit structural assertions: every target is a valid stage, every stage has a transition entry, no dangling references.
+
+Example: `assert set(VALID_TRANSITIONS.keys()) == VALID_STAGES`
+
+**Why:** Property-based tests on a malformed graph surface as mysterious assertion failures rather than clear "bad graph definition" errors.

--- a/repo_wiki/T-rav/hydraflow/testing/0198-issue-synthesis-grep-all-model-usages-before-committing-pydantic-o.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0198-issue-synthesis-grep-all-model-usages-before-committing-pydantic-o.md
@@ -1,0 +1,18 @@
+---
+id: 0198
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.788034+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Grep all model usages before committing Pydantic or TypedDict changes
+
+Before adding or removing a field, grep the test suite for the model name and update all affected assertions: model definition, factory defaults, `all_fields` tests, and round-trip serialization tests. For `NotRequired` fields, update exact-match assertions but not missing-key assertions.
+
+See also: testing — Type-only annotation changes require no new tests.
+
+**Why:** Missed exact-match assertions silently pass when a field is optional, masking coverage gaps until a stricter test runs.

--- a/repo_wiki/T-rav/hydraflow/testing/0199-issue-synthesis-feature-toggles-require-both-a-config-field-and-an.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0199-issue-synthesis-feature-toggles-require-both-a-config-field-and-an.md
@@ -1,0 +1,18 @@
+---
+id: 0199
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.788379+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Feature toggles require both a config field and an _ENV_INT_OVERRIDES entry
+
+Each new feature toggle needs a field in `src/config.py` AND an entry in `_ENV_INT_OVERRIDES`. Test both the default field value and the env-var override. The `_ENV_INT_OVERRIDES` tuple default must equal the Field default or env override silently stops applying.
+
+See also: architecture-state-persistence — `_ENV_INT_OVERRIDES` default sync.
+
+**Why:** A config field alone makes the toggle code-only; without `_ENV_INT_OVERRIDES`, the environment variable silently has no effect.

--- a/repo_wiki/T-rav/hydraflow/testing/0200-issue-synthesis-test-concurrent-jsonl-appends-with-exact-counts-no.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0200-issue-synthesis-test-concurrent-jsonl-appends-with-exact-counts-no.md
@@ -1,0 +1,20 @@
+---
+id: 0200
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.788716+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Test concurrent JSONL appends with exact counts, not timing
+
+Use `ThreadPoolExecutor` with fixed thread and iteration counts; assert the exact expected line count after completion.
+
+Example: 10 threads × 20 events = 200 lines — assert `len(lines) == 200`.
+
+POSIX guarantees atomicity for writes under ~4 KB; validate empirically before relying on this.
+
+**Why:** Timing-based assertions are non-deterministic; exact counts reliably expose real data loss or line corruption.

--- a/repo_wiki/T-rav/hydraflow/testing/0201-issue-synthesis-use-identical-string-keys-across-memory-bank-dedup.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0201-issue-synthesis-use-identical-string-keys-across-memory-bank-dedup.md
@@ -1,0 +1,16 @@
+---
+id: 0201
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.789055+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Use identical string keys across memory bank deduplication and assembly
+
+The `bank_order` list and bank dict keys must use identical strings throughout (e.g., `'review_insights'` everywhere, never mixed with `'review-insights'`). Fallback recall functions should try multiple field names (`learning`, `text`, `content`, `display_text`) to extract text payloads.
+
+**Why:** Key mismatches silently skip entire banks during deduplication or assembly with no error or warning.

--- a/repo_wiki/T-rav/hydraflow/testing/0202-issue-synthesis-skill-definition-changes-must-update-all-4-backend.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0202-issue-synthesis-skill-definition-changes-must-update-all-4-backend.md
@@ -1,0 +1,16 @@
+---
+id: 0202
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.789384+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Skill definition changes must update all 4 backend copies
+
+HydraFlow skills replicate across `.claude/commands/`, `.pi/skills/`, `.codex/skills/`, and `src/*.py`. Use a manual `SKILL_MARKERS` mapping (not regex introspection) to validate all copies contain matching output markers via substring search. A single skill change can require updates across 3+ test fixture files.
+
+**Why:** Missing updates in any one copy cause consistency test failures and silent runtime behavior divergence.

--- a/repo_wiki/T-rav/hydraflow/testing/0203-issue-synthesis-auto-generated-adr-tests-must-use-pytest-mark-skip.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0203-issue-synthesis-auto-generated-adr-tests-must-use-pytest-mark-skip.md
@@ -1,0 +1,16 @@
+---
+id: 0203
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.789727+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Auto-generated ADR tests must use @pytest.mark.skip by default
+
+When auto-generating tests from ADR Decision sections, emit all tests with `@pytest.mark.skip(reason='skeleton: requires human review')`. Extract only 4 high-confidence baseline patterns per ADR: uniqueness, usage, negative, coverage.
+
+**Why:** Automated pattern matching on ADR language is ambiguous; unskipped generated tests produce false-positive CI failures until a human validates each pattern.

--- a/repo_wiki/T-rav/hydraflow/testing/0204-issue-synthesis-every-adr-must-pass-structural-section-validation-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0204-issue-synthesis-every-adr-must-pass-structural-section-validation-.md
@@ -1,0 +1,18 @@
+---
+id: 0204
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.790066+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Every ADR must pass structural section validation before merge
+
+ADRs must pass `tests/test_adr_pre_validator.py`, which enforces required sections (Status, Context, Decision, Consequences) and valid status values: Proposed, Accepted, Deprecated, Superseded.
+
+See also: architecture — ADR number collision and README guards.
+
+**Why:** ADRs missing required sections cause false-positive or false-negative ADR drift reports from automated tooling.

--- a/repo_wiki/T-rav/hydraflow/testing/0205-issue-synthesis-specify-exact-logger-name-in-caplog-at-level-asser.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0205-issue-synthesis-specify-exact-logger-name-in-caplog-at-level-asser.md
@@ -1,0 +1,22 @@
+---
+id: 0205
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.790404+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Specify exact logger name in caplog.at_level() assertions
+
+Always pass the exact logger name to `caplog.at_level()` and clear caplog before the action under test.
+
+```python
+with caplog.at_level(logging.WARNING, logger='src.billing'):
+    trigger_action()
+assert 'expected substring' in caplog.text
+```
+
+**Why:** Without the logger filter, unrelated log messages from other modules pollute captured output and produce false positives.

--- a/repo_wiki/T-rav/hydraflow/testing/0206-issue-synthesis-js-rendered-accessibility-attributes-require-playw.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0206-issue-synthesis-js-rendered-accessibility-attributes-require-playw.md
@@ -1,0 +1,16 @@
+---
+id: 0206
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.790762+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# JS-rendered accessibility attributes require Playwright, not TestClient
+
+Server-side `TestClient` (Django/FastAPI) returns only the initial HTML shell; `aria-labelledby` and other JS-rendered attributes are absent. Delete dead Python `TestClient` tests for these attributes and replace with Playwright tests.
+
+**Why:** TestClient assertions on JS-rendered attributes always pass vacuously — the attribute is missing from the initial render, so assertions check an empty string or missing key.

--- a/repo_wiki/T-rav/hydraflow/testing/0207-issue-synthesis-use-word-boundary-matching-in-name-coverage-checks.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0207-issue-synthesis-use-word-boundary-matching-in-name-coverage-checks.md
@@ -1,0 +1,19 @@
+---
+id: 0207
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.791102+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Use word-boundary matching in name-coverage checks to prevent collisions
+
+Substring matching in coverage or name checks produces false positives when short names appear inside longer ones.
+
+- Bad: `'Foo' in text` — also matches `FooBar`, `PrefixFoo`
+- Good: `re.search(r'\bFoo\b', text)` or full-name match
+
+**Why:** Short-name collisions silently mark unrelated targets as covered, hiding real gaps in coverage.

--- a/repo_wiki/T-rav/hydraflow/testing/0208-issue-synthesis-keep-test-label-stage-constants-synchronized-with-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0208-issue-synthesis-keep-test-label-stage-constants-synchronized-with-.md
@@ -1,0 +1,18 @@
+---
+id: 0208
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.791449+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Keep test label/stage constants synchronized with production definitions
+
+Test constants (`ALL_PIPELINE_LABELS`, `VALID_STAGES`, `VALID_TRANSITIONS`) must mirror production definitions. Add a sync test asserting set equality: `assert set(VALID_TRANSITIONS.keys()) == VALID_STAGES`.
+
+See also: testing — Test direct-swap labels via swap_pipeline_labels(), not transitions.
+
+**Why:** Stale test constants become false documentation and silently mask missing transition or label coverage.

--- a/repo_wiki/T-rav/hydraflow/testing/0209-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels-n.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0209-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels-n.md
@@ -1,0 +1,18 @@
+---
+id: 0209
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.791797+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Test direct-swap labels via swap_pipeline_labels(), not transitions
+
+Labels set via atomic swap (`hitl-active`, `fixed`) bypass the transition graph and are applied by `swap_pipeline_labels()` — test them on that call path, not through `VALID_TRANSITIONS`.
+
+See also: testing — Keep test label/stage constants synchronized with production definitions.
+
+**Why:** Testing swap labels through the transition graph masks missing coverage; they have no transition entry by design.

--- a/repo_wiki/T-rav/hydraflow/testing/0210-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0210-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
@@ -1,0 +1,20 @@
+---
+id: 0210
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.792140+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Allow ±3 line drift in AST-based structure assertions
+
+For tests that verify code structure by parsing source ASTs (e.g., checking function length), allow ±3 line tolerance.
+
+Example: Assert `len(func.body) <= 53` rather than `<= 50` to account for blank lines and decorator variations.
+
+See also: testing — Enforce 50-line handler and 30-line wiring limits for testability.
+
+**Why:** Exact line-count assertions redden CI on whitespace-only diffs, creating maintenance noise without improving correctness.

--- a/repo_wiki/T-rav/hydraflow/testing/0211-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0211-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md
@@ -1,0 +1,16 @@
+---
+id: 0211
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.792497+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Existing tests cover private-method extractions; add only new-behavior tests
+
+When extracting a private method from a public one with an unchanged public API, the existing test suite provides full coverage — no new tests are needed for the extraction itself. When extracting prompt-building methods, run prompt-assertion tests in isolation immediately after extraction to verify parity.
+
+**Why:** Adding duplicate tests for unchanged behavior inflates the suite; the real regression risk is behavioral, which existing tests already guard.

--- a/repo_wiki/T-rav/hydraflow/testing/0212-issue-synthesis-enforce-50-line-handler-and-30-line-wiring-limits-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0212-issue-synthesis-enforce-50-line-handler-and-30-line-wiring-limits-.md
@@ -1,0 +1,18 @@
+---
+id: 0212
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.792854+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Enforce 50-line handler and 30-line wiring limits for testability
+
+Handler functions must stay under 50 lines; registration wiring under 30 lines. Extract nested closures into instance methods to flatten nesting to ≤3 levels. Enforce via AST-based tests with ±3 line tolerance.
+
+See also: testing — Allow ±3 line drift in AST-based structure assertions.
+
+**Why:** Deep nesting and long handlers are hard to unit-test in isolation; the limit forces decomposition that makes individual behaviors independently testable.

--- a/repo_wiki/T-rav/hydraflow/testing/0213-issue-synthesis-type-only-annotation-changes-require-no-new-tests.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0213-issue-synthesis-type-only-annotation-changes-require-no-new-tests.md
@@ -1,0 +1,18 @@
+---
+id: 0213
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.793210+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Type-only annotation changes require no new tests
+
+Migrating from `dict[str, Any]` to a `TypedDict` return type, or narrowing a parameter from `Any` to a specific type, requires no new tests — `TypedDict` values are plain dicts at runtime. Verify via `make quality-lite` and `make test`; the existing suite suffices.
+
+See also: testing — Grep all model usages before committing Pydantic or TypedDict changes.
+
+**Why:** Runtime behavior is unchanged; new tests for type-only changes create maintenance overhead without catching real bugs.

--- a/repo_wiki/T-rav/hydraflow/testing/0214-issue-synthesis-assert-numeric-values-in-sentry-breadcrumbs-not-ju.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0214-issue-synthesis-assert-numeric-values-in-sentry-breadcrumbs-not-ju.md
@@ -1,0 +1,23 @@
+---
+id: 0214
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.793574+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Assert numeric values in Sentry breadcrumbs, not just key presence
+
+When testing Sentry integration, assert actual numeric values in breadcrumbs and metrics, not just that a key exists.
+
+```python
+# good
+assert breadcrumb['data']['latency_ms'] == 42
+# bad
+assert 'latency_ms' in breadcrumb['data']
+```
+
+**Why:** Key-presence assertions pass even when values are wrong or zero; numeric value assertions catch metric miscalculation bugs that presence checks miss entirely.

--- a/repo_wiki/T-rav/hydraflow/testing/0215-issue-synthesis-test-pydantic-literal-constraints-cover-both-valid.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0215-issue-synthesis-test-pydantic-literal-constraints-cover-both-valid.md
@@ -1,0 +1,18 @@
+---
+id: 0215
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.794015+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Test Pydantic Literal constraints: cover both valid and invalid values
+
+When adding `Literal` constraints to Pydantic fields, test both valid and invalid values — verify valid values are accepted and invalid values raise `ValidationError`.
+
+Example: For `status: Literal['open', 'closed']`, test `status='open'` passes and `status='unknown'` raises.
+
+**Why:** Literal constraints are invisible at runtime if only valid values are tested; invalid-value tests confirm the constraint is actually enforced.

--- a/repo_wiki/T-rav/hydraflow/testing/0216-issue-synthesis-verify-fatal-exception-propagation-through-multi-p.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0216-issue-synthesis-verify-fatal-exception-propagation-through-multi-p.md
@@ -1,0 +1,18 @@
+---
+id: 0216
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-06-20T05:43:45.794459+00:00
+status: active
+corroborations: 1
+supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+---
+
+# Verify fatal exception propagation through multi-phase loops
+
+Test that fatal exceptions propagate through multi-phase loops by mocking internal methods to raise specific exception types, then asserting the exception reaches the caller without being swallowed.
+
+Example: `mock._execute.side_effect = FatalError(); with pytest.raises(FatalError): await loop.run_once()`
+
+**Why:** Broad `except Exception` blocks in loop runners silently swallow fatal exceptions, making multi-phase loops appear to succeed when they have failed.


### PR DESCRIPTION
Automated wiki maintenance PR opened by `RepoWikiLoop`.

## Actions

- 0 entries marked stale
- 0 entries pruned
- 34 entries compiled / synthesized
- 0 console-triggered tasks drained

## Files changed

- `repo_wiki/T-rav/hydraflow/testing/0001-issue-unknown-core-testing-strategy-and-design-for-testability.md`
- `repo_wiki/T-rav/hydraflow/testing/0002-issue-unknown-type-system-and-data-model-consistency-testing.md`
- `repo_wiki/T-rav/hydraflow/testing/0003-issue-unknown-multi-location-consistency-and-concurrent-file-i-o.md`
- `repo_wiki/T-rav/hydraflow/testing/0004-issue-unknown-adr-testing-patterns-conservative-pattern-matching.md`
- `repo_wiki/T-rav/hydraflow/testing/0005-issue-7644-never-import-private-helpers-at-module-level-in-te.md`
- `repo_wiki/T-rav/hydraflow/testing/0006-issue-7644-pin-function-signatures-in-one-canonical-location-.md`
- `repo_wiki/T-rav/hydraflow/testing/0007-issue-9442-use-public-fakegithub-api-in-scenario-tests-never-.md`
- `repo_wiki/T-rav/hydraflow/testing/0153-issue-synthesis-mock-at-definition-site-not-at-the-import-site.md`
- `repo_wiki/T-rav/hydraflow/testing/0154-issue-synthesis-reserve-pytest-mark-integration-for-real-external-.md`
- `repo_wiki/T-rav/hydraflow/testing/0155-issue-synthesis-await-asyncio-sleep-0-before-asserting-on-create-t.md`
- `repo_wiki/T-rav/hydraflow/testing/0156-issue-synthesis-test-async-context-managers-in-three-standard-scen.md`
- `repo_wiki/T-rav/hydraflow/testing/0157-issue-synthesis-use-python-script-stand-ins-to-test-subprocess-bou.md`
- `repo_wiki/T-rav/hydraflow/testing/0158-issue-synthesis-reset-module-level-global-state-in-both-setup-and-.md`
- `repo_wiki/T-rav/hydraflow/testing/0159-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md`
- `repo_wiki/T-rav/hydraflow/testing/0160-issue-synthesis-wire-real-business-logic-in-phase-runner-integrati.md`
- `repo_wiki/T-rav/hydraflow/testing/0161-issue-synthesis-test-protocol-compliance-with-structural-typing-an.md`
- `repo_wiki/T-rav/hydraflow/testing/0162-issue-synthesis-test-fa-ade-getattr-routing-attributeerror-and-pro.md`
- `repo_wiki/T-rav/hydraflow/testing/0163-issue-synthesis-assert-relative-event-id-ordering-never-absolute-v.md`
- `repo_wiki/T-rav/hydraflow/testing/0164-issue-synthesis-add-structural-tests-before-property-based-transit.md`
- `repo_wiki/T-rav/hydraflow/testing/0165-issue-synthesis-grep-all-model-usages-before-committing-pydantic-o.md`
- `repo_wiki/T-rav/hydraflow/testing/0166-issue-synthesis-feature-toggles-require-both-a-config-field-and-an.md`
- `repo_wiki/T-rav/hydraflow/testing/0167-issue-synthesis-test-concurrent-jsonl-appends-with-exact-counts-no.md`
- `repo_wiki/T-rav/hydraflow/testing/0168-issue-synthesis-use-identical-string-keys-across-memory-bank-dedup.md`
- `repo_wiki/T-rav/hydraflow/testing/0169-issue-synthesis-skill-definition-changes-must-update-all-4-backend.md`
- `repo_wiki/T-rav/hydraflow/testing/0170-issue-synthesis-auto-generated-adr-tests-must-use-pytest-mark-skip.md`
- `repo_wiki/T-rav/hydraflow/testing/0171-issue-synthesis-every-adr-must-pass-structural-section-validation-.md`
- `repo_wiki/T-rav/hydraflow/testing/0172-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md`
- `repo_wiki/T-rav/hydraflow/testing/0173-issue-synthesis-pin-function-signatures-in-the-source-file-before-.md`
- `repo_wiki/T-rav/hydraflow/testing/0174-issue-synthesis-specify-exact-logger-name-in-caplog-at-level-asser.md`
- `repo_wiki/T-rav/hydraflow/testing/0175-issue-synthesis-js-rendered-accessibility-attributes-require-playw.md`
- `repo_wiki/T-rav/hydraflow/testing/0176-issue-synthesis-use-word-boundary-matching-in-name-coverage-checks.md`
- `repo_wiki/T-rav/hydraflow/testing/0177-issue-synthesis-keep-test-label-stage-constants-synchronized-with-.md`
- `repo_wiki/T-rav/hydraflow/testing/0178-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels-n.md`
- `repo_wiki/T-rav/hydraflow/testing/0179-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md`
- `repo_wiki/T-rav/hydraflow/testing/0180-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md`
- `repo_wiki/T-rav/hydraflow/testing/0181-issue-synthesis-enforce-50-line-handler-and-30-line-wiring-limits-.md`
- `repo_wiki/T-rav/hydraflow/testing/0182-issue-synthesis-type-only-annotation-changes-require-no-new-tests.md`
- `repo_wiki/T-rav/hydraflow/testing/0183-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md`
- `repo_wiki/T-rav/hydraflow/testing/0184-issue-synthesis-pin-function-signatures-in-the-source-file-before-.md`
- `repo_wiki/T-rav/hydraflow/testing/0185-issue-synthesis-use-public-fakegithub-api-in-scenario-tests-never-.md`
- `repo_wiki/T-rav/hydraflow/testing/0186-issue-synthesis-mock-at-definition-site-not-at-the-import-site.md`
- `repo_wiki/T-rav/hydraflow/testing/0187-issue-synthesis-reserve-pytest-mark-integration-for-real-external-.md`
- `repo_wiki/T-rav/hydraflow/testing/0188-issue-synthesis-await-asyncio-sleep-0-before-asserting-on-create-t.md`
- `repo_wiki/T-rav/hydraflow/testing/0189-issue-synthesis-test-async-context-managers-in-three-standard-scen.md`
- `repo_wiki/T-rav/hydraflow/testing/0190-issue-synthesis-use-python-script-stand-ins-to-test-subprocess-bou.md`
- `repo_wiki/T-rav/hydraflow/testing/0191-issue-synthesis-reset-module-level-global-state-in-both-setup-and-.md`
- `repo_wiki/T-rav/hydraflow/testing/0192-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md`
- `repo_wiki/T-rav/hydraflow/testing/0193-issue-synthesis-wire-real-business-logic-in-phase-runner-integrati.md`
- `repo_wiki/T-rav/hydraflow/testing/0194-issue-synthesis-test-protocol-compliance-with-structural-typing-an.md`
- `repo_wiki/T-rav/hydraflow/testing/0195-issue-synthesis-test-fa-ade-getattr-routing-attributeerror-and-pro.md`
- `repo_wiki/T-rav/hydraflow/testing/0196-issue-synthesis-assert-relative-event-id-ordering-never-absolute-v.md`
- `repo_wiki/T-rav/hydraflow/testing/0197-issue-synthesis-add-structural-tests-before-property-based-transit.md`
- `repo_wiki/T-rav/hydraflow/testing/0198-issue-synthesis-grep-all-model-usages-before-committing-pydantic-o.md`
- `repo_wiki/T-rav/hydraflow/testing/0199-issue-synthesis-feature-toggles-require-both-a-config-field-and-an.md`
- `repo_wiki/T-rav/hydraflow/testing/0200-issue-synthesis-test-concurrent-jsonl-appends-with-exact-counts-no.md`
- `repo_wiki/T-rav/hydraflow/testing/0201-issue-synthesis-use-identical-string-keys-across-memory-bank-dedup.md`
- `repo_wiki/T-rav/hydraflow/testing/0202-issue-synthesis-skill-definition-changes-must-update-all-4-backend.md`
- `repo_wiki/T-rav/hydraflow/testing/0203-issue-synthesis-auto-generated-adr-tests-must-use-pytest-mark-skip.md`
- `repo_wiki/T-rav/hydraflow/testing/0204-issue-synthesis-every-adr-must-pass-structural-section-validation-.md`
- `repo_wiki/T-rav/hydraflow/testing/0205-issue-synthesis-specify-exact-logger-name-in-caplog-at-level-asser.md`
- `repo_wiki/T-rav/hydraflow/testing/0206-issue-synthesis-js-rendered-accessibility-attributes-require-playw.md`
- `repo_wiki/T-rav/hydraflow/testing/0207-issue-synthesis-use-word-boundary-matching-in-name-coverage-checks.md`
- `repo_wiki/T-rav/hydraflow/testing/0208-issue-synthesis-keep-test-label-stage-constants-synchronized-with-.md`
- `repo_wiki/T-rav/hydraflow/testing/0209-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels-n.md`
- `repo_wiki/T-rav/hydraflow/testing/0210-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md`
- `repo_wiki/T-rav/hydraflow/testing/0211-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md`
- `repo_wiki/T-rav/hydraflow/testing/0212-issue-synthesis-enforce-50-line-handler-and-30-line-wiring-limits-.md`
- `repo_wiki/T-rav/hydraflow/testing/0213-issue-synthesis-type-only-annotation-changes-require-no-new-tests.md`
- `repo_wiki/T-rav/hydraflow/testing/0214-issue-synthesis-assert-numeric-values-in-sentry-breadcrumbs-not-ju.md`
- `repo_wiki/T-rav/hydraflow/testing/0215-issue-synthesis-test-pydantic-literal-constraints-cover-both-valid.md`
- `repo_wiki/T-rav/hydraflow/testing/0216-issue-synthesis-verify-fatal-exception-propagation-through-multi-p.md`

Auto-merge is enabled when CI is green; if CI fails, the PR stays open and subsequent ticks will append commits instead of opening a new PR.