### PR TITLE
fix(factory): CorpusLearningLoop generate-in-worktree (#9539)

### DIFF
--- a/src/corpus_learning_loop.py
+++ b/src/corpus_learning_loop.py
@@ -35,11 +35,13 @@ Phase 2 Tasks 11–15 are wired in:
   ``cases_validated``.
 
 - **Task 15** (materialize + PR): validated cases are written to
-  ``tests/trust/adversarial/cases/<slug>/`` (via
-  :meth:`CorpusLearningLoop._materialize_case_on_disk`) and filed as
-  PRs (via :meth:`CorpusLearningLoop._open_pr_for_case`, which
-  delegates to :func:`auto_pr.open_automated_pr_async`). A
-  :class:`dedup_store.DedupStore` keyed on
+  ``tests/trust/adversarial/cases/<slug>/`` *inside an ephemeral
+  worktree* (via :meth:`CorpusLearningLoop._materialize_case_on_disk`,
+  passed the worktree path) and filed as PRs (via
+  :meth:`CorpusLearningLoop._open_pr_for_case`, which delegates to
+  :func:`auto_pr.generate_and_open_pr_async`). The loop never mutates
+  ``repo_root`` — the generate callback writes only into the worktree
+  it is handed (#9539). A :class:`dedup_store.DedupStore` keyed on
   ``corpus_learning:<issue_number>:<slug>`` prevents re-filing the
   same case on subsequent ticks. The final status dict gains a
   ``cases_filed`` counter.
@@ -62,7 +64,6 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from auto_pr import open_automated_pr_async
 from base_background_loop import BaseBackgroundLoop, LoopDeps  # noqa: TCH001
 from exception_classify import reraise_on_credit_or_bug
 from models import WorkCycleResult  # noqa: TCH001
@@ -594,9 +595,14 @@ class CorpusLearningLoop(BaseBackgroundLoop):
     # ------------------------------------------------------------------
 
     def _materialize_case_on_disk(
-        self, case: SynthesizedCase, repo_root: Path
+        self, case: SynthesizedCase, root: Path
     ) -> list[Path]:
         """Write a :class:`SynthesizedCase` out under ``tests/trust/adversarial/cases/<slug>/``.
+
+        ``root`` is the directory the case tree is written *relative to*.
+        Under the generate-in-worktree flow (#9539) this is the ephemeral
+        worktree handed to the ``generate`` callback — never ``repo_root`` —
+        so the factory's checkout is left untouched.
 
         Layout mirrors the existing authored cases: every entry in
         ``case.before_files`` lands under ``before/<rel>`` and every
@@ -608,12 +614,10 @@ class CorpusLearningLoop(BaseBackgroundLoop):
         from README.md — is preserved by prepending a ``Keyword:`` line
         so the harness's ``_read_keyword`` helper finds it there.
 
-        Returns the list of absolute paths actually written so the
-        caller can pass them straight to
-        :func:`auto_pr.open_automated_pr_async` without a second
-        `os.walk`.
+        Returns the list of absolute paths actually written (used by
+        callers/tests that assert the on-disk shape).
         """
-        case_dir = repo_root / _CASES_ROOT / case.slug
+        case_dir = root / _CASES_ROOT / case.slug
         written: list[Path] = []
 
         for rel_path, content in case.before_files.items():
@@ -657,16 +661,19 @@ class CorpusLearningLoop(BaseBackgroundLoop):
     async def _open_pr_for_case(
         self,
         case: SynthesizedCase,
-        paths: list[Path],
         *,
         title: str,
         body: str,
     ) -> int | None:
-        """File a PR for ``case`` via :func:`auto_pr.open_automated_pr_async`.
+        """File a PR for ``case`` via :func:`auto_pr.generate_and_open_pr_async`.
+
+        The case tree is materialized *inside the ephemeral worktree*
+        (#9539) by the ``generate`` callback — ``repo_root`` is never
+        mutated. ``path_specs`` stages only the case directory.
 
         Returns the parsed PR number on success, or ``None`` when the
         case has already been filed (dedup hit) or
-        ``open_automated_pr_async`` reported a non-``opened`` status.
+        ``generate_and_open_pr_async`` reported a non-``opened`` status.
         The dedup key is ``corpus_learning:<issue_number>:<slug>`` —
         encoded with both components so that a retitled issue (new
         slug) and a re-filing of the original escape (same slug) are
@@ -676,6 +683,8 @@ class CorpusLearningLoop(BaseBackgroundLoop):
         ``gh``/``git`` failure leaves the set untouched so the next tick
         retries instead of silently dropping the case.
         """
+        from auto_pr import generate_and_open_pr_async  # noqa: PLC0415
+
         dedup_key = f"corpus_learning:{case.issue_number}:{case.slug}"
         if dedup_key in self._dedup.get():
             logger.info(
@@ -686,15 +695,24 @@ class CorpusLearningLoop(BaseBackgroundLoop):
             return None
 
         branch = f"hydraflow/corpus-learning/issue-{case.issue_number}-{case.slug}"
+        case_spec = str(_CASES_ROOT / case.slug)
+
+        async def _generate(worktree: Path) -> None:
+            # Write the case tree INTO the worktree — never repo_root (#9539).
+            # Materialization is synchronous file IO; run it in a thread so the
+            # event loop keeps ticking other loops' heartbeats.
+            await asyncio.to_thread(self._materialize_case_on_disk, case, worktree)
+
         # T2 (audit pass-5): emit a fleet trace for the PR-open
         # subprocess fan-out (auto_pr shells out gh + git multiple times).
         # Spec §4.11 mandates emit_loop_subprocess_trace on every
         # subprocess invocation across all 10 trust loops.
         t0 = time.perf_counter()
-        result = await open_automated_pr_async(
+        result = await generate_and_open_pr_async(
             repo_root=self._config.repo_root,
             branch=branch,
-            files=paths,
+            generate=_generate,
+            path_specs=[case_spec],
             pr_title=title,
             pr_body=body,
             base=self._config.base_branch(),
@@ -729,7 +747,7 @@ class CorpusLearningLoop(BaseBackgroundLoop):
     def _emit_pr_trace(self, t0: float, branch: str, status: str | None) -> None:
         """Spec §4.11: emit a fleet trace per subprocess invocation.
 
-        ``open_automated_pr_async`` shells out to ``git`` and ``gh``
+        ``generate_and_open_pr_async`` shells out to ``git`` and ``gh``
         multiple times under the hood; we record one synthetic trace
         per logical PR-open call so deploy-time observability surfaces
         slow/broken PR opens without cracking open the loop.
@@ -742,7 +760,7 @@ class CorpusLearningLoop(BaseBackgroundLoop):
             return
         emit_loop_subprocess_trace(
             loop=self._worker_name,
-            command=["auto_pr.open_automated_pr_async", branch],
+            command=["auto_pr.generate_and_open_pr_async", branch],
             exit_code=0 if status == "opened" else 1,
             duration_ms=int((time.perf_counter() - t0) * 1000),
             stderr_excerpt=f"status={status}" if status else None,
@@ -896,7 +914,6 @@ class CorpusLearningLoop(BaseBackgroundLoop):
                     result.reason,
                 )
 
-        repo_root = Path(self._config.repo_root)
         # Per-tick cap. Spec §3.2: a misbehaving loop must not flood
         # the issue queue. The dedup is keyed on (issue_number, slug),
         # so a burst of escape issues with churning slugs (e.g. retitled
@@ -904,18 +921,19 @@ class CorpusLearningLoop(BaseBackgroundLoop):
         # `issues_per_hour` detector is post-hoc — by the time it fires,
         # the burst has already happened. This cap bounds blast radius
         # to a known multiple before any anomaly detector runs.
+        #
+        # Materialization (writing the case tree) now happens inside the
+        # ephemeral worktree the PR helper hands to its ``generate``
+        # callback — repo_root is never mutated (#9539).
         max_per_tick = self._config.corpus_learning_max_prs_per_tick
         truncated = False
         for case in validated_cases:
             if cases_filed >= max_per_tick:
                 truncated = True
                 break
-            paths = self._materialize_case_on_disk(case, repo_root)
             title = f"test(trust): corpus-learning case for escape #{case.issue_number}"
             body = _build_pr_body(case)
-            pr_number = await self._open_pr_for_case(
-                case, paths, title=title, body=body
-            )
+            pr_number = await self._open_pr_for_case(case, title=title, body=body)
             if pr_number is not None:
                 cases_filed += 1
         if truncated:

--- a/tests/regressions/test_corpus_learning_status_telemetry.py
+++ b/tests/regressions/test_corpus_learning_status_telemetry.py
@@ -121,7 +121,6 @@ def test_do_work_returns_ok_status_when_cases_are_filed(
         readme="Repro.",
     )
     loop._validate_case = lambda c: ValidationResult(ok=True)  # type: ignore[method-assign]
-    loop._materialize_case_on_disk = lambda c, r: []  # type: ignore[method-assign]
 
     async def fake_open(**kwargs: object) -> object:  # noqa: ARG001
         return _AutoPrResultStub(
@@ -129,9 +128,9 @@ def test_do_work_returns_ok_status_when_cases_are_filed(
             pr_url="https://github.com/hydra/hydraflow/pull/999",
         )
 
-    import corpus_learning_loop as mod
+    import auto_pr
 
-    monkeypatch.setattr(mod, "open_automated_pr_async", fake_open)  # type: ignore[attr-defined]
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", fake_open)
 
     result = asyncio.run(loop._do_work())
 

--- a/tests/scenarios/catalog/loop_registrations.py
+++ b/tests/scenarios/catalog/loop_registrations.py
@@ -946,14 +946,16 @@ def _build_corpus_learning(ports: dict[str, Any], config: Any, deps: Any) -> Any
         deps=deps,
     )
 
-    # Optional: replace the auto_pr seam on the loop's module with a
-    # seeded async callable so tests can assert the opened PR without
-    # shelling out to ``git``/``gh``.
+    # Optional: replace the auto_pr seam with a seeded async callable so
+    # tests can assert the opened PR without shelling out to ``git``/``gh``.
+    # The loop now generates the case tree inside the worktree (#9539) and
+    # lazily imports :func:`auto_pr.generate_and_open_pr_async`, so the seam
+    # to patch is on the ``auto_pr`` module itself (mirrors DiagramLoop).
     auto_pr_stub = ports.get("corpus_learning_auto_pr")
     if auto_pr_stub is not None:
-        import corpus_learning_loop as _mod  # noqa: PLC0415
+        import auto_pr as _auto_pr  # noqa: PLC0415
 
-        _mod.open_automated_pr_async = auto_pr_stub  # type: ignore[assignment]
+        _auto_pr.generate_and_open_pr_async = auto_pr_stub  # type: ignore[assignment]
 
     return loop
 

--- a/tests/scenarios/test_corpus_learning_scenario.py
+++ b/tests/scenarios/test_corpus_learning_scenario.py
@@ -7,24 +7,26 @@ Two scenarios cover the loop's ends-of-the-world:
   nothing. ``cases_filed == 0``.
 * ``test_escape_signal_produces_case`` — one parseable escape issue is
   seeded via FakeGitHub. The loop reads it, synthesizes a
-  :class:`SynthesizedCase`, runs the three-gate validator, materializes
-  the case on disk, and files one PR via the stubbed ``auto_pr`` seam.
-  ``cases_filed >= 1``.
+  :class:`SynthesizedCase`, runs the three-gate validator, and files one
+  PR via the stubbed ``auto_pr`` seam. Materialization now happens inside
+  the ephemeral worktree the PR helper hands to its ``generate`` callback
+  (#9539); with the helper stubbed, the captured ``generate`` is driven
+  against a scratch worktree to prove the case tree lands there — never
+  under ``repo_root``. ``cases_filed >= 1``.
 
 The loop's external surfaces are handled as follows:
 
 * :meth:`PRManager.list_issues_by_label` is served by ``FakeGitHub``
   directly (no monkey-patching needed — the fake already returns the
   correct row shape).
-* :func:`auto_pr.open_automated_pr_async` is stubbed via the
+* :func:`auto_pr.generate_and_open_pr_async` is stubbed via the
   ``corpus_learning_auto_pr`` port seeded through
   :func:`tests.scenarios.helpers.loop_port_seeding.seed_ports` so no
   ``git`` or ``gh`` subprocess actually runs.
 
-Materialization writes under ``config.repo_root / tests / trust /
-adversarial / cases / <slug>`` — by default that is the temporary
-``tmp_path`` MockWorld hands out, so the sandbox never leaks onto the
-real repo.
+The loop never writes under ``config.repo_root`` for the PR — the
+generate callback writes only into the worktree it is given (#9539), so
+the factory checkout stays clean.
 """
 
 from __future__ import annotations
@@ -154,7 +156,7 @@ class TestCorpusLearningScenario:
         assert stats["corpus_learning"]["cases_filed"] >= 1, stats
 
         # The stubbed PR opener saw exactly one call with the expected
-        # title + label shape.
+        # title + label shape, a callable generate, and the case path_spec.
         assert len(open_calls) == 1
         kwargs = open_calls[0]
         assert kwargs["pr_title"] == (
@@ -163,13 +165,20 @@ class TestCorpusLearningScenario:
         labels = kwargs["labels"]
         assert "hydraflow-agent" in labels
         assert "corpus-learning" in labels
-
-        # The case directory actually landed on disk under the tmp sandbox.
-        # ``make_bg_loop_deps`` roots the loop's ``config.repo_root`` at
-        # ``tmp_path / "repo"``, so the materializer writes under there —
-        # not under tmp_path itself.
         slug = "diff-sanity-missed-renamed-symbol"
-        case_dir = (
-            tmp_path / "repo" / "tests" / "trust" / "adversarial" / "cases" / slug
-        )
+        assert "files" not in kwargs, "loop must generate in-worktree, not pre-write"
+        assert callable(kwargs["generate"])
+        assert kwargs["path_specs"] == [f"tests/trust/adversarial/cases/{slug}"]
+
+        # Drive the captured generate callback against a scratch worktree —
+        # the case tree materializes THERE, never under repo_root (#9539).
+        # ``make_bg_loop_deps`` roots the loop's ``config.repo_root`` at
+        # ``tmp_path / "repo"``; with the helper stubbed the generate
+        # callback never ran, so that checkout must stay clean.
+        worktree = tmp_path / "scratch-worktree"
+        worktree.mkdir()
+        await kwargs["generate"](worktree)
+        case_dir = worktree / "tests" / "trust" / "adversarial" / "cases" / slug
         assert (case_dir / "README.md").exists()
+        repo_root = tmp_path / "repo"
+        assert not (repo_root / "tests").exists()

--- a/tests/test_corpus_learning_integration.py
+++ b/tests/test_corpus_learning_integration.py
@@ -11,18 +11,21 @@ Scope (per the plan's Task 16):
 
 - **Happy path**: a seeded escape issue flows through the full
   ``_do_work`` pipeline (reader → synth → three-gate validation →
-  materialize → PR open → dedup) and surfaces the expected counters
-  plus the expected :func:`auto_pr.open_automated_pr_async` call shape.
+  generate-in-worktree → PR open → dedup) and surfaces the expected
+  counters plus the expected :func:`auto_pr.generate_and_open_pr_async`
+  call shape (callable ``generate`` + case ``path_specs``). Driving the
+  captured ``generate`` callback against a scratch worktree proves the
+  case tree materializes there — never under ``repo_root`` (#9539).
 - **Unparseable signal**: a body that misses the envelope convention is
   dropped at synthesis without crashing the tick or filing a PR.
 - **Validation failure**: synthesis succeeds but gate (b) rejects the
   case (no catcher trip) — no PR is filed and the counter stays at 0.
 - **Dedup hit on re-run**: ticking a second time against the same
   escape signal short-circuits at the dedup set, so no second
-  :func:`auto_pr.open_automated_pr_async` call is made.
+  :func:`auto_pr.generate_and_open_pr_async` call is made.
 
 All seams (``PRManager.list_issues_by_label``,
-``auto_pr.open_automated_pr_async``, and — for the gate-(b) failure
+``auto_pr.generate_and_open_pr_async``, and — for the gate-(b) failure
 scenario — ``CorpusLearningLoop._fixture_transcript_for``) are mocked
 at module boundaries; everything in between runs the real code path.
 The suite stays well under 2 s on a modern laptop because there is
@@ -139,15 +142,18 @@ def _loop(
     *,
     enabled: bool = True,
 ) -> CorpusLearningLoop:
-    """Build a :class:`CorpusLearningLoop` rooted at ``tmp_path``.
+    """Build a :class:`CorpusLearningLoop` rooted at ``tmp_path / "repo"``.
 
-    ``repo_root`` is set to ``tmp_path`` so Task 15's materialization
-    writes under the sandbox and never escapes to the real repo.
+    ``repo_root`` is set to a dedicated ``repo`` subdir so the
+    generate-in-worktree assertions can prove the factory checkout
+    (``repo_root``) is never mutated (#9539).
     """
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(exist_ok=True)
     cfg = HydraFlowConfig(
         data_root=tmp_path,
         repo="hydra/hydraflow",
-        repo_root=tmp_path,
+        repo_root=repo_root,
     )
     deps = LoopDeps(
         event_bus=EventBus(),
@@ -172,10 +178,13 @@ def test_end_to_end_happy_path_files_one_pr(
     """Parseable + validatable escape → one PR, dedup recorded, counters aligned.
 
     Asserts the full contract of a green tick: the issue is seen, the
-    envelope is synthesized, the three-gate validator passes, the case
-    is materialized to disk, and ``auto_pr.open_automated_pr_async`` is
-    invoked with the expected title/body/labels shape. The dedup store
-    is updated so a later tick won't re-file.
+    envelope is synthesized, the three-gate validator passes, and
+    ``auto_pr.generate_and_open_pr_async`` is invoked with the expected
+    title/body/labels shape plus a callable ``generate`` + case
+    ``path_specs``. Driving the captured ``generate`` callback against a
+    scratch worktree proves the case tree lands there — never under
+    ``repo_root`` (#9539). The dedup store is updated so a later tick
+    won't re-file.
     """
     _prs.list_issues_by_label = AsyncMock(
         return_value=[
@@ -197,9 +206,9 @@ def test_end_to_end_happy_path_files_one_pr(
             pr_url="https://github.com/hydra/hydraflow/pull/999",
         )
 
-    import corpus_learning_loop as mod
+    import auto_pr
 
-    monkeypatch.setattr(mod, "open_automated_pr_async", fake_open)
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", fake_open)
 
     loop = _loop(tmp_path, _prs, _dedup)
     result = asyncio.run(loop._do_work())
@@ -231,20 +240,27 @@ def test_end_to_end_happy_path_files_one_pr(
     assert isinstance(labels, list)
     assert "hydraflow-agent" in labels
     assert "corpus-learning" in labels
-    # Branch + files carry the slug derived from the issue title.
+    # Branch carries the slug derived from the issue title.
     slug = "diff-sanity-missed-renamed-symbol"
     assert slug in str(kwargs["branch"])
     assert "4242" in str(kwargs["branch"])
-    files = kwargs["files"]
-    assert isinstance(files, list)
-    assert files, "expected materialized files to be passed to auto_pr"
+    # No pre-written files: the loop generates in-worktree (#9539).
+    assert "files" not in kwargs
+    assert callable(kwargs["generate"])
+    assert kwargs["path_specs"] == [f"tests/trust/adversarial/cases/{slug}"]
 
-    # Case directory actually landed on disk.
-    case_dir = tmp_path / "tests" / "trust" / "adversarial" / "cases" / slug
+    # Drive the captured generate callback against a scratch worktree —
+    # the case tree must materialize THERE, not under repo_root.
+    worktree = tmp_path / "scratch-worktree"
+    worktree.mkdir()
+    asyncio.run(kwargs["generate"](worktree))
+    case_dir = worktree / "tests" / "trust" / "adversarial" / "cases" / slug
     assert (case_dir / "README.md").exists()
     assert (case_dir / "expected_catcher.txt").read_text().strip() == "diff-sanity"
     assert (case_dir / "before" / "src" / "foo.py").exists()
     assert (case_dir / "after" / "src" / "foo.py").exists()
+    # repo_root stays clean — the factory checkout is never mutated.
+    assert not (loop._config.repo_root / "tests").exists()
 
     # Dedup entry was persisted, keyed on issue number + slug.
     assert f"corpus_learning:4242:{slug}" in _dedup.get()
@@ -284,9 +300,9 @@ def test_end_to_end_unparseable_signal_is_skipped(
         open_calls.append(kwargs)
         return _AutoPrResultStub(status="opened", pr_url="x/y/pull/1")
 
-    import corpus_learning_loop as mod
+    import auto_pr
 
-    monkeypatch.setattr(mod, "open_automated_pr_async", fake_open)
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", fake_open)
 
     loop = _loop(tmp_path, _prs, _dedup)
     result = asyncio.run(loop._do_work())
@@ -333,9 +349,9 @@ def test_end_to_end_validation_failure_skips_pr(
         open_calls.append(kwargs)
         return _AutoPrResultStub(status="opened", pr_url="x/y/pull/1")
 
-    import corpus_learning_loop as mod
+    import auto_pr
 
-    monkeypatch.setattr(mod, "open_automated_pr_async", fake_open)
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", fake_open)
 
     loop = _loop(tmp_path, _prs, _dedup)
 
@@ -399,9 +415,9 @@ def test_end_to_end_dedup_prevents_refile_on_second_tick(
             pr_url="https://github.com/hydra/hydraflow/pull/999",
         )
 
-    import corpus_learning_loop as mod
+    import auto_pr
 
-    monkeypatch.setattr(mod, "open_automated_pr_async", fake_open)
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", fake_open)
 
     loop = _loop(tmp_path, _prs, _dedup)
 

--- a/tests/test_corpus_learning_loop.py
+++ b/tests/test_corpus_learning_loop.py
@@ -46,14 +46,16 @@ from events import EventBus
 
 
 @pytest.fixture(autouse=True)
-def _stub_open_automated_pr_async(
+def _stub_generate_and_open_pr_async(
     monkeypatch: pytest.MonkeyPatch,
 ) -> list[dict[str, object]]:
     """Neutralize PR-open side effects in Task 14/15 ``_do_work`` tests.
 
     Without this, older tests that feed a validatable signal would reach
-    :func:`auto_pr.open_automated_pr_async` and try to ``git worktree
-    add`` against the real repo. Tests that want to observe PR-open
+    :func:`auto_pr.generate_and_open_pr_async` and try to ``git worktree
+    add`` against the real repo. The loop now generates the case tree
+    inside that worktree (#9539), so the seam to stub is the
+    generate-in-worktree helper. Tests that want to observe PR-open
     arguments monkeypatch the hook explicitly (overriding this stub);
     the rest get a silent no-op that returns ``status="no-diff"``.
     """
@@ -63,9 +65,9 @@ def _stub_open_automated_pr_async(
         calls.append(kwargs)
         return _AutoPrResultStub(status="no-diff", pr_url=None)
 
-    import corpus_learning_loop as mod
+    import auto_pr
 
-    monkeypatch.setattr(mod, "open_automated_pr_async", fake)  # type: ignore[attr-defined]
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", fake)
     return calls
 
 
@@ -819,15 +821,17 @@ def test_materialize_case_on_disk_handles_multiple_files(tmp_path: Path) -> None
     assert len(paths) == 6
 
 
-def test_open_pr_for_case_calls_open_automated_pr_async(
+def test_open_pr_for_case_calls_generate_and_open_pr_async(
     monkeypatch: object, tmp_path: Path
 ) -> None:
-    # `_open_pr_for_case` must delegate to auto_pr.open_automated_pr_async
-    # with a branch derived from the slug, the supplied files, and the
-    # supplied title/body. Returns the parsed PR number from the URL.
+    # `_open_pr_for_case` must delegate to auto_pr.generate_and_open_pr_async
+    # with a branch derived from the slug, a callable ``generate`` that
+    # writes the case tree into the worktree, the case-dir ``path_specs``,
+    # and the supplied title/body. Returns the parsed PR number from the URL.
+    # The loop never passes pre-written ``files`` — it generates in-worktree
+    # so repo_root stays clean (#9539).
     loop = _loop(tmp_path, dedup=_InMemoryDedup())
     case = _valid_case(issue_number=42, slug="my-slug")
-    paths = [tmp_path / "x"]
 
     captured: dict[str, object] = {}
 
@@ -838,16 +842,19 @@ def test_open_pr_for_case_calls_open_automated_pr_async(
             pr_url="https://github.com/hydra/hydraflow/pull/777",
         )
 
-    import corpus_learning_loop as mod
+    import auto_pr
 
-    monkeypatch.setattr(mod, "open_automated_pr_async", fake_open)  # type: ignore[attr-defined]
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", fake_open)
 
-    pr_number = asyncio.run(loop._open_pr_for_case(case, paths, title="tt", body="bb"))
+    pr_number = asyncio.run(loop._open_pr_for_case(case, title="tt", body="bb"))
 
     assert pr_number == 777
     assert captured["pr_title"] == "tt"
     assert captured["pr_body"] == "bb"
-    assert captured["files"] == paths
+    # No pre-written files: the loop generates inside the worktree.
+    assert "files" not in captured
+    assert callable(captured["generate"])
+    assert captured["path_specs"] == ["tests/trust/adversarial/cases/my-slug"]
     assert captured["base"] == loop._config.base_branch()
     # Branch is derived from the case slug + issue number for traceability.
     assert "my-slug" in str(captured["branch"])
@@ -855,6 +862,45 @@ def test_open_pr_for_case_calls_open_automated_pr_async(
     labels = captured["labels"]
     assert isinstance(labels, list)
     assert "corpus-learning" in labels
+
+
+def test_open_pr_for_case_generate_writes_into_worktree_not_repo_root(
+    monkeypatch: object, tmp_path: Path
+) -> None:
+    # The ``generate`` callback handed to the PR helper must materialize the
+    # case tree under the WORKTREE it is given — never under repo_root.
+    # repo_root must stay clean (#9539): the loop's whole point is to stop
+    # mutating the factory checkout.
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    loop = _loop(tmp_path, dedup=_InMemoryDedup(), repo_root=repo_root)
+    case = _valid_case(issue_number=42, slug="my-slug")
+
+    captured: dict[str, object] = {}
+
+    async def fake_open(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return _AutoPrResultStub(status="opened", pr_url="x/y/pull/1")
+
+    import auto_pr
+
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", fake_open)
+
+    asyncio.run(loop._open_pr_for_case(case, title="t", body="b"))
+
+    # Invoke the captured generate callback against the worktree and assert
+    # the case landed there.
+    generate = captured["generate"]
+    assert callable(generate)
+    asyncio.run(generate(worktree))  # type: ignore[operator]
+
+    case_dir = worktree / "tests" / "trust" / "adversarial" / "cases" / "my-slug"
+    assert (case_dir / "README.md").exists()
+    assert (case_dir / "expected_catcher.txt").exists()
+    # repo_root is untouched — no case tree leaked into the factory checkout.
+    assert not (repo_root / "tests").exists()
 
 
 def test_open_pr_for_case_dedup_suppresses_refile(
@@ -877,13 +923,11 @@ def test_open_pr_for_case_dedup_suppresses_refile(
             pr_url="https://github.com/x/y/pull/1",
         )
 
-    import corpus_learning_loop as mod
+    import auto_pr
 
-    monkeypatch.setattr(mod, "open_automated_pr_async", fake_open)  # type: ignore[attr-defined]
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", fake_open)
 
-    result = asyncio.run(
-        loop._open_pr_for_case(case, [tmp_path / "f"], title="t", body="b")
-    )
+    result = asyncio.run(loop._open_pr_for_case(case, title="t", body="b"))
 
     assert result is None
     assert calls == []
@@ -902,11 +946,11 @@ def test_open_pr_for_case_records_dedup_after_success(
             pr_url="https://github.com/x/y/pull/99",
         )
 
-    import corpus_learning_loop as mod
+    import auto_pr
 
-    monkeypatch.setattr(mod, "open_automated_pr_async", fake_open)  # type: ignore[attr-defined]
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", fake_open)
 
-    asyncio.run(loop._open_pr_for_case(case, [tmp_path / "f"], title="t", body="b"))
+    asyncio.run(loop._open_pr_for_case(case, title="t", body="b"))
 
     assert "corpus_learning:13:slug-x" in dedup.get()
 
@@ -924,13 +968,11 @@ def test_open_pr_for_case_returns_none_when_pr_open_fails(
     async def fake_open(**kwargs: object) -> object:
         return _AutoPrResultStub(status="failed", pr_url=None, error="boom")
 
-    import corpus_learning_loop as mod
+    import auto_pr
 
-    monkeypatch.setattr(mod, "open_automated_pr_async", fake_open)  # type: ignore[attr-defined]
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", fake_open)
 
-    result = asyncio.run(
-        loop._open_pr_for_case(case, [tmp_path / "f"], title="t", body="b")
-    )
+    result = asyncio.run(loop._open_pr_for_case(case, title="t", body="b"))
 
     assert result is None
     # Failed filings must not pollute dedup — next tick should try again.
@@ -941,8 +983,9 @@ def test_do_work_files_validated_cases_and_reports_count(
     monkeypatch: object, tmp_path: Path
 ) -> None:
     # End-to-end wiring: a parseable + validatable signal must walk all
-    # three Task 15 steps (materialize, PR-open, dedup) and surface
-    # `cases_filed=1` in the status dict alongside the earlier counters.
+    # three Task 15 steps (generate-in-worktree, PR-open, dedup) and
+    # surface `cases_filed=1` in the status dict alongside the earlier
+    # counters.
     dedup = _InMemoryDedup()
     prs = AsyncMock()
     prs.list_issues_by_label = AsyncMock(
@@ -965,28 +1008,30 @@ def test_do_work_files_validated_cases_and_reports_count(
             pr_url="https://github.com/x/y/pull/321",
         )
 
-    import corpus_learning_loop as mod
+    import auto_pr
 
-    monkeypatch.setattr(mod, "open_automated_pr_async", fake_open)  # type: ignore[attr-defined]
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", fake_open)
 
-    loop = _loop(tmp_path, prs=prs, dedup=dedup, repo_root=tmp_path)
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    loop = _loop(tmp_path, prs=prs, dedup=dedup, repo_root=repo_root)
     result = asyncio.run(loop._do_work())
 
     assert result.get("escape_issues_seen") == 1
     assert result.get("cases_synthesized") == 1
     assert result.get("cases_validated") == 1
     assert result.get("cases_filed") == 1
-    # Materialized files landed under repo_root / tests/trust/adversarial/…
-    case_dir = (
-        tmp_path
-        / "tests"
-        / "trust"
-        / "adversarial"
-        / "cases"
-        / "diff-sanity-missed-renamed-symbol"
-    )
-    assert case_dir.exists()
-    assert open_calls, "expected one open_automated_pr_async call"
+    assert open_calls, "expected one generate_and_open_pr_async call"
+    # The PR-open seam was handed a callable generate + the case path_spec —
+    # not pre-written files. repo_root is never mutated (#9539): with the
+    # helper stubbed, the generate callback is not invoked, so no case tree
+    # leaks into the factory checkout.
+    kwargs = open_calls[0]
+    assert callable(kwargs["generate"])
+    assert kwargs["path_specs"] == [
+        "tests/trust/adversarial/cases/diff-sanity-missed-renamed-symbol"
+    ]
+    assert not (repo_root / "tests").exists()
 
 
 def test_do_work_skips_cases_already_in_dedup(
@@ -1014,9 +1059,9 @@ def test_do_work_skips_cases_already_in_dedup(
         open_calls.append(kwargs)
         return _AutoPrResultStub(status="opened", pr_url="x/y/pull/1")
 
-    import corpus_learning_loop as mod
+    import auto_pr
 
-    monkeypatch.setattr(mod, "open_automated_pr_async", fake_open)  # type: ignore[attr-defined]
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", fake_open)
 
     loop = _loop(tmp_path, prs=prs, dedup=dedup)
     result = asyncio.run(loop._do_work())
@@ -1091,7 +1136,6 @@ def test_do_work_caps_prs_per_tick(tmp_path: Path) -> None:
         readme="r",
     )
     loop._validate_case = lambda c: ValidationResult(ok=True)  # type: ignore[method-assign]
-    loop._materialize_case_on_disk = lambda c, r: []  # type: ignore[method-assign]
     loop._open_pr_for_case = AsyncMock(return_value=42)  # type: ignore[method-assign]
 
     result = asyncio.run(loop._do_work())

--- a/tests/test_pr_base_branch_convention.py
+++ b/tests/test_pr_base_branch_convention.py
@@ -22,7 +22,13 @@ from pathlib import Path
 SRC_DIR = Path(__file__).resolve().parent.parent / "src"
 
 # The auto_pr helpers that branch off / target ``origin/{base}``.
-_PR_HELPERS = {"open_automated_pr_async", "open_automated_pr"}
+# ``generate_and_open_pr_async`` is the generate-in-worktree variant (#9539)
+# used by DiagramLoop + CorpusLearningLoop — same base-branch contract.
+_PR_HELPERS = {
+    "open_automated_pr_async",
+    "open_automated_pr",
+    "generate_and_open_pr_async",
+}
 
 
 def _called_name(func: ast.expr) -> str | None:


### PR DESCRIPTION
Migrates this loop to `auto_pr.generate_and_open_pr_async` (proposal #9539) — generation happens inside the ephemeral worktree, so `repo_root` is never mutated. Follows the merged DiagramLoop pattern (#9614). Tests updated for the worktree flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)