### PR TITLE
fix(factory): ContractRefreshLoop generate-in-worktree (#9539)

### DIFF
--- a/src/contract_refresh_loop.py
+++ b/src/contract_refresh_loop.py
@@ -10,12 +10,15 @@ Tick body (Tasks 15 + 16 + 20 wired; Tasks 17/18/19 still pending):
 3. If drift is detected, hash the drift report and look the hash up in a
    per-loop :class:`DedupStore`. Hash hit → short-circuit so identical
    drift on back-to-back ticks does not refile the same PR.
-4. Stage the drifted/new cassettes into the worktree (their committed
-   paths under ``tests/trust/contracts/``) and open a refresh PR via
-   :func:`auto_pr.open_automated_pr_async` — title ``contract-refresh:
-   YYYY-MM-DD (<adapters>)``, body summarising per-adapter slugs, labels
-   ``contract-refresh`` + ``auto-merge``, ``auto_merge=True``,
-   ``raise_on_failure=False``.
+4. Open a refresh PR via :func:`auto_pr.generate_and_open_pr_async`
+   (#9539 generate-in-worktree): the loop hands a ``generate(worktree)``
+   callback that copies the drifted/new cassettes into the ephemeral
+   worktree's committed paths under ``tests/trust/contracts/`` — the
+   factory's ``repo_root`` is never mutated. ``path_specs`` cover the
+   cassette dirs so only those generated paths are staged. Title
+   ``contract-refresh: YYYY-MM-DD (<adapters>)``, body summarising
+   per-adapter slugs, labels ``contract-refresh`` + ``auto-merge``,
+   ``auto_merge=True``, ``raise_on_failure=False``.
 5. Post-refresh replay gate (Task 16): invoke ``make trust-contracts``
    via :func:`subprocess.run`. Pass → clean exit. Fail → the fresh
    cassettes have outrun the fakes; file a ``hydraflow-find`` +
@@ -57,7 +60,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import trace_collector
-from auto_pr import open_automated_pr_async
 from base_background_loop import BaseBackgroundLoop, LoopDeps  # noqa: TCH001
 from contract_diff import (
     AdapterDriftReport,
@@ -329,25 +331,57 @@ class ContractRefreshLoop(BaseBackgroundLoop):
         blob = json.dumps(payload, sort_keys=True).encode("utf-8")
         return hashlib.sha256(blob).hexdigest()
 
-    def _stage_drifted_cassettes(self, reports: list[AdapterDriftReport]) -> list[Path]:
-        """Copy each drifted/new cassette into its committed path under ``repo_root``.
+    def _stage_drifted_cassettes(
+        self, reports: list[AdapterDriftReport], dest_root: Path
+    ) -> list[Path]:
+        """Copy each drifted/new cassette into its committed path under ``dest_root``.
 
-        ``auto_pr.open_automated_pr_async`` reads the file bytes from the
-        paths we return and stages them into the ephemeral worktree, so
-        we *must* write to paths under ``repo_root``. Returns the list
-        of committed paths that now hold the fresh bytes.
+        ``dest_root`` is the ephemeral worktree handed to the
+        :func:`auto_pr.generate_and_open_pr_async` ``generate`` callback
+        (#9539 generate-in-worktree), *not* the factory's ``repo_root``:
+        the source bytes live in the recorder's tmp dir (outside both),
+        so copying them into the worktree's committed cassette paths
+        produces the PR diff without ever dirtying the host checkout.
+        Returns the list of worktree paths that now hold the fresh bytes.
         """
         written: list[Path] = []
         plans_by_name = {p.name: p for p in ADAPTER_PLANS}
         for report in reports:
             plan = plans_by_name[report.adapter]
-            committed_dir = self._config.repo_root / plan.cassette_dir_relpath
+            committed_dir = dest_root / plan.cassette_dir_relpath
             committed_dir.mkdir(parents=True, exist_ok=True)
             for src in [*report.drifted_cassettes, *report.new_cassettes]:
                 dst = committed_dir / src.name
                 dst.write_bytes(src.read_bytes())
                 written.append(dst)
         return written
+
+    def _cassette_path_specs(self, reports: list[AdapterDriftReport]) -> list[str]:
+        """Repo-relative cassette dirs to ``git add`` after generation.
+
+        One entry per drifted adapter (deduped, order-stable). Mirrors the
+        ``path_specs`` contract of :func:`auto_pr.generate_and_open_pr_async`:
+        only these generated paths are staged, so the host checkout's own
+        untracked files can never leak into the refresh PR.
+        """
+        plans_by_name = {p.name: p for p in ADAPTER_PLANS}
+        specs: list[str] = []
+        for report in reports:
+            relpath = plans_by_name[report.adapter].cassette_dir_relpath
+            if relpath not in specs:
+                specs.append(relpath)
+        return specs
+
+    def _count_staged_cassettes(self, reports: list[AdapterDriftReport]) -> int:
+        """Number of drifted/new cassettes the ``generate`` callback will write.
+
+        Computed from the drift report up front because, under
+        generate-in-worktree, the copy happens inside the PR helper's
+        ephemeral worktree (torn down in ``finally``) — the caller can't
+        count the written paths after the fact, so it derives the
+        ``adapters_refreshed`` stat from the report directly.
+        """
+        return sum(len(r.drifted_cassettes) + len(r.new_cassettes) for r in reports)
 
     def _pr_title_and_body(
         self, fleet: FleetDriftReport, stamp: str
@@ -387,17 +421,35 @@ class ContractRefreshLoop(BaseBackgroundLoop):
         )
         return title, "\n".join(body_lines)
 
-    async def _open_refresh_pr(
-        self, written: list[Path], fleet: FleetDriftReport
-    ) -> str | None:
+    async def _open_refresh_pr(self, fleet: FleetDriftReport) -> str | None:
+        """Open the refresh PR via generate-in-worktree (#9539).
+
+        The ``generate`` callback copies the freshly-recorded cassettes
+        (whose bytes live in the recorder's tmp dir) into the ephemeral
+        worktree's committed cassette paths via
+        :meth:`_stage_drifted_cassettes`. ``repo_root`` is never mutated —
+        the worktree is the only thing written, and it is torn down in the
+        helper's ``finally``. ``path_specs`` cover exactly the drifted
+        adapters' cassette dirs so only the generated bytes are staged.
+        """
+        from auto_pr import generate_and_open_pr_async  # noqa: PLC0415
+
         stamp = datetime.now(UTC).strftime("%Y-%m-%d")
         branch = f"contract-refresh/{stamp}"
         title, body = self._pr_title_and_body(fleet, stamp)
+        reports = fleet.reports
 
-        result = await open_automated_pr_async(
+        async def _generate(worktree: Path) -> None:
+            # Copy the recorder's tmp bytes into the worktree's committed
+            # cassette paths. Sync filesystem work — wrap in a thread so the
+            # event loop keeps ticking while many cassettes are written.
+            await asyncio.to_thread(self._stage_drifted_cassettes, reports, worktree)
+
+        result = await generate_and_open_pr_async(
             repo_root=self._config.repo_root,
             branch=branch,
-            files=written,
+            generate=_generate,
+            path_specs=self._cassette_path_specs(reports),
             pr_title=title,
             pr_body=body,
             commit_message=title,
@@ -688,20 +740,23 @@ class ContractRefreshLoop(BaseBackgroundLoop):
 
     async def _stage_and_open_pr(
         self, fleet: FleetDriftReport, dedup_key: str
-    ) -> tuple[list[Path], str | None]:
-        """Stage drifted cassettes, open the refresh PR, and record the dedup key.
+    ) -> tuple[int, str | None]:
+        """Open the refresh PR (generate-in-worktree) and record the dedup key.
 
-        Returns ``(written_paths, pr_url)``.  The dedup key is recorded only
+        Returns ``(staged_count, pr_url)`` — ``staged_count`` is the number
+        of cassettes the worktree ``generate`` callback writes, derived from
+        the drift report up front because the copy now happens inside the
+        helper's ephemeral worktree (#9539). The dedup key is recorded only
         after a successful PR open so a transient failure (branch conflict,
         ``gh`` auth, push rejection) does not silently block the next tick
-        behind a dedup entry while the primary checkout stays dirty with
-        uncommitted cassette writes.
+        behind a dedup entry. ``repo_root`` is never mutated, so there is no
+        dirty-checkout hazard to clean up on failure.
         """
-        written = self._stage_drifted_cassettes(fleet.reports)
-        pr_url = await self._open_refresh_pr(written, fleet)
+        staged_count = self._count_staged_cassettes(fleet.reports)
+        pr_url = await self._open_refresh_pr(fleet)
         if pr_url is not None:
             self._dedup.add(dedup_key)
-        return written, pr_url
+        return staged_count, pr_url
 
     async def _check_replay_and_maybe_file_issue(
         self, fleet: FleetDriftReport, pr_url: str | None
@@ -783,7 +838,7 @@ class ContractRefreshLoop(BaseBackgroundLoop):
         if dedup_key in self._dedup.get():
             return self._on_dedup_hit(fleet, escalated)
 
-        written, pr_url = await self._stage_and_open_pr(fleet, dedup_key)
+        staged_count, pr_url = await self._stage_and_open_pr(fleet, dedup_key)
 
         # Task 16 — replay gate runs after the PR is opened. A failed gate
         # files a fake-drift companion issue; a passing gate does not.
@@ -793,7 +848,7 @@ class ContractRefreshLoop(BaseBackgroundLoop):
 
         return {
             "status": "refreshed",
-            "adapters_refreshed": len(written),
+            "adapters_refreshed": staged_count,
             "adapters_drifted": len(fleet.reports),
             "pr_url": pr_url,
             "replay_gate_passed": replay_proc.returncode == 0,

--- a/tests/regressions/test_contract_refresh_pr_targets_staging.py
+++ b/tests/regressions/test_contract_refresh_pr_targets_staging.py
@@ -2,7 +2,7 @@
 
 Per CLAUDE.md (ADR-0042 two-tier branch model): "PRs target staging, not main.
 Only RC promotion PRs use --base main." ``ContractRefreshLoop._open_refresh_pr``
-defaulted to ``main`` (the ``open_automated_pr_async`` parameter default),
+defaulted to ``main`` (the ``generate_and_open_pr_async`` parameter default),
 which meant every contract-refresh PR was opened against a protected branch
 that requires an RC promotion to merge into. The "auto-merge" label and
 ``auto_merge=True`` flag both became no-ops because the merge gate at GitHub
@@ -24,6 +24,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+import auto_pr
 import contract_refresh_loop as crl_module
 from auto_pr import AutoPrResult
 from base_background_loop import LoopDeps
@@ -33,7 +34,7 @@ from events import EventBus
 
 
 class _CaptureAutoPR:
-    """Captures ``open_automated_pr_async`` kwargs for assertion."""
+    """Captures ``generate_and_open_pr_async`` kwargs for assertion."""
 
     def __init__(self) -> None:
         self.calls: list[dict[str, Any]] = []
@@ -76,7 +77,7 @@ async def test_refresh_pr_targets_staging_when_enabled(
     not main — otherwise auto-merge can never fire against the protected
     main branch and the closed-loop chain is broken."""
     capture = _CaptureAutoPR()
-    monkeypatch.setattr(crl_module, "open_automated_pr_async", capture)
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", capture)
 
     loop = _loop(tmp_path, staging_enabled=True)
     drifted = tmp_path / "drift.yaml"
@@ -93,7 +94,7 @@ async def test_refresh_pr_targets_staging_when_enabled(
         has_drift=True,
     )
 
-    pr_url = await loop._open_refresh_pr([drifted], fleet)
+    pr_url = await loop._open_refresh_pr(fleet)
 
     assert pr_url == "https://github.com/x/y/pull/1"
     assert len(capture.calls) == 1
@@ -114,7 +115,7 @@ async def test_refresh_pr_targets_main_when_staging_disabled(
     """When staging is disabled, base_branch() returns main_branch — the
     fix must respect that, not hardcode staging."""
     capture = _CaptureAutoPR()
-    monkeypatch.setattr(crl_module, "open_automated_pr_async", capture)
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", capture)
 
     loop = _loop(tmp_path, staging_enabled=False)
     drifted = tmp_path / "drift.yaml"
@@ -131,7 +132,7 @@ async def test_refresh_pr_targets_main_when_staging_disabled(
         has_drift=True,
     )
 
-    await loop._open_refresh_pr([drifted], fleet)
+    await loop._open_refresh_pr(fleet)
 
     assert len(capture.calls) == 1
     assert capture.calls[0].get("base") == loop._config.main_branch

--- a/tests/scenarios/catalog/loop_registrations.py
+++ b/tests/scenarios/catalog/loop_registrations.py
@@ -1087,7 +1087,9 @@ def _build_contract_refresh(ports: dict[str, Any], config: Any, deps: Any) -> An
     * ``contract_refresh_record_git`` → ``record_git``
     * ``contract_refresh_record_docker`` → ``record_docker``
     * ``contract_refresh_record_claude`` → ``record_claude_stream``
-    * ``contract_refresh_auto_pr`` → ``open_automated_pr_async``
+    * ``contract_refresh_auto_pr`` → ``auto_pr.generate_and_open_pr_async``
+      (generate-in-worktree, #9539 — the loop imports it lazily so the
+      seam lives on the ``auto_pr`` module, not ``crl_module``)
 
     ``state`` defaults to a MagicMock wired with int-returning stubs for
     the Task 18 attempt counters (``get_contract_refresh_attempts`` →
@@ -1124,13 +1126,16 @@ def _build_contract_refresh(ports: dict[str, Any], config: Any, deps: Any) -> An
         "contract_refresh_record_claude", default_empty
     )
 
-    # Optional: replace the auto_pr seam on the loop's module with a
-    # seeded async callable so tests can assert the opened PR shape
-    # without shelling out to ``git`` / ``gh``. Mirrors the F1
-    # corpus-learning pattern.
+    # Optional: replace the generate-in-worktree seam (#9539) with a seeded
+    # async callable so tests can assert the opened PR shape without shelling
+    # out to ``git`` / ``gh`` or creating a real worktree. The loop imports
+    # ``generate_and_open_pr_async`` lazily from ``auto_pr`` at call time, so
+    # the seam must be patched on the ``auto_pr`` module (not ``_module``).
     auto_pr_stub = ports.get("contract_refresh_auto_pr")
     if auto_pr_stub is not None:
-        _module.open_automated_pr_async = auto_pr_stub  # type: ignore[assignment]
+        import auto_pr as _auto_pr_module  # noqa: PLC0415
+
+        _auto_pr_module.generate_and_open_pr_async = auto_pr_stub  # type: ignore[assignment]
 
     loop = ContractRefreshLoop(
         config=config,

--- a/tests/scenarios/test_contract_refresh_scenario.py
+++ b/tests/scenarios/test_contract_refresh_scenario.py
@@ -19,17 +19,24 @@ The loop's external surfaces are handled as follows:
   / ``record_git`` / ``record_docker`` / ``record_claude_stream``)
   are monkey-patched on the loop's module via the builder's
   existing ``contract_refresh_record_*`` port seams.
-* :func:`auto_pr.open_automated_pr_async` is monkey-patched on the
-  loop's module via the new ``contract_refresh_auto_pr`` port seam
-  (mirrors the F1 corpus-learning pattern in
-  ``tests/scenarios/catalog/loop_registrations.py``).
+* :func:`auto_pr.generate_and_open_pr_async` (generate-in-worktree,
+  #9539) is monkey-patched on the ``auto_pr`` module via the
+  ``contract_refresh_auto_pr`` port seam (mirrors the F1 corpus-learning
+  pattern in ``tests/scenarios/catalog/loop_registrations.py``). The
+  ``generate`` callback is not invoked while the helper is mocked, so the
+  scenario asserts the call kwargs (branch, labels, path_specs, callable
+  generate) rather than written cassette bytes.
 * :func:`subprocess.run` (the replay gate) is monkey-patched at the
   module level for the drift scenario so the loop's
   ``make trust-contracts`` call does not spawn a real make.
 
 The committed cassette is written under ``config.repo_root / tests /
 trust / contracts / cassettes / git`` so the real
-:func:`contract_diff._committed_cassettes_for` can find it. Everything
+:func:`contract_diff._committed_cassettes_for` can find it. Under
+generate-in-worktree the loop never writes cassettes under
+``config.repo_root`` — it stages them into the worktree the PR helper
+hands its ``generate`` callback — so the scenario also asserts the
+committed cassette under ``repo_root`` is left untouched. Everything
 stays inside the MockWorld's ``tmp_path`` sandbox.
 """
 
@@ -230,10 +237,16 @@ class TestContractRefreshScenario:
         labels = kwargs["labels"]
         assert "contract-refresh" in labels
         assert "auto-merge" in labels
-        # The staged file lives under the loop's repo_root — not the
-        # ephemeral tmp/rec/git the recorder wrote to — because
-        # ``_stage_drifted_cassettes`` copies into the committed path.
-        files = [Path(p) for p in kwargs["files"]]
-        assert len(files) == 1
-        assert files[0].name == "commit.yaml"
-        assert files[0].is_relative_to(repo_root)
+        # Generate-in-worktree (#9539): no `files` kwarg — the helper gets a
+        # callable `generate` plus the drifted adapter's cassette dir in
+        # `path_specs`. The cassettes are written into the worktree by the
+        # callback (not invoked while the helper is mocked), never repo_root.
+        assert "files" not in kwargs
+        assert callable(kwargs["generate"])
+        assert kwargs["path_specs"] == ["tests/trust/contracts/cassettes/git"]
+
+        # repo_root is left untouched — the committed cassette still holds its
+        # original bytes; the refresh diff lives only in the torn-down worktree.
+        committed = repo_root / "tests/trust/contracts/cassettes/git/commit.yaml"
+        assert b"initial" in committed.read_bytes()
+        assert b"renamed" not in committed.read_bytes()

--- a/tests/test_contract_refresh_integration.py
+++ b/tests/test_contract_refresh_integration.py
@@ -3,7 +3,7 @@
 This file is intentionally separate from
 ``tests/test_contract_refresh_loop.py`` — that module mocks
 :func:`contract_diff.detect_fleet_drift` and
-:func:`auto_pr.open_automated_pr_async` as independent pinholes,
+:func:`auto_pr.generate_and_open_pr_async` as independent pinholes,
 never exercising the recorder→diff→stage→PR ladder as one unit. The
 integration tests below stitch those stages together against the
 *real* ``detect_fleet_drift`` implementation + the real
@@ -13,22 +13,28 @@ mocking only the two genuine external surfaces:
 * the per-adapter recorders (``record_github`` / ``record_git`` /
   ``record_docker`` / ``record_claude_stream``) — these spawn real
   binaries and must not run in a unit-test harness.
-* :func:`auto_pr.open_automated_pr_async` — this shells out to
-  ``git`` + ``gh``; stubbing it keeps the test hermetic without
-  coupling to the real worktree / gh auth machinery.
+* :func:`auto_pr.generate_and_open_pr_async` — this shells out to
+  ``git`` + ``gh`` and creates an ephemeral worktree; stubbing it keeps
+  the test hermetic without coupling to the real worktree / gh auth
+  machinery. Under generate-in-worktree (#9539) the loop's ``generate``
+  callback writes cassettes into the worktree the helper hands it, so
+  with the helper mocked the callback never runs — these tests assert
+  the call kwargs (branch, labels, path_specs, callable generate) and
+  that ``repo_root`` stays clean.
 
 The replay gate (``make trust-contracts``) is mocked at the
-``subprocess.run`` seam the loop reads — the same seam the Task 16
-unit tests drive — so both gate-pass and gate-fail paths flow through
-the real issue-filing code.
+``asyncio.create_subprocess_exec`` seam the loop reads — the same seam
+the Task 16 unit tests drive — so both gate-pass and gate-fail paths
+flow through the real issue-filing code.
 
 Scope (per Task 21 of the plan):
 
 * **Happy-path drift** — seeded mismatched cassettes flow through the
-  real ``detect_fleet_drift`` → ``_stage_drifted_cassettes`` →
-  ``_open_refresh_pr`` → ``_run_replay_gate`` ladder. Assertions:
-  PR opened with the expected title/labels/files, dedup entry
-  persisted to JSON, replay gate invoked, no companion issue filed.
+  real ``detect_fleet_drift`` → ``_open_refresh_pr`` (generate-in-worktree)
+  → ``_run_replay_gate`` ladder. Assertions: PR opened with the expected
+  title/labels/path_specs + callable generate, ``repo_root`` untouched,
+  dedup entry persisted to JSON, replay gate invoked, no companion issue
+  filed.
 * **Replay-gate fail → companion issue** — same drift, but the
   replay gate exits non-zero. Assertions: refresh PR still opens,
   ``PRManager.create_issue`` fires with ``hydraflow-find`` +
@@ -49,6 +55,7 @@ from unittest.mock import AsyncMock
 import pytest
 import yaml
 
+import auto_pr
 import contract_refresh_loop as crl_module
 from auto_pr import AutoPrResult
 from base_background_loop import LoopDeps
@@ -123,9 +130,11 @@ class _FakeState:
 def _loop(tmp_path: Path, *, prs: Any | None = None) -> ContractRefreshLoop:
     """Build a :class:`ContractRefreshLoop` rooted at ``tmp_path``.
 
-    The loop's ``config.repo_root`` is set to ``tmp_path / "repo"`` so
-    cassette writes from :meth:`_stage_drifted_cassettes` land under
-    the sandbox and never escape to the real HydraFlow tree.
+    The loop's ``config.repo_root`` is set to ``tmp_path / "repo"``. Under
+    generate-in-worktree (#9539) the loop never writes cassettes under
+    ``repo_root`` at all — :meth:`_stage_drifted_cassettes` copies into the
+    ephemeral worktree the PR helper hands its ``generate`` callback — so
+    these tests additionally assert ``repo_root`` stays clean.
     """
     cfg = HydraFlowConfig(
         data_root=tmp_path / "data",
@@ -214,7 +223,13 @@ def _write_recorded_git_cassette(tmp_dir: Path, *, stdout: str) -> Path:
 
 
 class _FakeAutoPR:
-    """Captures ``open_automated_pr_async`` calls and returns a canned result."""
+    """Captures ``generate_and_open_pr_async`` calls and returns a canned result.
+
+    The generate-in-worktree helper (#9539) is patched on ``auto_pr`` — the
+    loop imports it lazily — and its ``generate`` callback is not invoked
+    while the helper is mocked, so the captured kwargs carry ``generate`` +
+    ``path_specs`` (no ``files``).
+    """
 
     def __init__(self, status: str = "opened") -> None:
         self.calls: list[dict[str, Any]] = []
@@ -315,7 +330,7 @@ async def test_end_to_end_drift_opens_pr_and_records_dedup(
     _stub_recorders_only_git(monkeypatch, recorded)
 
     fake_pr = _FakeAutoPR()
-    monkeypatch.setattr(crl_module, "open_automated_pr_async", fake_pr)
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", fake_pr)
 
     replay_calls = _patch_subprocess_run(monkeypatch, returncode=0)
 
@@ -344,26 +359,35 @@ async def test_end_to_end_drift_opens_pr_and_records_dedup(
     assert "git" in kwargs["pr_title"]
     assert "contract-refresh" in kwargs["labels"]
     assert "auto-merge" in kwargs["labels"]
-    # The staged file is the committed cassette path under repo_root.
-    staged = [Path(p) for p in kwargs["files"]]
-    assert len(staged) == 1
-    assert staged[0].name == "commit.yaml"
-    assert staged[0].is_relative_to(repo_root)
+    # Generate-in-worktree (#9539): no `files` kwarg — the helper gets a
+    # callable `generate` and the drifted adapter's cassette dir in
+    # `path_specs`. The bytes are written INTO the worktree by the callback,
+    # never into repo_root.
+    assert "files" not in kwargs
+    assert callable(kwargs["generate"])
+    assert kwargs["path_specs"] == ["tests/trust/contracts/cassettes/git"]
 
-    # The staged cassette now carries the recorder bytes — not the
-    # original committed bytes — so the PR actually ships the fresh
-    # recording. This is the load-bearing invariant: a refresh PR that
-    # didn't overwrite the committed file would merge into a no-op.
-    # We key off the distinct stdout tokens (``renamed`` in recorder,
-    # ``initial`` in committed's output) because the commit-message
-    # args happen to match between the two; it's the stdout the fake
-    # replays, not the input args.
-    staged_bytes = staged[0].read_bytes()
-    assert b"renamed" in staged_bytes, staged_bytes
-    # The fresh recorder_sha marker pins this down — committed side
-    # had ``deadbeef``, recorder emitted ``cafef00d``.
-    assert b"cafef00d" in staged_bytes, staged_bytes
-    assert b"deadbeef" not in staged_bytes, staged_bytes
+    # repo_root must stay clean: the committed cassette retains its ORIGINAL
+    # bytes — the loop never overwrote it (that's the whole point of #9539).
+    committed = repo_root / "tests/trust/contracts/cassettes/git/commit.yaml"
+    committed_bytes = committed.read_bytes()
+    assert b"initial" in committed_bytes, committed_bytes
+    assert b"deadbeef" in committed_bytes, committed_bytes
+    assert b"renamed" not in committed_bytes, committed_bytes
+
+    # Driving the captured `generate` callback against a throwaway worktree
+    # proves the PR ships the FRESH recording: it copies the recorder bytes
+    # (``renamed`` / ``cafef00d``) into the worktree's committed cassette
+    # path — the load-bearing invariant a no-op refresh would violate.
+    fake_worktree = tmp_path / "fake_worktree"
+    fake_worktree.mkdir()
+    await kwargs["generate"](fake_worktree)
+    generated = fake_worktree / "tests/trust/contracts/cassettes/git/commit.yaml"
+    assert generated.exists(), "generate callback must write into the worktree"
+    generated_bytes = generated.read_bytes()
+    assert b"renamed" in generated_bytes, generated_bytes
+    assert b"cafef00d" in generated_bytes, generated_bytes
+    assert b"deadbeef" not in generated_bytes, generated_bytes
 
     # Replay gate ran exactly once.
     assert replay_calls == [["make", "trust-contracts"]]
@@ -403,7 +427,7 @@ async def test_end_to_end_replay_gate_fail_files_fake_drift_issue(
     _stub_recorders_only_git(monkeypatch, recorded)
 
     fake_pr = _FakeAutoPR()
-    monkeypatch.setattr(crl_module, "open_automated_pr_async", fake_pr)
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", fake_pr)
 
     _patch_subprocess_run(
         monkeypatch,
@@ -439,29 +463,25 @@ async def test_end_to_end_replay_gate_fail_files_fake_drift_issue(
 
 
 # ---------------------------------------------------------------------------
-# Scenario 3 — post-refresh quiescence: second tick reads clean
+# Scenario 3 — post-refresh quiescence: second identical tick dedups
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_second_tick_after_refresh_is_clean(
+async def test_second_tick_after_refresh_dedups(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """After a successful refresh, the next tick sees no drift.
+    """After a successful refresh, an identical next tick short-circuits on dedup.
 
-    ``_stage_drifted_cassettes`` overwrites the committed file with
-    the recorder bytes. On the next tick the recorder emits those
-    same bytes again, so the real ``detect_fleet_drift`` canonicalizes
-    both sides identically and reports no drift — the loop returns
-    ``status="clean"`` without touching ``auto_pr`` or the replay
-    gate a second time. This is the load-bearing "weekly loop
-    quiesces after a successful refresh" guarantee.
-
-    Note: the dedup short-circuit (``status="dedup_hit"``) is
-    exercised by the unit test ``test_do_work_dedup_hit_skips_pr``
-    against a mocked ``detect_fleet_drift`` — in integration, real
-    diff sees matching bytes and returns no reports, which is the
-    happy-path the dedup guard exists to defend.
+    Under generate-in-worktree (#9539) the loop NO LONGER overwrites the
+    committed cassette under ``repo_root`` — the refresh bytes are written
+    only into the ephemeral worktree the PR helper tears down. So the real
+    ``detect_fleet_drift`` on the next tick still sees the same drift; the
+    quiescence guarantee is now provided by the per-loop ``DedupStore``: the
+    drift hash recorded on tick #1 short-circuits tick #2 to
+    ``status="dedup_hit"`` — no second PR, no second replay gate. This is the
+    load-bearing "weekly loop does not re-file an identical refresh PR every
+    tick" guarantee, and it proves ``repo_root`` is never mutated.
     """
     loop = _loop(tmp_path)
     repo_root = loop._config.repo_root
@@ -473,22 +493,30 @@ async def test_second_tick_after_refresh_is_clean(
     _stub_recorders_only_git(monkeypatch, recorded)
 
     fake_pr = _FakeAutoPR()
-    monkeypatch.setattr(crl_module, "open_automated_pr_async", fake_pr)
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", fake_pr)
     replay_calls = _patch_subprocess_run(monkeypatch, returncode=0)
 
     prs = AsyncMock()
     prs.create_issue = AsyncMock(return_value=0)
     loop = _loop(tmp_path, prs=prs)
+    repo_root = loop._config.repo_root
+    _write_committed_git_cassette(repo_root, stdout="[main abc1234] initial\n")
 
-    # Tick #1: PR filed, staged cassette overwrites committed.
+    # Tick #1: drift → PR filed → dedup key recorded.
     first = await loop._do_work()
     assert first["status"] == "refreshed"
     assert len(fake_pr.calls) == 1
     assert len(replay_calls) == 1
 
-    # Tick #2: committed matches recorder → no drift, no extra work.
+    # repo_root was NOT mutated — the committed cassette still holds the
+    # original bytes (the refresh diff lives only in the torn-down worktree).
+    committed = repo_root / "tests/trust/contracts/cassettes/git/commit.yaml"
+    assert b"initial" in committed.read_bytes()
+    assert b"renamed" not in committed.read_bytes()
+
+    # Tick #2: same drift, but the dedup hash short-circuits before any PR.
     second = await loop._do_work()
-    assert second["status"] == "clean", second
-    assert second["adapters_drifted"] == 0
-    assert len(fake_pr.calls) == 1, "clean tick must not fire a second PR"
-    assert len(replay_calls) == 1, "clean tick must not fire a second replay gate"
+    assert second["status"] == "dedup_hit", second
+    assert second["adapters_drifted"] == 1
+    assert len(fake_pr.calls) == 1, "dedup tick must not fire a second PR"
+    assert len(replay_calls) == 1, "dedup tick must not fire a second replay gate"

--- a/tests/test_contract_refresh_loop.py
+++ b/tests/test_contract_refresh_loop.py
@@ -29,6 +29,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+import auto_pr
 import contract_refresh_loop as crl_module
 from auto_pr import AutoPrResult
 from base_background_loop import LoopDeps
@@ -223,7 +224,15 @@ def _install_async_subprocess_stub(
 
 
 class _FakeAutoPR:
-    """Captures ``open_automated_pr_async`` calls and returns a canned result."""
+    """Captures ``generate_and_open_pr_async`` calls and returns a canned result.
+
+    The generate-in-worktree helper (#9539) is patched on the ``auto_pr``
+    module — the loop imports it lazily at call time, so the seam lives
+    there, not on ``crl_module``. The ``generate`` callback is *not*
+    invoked when the helper is mocked, so tests assert the call kwargs
+    (branch, labels, path_specs, callable generate) rather than the
+    written cassette bytes.
+    """
 
     def __init__(self, status: str = "opened") -> None:
         self.calls: list[dict[str, Any]] = []
@@ -261,7 +270,7 @@ async def test_do_work_no_drift_no_pr(
     """All adapters clean → no PR, no replay gate run, no issue."""
     _stub_recording(monkeypatch)
     fake = _FakeAutoPR()
-    monkeypatch.setattr(crl_module, "open_automated_pr_async", fake)
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", fake)
     calls = _stub_make_trust_contracts_ok(monkeypatch)
 
     # Force detect_fleet_drift to report no drift regardless of input.
@@ -304,7 +313,7 @@ async def test_do_work_drift_opens_refresh_pr_and_records_dedup(
     monkeypatch.setattr(crl_module, "detect_fleet_drift", lambda *_a, **_k: fleet)
 
     fake = _FakeAutoPR()
-    monkeypatch.setattr(crl_module, "open_automated_pr_async", fake)
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", fake)
     _stub_make_trust_contracts_ok(monkeypatch)
 
     loop = _loop(tmp_path)
@@ -317,9 +326,21 @@ async def test_do_work_drift_opens_refresh_pr_and_records_dedup(
     assert "git" in kwargs["pr_body"]
     labels = kwargs.get("labels") or []
     assert "contract-refresh" in labels
-    # At least the drifted cassette is in the file list.
-    staged_names = [Path(p).name for p in kwargs["files"]]
-    assert "commit.yaml" in staged_names
+    # Generate-in-worktree (#9539): the helper gets a callable generate +
+    # the drifted adapter's cassette dir in path_specs. There is no
+    # `files` kwarg — the cassettes are written into the worktree by the
+    # callback (not invoked while the helper is mocked), never repo_root.
+    assert "files" not in kwargs
+    assert callable(kwargs["generate"])
+    assert "tests/trust/contracts/cassettes/git" in kwargs["path_specs"], kwargs[
+        "path_specs"
+    ]
+
+    # repo_root must stay clean — nothing was copied into it.
+    committed = (
+        loop._config.repo_root / "tests/trust/contracts/cassettes/git" / "commit.yaml"
+    )
+    assert not committed.exists(), "refresh must not write cassettes under repo_root"
 
     # Dedup key recorded.
     dedup_path = loop._config.data_root / "dedup" / "contract_refresh.json"
@@ -349,7 +370,7 @@ async def test_do_work_dedup_hit_skips_pr(
     monkeypatch.setattr(crl_module, "detect_fleet_drift", lambda *_a, **_k: fleet)
 
     fake = _FakeAutoPR()
-    monkeypatch.setattr(crl_module, "open_automated_pr_async", fake)
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", fake)
     _stub_make_trust_contracts_ok(monkeypatch)
 
     loop = _loop(tmp_path)
@@ -386,7 +407,7 @@ async def test_do_work_replay_gate_fails_files_companion_issue(
     monkeypatch.setattr(crl_module, "detect_fleet_drift", lambda *_a, **_k: fleet)
 
     fake = _FakeAutoPR()
-    monkeypatch.setattr(crl_module, "open_automated_pr_async", fake)
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", fake)
     calls = _stub_make_trust_contracts_fail(monkeypatch)
 
     prs = AsyncMock()
@@ -427,7 +448,7 @@ async def test_do_work_replay_gate_passes_no_companion_issue(
     monkeypatch.setattr(crl_module, "detect_fleet_drift", lambda *_a, **_k: fleet)
 
     fake = _FakeAutoPR()
-    monkeypatch.setattr(crl_module, "open_automated_pr_async", fake)
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", fake)
     _stub_make_trust_contracts_ok(monkeypatch)
 
     prs = AsyncMock()
@@ -444,7 +465,7 @@ async def test_clean_tick_closes_open_fake_drift_issue(
 ) -> None:
     """#9359: a drift-free tick closes a previously-open fake-drift rollup issue."""
     _stub_recording(monkeypatch)
-    monkeypatch.setattr(crl_module, "open_automated_pr_async", _FakeAutoPR())
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", _FakeAutoPR())
     _stub_make_trust_contracts_ok(monkeypatch)
     monkeypatch.setattr(
         crl_module,
@@ -482,7 +503,7 @@ async def test_replay_pass_closes_open_fake_drift_issue(
     )
     fleet = crl_module.FleetDriftReport(reports=[drifted_report], has_drift=True)
     monkeypatch.setattr(crl_module, "detect_fleet_drift", lambda *_a, **_k: fleet)
-    monkeypatch.setattr(crl_module, "open_automated_pr_async", _FakeAutoPR())
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", _FakeAutoPR())
     _stub_make_trust_contracts_ok(monkeypatch)
 
     state = _FakeState()
@@ -546,7 +567,7 @@ async def test_do_work_emits_telemetry_for_each_recorder_and_replay(
     monkeypatch.setattr(crl_module, "detect_fleet_drift", lambda *_a, **_k: fleet)
 
     fake = _FakeAutoPR()
-    monkeypatch.setattr(crl_module, "open_automated_pr_async", fake)
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", fake)
     _stub_make_trust_contracts_ok(monkeypatch)
 
     emitted = _patch_emit_trace(monkeypatch)
@@ -603,7 +624,7 @@ async def test_replay_gate_failure_trace_carries_exit_code_and_stderr(
     monkeypatch.setattr(crl_module, "detect_fleet_drift", lambda *_a, **_k: fleet)
 
     fake = _FakeAutoPR()
-    monkeypatch.setattr(crl_module, "open_automated_pr_async", fake)
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", fake)
     _stub_make_trust_contracts_fail(monkeypatch)
 
     emitted = _patch_emit_trace(monkeypatch)
@@ -669,7 +690,7 @@ async def test_drift_detection_increments_per_adapter_attempts(
         "detect_fleet_drift",
         lambda *_a, **_k: _drift_fleet_for("git", rec),
     )
-    monkeypatch.setattr(crl_module, "open_automated_pr_async", _FakeAutoPR())
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", _FakeAutoPR())
     _stub_make_trust_contracts_ok(monkeypatch)
 
     state = _FakeState()
@@ -729,7 +750,7 @@ async def test_drift_clears_attempts_for_adapters_not_in_this_tick(
         "detect_fleet_drift",
         lambda *_a, **_k: _drift_fleet_for("docker", rec),
     )
-    monkeypatch.setattr(crl_module, "open_automated_pr_async", _FakeAutoPR())
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", _FakeAutoPR())
     _stub_make_trust_contracts_ok(monkeypatch)
 
     state = _FakeState()
@@ -762,7 +783,7 @@ async def test_third_attempt_files_escalation_issue(
         "detect_fleet_drift",
         lambda *_a, **_k: _drift_fleet_for("git", rec),
     )
-    monkeypatch.setattr(crl_module, "open_automated_pr_async", _FakeAutoPR())
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", _FakeAutoPR())
     _stub_make_trust_contracts_ok(monkeypatch)
 
     state = _FakeState()
@@ -808,7 +829,7 @@ async def test_escalation_is_deduped_across_ticks(
         "detect_fleet_drift",
         lambda *_a, **_k: _drift_fleet_for("git", rec),
     )
-    monkeypatch.setattr(crl_module, "open_automated_pr_async", _FakeAutoPR())
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", _FakeAutoPR())
     _stub_make_trust_contracts_ok(monkeypatch)
 
     state = _FakeState()
@@ -856,7 +877,7 @@ async def test_escalation_zero_sentinel_does_not_dedup(
         "detect_fleet_drift",
         lambda *_a, **_k: _drift_fleet_for("git", rec),
     )
-    monkeypatch.setattr(crl_module, "open_automated_pr_async", _FakeAutoPR())
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", _FakeAutoPR())
     _stub_make_trust_contracts_ok(monkeypatch)
 
     state = _FakeState()
@@ -896,7 +917,7 @@ async def test_escalation_resets_after_clean_tick(
     _stub_recording(monkeypatch)
     rec = _seed_recorded_cassette(tmp_path / "rec" / "git", "git", "commit")
     monkeypatch.setattr(crl_module, "record_git", lambda *_a, **_k: [rec])
-    monkeypatch.setattr(crl_module, "open_automated_pr_async", _FakeAutoPR())
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", _FakeAutoPR())
     _stub_make_trust_contracts_ok(monkeypatch)
 
     state = _FakeState()


### PR DESCRIPTION
Migrates this loop to `auto_pr.generate_and_open_pr_async` (proposal #9539) — generation happens inside the ephemeral worktree, so `repo_root` is never mutated. Follows the merged DiagramLoop pattern (#9614). Tests updated for the worktree flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)