### PR TITLE
fix(factory): ADRCouncilReviewer generate-in-worktree (#9539)

### DIFF
--- a/src/adr_reviewer.py
+++ b/src/adr_reviewer.py
@@ -727,19 +727,14 @@ minority_note: <dissenting opinion if not unanimous, or "none">"""
             )
             return False
 
-        try:
-            adr_path.write_text(amended, encoding="utf-8")
-        except OSError:
-            logger.exception(
-                "ADR-%04d clerk amend accepted but file write failed", result.adr_number
-            )
-            return False
-
         logger.info(
             "ADR-%04d accepted after clerk amendment re-vote",
             result.adr_number,
         )
-        await self._accept_adr(rerun, adr_path, adr_dir)
+        # Hand the amended content straight to acceptance — it is written into
+        # the PR worktree, never back into repo_root (#9539). The clerk-amend
+        # re-read therefore happens off the worktree path inside ``_accept_adr``.
+        await self._accept_adr(rerun, adr_path, adr_dir, source_content=amended)
         return True
 
     def _build_clerk_amendment(self, content: str, result: ADRCouncilResult) -> str:
@@ -812,54 +807,84 @@ minority_note: <dissenting opinion if not unanimous, or "none">"""
         result: ADRCouncilResult,
         adr_path: Path,
         adr_dir: Path,
+        *,
+        source_content: str | None = None,
     ) -> None:
-        """Accept an ADR: update status, update README, commit and create PR."""
+        """Accept an ADR: compute the Accepted ADR + README and open a PR.
+
+        The acceptance edits (Status flip, Enforced-by line, README row) are
+        produced as in-memory content and written into the PR *worktree*
+        (#9539) — ``repo_root`` is never mutated. ``source_content`` lets the
+        clerk-amend path hand in its already-amended body so the file is not
+        re-read from disk.
+        """
         logger.info("ADR-%04d accepted by council", result.adr_number)
 
-        try:
-            content = adr_path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
-            logger.exception("Failed to read ADR file: %s", adr_path)
-            return
+        if source_content is not None:
+            content = source_content
+        else:
+            try:
+                content = adr_path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                logger.exception("Failed to read ADR file: %s", adr_path)
+                return
 
         # Update status in ADR file and guarantee the Enforced-by line
         # (required by tests/test_adr_enforcement.py on every Accepted ADR).
-        updated = _STATUS_RE.sub("**Status:** Accepted", content, count=1)
-        updated = _ensure_enforced_by_line(updated)
-        adr_path.write_text(updated, encoding="utf-8")
+        updated_adr = _STATUS_RE.sub("**Status:** Accepted", content, count=1)
+        updated_adr = _ensure_enforced_by_line(updated_adr)
 
-        # Update README if present
+        # Compute the updated README content (if present) — content only; the
+        # write happens inside the worktree generate callback.
         readme_path = adr_dir / "README.md"
+        updated_readme: str | None = None
         if readme_path.exists():
-            self._update_readme_status(readme_path, result.adr_number)
+            try:
+                readme_content = readme_path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                logger.warning("Failed to read ADR README: %s", readme_path)
+            else:
+                changed = self._readme_with_accepted_status(
+                    readme_content, result.adr_number
+                )
+                if changed != readme_content:
+                    updated_readme = changed
 
-        # Commit and create PR
-        await self._commit_acceptance(adr_path, readme_path, result)
+        # Commit and create PR (writes into the worktree, not repo_root).
+        await self._commit_acceptance(
+            adr_path=adr_path,
+            readme_path=readme_path,
+            adr_content=updated_adr,
+            readme_content=updated_readme,
+            result=result,
+        )
 
-    def _update_readme_status(self, readme_path: Path, adr_number: int) -> None:
-        """Update the ADR status in README.md from Proposed to Accepted."""
-        content = readme_path.read_text(encoding="utf-8")
+    def _readme_with_accepted_status(self, content: str, adr_number: int) -> str:
+        """Return README content with the ADR's row flipped Proposed→Accepted."""
         # Match table rows like "| 0001 | ... | Proposed |"
         pattern = re.compile(
             rf"(\|\s*{adr_number:04d}\s*\|.*?\|)\s*Proposed\s*\|",
             re.IGNORECASE,
         )
-        updated = pattern.sub(r"\1 Accepted |", content)
-        if updated != content:
-            readme_path.write_text(updated, encoding="utf-8")
+        return pattern.sub(r"\1 Accepted |", content)
 
     async def _commit_acceptance(
         self,
+        *,
         adr_path: Path,
         readme_path: Path,
+        adr_content: str,
+        readme_content: str | None,
         result: ADRCouncilResult,
     ) -> None:
-        """Create worktree, commit status update, push, and create PR.
+        """Generate the acceptance files in a worktree, commit, push, open PR.
 
         Delegates the worktree/commit/push/PR lifecycle to
-        :func:`auto_pr.open_automated_pr_async`.
+        :func:`auto_pr.generate_and_open_pr_async`. The ``generate`` callback
+        writes the Accepted ADR (and updated README, if any) INTO the worktree
+        it is handed — ``repo_root`` is never written for the PR (#9539).
         """
-        from auto_pr import open_automated_pr_async  # noqa: PLC0415
+        from auto_pr import generate_and_open_pr_async  # noqa: PLC0415
 
         if self._config.dry_run:
             logger.info(
@@ -867,12 +892,25 @@ minority_note: <dissenting opinion if not unanimous, or "none">"""
             )
             return
 
-        repo_root = Path(self._config.repo_root)
+        repo_root = Path(self._config.repo_root).resolve()
         branch = f"adr/accept-{result.adr_number:04d}"
 
-        files = [adr_path]
-        if readme_path.exists():
-            files.append(readme_path)
+        # Repo-relative paths for staging + worktree writes.
+        adr_rel = adr_path.resolve().relative_to(repo_root)
+        path_specs = [str(adr_rel)]
+        readme_rel: Path | None = None
+        if readme_content is not None:
+            readme_rel = readme_path.resolve().relative_to(repo_root)
+            path_specs.append(str(readme_rel))
+
+        async def _generate(worktree: Path) -> None:
+            adr_dst = worktree / adr_rel
+            adr_dst.parent.mkdir(parents=True, exist_ok=True)
+            adr_dst.write_text(adr_content, encoding="utf-8")
+            if readme_rel is not None and readme_content is not None:
+                readme_dst = worktree / readme_rel
+                readme_dst.parent.mkdir(parents=True, exist_ok=True)
+                readme_dst.write_text(readme_content, encoding="utf-8")
 
         minority = (
             f"\n\nMinority note: {result.minority_note}"
@@ -897,10 +935,11 @@ minority_note: <dissenting opinion if not unanimous, or "none">"""
             f"Generated by HydraFlow ADR Council"
         )
 
-        await open_automated_pr_async(
+        await generate_and_open_pr_async(
             repo_root=repo_root,
             branch=branch,
-            files=files,
+            generate=_generate,
+            path_specs=path_specs,
             pr_title=pr_title,
             pr_body=pr_body,
             commit_message=commit_message,

--- a/tests/test_adr_reviewer.py
+++ b/tests/test_adr_reviewer.py
@@ -919,12 +919,60 @@ class TestAcceptADR:
             ],
         )
 
-        with patch("auto_pr.open_automated_pr_async", new_callable=AsyncMock):
+        with patch(
+            "auto_pr.generate_and_open_pr_async", new_callable=AsyncMock
+        ) as mock_pr:
             await reviewer._accept_adr(result, adr_path, adr_dir)
 
-        content = adr_path.read_text(encoding="utf-8")
-        assert "**Status:** Accepted" in content
-        assert "**Status:** Proposed" not in content
+        # #9539: repo_root is NEVER mutated for the PR — the proposed file
+        # on disk stays Proposed; the Accepted edit is written into the
+        # worktree by the generate callback (not invoked when mocked).
+        on_disk = adr_path.read_text(encoding="utf-8")
+        assert "**Status:** Proposed" in on_disk
+        assert "**Status:** Accepted" not in on_disk
+
+        kwargs = mock_pr.await_args.kwargs
+        assert kwargs["branch"] == "adr/accept-0001"
+        assert kwargs["path_specs"] == ["docs/adr/0001-test-adr.md"]
+        assert callable(kwargs["generate"])
+
+    @pytest.mark.asyncio
+    async def test_generate_writes_accepted_adr_into_worktree(
+        self, tmp_path: Path
+    ) -> None:
+        """The generate callback writes the Accepted ADR into the worktree it is
+        handed — never repo_root (#9539)."""
+        reviewer = _make_reviewer(tmp_path)
+        adr_dir = tmp_path / "repo" / "docs" / "adr"
+        adr_path = _write_adr(adr_dir, 1, "Test ADR", "Proposed")
+        result = ADRCouncilResult(
+            adr_number=1,
+            adr_title="Test ADR",
+            final_decision="ACCEPT",
+            summary="Council approves",
+            votes=[
+                CouncilVote(
+                    role="architect", verdict=CouncilVerdict.APPROVE, reasoning="Good"
+                ),
+            ],
+        )
+
+        captured: dict = {}
+
+        async def intercept(**kw):
+            captured.update(kw)
+
+        with patch("auto_pr.generate_and_open_pr_async", intercept):
+            await reviewer._accept_adr(result, adr_path, adr_dir)
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        await captured["generate"](worktree)
+
+        written = (worktree / "docs/adr/0001-test-adr.md").read_text(encoding="utf-8")
+        assert "**Status:** Accepted" in written
+        # repo_root file still untouched.
+        assert "**Status:** Proposed" in adr_path.read_text(encoding="utf-8")
 
     @pytest.mark.asyncio
     async def test_updates_readme_row(self, tmp_path: Path) -> None:
@@ -949,10 +997,24 @@ class TestAcceptADR:
             ],
         )
 
-        with patch("auto_pr.open_automated_pr_async", new_callable=AsyncMock):
+        captured: dict = {}
+
+        async def intercept(**kw):
+            captured.update(kw)
+
+        with patch("auto_pr.generate_and_open_pr_async", intercept):
             await reviewer._accept_adr(result, adr_path, adr_dir)
 
-        readme_content = readme.read_text(encoding="utf-8")
+        # #9539: repo_root README is untouched; the README is staged + written
+        # into the worktree only.
+        assert "| 0001 | Test ADR | Proposed |" in readme.read_text(encoding="utf-8")
+        assert "docs/adr/README.md" in captured["path_specs"]
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        await captured["generate"](worktree)
+
+        readme_content = (worktree / "docs/adr/README.md").read_text(encoding="utf-8")
         assert "Accepted" in readme_content.split("\n")[1]
         # Other rows unchanged
         assert "| 0002 | Other | Accepted |" in readme_content
@@ -984,7 +1046,7 @@ class TestAcceptADR:
         )
 
         mock_open_pr = AsyncMock()
-        with patch("auto_pr.open_automated_pr_async", mock_open_pr):
+        with patch("auto_pr.generate_and_open_pr_async", mock_open_pr):
             await reviewer._accept_adr(result, adr_path, adr_dir)
 
         # Helper called once; commit_message kwarg carries the minority note.
@@ -1220,6 +1282,7 @@ class TestClerkAmendment:
             ],
         )
         reviewer._run_council_session = AsyncMock(return_value=rerun_result)
+        original = adr_path.read_text(encoding="utf-8")
 
         with patch.object(
             reviewer, "_accept_adr", new_callable=AsyncMock
@@ -1228,11 +1291,16 @@ class TestClerkAmendment:
                 original_result, adr_path, adr_dir
             )
             assert accepted is True
-            mock_accept.assert_awaited_once_with(rerun_result, adr_path, adr_dir)
 
-        updated = adr_path.read_text(encoding="utf-8")
-        assert "## Council Amendment Notes" in updated
-        assert "Clarify tradeoffs" in updated
+        # The amended content is handed to acceptance via source_content (#9539);
+        # repo_root is never written for the PR — the file stays untouched.
+        mock_accept.assert_awaited_once()
+        call = mock_accept.await_args
+        assert call.args == (rerun_result, adr_path, adr_dir)
+        amended = call.kwargs["source_content"]
+        assert "## Council Amendment Notes" in amended
+        assert "Clarify tradeoffs" in amended
+        assert adr_path.read_text(encoding="utf-8") == original
 
     @pytest.mark.asyncio
     async def test_clerk_revote_non_accept_falls_back(self, tmp_path: Path) -> None:
@@ -1601,7 +1669,7 @@ class TestAcceptADREdgeCases:
 
         # Should not raise
         with patch(
-            "auto_pr.open_automated_pr_async", new_callable=AsyncMock
+            "auto_pr.generate_and_open_pr_async", new_callable=AsyncMock
         ) as mock_open_pr:
             await reviewer._accept_adr(result, adr_path, adr_dir)
             # Should not reach commit since file couldn't be read
@@ -1624,10 +1692,14 @@ class TestCommitAcceptance:
         )
 
         with patch(
-            "auto_pr.open_automated_pr_async", new_callable=AsyncMock
+            "auto_pr.generate_and_open_pr_async", new_callable=AsyncMock
         ) as mock_open_pr:
             await reviewer._commit_acceptance(
-                tmp_path / "adr.md", tmp_path / "README.md", result
+                adr_path=tmp_path / "adr.md",
+                readme_path=tmp_path / "README.md",
+                adr_content="**Status:** Accepted\n",
+                readme_content=None,
+                result=result,
             )
             mock_open_pr.assert_not_awaited()
 
@@ -1646,10 +1718,14 @@ class TestCommitAcceptance:
         adr_path.write_text("**Status:** Accepted")
 
         with patch(
-            "auto_pr.open_automated_pr_async", new_callable=AsyncMock
+            "auto_pr.generate_and_open_pr_async", new_callable=AsyncMock
         ) as mock_open_pr:
             await reviewer._commit_acceptance(
-                adr_path, tmp_path / "repo" / "docs" / "adr" / "README.md", result
+                adr_path=adr_path,
+                readme_path=tmp_path / "repo" / "docs" / "adr" / "README.md",
+                adr_content="**Status:** Accepted\n",
+                readme_content=None,
+                result=result,
             )
         assert mock_open_pr.await_count == 1
         assert mock_open_pr.await_args is not None
@@ -1657,6 +1733,9 @@ class TestCommitAcceptance:
         assert kwargs["raise_on_failure"] is False
         assert kwargs["auto_merge"] is False
         assert kwargs["branch"] == "adr/accept-0001"
+        # Generate-in-worktree: never stages files from repo_root (#9539).
+        assert kwargs["path_specs"] == ["docs/adr/0001-test.md"]
+        assert callable(kwargs["generate"])
         # Commit author threaded through from HydraFlowConfig, not hardcoded.
         assert kwargs["commit_author_name"] == reviewer._config.git_user_name
         assert kwargs["commit_author_email"] == reviewer._config.git_user_email


### PR DESCRIPTION
Migrates this loop to `auto_pr.generate_and_open_pr_async` (proposal #9539) — generation happens inside the ephemeral worktree, so `repo_root` is never mutated. Follows the merged DiagramLoop pattern (#9614). Tests updated for the worktree flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)