### PR TITLE
fix(ci): arch-check must trigger on docs/wiki and docs/standards edits

### DIFF
--- a/.github/workflows/arch-regen.yml
+++ b/.github/workflows/arch-regen.yml
@@ -5,6 +5,15 @@ on:
       - 'src/**'
       - 'docs/adr/**'
       - 'docs/arch/**'
+      # coverage_matrix.py rglobs docs/wiki/** (wiki column) and
+      # docs/standards/** (standards column); ubiquitous-language views render
+      # from docs/wiki/terms/**. Without these paths a wiki/standards edit that
+      # adds or removes a loop-referencing file changes the generated matrix
+      # without ever running the drift check, so drift accumulates silently on
+      # staging until an unrelated docs/arch/** PR trips it. See arch.generators
+      # .coverage_matrix._wiki_check / _standards_check.
+      - 'docs/wiki/**'
+      - 'docs/standards/**'
       - 'tests/scenarios/fakes/**'
       - 'tests/architecture/**'
 


### PR DESCRIPTION
## Root cause

`coverage_matrix.py` `_wiki_check` rglobs **`docs/wiki/**`** and `_standards_check` rglobs **`docs/standards/**`**; the ubiquitous-language views render from `docs/wiki/terms/**`. But `arch-regen.yml` only triggered on `src/**`, `docs/adr/**`, `docs/arch/**`, `tests/scenarios/fakes/**`, `tests/architecture/**`.

So a PR editing **only** `docs/wiki/**` or `docs/standards/**` (e.g. adding/removing a loop-referencing wiki file) could change the generated coverage matrix and **merge without the drift check ever running**. Drift then accumulated silently on staging until an unrelated `docs/arch/**` PR tripped `arch-check` with a confusing `coverage_matrix.md` diff unrelated to its own change.

This was the exact failure mode on the in-flight UL bot PRs: they failed `arch-check` / the `test_curated_drift` test on a `TermProposerLoop` wiki-list delta (`credentials.md`) they never touched.

## Fix

Add `docs/wiki/**` and `docs/standards/**` to the `arch-regen.yml` PR trigger so drift is caught at the PR that causes it. `DiagramLoop` (every 4h, ADR-0029) remains the post-merge healer; this restores the missing PR-time guard.

## Verification

- `arch.runner --check` is RC=0 on current staging (matrix already in sync).
- An entry-evidence-style term edit does **not** trip the gated matrix drift, so this won't spuriously fail entry-evidence bot PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)