### PR TITLE
fix(tests): remove runtime skip flagged by test_no_ignored_active_tests

### DIFF
--- a/tests/regressions/test_issue_9567.py
+++ b/tests/regressions/test_issue_9567.py
@@ -79,8 +79,10 @@ def test_slash_command_remains_read_only(skill_file: Path) -> None:
     the slash-command performs, because the slash command has no worktree or
     subprocess access in interactive sessions.
     """
-    if not skill_file.exists():
-        pytest.skip(f"{skill_file} does not exist")
+    assert skill_file.exists(), (
+        f"{skill_file} is missing; the hf.test-adequacy skill file is a "
+        "committed contract and must exist to declare read-only behaviour"
+    )
 
     text = skill_file.read_text()
     assert "read-only" in text.lower(), (


### PR DESCRIPTION
## Problem

PR #9646 (test-adequacy, issue #9567) added `tests/regressions/test_issue_9567.py` whose `test_slash_command_remains_read_only` does `pytest.skip(...)` when a skill file is absent. `tests/architecture/test_no_ignored_active_tests.py` is a **static** scan and flags any `pytest.skip(` in an active test as hidden coverage — failing the architecture suite on staging (would block rc-promotion to main).

## Fix

Both candidate skill files are committed and always present, so the skip was dead code. Replace it with an `assert skill_file.exists()` — the committed skill files are a real contract, so asserting their presence is the correct invariant.

## Verification

`pytest tests/regressions/test_issue_9567.py tests/architecture/test_no_ignored_active_tests.py` → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)