### PR TITLE
fix(sandbox): pin @beads/bd to 1.0.4 (v1.0.5 release asset missing)

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -73,7 +73,10 @@ RUN npm install -g @anthropic-ai/claude-code @openai/codex @google/gemini-cli @m
 
 # Install bd (beads) separately — its postinstall downloads a native binary
 # that needs the ICU compat symlinks from the base stage.
-RUN npm install -g @beads/bd --no-fund --no-audit
+# Pinned to 1.0.4: npm 1.0.5 is published but its v1.0.5 GitHub release asset
+# (beads_1.0.5_linux_amd64.tar.gz) was never created, so postinstall 404s.
+# Unpin once upstream publishes the v1.0.5 release asset. ref #9674
+RUN npm install -g @beads/bd@1.0.4 --no-fund --no-audit
 
 # Pre-clone Claude Code plugins into /opt/plugins/ (strip .git to save image space)
 RUN git clone --depth 1 https://github.com/anthropics/claude-plugins-official.git /opt/plugins/claude-plugins-official \

--- a/Dockerfile.agent-base
+++ b/Dockerfile.agent-base
@@ -65,7 +65,10 @@ RUN npm install -g @anthropic-ai/claude-code @openai/codex @google/gemini-cli @m
 
 # Install bd (beads) separately — its postinstall downloads a native binary
 # that needs the ICU compat symlinks from the base stage.
-RUN npm install -g @beads/bd --no-fund --no-audit
+# Pinned to 1.0.4: npm 1.0.5 is published but its v1.0.5 GitHub release asset
+# (beads_1.0.5_linux_amd64.tar.gz) was never created, so postinstall 404s.
+# Unpin once upstream publishes the v1.0.5 release asset. ref #9674
+RUN npm install -g @beads/bd@1.0.4 --no-fund --no-audit
 
 # Pre-clone Claude Code plugins into /opt/plugins/ (strip .git to save image space)
 RUN git clone --depth 1 https://github.com/anthropics/claude-plugins-official.git /opt/plugins/claude-plugins-official \


### PR DESCRIPTION
Fixes #9674.

## Problem

The sandbox Docker build (`Dockerfile.agent`, `Dockerfile.agent-base`) fails for every PR at `npm install -g @beads/bd`: the npm package `@beads/bd@1.0.5` is published, but the upstream **`v1.0.5` GitHub release asset was never created**, so the package's `postinstall.js` download 404s and aborts the build.

```
Downloading from: https://github.com/gastownhall/beads/releases/download/v1.0.5/beads_1.0.5_linux_amd64.tar.gz
Error installing bd: Failed to download: HTTP 404
```

## Fix

Pin to **`@beads/bd@1.0.4`** in both Dockerfiles. `bd` is genuinely used (the `bd --version` smoke test in `scripts/docker-smoke-test.sh` and `bd create`/`bd link` in `scripts/trust-arch-beads.sh`), so dropping or `|| true`-softening it would silently ship a broken image — pinning is the correct fix.

## Verification

- `npm view @beads/bd@1.0.4 version` → `1.0.4` (on npm)
- `curl -sIL https://github.com/gastownhall/beads/releases/download/v1.0.4/beads_1.0.4_linux_amd64.tar.gz` → **HTTP 302** to GitHub CDN (asset is live)
- **End-to-end gate is the CI `Sandbox` check on this PR** — this change isn't covered by `make quality` (which doesn't build the image), and a local docker build wasn't available. Please confirm the Sandbox check goes green here.

## Human-verify / follow-up

The `v1.0.5` gap looks like an accidental npm publish without a matching GitHub release. **Worth confirming with the upstream maintainer** whether v1.0.5 (or v1.1.0) assets will be posted; unpin once they are (comment in both Dockerfiles references #9674).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
