### PR TITLE
feat(dashboard): Loop Fitness panel (#9669)

### DIFF
--- a/src/ui/src/App.jsx
+++ b/src/ui/src/App.jsx
@@ -10,16 +10,18 @@ import { StreamView } from './components/StreamView'
 import { SessionSidebar } from './components/SessionSidebar'
 import { AtlasExplorer } from './components/atlas/AtlasExplorer'
 import { ProjectView } from './components/ProjectView'
+import { LoopFitnessPanel } from './components/LoopFitnessPanel'
 import { theme } from './theme'
 import { canonicalRepoSlug } from './constants'
 
-const TABS = ['issues', 'hitl', 'outcomes', 'atlas', 'system']
+const TABS = ['issues', 'hitl', 'outcomes', 'atlas', 'loop-fitness', 'system']
 
 const TAB_LABELS = {
   issues: 'Work Stream',
   outcomes: 'Outcomes',
   hitl: 'HITL',
   atlas: 'Atlas',
+  'loop-fitness': 'Loop Fitness',
   system: 'System',
 }
 
@@ -272,6 +274,7 @@ function AppContent() {
               : <div style={idleMessage}>Pipeline is not running — HITL actions are unavailable.</div>
           )}
           {activeTab === 'atlas' && <AtlasExplorer />}
+          {activeTab === 'loop-fitness' && <LoopFitnessPanel />}
           {activeTab === 'system' && (
             <SystemPanel
               backgroundWorkers={backgroundWorkers}

--- a/src/ui/src/components/LoopFitnessPanel.jsx
+++ b/src/ui/src/components/LoopFitnessPanel.jsx
@@ -1,0 +1,252 @@
+import React from 'react'
+import { theme } from '../theme'
+import { useHydraFlow } from '../context/HydraFlowContext'
+
+function ConfidenceBadge({ confidence }) {
+  const isInsufficient = confidence === 'insufficient_data'
+  return (
+    <span
+      style={isInsufficient ? styles.badgeInsufficient : styles.badgeOk}
+      data-testid={isInsufficient ? 'confidence-insufficient' : 'confidence-ok'}
+    >
+      {isInsufficient ? 'insufficient data' : confidence}
+    </span>
+  )
+}
+
+function ComponentsTable({ components }) {
+  if (!components || Object.keys(components).length === 0) return null
+  return (
+    <div style={styles.componentsTable} data-testid="loop-fitness-components">
+      {Object.entries(components).map(([key, val]) => (
+        <div key={key} style={styles.componentRow}>
+          <span style={styles.componentKey}>{key}</span>
+          <span style={styles.componentVal}>
+            {val == null ? 'n/a' : typeof val === 'number' ? val.toFixed(3) : String(val)}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function LoopRow({ workerName, row }) {
+  const scoreDisplay = row.score == null ? 'n/a' : row.score.toFixed(3)
+  const isInsufficient = row.confidence === 'insufficient_data'
+  return (
+    <div
+      style={isInsufficient ? styles.rowInsufficient : styles.row}
+      data-testid={`loop-fitness-row-${workerName}`}
+    >
+      <div style={styles.rowHeader}>
+        <span style={styles.workerName} data-testid={`loop-fitness-name-${workerName}`}>
+          {workerName}
+        </span>
+        <span style={styles.kindBadge}>{row.kind}</span>
+      </div>
+      <div style={styles.rowMeta}>
+        <div style={styles.metaItem}>
+          <span style={styles.metaLabel}>score</span>
+          <span
+            style={row.score == null ? styles.metaValueNa : styles.metaValue}
+            data-testid={`loop-fitness-score-${workerName}`}
+          >
+            {scoreDisplay}
+          </span>
+        </div>
+        <div style={styles.metaItem}>
+          <span style={styles.metaLabel}>confidence</span>
+          <ConfidenceBadge confidence={row.confidence} />
+        </div>
+        <div style={styles.metaItem}>
+          <span style={styles.metaLabel}>samples</span>
+          <span style={styles.metaValue}>{row.sample_count}</span>
+        </div>
+      </div>
+      {row.notes && (
+        <div style={styles.notes} data-testid={`loop-fitness-notes-${workerName}`}>
+          {row.notes}
+        </div>
+      )}
+      <ComponentsTable components={row.components} />
+    </div>
+  )
+}
+
+export function LoopFitnessPanel() {
+  const { loopFitness } = useHydraFlow()
+
+  const entries = Object.entries(loopFitness || {})
+    .sort(([a], [b]) => a.localeCompare(b))
+
+  if (entries.length === 0) {
+    return (
+      <div style={styles.container} data-testid="loop-fitness-panel-root">
+        <div style={styles.empty}>No loop fitness data available yet.</div>
+      </div>
+    )
+  }
+
+  return (
+    <div style={styles.container} data-testid="loop-fitness-panel-root">
+      <div style={styles.header}>
+        <h2 style={styles.title}>Loop Fitness</h2>
+        <p style={styles.subtitle}>
+          Per-loop quality scores, sorted by name. Scores reflect recent behavior — not a ranking.
+        </p>
+      </div>
+      <div style={styles.rows} data-testid="loop-fitness-rows">
+        {entries.map(([workerName, row]) => (
+          <LoopRow key={workerName} workerName={workerName} row={row} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+const styles = {
+  container: {
+    flex: 1,
+    overflowY: 'auto',
+    padding: 20,
+  },
+  header: {
+    marginBottom: 20,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: 700,
+    color: theme.textBright,
+    margin: 0,
+    marginBottom: 6,
+  },
+  subtitle: {
+    fontSize: 12,
+    color: theme.textMuted,
+    margin: 0,
+  },
+  rows: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 12,
+  },
+  row: {
+    border: `1px solid ${theme.border}`,
+    borderRadius: 8,
+    padding: 16,
+    background: theme.surface,
+  },
+  rowInsufficient: {
+    border: `1px solid ${theme.border}`,
+    borderRadius: 8,
+    padding: 16,
+    background: theme.surfaceInset,
+    opacity: 0.75,
+  },
+  rowHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 10,
+    marginBottom: 10,
+  },
+  workerName: {
+    fontSize: 14,
+    fontWeight: 600,
+    color: theme.textBright,
+    fontFamily: 'monospace',
+  },
+  kindBadge: {
+    fontSize: 10,
+    fontWeight: 600,
+    color: theme.accent,
+    background: theme.accentSubtle,
+    borderRadius: 4,
+    padding: '2px 8px',
+    textTransform: 'uppercase',
+    letterSpacing: '0.05em',
+  },
+  rowMeta: {
+    display: 'flex',
+    gap: 24,
+    flexWrap: 'wrap',
+    marginBottom: 8,
+  },
+  metaItem: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 2,
+  },
+  metaLabel: {
+    fontSize: 10,
+    color: theme.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: '0.05em',
+  },
+  metaValue: {
+    fontSize: 14,
+    fontWeight: 600,
+    color: theme.textBright,
+  },
+  metaValueNa: {
+    fontSize: 14,
+    fontWeight: 600,
+    color: theme.textInactive,
+    fontStyle: 'italic',
+  },
+  badgeOk: {
+    fontSize: 11,
+    fontWeight: 600,
+    color: theme.green,
+    background: theme.greenSubtle,
+    borderRadius: 4,
+    padding: '2px 8px',
+  },
+  badgeInsufficient: {
+    fontSize: 11,
+    fontWeight: 600,
+    color: theme.textMuted,
+    background: theme.mutedSubtle,
+    borderRadius: 4,
+    padding: '2px 8px',
+    border: `1px dashed ${theme.border}`,
+  },
+  notes: {
+    fontSize: 12,
+    color: theme.textMuted,
+    fontStyle: 'italic',
+    marginBottom: 8,
+    paddingLeft: 4,
+    borderLeft: `2px solid ${theme.border}`,
+  },
+  componentsTable: {
+    marginTop: 8,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 3,
+    background: theme.surfaceInset,
+    borderRadius: 6,
+    padding: '8px 12px',
+  },
+  componentRow: {
+    display: 'flex',
+    gap: 12,
+    alignItems: 'baseline',
+  },
+  componentKey: {
+    fontSize: 11,
+    color: theme.textMuted,
+    fontFamily: 'monospace',
+    minWidth: 160,
+    flexShrink: 0,
+  },
+  componentVal: {
+    fontSize: 11,
+    color: theme.text,
+    fontFamily: 'monospace',
+  },
+  empty: {
+    fontSize: 13,
+    color: theme.textMuted,
+    padding: 20,
+  },
+}

--- a/src/ui/src/components/__tests__/App.test.jsx
+++ b/src/ui/src/components/__tests__/App.test.jsx
@@ -233,10 +233,10 @@ describe('Config warning banner', () => {
 })
 
 describe('Main tab bar', () => {
-  it('has exactly 5 main tabs including Atlas', async () => {
+  it('has exactly 6 main tabs including Atlas and Loop Fitness', async () => {
     const { default: App } = await import('../../App')
     render(<App />)
-    const tabLabels = ['Work Stream', 'HITL', 'Outcomes', 'Atlas', 'System']
+    const tabLabels = ['Work Stream', 'HITL', 'Outcomes', 'Atlas', 'Loop Fitness', 'System']
     const tabContainer = screen.getByTestId('main-tabs')
     expect(tabContainer.childElementCount).toBe(tabLabels.length)
     for (const label of tabLabels) {

--- a/src/ui/src/components/__tests__/LoopFitnessPanel.test.jsx
+++ b/src/ui/src/components/__tests__/LoopFitnessPanel.test.jsx
@@ -1,0 +1,228 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+const mockUseHydraFlow = vi.fn()
+
+vi.mock('../../context/HydraFlowContext', () => ({
+  useHydraFlow: (...args) => mockUseHydraFlow(...args),
+}))
+
+const { LoopFitnessPanel } = await import('../LoopFitnessPanel')
+
+function defaultContext(overrides = {}) {
+  return {
+    loopFitness: {},
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  mockUseHydraFlow.mockReturnValue(defaultContext())
+})
+
+describe('LoopFitnessPanel', () => {
+  it('shows empty state when loopFitness is empty', () => {
+    render(<LoopFitnessPanel />)
+    expect(screen.getByTestId('loop-fitness-panel-root')).toBeInTheDocument()
+    expect(screen.getByText('No loop fitness data available yet.')).toBeInTheDocument()
+  })
+
+  it('shows empty state when loopFitness is null', () => {
+    mockUseHydraFlow.mockReturnValue(defaultContext({ loopFitness: null }))
+    render(<LoopFitnessPanel />)
+    expect(screen.getByText('No loop fitness data available yet.')).toBeInTheDocument()
+  })
+
+  it('renders scored loop rows with score, kind, confidence, and sample_count', () => {
+    mockUseHydraFlow.mockReturnValue(defaultContext({
+      loopFitness: {
+        ImplementerLoop: {
+          worker_name: 'ImplementerLoop',
+          kind: 'scored',
+          score: 0.82,
+          components: { test_coverage: 0.9, quality_pass_rate: 0.74 },
+          sample_count: 12,
+          confidence: 'ok',
+          notes: null,
+          timestamp: '2026-06-30T00:00:00Z',
+        },
+      },
+    }))
+    render(<LoopFitnessPanel />)
+    expect(screen.getByTestId('loop-fitness-row-ImplementerLoop')).toBeInTheDocument()
+    expect(screen.getByTestId('loop-fitness-name-ImplementerLoop')).toBeInTheDocument()
+    expect(screen.getByTestId('loop-fitness-score-ImplementerLoop').textContent).toBe('0.820')
+    expect(screen.getByText('scored')).toBeInTheDocument()
+    expect(screen.getByTestId('confidence-ok')).toBeInTheDocument()
+    expect(screen.getByText('12')).toBeInTheDocument()
+  })
+
+  it('renders housekeeping loop rows', () => {
+    mockUseHydraFlow.mockReturnValue(defaultContext({
+      loopFitness: {
+        WikiLoop: {
+          worker_name: 'WikiLoop',
+          kind: 'housekeeping',
+          score: 0.65,
+          components: { freshness: 0.65 },
+          sample_count: 5,
+          confidence: 'ok',
+          notes: null,
+          timestamp: '2026-06-30T00:00:00Z',
+        },
+      },
+    }))
+    render(<LoopFitnessPanel />)
+    expect(screen.getByText('housekeeping')).toBeInTheDocument()
+    expect(screen.getByTestId('loop-fitness-row-WikiLoop')).toBeInTheDocument()
+  })
+
+  it('renders null score as "n/a", not 0', () => {
+    mockUseHydraFlow.mockReturnValue(defaultContext({
+      loopFitness: {
+        TriageLoop: {
+          worker_name: 'TriageLoop',
+          kind: 'scored',
+          score: null,
+          components: {},
+          sample_count: 2,
+          confidence: 'insufficient_data',
+          notes: null,
+          timestamp: '2026-06-30T00:00:00Z',
+        },
+      },
+    }))
+    render(<LoopFitnessPanel />)
+    const scoreEl = screen.getByTestId('loop-fitness-score-TriageLoop')
+    expect(scoreEl.textContent).toBe('n/a')
+    // Must not render '0' as a score
+    expect(scoreEl.textContent).not.toBe('0')
+    expect(scoreEl.textContent).not.toBe('0.000')
+  })
+
+  it('renders insufficient_data confidence visually distinct from ok', () => {
+    mockUseHydraFlow.mockReturnValue(defaultContext({
+      loopFitness: {
+        AlphaLoop: {
+          worker_name: 'AlphaLoop',
+          kind: 'scored',
+          score: null,
+          components: {},
+          sample_count: 1,
+          confidence: 'insufficient_data',
+          notes: null,
+          timestamp: '2026-06-30T00:00:00Z',
+        },
+        BetaLoop: {
+          worker_name: 'BetaLoop',
+          kind: 'scored',
+          score: 0.9,
+          components: {},
+          sample_count: 20,
+          confidence: 'ok',
+          notes: null,
+          timestamp: '2026-06-30T00:00:00Z',
+        },
+      },
+    }))
+    render(<LoopFitnessPanel />)
+    const insufficientBadge = screen.getByTestId('confidence-insufficient')
+    const okBadge = screen.getByTestId('confidence-ok')
+    // They must both exist and be distinct elements
+    expect(insufficientBadge).toBeInTheDocument()
+    expect(okBadge).toBeInTheDocument()
+    // Visually distinct: the insufficient badge shows 'insufficient data' label
+    expect(insufficientBadge.textContent).toBe('insufficient data')
+    expect(okBadge.textContent).toBe('ok')
+  })
+
+  it('sorts rows by worker_name alphabetically, not by score', () => {
+    // ZebraLoop has a higher score than AlphaLoop — it must NOT jump above it
+    mockUseHydraFlow.mockReturnValue(defaultContext({
+      loopFitness: {
+        ZebraLoop: {
+          worker_name: 'ZebraLoop',
+          kind: 'scored',
+          score: 0.99,
+          components: {},
+          sample_count: 30,
+          confidence: 'ok',
+          notes: null,
+          timestamp: '2026-06-30T00:00:00Z',
+        },
+        AlphaLoop: {
+          worker_name: 'AlphaLoop',
+          kind: 'scored',
+          score: 0.10,
+          components: {},
+          sample_count: 15,
+          confidence: 'ok',
+          notes: null,
+          timestamp: '2026-06-30T00:00:00Z',
+        },
+        MidLoop: {
+          worker_name: 'MidLoop',
+          kind: 'housekeeping',
+          score: 0.55,
+          components: {},
+          sample_count: 8,
+          confidence: 'ok',
+          notes: null,
+          timestamp: '2026-06-30T00:00:00Z',
+        },
+      },
+    }))
+    render(<LoopFitnessPanel />)
+    const rows = screen.getByTestId('loop-fitness-rows')
+    const rowElements = rows.querySelectorAll('[data-testid^="loop-fitness-row-"]')
+    const names = Array.from(rowElements).map(el => el.getAttribute('data-testid').replace('loop-fitness-row-', ''))
+    // Alphabetical order: AlphaLoop < MidLoop < ZebraLoop
+    expect(names).toEqual(['AlphaLoop', 'MidLoop', 'ZebraLoop'])
+    // The highest-scoring ZebraLoop is last, not first
+    expect(names[0]).toBe('AlphaLoop')
+    expect(names[names.length - 1]).toBe('ZebraLoop')
+  })
+
+  it('renders raw components when present', () => {
+    mockUseHydraFlow.mockReturnValue(defaultContext({
+      loopFitness: {
+        ImplementerLoop: {
+          worker_name: 'ImplementerLoop',
+          kind: 'scored',
+          score: 0.75,
+          components: { test_coverage: 0.8, pr_merge_rate: 0.7 },
+          sample_count: 10,
+          confidence: 'ok',
+          notes: null,
+          timestamp: '2026-06-30T00:00:00Z',
+        },
+      },
+    }))
+    render(<LoopFitnessPanel />)
+    const componentsEl = screen.getByTestId('loop-fitness-components')
+    expect(componentsEl).toBeInTheDocument()
+    expect(componentsEl.textContent).toContain('test_coverage')
+    expect(componentsEl.textContent).toContain('pr_merge_rate')
+  })
+
+  it('renders notes when present', () => {
+    mockUseHydraFlow.mockReturnValue(defaultContext({
+      loopFitness: {
+        ReviewLoop: {
+          worker_name: 'ReviewLoop',
+          kind: 'scored',
+          score: 0.6,
+          components: {},
+          sample_count: 4,
+          confidence: 'ok',
+          notes: 'Score suppressed: low sample window.',
+          timestamp: '2026-06-30T00:00:00Z',
+        },
+      },
+    }))
+    render(<LoopFitnessPanel />)
+    expect(screen.getByTestId('loop-fitness-notes-ReviewLoop')).toBeInTheDocument()
+    expect(screen.getByText('Score suppressed: low sample window.')).toBeInTheDocument()
+  })
+})

--- a/src/ui/src/components/__tests__/LoopFitnessPanel.test.jsx
+++ b/src/ui/src/components/__tests__/LoopFitnessPanel.test.jsx
@@ -101,6 +101,28 @@ describe('LoopFitnessPanel', () => {
     expect(scoreEl.textContent).not.toBe('0.000')
   })
 
+  it('renders score of 0 as "0.000", not "n/a"', () => {
+    mockUseHydraFlow.mockReturnValue(defaultContext({
+      loopFitness: {
+        ZeroScoredLoop: {
+          worker_name: 'ZeroScoredLoop',
+          kind: 'scored',
+          score: 0,
+          components: {},
+          sample_count: 8,
+          confidence: 'ok',
+          notes: null,
+          timestamp: '2026-06-30T00:00:00Z',
+        },
+      },
+    }))
+    render(<LoopFitnessPanel />)
+    const scoreEl = screen.getByTestId('loop-fitness-score-ZeroScoredLoop')
+    expect(scoreEl.textContent).toBe('0.000')
+    // Must not render as "n/a"
+    expect(scoreEl.textContent).not.toBe('n/a')
+  })
+
   it('renders insufficient_data confidence visually distinct from ok', () => {
     mockUseHydraFlow.mockReturnValue(defaultContext({
       loopFitness: {

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -56,6 +56,7 @@ export const initialState = {
   retrospectives: null,
   troubleshooting: null,
   trackedReports: [],
+  loopFitness: {},
   // True when the orchestrator backend is wired to Fake adapters (sandbox tier).
   // Set from /api/control/status. Drives the persistent MOCKWORLD MODE banner.
   mockworldActive: false,
@@ -544,6 +545,9 @@ export function reducer(state, action) {
     case 'METRICS_HISTORY':
       return { ...state, metricsHistory: action.data }
 
+    case 'LOOP_FITNESS':
+      return { ...state, loopFitness: action.data }
+
     case 'metrics_update':
       return {
         ...addEvent(state, action),
@@ -1025,6 +1029,13 @@ export function HydraFlowProvider({ children }) {
     fetchWithRepo('/api/metrics/history')
       .then(r => r.json())
       .then(data => dispatch({ type: 'METRICS_HISTORY', data }))
+      .catch(() => {})
+  }, [fetchWithRepo])
+
+  const fetchLoopFitness = useCallback(() => {
+    fetchWithRepo('/api/loop-fitness')
+      .then(r => r.json())
+      .then(data => dispatch({ type: 'LOOP_FITNESS', data }))
       .catch(() => {})
   }, [fetchWithRepo])
 
@@ -1606,6 +1617,7 @@ export function HydraFlowProvider({ children }) {
         .catch(() => {})
       fetchGithubMetrics()
       fetchMetricsHistory()
+      fetchLoopFitness()
       fetchPipeline()
       fetchPipelineStats()
       fetchEpics()
@@ -1638,6 +1650,9 @@ export function HydraFlowProvider({ children }) {
           fetchWithRepo('/api/metrics').then(r => r.json()).then(data => dispatch({ type: 'METRICS', data })).catch(() => {})
           fetchGithubMetrics()
           fetchMetricsHistory()
+        }
+        if (event.type === 'loop_fitness_update') {
+          fetchLoopFitness()
         }
         // queue_update no longer triggers a pipeline fetch: the QUEUE_UPDATE
         // storm is the source of the REST-poll thrash. The authoritative
@@ -1680,7 +1695,7 @@ export function HydraFlowProvider({ children }) {
       console.warn('[HydraFlow] WebSocket error; awaiting close for reconnect', err)
     }
     wsRef.current = ws
-  }, [state.selectedRepoSlug, applyRepoParam, fetchLifetimeStats, fetchHitlItems, fetchGithubMetrics, fetchMetricsHistory, fetchPipeline, fetchPipelineStats, fetchEpics, fetchSessions, fetchRepos, fetchRuntimes, fetchWithRepo])
+  }, [state.selectedRepoSlug, applyRepoParam, fetchLifetimeStats, fetchHitlItems, fetchGithubMetrics, fetchMetricsHistory, fetchLoopFitness, fetchPipeline, fetchPipelineStats, fetchEpics, fetchSessions, fetchRepos, fetchRuntimes, fetchWithRepo])
 
   useEffect(() => {
     const poll = () => {


### PR DESCRIPTION
Closes #9669. Follow-up to the loop-fitness scorecard (#9672) — ships the dashboard panel that consumes the already-merged `GET /api/loop-fitness` route and `LOOP_FITNESS_UPDATE` event.

## What

- **`LoopFitnessPanel.jsx`** — a new "Loop Fitness" tab rendering per-loop fitness: `kind`, score-or-`n/a`, `confidence`, `sample_count`, and raw `components`.
- **Context wiring** (`HydraFlowContext.jsx`) — `loopFitness` state + a `fetchLoopFitness()` that hits `/api/loop-fitness`, triggered on mount and on the `loop_fitness_update` event (mirrors the `metrics_update`→`fetchMetrics` pattern).
- **App integration** — new tab in `TABS`/`TAB_LABELS`.

## Spec constraints (enforced + tested)

- **No cross-loop leaderboard** — rows sorted strictly by `worker_name` (`localeCompare`); score/kind never affect order. Adversarial test places the highest-scoring loop first in the fixture to catch insertion-order shortcuts.
- **`score === null` → "n/a", never `0`** — uses `row.score == null` (not `!score`), so a real `0` correctly renders `0.000`. Both the negative (null→"n/a") and positive (0→"0.000") cases are tested.
- **`insufficient_data` visually distinct** — muted/dashed badge + reduced-opacity row, distinct `data-testid`s, test-asserted.

## Tests

10 `LoopFitnessPanel` cases + updated `App.test.jsx` tab count. `npm run build` OK; full dashboard suite green. CI **Dashboard Build** + **Browser Scenarios** are the end-to-end gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
