### PR TITLE
Two-level convergence Phase 2b: boundary verdict recording (Triage/Shape/Plan)

### DIFF
--- a/docs/adr/0096-boundary-verdict-recording.md
+++ b/docs/adr/0096-boundary-verdict-recording.md
@@ -1,0 +1,67 @@
+# ADR-0096: Boundary verdict recording (Phase 2b)
+
+- **Status:** Accepted
+- **Date:** 2026-06-30
+- **Refines:** ADR-0094 (two-level convergence: Gate + ConvergenceLedger)
+- **Extends:** ADR-0095 (approve-path gating)
+
+## Context
+
+ADR-0094 wired the convergence Gate and ConvergenceLedger at the Review boundary only. Phase 2a (ADR-0095) then gated the approve path so that `ledger.converged` became a real, reachable signal. Lap accounting and `mark_lap`/`recompute_converged` are Review-owned throughout both phases.
+
+The other pipeline boundaries (Triage, Shape, Plan) still make ADVANCE/LOOP_BACK/ESCALATE-shaped decisions inside their own engines: `AdversarialRetryLoop`-backed councils and judges (Shape, Plan), and scoring-based routing (Triage). However, the ledger has no pipeline-wide view of those decisions. That gap blocks the Phase 2d oscillation caretaker, which needs cross-boundary verdict history to detect oscillation across stage boundaries, not just within the Review boundary.
+
+## Decision
+
+Each pipeline boundary records a uniform verdict and finding signatures into the per-issue `ConvergenceLedger` AFTER its existing decision, via one gated helper:
+
+```
+record_stage_verdict(state, *, enabled, issue_number, stage, decision, signatures)
+```
+
+This helper lives in `src/convergence_recording.py`.
+
+### Record, not replace (Fork 2)
+
+The helper is a side-write, inserted immediately before an existing return site. It does NOT alter any phase's control flow, decision logic, or inner engine. Triage scoring, ShapeExpertCouncil, PlanCouncil, SpecJudge, and AssumptionSurfacer are all untouched. The boundary still makes its own decision by its own mechanism; the recording is purely observational.
+
+### Verdict mapping per boundary
+
+- **Triage:** outcomes `{plan, sentry_noise_closed, already_addressed, epic_decomposed, bug_not_present}` map to ADVANCE; outcomes `{discover, parked}` map to LOOP_BACK; any other outcome produces no record.
+- **Shape:** finalized / selection-made / council-consensus maps to ADVANCE; waiting maps to LOOP_BACK.
+- **Plan:** outcome `success` maps to ADVANCE; outcome `failed` maps to LOOP_BACK; outcome `escalated` maps to ESCALATE; an already-satisfied-closed early exit maps to ADVANCE.
+- **Signatures:** Shape and Plan use `signatures_from_concerns(adv.pending_concerns)`, which extracts sorted, unique CRITICAL/HIGH concern text from the adversarial loop state. Triage uses `[]` (no adversarial concerns at that boundary).
+
+### Lap/converged stay review-owned
+
+The boundary recording writes only `stage_state[stage].last_verdict` and `last_finding_signatures` into the ledger. It does NOT call `mark_lap` or `recompute_converged`. Those remain the Review boundary's exclusive responsibility, preserving the Phase 1/2a lap and `converged` semantics without change.
+
+Rationale: a single outer-lap definition anchored at Review is simpler to reason about and avoids multiplying the lap concept across boundaries. Boundary records are observability and oscillation input, not lap drivers.
+
+## Rules and consequences
+
+1. **Inert when disabled.** When `convergence_gate_enabled` is off, the helper is a no-op, and each phase is byte-for-byte unchanged.
+2. **Verdict strings are exact.** The only legal values are `"ADVANCE"`, `"LOOP_BACK"`, and `"ESCALATE"`. No other strings are written to the ledger.
+3. **Pipeline-wide history.** With recording active, the ledger accumulates a verdict history across Triage, Shape, Plan, and Review boundaries. The Phase 2d oscillation caretaker consumes this history to detect repeated LOOP_BACK patterns that span multiple stages.
+4. **Cost.** One small ledger write and save per boundary decision when the flag is on. No additional LLM calls.
+
+## Scope (Phase 2b)
+
+This ADR covers the `record_stage_verdict` helper, its integration at the Triage, Shape, and Plan boundaries, and the MockWorld pipeline scenario that exercises the full recording flow. Out of scope: counter migration into the ledger (Phase 2c) and the `ConvergenceOscillationLoop` caretaker (Phase 2d).
+
+## Alternatives considered
+
+1. **Replace each boundary's engine with the Gate.** Rejected. The councils and judges are the domain logic for those phases. The Gate is a referee for convergence, not a planner or shape evaluator. Replacing the engines would conflate two distinct concerns and break the established domain decomposition.
+2. **Have each boundary call `mark_lap`/`recompute_converged`.** Rejected. That would multiply the lap definition across boundaries, producing multiple conflicting lap anchors and breaking the single review-anchored outer lap established in Phases 1 and 2a.
+
+## When to supersede this ADR
+
+Supersede when a boundary's recording contract changes (for example, if a boundary begins driving laps), or when Phases 2c or 2d change what the ledger stores or how verdict history is structured.
+
+## Source-file citations
+
+- `src/convergence_recording.py`: `record_stage_verdict`, `signatures_from_concerns`.
+- `src/triage_phase.py`: integration of `record_stage_verdict` at Triage decision sites.
+- `src/shape_phase.py`: integration of `record_stage_verdict` at Shape decision sites.
+- `src/plan_phase.py`: integration of `record_stage_verdict` at Plan decision sites.
+- `tests/scenarios/test_convergence_pipeline_mockworld.py`: MockWorld pipeline scenario exercising the full cross-boundary recording flow.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -127,6 +127,7 @@ ADR and that named test files actually exist.
 | [0093](0093-loop-fitness-as-measured-contract.md) | Loop fitness as a measured contract | Accepted |
 | [0094](0094-two-level-convergence-gate-and-ledger.md) | Two-level convergence: Gate + ConvergenceLedger | Accepted |
 | [0095](0095-approve-path-gating-and-converged.md) | Approve-path gating and live convergence (Phase 2a) | Accepted |
+| [0096](0096-boundary-verdict-recording.md) | Boundary verdict recording (Phase 2b) | Accepted |
 
 ## Adding a new ADR
 

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-07-01T00:15:27.848851+00:00",
-  "commit_sha": "74f762b9864fc53c22c6b32f168195c5b7d24567",
+  "regenerated_at": "2026-07-01T01:41:40.928641+00:00",
+  "commit_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9",
   "artifacts": {
     "loops.md": {
-      "source_sha": "74f762b9864fc53c22c6b32f168195c5b7d24567"
+      "source_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9"
     },
     "ports.md": {
-      "source_sha": "74f762b9864fc53c22c6b32f168195c5b7d24567"
+      "source_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9"
     },
     "labels.md": {
-      "source_sha": "74f762b9864fc53c22c6b32f168195c5b7d24567"
+      "source_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9"
     },
     "modules.md": {
-      "source_sha": "74f762b9864fc53c22c6b32f168195c5b7d24567"
+      "source_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9"
     },
     "events.md": {
-      "source_sha": "74f762b9864fc53c22c6b32f168195c5b7d24567"
+      "source_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9"
     },
     "adr_xref.md": {
-      "source_sha": "74f762b9864fc53c22c6b32f168195c5b7d24567"
+      "source_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9"
     },
     "mockworld.md": {
-      "source_sha": "74f762b9864fc53c22c6b32f168195c5b7d24567"
+      "source_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9"
     },
     "changelog.md": {
-      "source_sha": "74f762b9864fc53c22c6b32f168195c5b7d24567"
+      "source_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9"
     },
     "coverage_matrix.md": {
-      "source_sha": "74f762b9864fc53c22c6b32f168195c5b7d24567"
+      "source_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9"
     },
     "functional_areas.md": {
-      "source_sha": "74f762b9864fc53c22c6b32f168195c5b7d24567"
+      "source_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9"
     },
     "ubiquitous-language.md": {
-      "source_sha": "74f762b9864fc53c22c6b32f168195c5b7d24567"
+      "source_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "74f762b9864fc53c22c6b32f168195c5b7d24567"
+      "source_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -102,6 +102,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | ADR-0093 | `src.base_background_loop`, `src.fitness_scorecard_loop`, `src.loop_fitness` |
 | ADR-0094 | `src.config`, `src.convergence_gate`, `src.models`, `src.review_advisor`, `src.review_phase._phase`, `src.state._convergence` |
 | ADR-0095 | `src.convergence_gate`, `src.models`, `src.review_advisor`, `src.review_phase._phase` |
+| ADR-0096 | `src.convergence_recording`, `src.plan_phase`, `src.shape_phase`, `src.triage_phase` |
 
 ## Module → ADRs
 
@@ -133,6 +134,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.contract_refresh_loop` | ADR-0045, ADR-0047 |
 | `src.contracts.shadow` | ADR-0086 |
 | `src.convergence_gate` | ADR-0094, ADR-0095 |
+| `src.convergence_recording` | ADR-0096 |
 | `src.corpus_learning_loop` | ADR-0045 |
 | `src.dashboard` | ADR-0007, ADR-0008, ADR-0038 |
 | `src.dashboard_routes` | ADR-0008, ADR-0013, ADR-0019, ADR-0038 |
@@ -185,7 +187,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.pending_concerns` | ADR-0064 |
 | `src.plan_council` | ADR-0064 |
 | `src.plan_council_prompts` | ADR-0064 |
-| `src.plan_phase` | ADR-0014, ADR-0031, ADR-0063, ADR-0064 |
+| `src.plan_phase` | ADR-0014, ADR-0031, ADR-0063, ADR-0064, ADR-0096 |
 | `src.ports` | ADR-0003, ADR-0044, ADR-0066, ADR-0067, ADR-0068, ADR-0069, ADR-0070 |
 | `src.post_merge_handler` | ADR-0012, ADR-0014, ADR-0015, ADR-0016, ADR-0019, ADR-0064 |
 | `src.pr_manager` | ADR-0002, ADR-0005, ADR-0011, ADR-0013, ADR-0018, ADR-0045, ADR-0055, ADR-0084, ADR-0088 |
@@ -227,7 +229,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.service_registry` | ADR-0045 |
 | `src.shape_challenger` | ADR-0064 |
 | `src.shape_expert_council` | ADR-0064 |
-| `src.shape_phase` | ADR-0031, ADR-0045, ADR-0063, ADR-0064 |
+| `src.shape_phase` | ADR-0031, ADR-0045, ADR-0063, ADR-0064, ADR-0096 |
 | `src.shape_runner` | ADR-0031, ADR-0045 |
 | `src.skill_prompt_eval_loop` | ADR-0045 |
 | `src.skill_registry` | ADR-0065 |
@@ -250,7 +252,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.term_proposer_loop` | ADR-0054, ADR-0068 |
 | `src.term_pruner_loop` | ADR-0057, ADR-0068 |
 | `src.trace_collector` | ADR-0055 |
-| `src.triage_phase` | ADR-0014, ADR-0017, ADR-0031, ADR-0039, ADR-0063 |
+| `src.triage_phase` | ADR-0014, ADR-0017, ADR-0031, ADR-0039, ADR-0063, ADR-0096 |
 | `src.trust_fleet_sanity_loop` | ADR-0045, ADR-0046 |
 | `src.ubiquitous_language` | ADR-0054, ADR-0057, ADR-0058, ADR-0090 |
 | `src.untrusted_text` | ADR-0092 |

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,12 +6,38 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W27
 
+- `e396bad` — Merge origin/staging into Phase1+2a; resolve ADR-0093 collision (convergence ADRs -> 0094/0095), union config + README *(2026-06-30)*
+- `1877391` — feat: loop-fitness scorecard (read-only measurement substrate) (#9672) (#9672) *(2026-06-30)*
 - `a642ac1` — docs(adr-0094): soften escalate-parity wording (reject adds oscillation cause) *(2026-06-30)*
 - `5a5a105` — docs(adr): ADR-0094 approve-path gating + live convergence (Phase 2a) *(2026-06-30)*
 - `4c9e6dc` — docs(adr): ADR-0093 two-level convergence (Gate + ConvergenceLedger) *(2026-06-30)*
 
+## 2026-W26
+
+- `5e72016` — Fixes #9080: Provision isolated GitHub contracts sandbox (sandbox session + teardown) (#9512) (#9512) *(2026-06-22)*
+- `0117ea0` — feat(test-adequacy): add deterministic coverage-delta cross-check (#9567) (#9646) (#9646) *(2026-06-22)*
+- `8e3a40d` — feat(ul): term-proposer batch — 1 drafts (#9655) (#9655) *(2026-06-22)*
+- `efdb1cb` — feat(ul): term-proposer batch — 1 drafts (#9654) (#9654) *(2026-06-22)*
+- `6f1dc99` — feat(ul): entry-evidence — 3 new entry links across 1 terms (#9653) (#9653) *(2026-06-22)*
+- `e4d1ef8` — feat(ul): entry-evidence — 27 new entry links across 12 terms (#9638) (#9638) *(2026-06-22)*
+- `1b9ef5b` — feat(ul): edge-proposer — 5 new edges across 5 terms (#9637) (#9637) *(2026-06-22)*
+- `e81d29d` — feat(ul): entry-evidence — 10 new entry links across 5 terms (#9620) (#9620) *(2026-06-22)*
+
 ## 2026-W25
 
+- `ef30b34` — feat(ul): edge-proposer — 5 new edges across 5 terms (#9619) (#9619) *(2026-06-21)*
+- `2865085` — feat(ul): term-proposer batch — 1 drafts (#9612) (#9612) *(2026-06-21)*
+- `376ea77` — feat(ul): entry-evidence — 3 new entry links across 2 terms (#9611) (#9611) *(2026-06-21)*
+- `dada382` — feat(ul): entry-evidence — 14 new entry links across 5 terms (#9573) (#9573) *(2026-06-21)*
+- `4dc2b15` — feat(ul): entry-evidence — 3 new entry links across 3 terms (#9571) (#9571) *(2026-06-21)*
+- `74c6d83` — feat(ul): entry-evidence — 3 new entry links across 3 terms (#9560) (#9560) *(2026-06-21)*
+- `79f2109` — feat(ul): entry-evidence — 20 new entry links across 11 terms (#9549) (#9549) *(2026-06-21)*
+- `27a4fe5` — feat(ul): entry-evidence — 3 new entry links across 3 terms (#9534) (#9534) *(2026-06-21)*
+- `9f3ae72` — feat(ul): entry-evidence — 7 new entry links across 4 terms (#9533) (#9533) *(2026-06-21)*
+- `5f5fb99` — feat(ul): entry-evidence — 5 new entry links across 4 terms (#9495) (#9495) *(2026-06-21)*
+- `bfc5425` — feat(ul): entry-evidence — 21 new entry links across 11 terms (#9610) (#9610) *(2026-06-21)*
+- `1e288b0` — feat(ul): entry-evidence — 8 new entry links across 5 terms (#9492) (#9492) *(2026-06-21)*
+- `5e24e54` — Accept ADR-0027: duplicate class merge artifact pattern (#9493) (#9493) *(2026-06-21)*
 - `d1d7e11` — Fixes #9507: ADR-0007/0013/0019 carry the same dashboard drift FP +... (#9518) (#9518) *(2026-06-20)*
 - `69fea6a` — feat(factory): generate-in-worktree foundation + DiagramLoop migration (#9539 pt1) (#9614) (#9614) *(2026-06-19)*
 - `e920762` — feat(loops): per-loop work-cycle watchdog (closes #9556) (#9594) (#9594) *(2026-06-19)*

--- a/src/convergence_recording.py
+++ b/src/convergence_recording.py
@@ -1,0 +1,37 @@
+"""Boundary verdict recording helpers for the convergence pipeline."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pending_concerns import Concern
+
+
+def record_stage_verdict(
+    state: Any,
+    *,
+    enabled: bool,
+    issue_number: int,
+    stage: str,
+    decision: str,
+    signatures: list[str],
+) -> None:
+    """Record a boundary verdict into the per-issue ConvergenceLedger.
+
+    No-op when not enabled. Records verdict + signatures ONLY (does NOT
+    mark_lap or recompute_converged — those stay review-owned).
+    """
+    if not enabled:
+        return
+    ledger = state.ensure_convergence_ledger(issue_number)
+    ledger.record_gate_result(stage, decision, signatures)
+    state.save_convergence_ledger(issue_number, ledger)
+
+
+def signatures_from_concerns(concerns: list[Concern]) -> list[str]:
+    """Sorted unique CRITICAL/HIGH concern texts.
+
+    Mirrors ``adversarial_retry_loop._signature_for`` filtering logic.
+    """
+    return sorted({c.concern for c in concerns if c.severity in {"CRITICAL", "HIGH"}})

--- a/src/plan_phase.py
+++ b/src/plan_phase.py
@@ -61,7 +61,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("hydraflow.plan_phase")
 
-# Verdict map for ConvergenceLedger boundary recording (ADR-0045 / convergence gate).
+# Verdict map for ConvergenceLedger boundary recording (ADR-0096 / convergence gate).
 # "ADVANCE" = issue moves forward in the pipeline.
 # "LOOP_BACK" = issue failed planning and must re-enter the plan stage.
 # "ESCALATE" = issue is handed off to HITL.

--- a/src/plan_phase.py
+++ b/src/plan_phase.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 from analysis import PlanAnalyzer
 from config import HydraFlowConfig
+from convergence_recording import record_stage_verdict, signatures_from_concerns
 from events import EventBus
 from exception_classify import reraise_on_credit_or_bug
 from harness_insights import FailureCategory, HarnessInsightStore
@@ -59,6 +60,16 @@ if TYPE_CHECKING:
     from wiki_compiler import CorroborationDecision, WikiCompiler  # noqa: TCH004
 
 logger = logging.getLogger("hydraflow.plan_phase")
+
+# Verdict map for ConvergenceLedger boundary recording (ADR-0045 / convergence gate).
+# "ADVANCE" = issue moves forward in the pipeline.
+# "LOOP_BACK" = issue failed planning and must re-enter the plan stage.
+# "ESCALATE" = issue is handed off to HITL.
+_PLAN_VERDICT_MAP: dict[str, str] = {
+    "success": "ADVANCE",
+    "failed": "LOOP_BACK",
+    "escalated": "ESCALATE",
+}
 
 # Minimum body length for auto-filed sub-issues discovered during planning.
 _MIN_ISSUE_BODY_CHARS: int = 50
@@ -1303,6 +1314,16 @@ class PlanPhase:
                         else:
                             closed = await self._handle_already_satisfied(issue, result)
                             if closed:
+                                record_stage_verdict(
+                                    self._state,
+                                    enabled=self._config.convergence_gate_enabled,
+                                    issue_number=issue.id,
+                                    stage="plan",
+                                    decision="ADVANCE",
+                                    signatures=signatures_from_concerns(
+                                        adv.pending_concerns
+                                    ),
+                                )
                                 return result
                             # Evidence validation failed — escalate directly
                             # to HITL (do NOT fall through to _handle_plan_failure
@@ -1347,6 +1368,16 @@ class PlanPhase:
                         ts_status = "failed"
 
                     await self._post_plan_transcript(issue, result, status=ts_status)
+                    _verdict = _PLAN_VERDICT_MAP.get(ts_status)
+                    if _verdict is not None:
+                        record_stage_verdict(
+                            self._state,
+                            enabled=self._config.convergence_gate_enabled,
+                            issue_number=issue.id,
+                            stage="plan",
+                            decision=_verdict,
+                            signatures=signatures_from_concerns(adv.pending_concerns),
+                        )
                     return result
 
     def _plan_one_with_context(

--- a/src/shape_phase.py
+++ b/src/shape_phase.py
@@ -426,6 +426,16 @@ class ShapePhase:
         if len(conv.turns) == 1 and self._council:
             council_result = await self._run_council_vote(issue, conv, result.content)
             if council_result:
+                record_stage_verdict(
+                    self._state,
+                    enabled=self._config.convergence_gate_enabled,
+                    issue_number=issue.id,
+                    stage="shape",
+                    decision="ADVANCE",
+                    signatures=signatures_from_concerns(adv.pending_concerns)
+                    if adv is not None
+                    else [],
+                )
                 return council_result
 
         # No consensus or no council — post turn and wait for human

--- a/src/shape_phase.py
+++ b/src/shape_phase.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from config import HydraFlowConfig
+from convergence_recording import record_stage_verdict, signatures_from_concerns
 from dedup_store import DedupStore
 from events import EventBus, EventType, HydraFlowEvent
 from expert_council import CouncilResult, ExpertCouncil  # noqa: TCH001
@@ -294,9 +295,25 @@ class ShapePhase:
                         self._store.enqueue_transition(issue, "plan")
                         await self._prs.transition(issue.id, "plan")
                         self._state.increment_session_counter("shaped")
+                        record_stage_verdict(
+                            self._state,
+                            enabled=self._config.convergence_gate_enabled,
+                            issue_number=issue.id,
+                            stage="shape",
+                            decision="ADVANCE",
+                            signatures=[],
+                        )
                         return 1
                     # No selection yet — re-enqueue and wait
                     self._store.enqueue_transition(issue, "shape")
+                    record_stage_verdict(
+                        self._state,
+                        enabled=self._config.convergence_gate_enabled,
+                        issue_number=issue.id,
+                        stage="shape",
+                        decision="LOOP_BACK",
+                        signatures=[],
+                    )
                     return 0
 
                 # --- No options marker: generate options ---
@@ -363,6 +380,7 @@ class ShapePhase:
         # Both run only when an AgentLike adversarial agent is attached
         # (legacy paths skip these entirely). Per dark-factory contract:
         # never deadlock — concerns persist + forward, even on exhaustion.
+        adv: AdversarialState | None = None
         if self._has_any_adversarial_agent():
             adv = self._state.get_adversarial_state(issue.id) or AdversarialState(
                 phase="shape"
@@ -392,6 +410,16 @@ class ShapePhase:
             await self._process_finalization(issue, conv, result.content)
             conv.status = "done"
             self._state.set_shape_conversation(issue.id, conv)
+            record_stage_verdict(
+                self._state,
+                enabled=self._config.convergence_gate_enabled,
+                issue_number=issue.id,
+                stage="shape",
+                decision="ADVANCE",
+                signatures=signatures_from_concerns(adv.pending_concerns)
+                if adv is not None
+                else [],
+            )
             return 1
 
         # After first agent turn with directions, run expert council vote
@@ -403,6 +431,16 @@ class ShapePhase:
         # No consensus or no council — post turn and wait for human
         await self._post_conversation_turn(issue, result.content, len(conv.turns), conv)
         self._store.enqueue_transition(issue, "shape")
+        record_stage_verdict(
+            self._state,
+            enabled=self._config.convergence_gate_enabled,
+            issue_number=issue.id,
+            stage="shape",
+            decision="LOOP_BACK",
+            signatures=signatures_from_concerns(adv.pending_concerns)
+            if adv is not None
+            else [],
+        )
 
         await self._bus.publish(
             HydraFlowEvent(

--- a/src/triage_phase.py
+++ b/src/triage_phase.py
@@ -12,6 +12,7 @@ from adr_utils import (
     is_adr_issue_title,
 )
 from config import HydraFlowConfig
+from convergence_recording import record_stage_verdict
 from events import EventBus, EventType, HydraFlowEvent
 from models import Task, TriageResult
 from phase_utils import (
@@ -35,6 +36,20 @@ logger = logging.getLogger("hydraflow.triage_phase")
 
 _SENTRY_MARKER = "<!-- [sentry:"
 _AUDITOR_MARKER = "<!-- [hydraflow-auditor:"
+
+# Verdict map for ConvergenceLedger boundary recording (ADR-0045 / convergence gate).
+# "ADVANCE" = issue moves forward in the pipeline.
+# "LOOP_BACK" = issue is requeued or parked and must re-enter triage.
+# Outcomes not in this map (e.g. "unknown") are not recorded.
+_TRIAGE_VERDICT_MAP: dict[str, str] = {
+    "plan": "ADVANCE",
+    "sentry_noise_closed": "ADVANCE",
+    "already_addressed": "ADVANCE",
+    "epic_decomposed": "ADVANCE",
+    "bug_not_present": "ADVANCE",
+    "discover": "LOOP_BACK",
+    "parked": "LOOP_BACK",
+}
 
 
 def _is_sentry_issue(issue: Task) -> bool:
@@ -466,6 +481,16 @@ class TriagePhase:
                         issue.id,
                         evidence,
                     )
+                    _verdict = _TRIAGE_VERDICT_MAP.get(routing_outcome)
+                    if _verdict is not None:
+                        record_stage_verdict(
+                            self._state,
+                            enabled=self._config.convergence_gate_enabled,
+                            issue_number=issue.id,
+                            stage="triage",
+                            decision=_verdict,
+                            signatures=[],
+                        )
                     return 1
                 if str(repro.outcome) == "unable":
                     logger.warning(
@@ -492,6 +517,17 @@ class TriagePhase:
             self._store.enqueue_transition(issue, "plan")
             await self._transitioner.transition(issue.id, "plan")
             self._state.increment_session_counter("triaged")
+
+        _verdict = _TRIAGE_VERDICT_MAP.get(routing_outcome)
+        if _verdict is not None:
+            record_stage_verdict(
+                self._state,
+                enabled=self._config.convergence_gate_enabled,
+                issue_number=issue.id,
+                stage="triage",
+                decision=_verdict,
+                signatures=[],
+            )
 
         return 1
 

--- a/src/triage_phase.py
+++ b/src/triage_phase.py
@@ -37,7 +37,7 @@ logger = logging.getLogger("hydraflow.triage_phase")
 _SENTRY_MARKER = "<!-- [sentry:"
 _AUDITOR_MARKER = "<!-- [hydraflow-auditor:"
 
-# Verdict map for ConvergenceLedger boundary recording (ADR-0045 / convergence gate).
+# Verdict map for ConvergenceLedger boundary recording (ADR-0096 / convergence gate).
 # "ADVANCE" = issue moves forward in the pipeline.
 # "LOOP_BACK" = issue is requeued or parked and must re-enter triage.
 # Outcomes not in this map (e.g. "unknown") are not recorded.

--- a/tests/scenarios/test_convergence_pipeline_mockworld.py
+++ b/tests/scenarios/test_convergence_pipeline_mockworld.py
@@ -1,0 +1,116 @@
+"""MockWorld scenario — convergence gate recording at triage and plan boundaries.
+
+Proves that the boundary recording introduced in Tasks 2–4 fires through REAL
+phase code, not hand-populated ledger entries.  A single issue is driven through
+the full MockWorld pipeline (triage → plan → implement → review) with the gate
+ON, and the test asserts the ledger accumulates ``stage_state`` entries for
+``"triage"`` and ``"plan"``, both with ``last_verdict == "ADVANCE"``.
+
+**Integration-level** — the real ``triage_phase`` and ``plan_phase`` run inside
+MockWorld; nothing in the ledger is set by hand.  This complements
+``test_convergence_review_mockworld.py``, which covers the review boundary.
+
+Note: ``run_pipeline`` does NOT run a shape phase, so no ``"shape"`` assertion
+is made.  The pipeline order is triage → plan → implement → review.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.scenarios.builders import IssueBuilder
+from tests.scenarios.fakes import MockWorld
+
+pytestmark = pytest.mark.scenario
+
+
+# ---------------------------------------------------------------------------
+# Helper — copied verbatim from test_convergence_review_mockworld.py
+# (replicating the small local helper is intentional per the task brief;
+#  do not refactor the existing file)
+# ---------------------------------------------------------------------------
+
+
+def _make_world_with_gate(tmp_path, *, max_convergence_laps: int = 3) -> MockWorld:
+    """Return a fresh MockWorld with the convergence gate enabled.
+
+    We pass a config built before constructing MockWorld so that
+    ``ReviewPhase`` (wired in ``PipelineHarness.__init__``) picks up the flag
+    at construction time.  Mutating ``world.harness.config`` after the fact
+    would also work because ``ReviewPhase._uses_convergence_gate()`` reads
+    ``self._config.convergence_gate_enabled`` at call time, but passing it in
+    is the cleaner contract.
+    """
+    from tests.helpers import ConfigFactory
+
+    cfg = ConfigFactory.create(
+        repo_root=tmp_path / "repo",
+        workspace_base=tmp_path / "worktrees",
+        state_file=tmp_path / "state.json",
+        max_workers=1,
+        max_planners=1,
+        max_reviewers=1,
+        visual_validation_enabled=False,
+        max_ci_fix_attempts=0,
+    )
+    cfg.convergence_gate_enabled = True
+    cfg.max_convergence_laps = max_convergence_laps
+    return MockWorld(tmp_path, config=cfg)
+
+
+# ---------------------------------------------------------------------------
+# Scenario — pipeline-level boundary recording (triage + plan)
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineBoundaryRecording:
+    """Gate ON: full pipeline run records triage and plan boundary verdicts.
+
+    This is the integration-level proof that the boundary recording added in
+    Tasks 2–4 fires through the REAL triage and plan phase code inside
+    MockWorld.  No LLM scripting is required: the default fakes route triage
+    to ``"plan"`` (which maps to ``"ADVANCE"`` via ``_TRIAGE_VERDICT_MAP``)
+    and plan succeeds (``ts_status=="success"`` → ``"ADVANCE"``).
+
+    The test drives issue #1 through the full pipeline, then inspects the
+    convergence ledger to confirm both boundaries recorded ``ADVANCE`` without
+    any hand-population of the ledger.
+
+    Note: ``run_pipeline`` does NOT include a shape phase; do not assert on
+    ``"shape"``.  The pipeline order is triage → plan → implement → review.
+    This scenario complements ``test_convergence_review_mockworld.py``, which
+    covers the review boundary.
+    """
+
+    async def test_pipeline_records_triage_and_plan_verdicts(self, tmp_path) -> None:
+        """Full gated pipeline populates ledger with ADVANCE for triage and plan."""
+        world = _make_world_with_gate(tmp_path)
+
+        IssueBuilder().numbered(1).titled("Add feature").bodied(
+            "Implement a feature"
+        ).at(world)
+
+        await world.run_pipeline()
+
+        # --- non-vacuity probe ---
+        # If this fails, the real triage/plan boundary recording did not run
+        # through MockWorld — a wiring regression, not a vacuous pass.
+        ledger = world.harness.state.get_convergence_ledger(1)
+        assert ledger is not None, (
+            "ConvergenceLedger is None after a gated full pipeline run — the real "
+            "triage/plan boundary recording did not run through MockWorld."
+        )
+
+        # --- triage boundary ---
+        triage_rec = ledger.stage_state.get("triage")
+        assert triage_rec is not None, "triage boundary did not record into the ledger"
+        assert triage_rec.last_verdict == "ADVANCE", (
+            f"expected triage ADVANCE (routed to plan); got {triage_rec.last_verdict}"
+        )
+
+        # --- plan boundary ---
+        plan_rec = ledger.stage_state.get("plan")
+        assert plan_rec is not None, "plan boundary did not record into the ledger"
+        assert plan_rec.last_verdict == "ADVANCE", (
+            f"expected plan ADVANCE (plan succeeded); got {plan_rec.last_verdict}"
+        )

--- a/tests/test_convergence_recording.py
+++ b/tests/test_convergence_recording.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from convergence_recording import record_stage_verdict, signatures_from_concerns
+
+
+def test_records_verdict_when_enabled(tmp_path):
+    from tests.helpers import make_tracker
+
+    t = make_tracker(tmp_path)
+    record_stage_verdict(
+        t,
+        enabled=True,
+        issue_number=7,
+        stage="triage",
+        decision="ADVANCE",
+        signatures=[],
+    )
+    led = t.get_convergence_ledger(7)
+    assert led is not None
+    assert led.stage_state["triage"].last_verdict == "ADVANCE"
+
+
+def test_noop_when_disabled(tmp_path):
+    from tests.helpers import make_tracker
+
+    t = make_tracker(tmp_path)
+    record_stage_verdict(
+        t,
+        enabled=False,
+        issue_number=7,
+        stage="triage",
+        decision="ADVANCE",
+        signatures=[],
+    )
+    assert t.get_convergence_ledger(7) is None
+
+
+def test_signatures_from_concerns_filters_high_critical():
+    from datetime import UTC, datetime
+
+    from pending_concerns import Concern
+
+    def c(sev, text):
+        return Concern(
+            id=text,
+            raised_in_phase="plan",
+            raised_in_stage="s",
+            severity=sev,
+            concern=text,
+            raised_at=datetime.now(UTC),
+            must_address_by="next",
+        )
+
+    out = signatures_from_concerns([c("CRITICAL", "a"), c("LOW", "b"), c("HIGH", "c")])
+    assert out == ["a", "c"]

--- a/tests/test_plan_phase.py
+++ b/tests/test_plan_phase.py
@@ -1312,4 +1312,138 @@ class TestPlanPhaseErrorPaths:
         await phase.plan_issues()
 
         prs.transition.assert_awaited_once_with(42, "ready")
+
+
+# ---------------------------------------------------------------------------
+# Plan phase — ConvergenceLedger boundary recording (Task 4)
+# ---------------------------------------------------------------------------
+
+
+class TestPlanConvergenceLedger:
+    """Plan phase records boundary verdicts into the ConvergenceLedger."""
+
+    @pytest.mark.asyncio
+    async def test_plan_success_records_advance(self, config: HydraFlowConfig) -> None:
+        """Gate ON + plan succeeds -> ledger stage_state['plan'].last_verdict == 'ADVANCE'."""
+        config.convergence_gate_enabled = True
+        phase, state, planners, prs, store, _stop = make_plan_phase(config)
+        issue = TaskFactory.create(id=201)
+        plan_result = PlanResultFactory.create(
+            issue_number=201,
+            success=True,
+            plan="## Plan\n\n1. Do the thing",
+            summary="Plan done",
+            use_defaults=True,
+        )
+
+        planners.plan = AsyncMock(return_value=plan_result)
+        store.get_plannable = supply_once([issue])
+
+        await phase.plan_issues()
+
+        ledger = state.get_convergence_ledger(201)
+        assert ledger is not None, "Ledger must be created when gate is on"
+        assert ledger.stage_state["plan"].last_verdict == "ADVANCE"
+
+    @pytest.mark.asyncio
+    async def test_plan_failed_records_loop_back(self, config: HydraFlowConfig) -> None:
+        """Gate ON + plan fails (no plan) -> ledger stage_state['plan'].last_verdict == 'LOOP_BACK'."""
+        config.convergence_gate_enabled = True
+        phase, state, planners, prs, store, _stop = make_plan_phase(config)
+        issue = TaskFactory.create(id=202)
+        plan_result = PlanResultFactory.create(
+            issue_number=202,
+            success=False,
+            error="Agent crashed",
+            use_defaults=True,
+        )
+
+        planners.plan = AsyncMock(return_value=plan_result)
+        store.get_plannable = supply_once([issue])
+
+        await phase.plan_issues()
+
+        ledger = state.get_convergence_ledger(202)
+        assert ledger is not None, "Ledger must be created when gate is on"
+        assert ledger.stage_state["plan"].last_verdict == "LOOP_BACK"
+
+    @pytest.mark.asyncio
+    async def test_plan_escalated_records_escalate(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Gate ON + epic-child already_satisfied (escalated path) -> last_verdict == 'ESCALATE'."""
+        config.convergence_gate_enabled = True
+        phase, state, planners, prs, store, _stop = make_plan_phase(config)
+        # Epic child: _is_epic_child returns True for issues with an epic_number
+        issue = TaskFactory.create(id=203)
+        plan_result = PlanResultFactory.create(
+            issue_number=203,
+            success=False,
+            already_satisfied=True,
+            retry_attempted=True,
+            use_defaults=True,
+        )
+
+        planners.plan = AsyncMock(return_value=plan_result)
+        store.get_plannable = supply_once([issue])
+        # Patch _is_epic_child to return True so the epic-child escalation path runs
+        phase._is_epic_child = lambda _issue: True  # type: ignore[method-assign]
+
+        await phase.plan_issues()
+
+        ledger = state.get_convergence_ledger(203)
+        assert ledger is not None, "Ledger must be created when gate is on"
+        assert ledger.stage_state["plan"].last_verdict == "ESCALATE"
+
+    @pytest.mark.asyncio
+    async def test_plan_already_satisfied_closed_records_advance(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Gate ON + already_satisfied closed (early return) -> last_verdict == 'ADVANCE', NOT 'LOOP_BACK'."""
+        config.convergence_gate_enabled = True
+        phase, state, planners, prs, store, _stop = make_plan_phase(config)
+        issue = TaskFactory.create(id=204)
+        plan_result = PlanResultFactory.create(
+            issue_number=204,
+            success=False,
+            already_satisfied=True,
+            use_defaults=True,
+        )
+
+        planners.plan = AsyncMock(return_value=plan_result)
+        store.get_plannable = supply_once([issue])
+        # Not an epic child
+        phase._is_epic_child = lambda _issue: False  # type: ignore[method-assign]
+        # _handle_already_satisfied returns True (closed) to trigger the early return
+        phase._handle_already_satisfied = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+        await phase.plan_issues()
+
+        ledger = state.get_convergence_ledger(204)
+        assert ledger is not None, "Ledger must be created when gate is on"
+        assert ledger.stage_state["plan"].last_verdict == "ADVANCE"
+
+    @pytest.mark.asyncio
+    async def test_plan_gate_off_records_no_ledger(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Gate OFF -> no ledger created even on a successful plan."""
+        config.convergence_gate_enabled = False
+        phase, state, planners, prs, store, _stop = make_plan_phase(config)
+        issue = TaskFactory.create(id=205)
+        plan_result = PlanResultFactory.create(
+            issue_number=205,
+            success=True,
+            plan="## Plan\n\n1. Do the thing",
+            summary="Plan done",
+            use_defaults=True,
+        )
+
+        planners.plan = AsyncMock(return_value=plan_result)
+        store.get_plannable = supply_once([issue])
+
+        await phase.plan_issues()
+
+        ledger = state.get_convergence_ledger(205)
+        assert ledger is None, "No ledger should be created when gate is off"
         assert prs.post_comment.await_count >= 1

--- a/tests/test_plan_phase.py
+++ b/tests/test_plan_phase.py
@@ -1446,4 +1446,3 @@ class TestPlanConvergenceLedger:
 
         ledger = state.get_convergence_ledger(205)
         assert ledger is None, "No ledger should be created when gate is off"
-        assert prs.post_comment.await_count >= 1

--- a/tests/test_shape_phase.py
+++ b/tests/test_shape_phase.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from config import HydraFlowConfig
 from expert_council import CouncilResult, CouncilVote
-from models import ShapeConversation, Task
+from models import ShapeConversation, ShapeTurnResult, Task
 from shape_phase import _SHAPE_OPTIONS_MARKER, ShapePhase
+from state import StateTracker
 
 
 @pytest.fixture
@@ -401,3 +404,197 @@ class TestCouncilVoteRoundThree:
             for call in deps["event_bus"].publish.await_args_list
         ]
         assert "council_diversified_round" in published_actions
+
+
+# ---------------------------------------------------------------------------
+# Convergence ledger recording (Task 3)
+# ---------------------------------------------------------------------------
+
+
+def _make_shape_phase_with_real_state(
+    tmp_path: Path,
+    *,
+    convergence_gate_enabled: bool,
+    shape_runner: MagicMock | None = None,
+) -> tuple[ShapePhase, StateTracker]:
+    """Build a ShapePhase backed by a real StateTracker for ledger assertions."""
+    from events import EventBus
+
+    cfg = HydraFlowConfig(
+        repo="test/repo",
+        state_file=tmp_path / "state.json",
+        convergence_gate_enabled=convergence_gate_enabled,
+    )
+    state = StateTracker(cfg.state_file)
+    bus = EventBus()
+    store = MagicMock()
+    prs = AsyncMock()
+    stop_event = asyncio.Event()
+    phase = ShapePhase(
+        cfg,
+        state,
+        store,
+        prs,
+        bus,
+        stop_event,
+        shape_runner=shape_runner,
+    )
+    return phase, state
+
+
+class TestShapeConvergenceLedger:
+    """Shape phase records boundary verdicts into the ConvergenceLedger (Task 3)."""
+
+    @pytest.mark.asyncio
+    async def test_selection_made_records_advance_verdict(self, tmp_path: Path) -> None:
+        """Gate ON + selection found in comments -> ledger records 'ADVANCE'."""
+        phase, state = _make_shape_phase_with_real_state(
+            tmp_path, convergence_gate_enabled=True
+        )
+        task = Task(id=55, title="Build notifications", body="", labels=[])
+        comments = [
+            f"{_SHAPE_OPTIONS_MARKER} for #55\n\n### Direction A: ...",
+            "Direction A — let's go with this",
+        ]
+        phase._store.enrich_with_comments = AsyncMock(
+            return_value=task.model_copy(update={"comments": comments})
+        )
+
+        await phase._shape_single(task)
+
+        ledger = state.get_convergence_ledger(55)
+        assert ledger is not None, "Ledger must be created when gate is on"
+        assert ledger.stage_state["shape"].last_verdict == "ADVANCE"
+
+    @pytest.mark.asyncio
+    async def test_waiting_records_loop_back_verdict(self, tmp_path: Path) -> None:
+        """Gate ON + no selection found (still waiting) -> ledger records 'LOOP_BACK'."""
+        phase, state = _make_shape_phase_with_real_state(
+            tmp_path, convergence_gate_enabled=True
+        )
+        task = Task(id=56, title="Build search", body="", labels=[])
+        comments = [
+            f"{_SHAPE_OPTIONS_MARKER} for #56\n\n### Direction A: ...",
+            "Hmm, not sure yet...",
+        ]
+        phase._store.enrich_with_comments = AsyncMock(
+            return_value=task.model_copy(update={"comments": comments})
+        )
+
+        await phase._shape_single(task)
+
+        ledger = state.get_convergence_ledger(56)
+        assert ledger is not None, "Ledger must be created when gate is on"
+        assert ledger.stage_state["shape"].last_verdict == "LOOP_BACK"
+
+    @pytest.mark.asyncio
+    async def test_runner_finalized_records_advance_verdict(
+        self, tmp_path: Path
+    ) -> None:
+        """Gate ON + runner returns is_final=True -> ledger records 'ADVANCE'."""
+        runner = MagicMock()
+        runner.bind_escalation_deps = MagicMock()
+        runner.run_turn = AsyncMock(
+            return_value=ShapeTurnResult(content="Final direction", is_final=True)
+        )
+        phase, state = _make_shape_phase_with_real_state(
+            tmp_path, convergence_gate_enabled=True, shape_runner=runner
+        )
+        task = Task(id=57, title="Build analytics", body="", labels=[])
+        # No options marker → goes into _shape_with_runner path
+        phase._store.enrich_with_comments = AsyncMock(
+            return_value=task.model_copy(update={"comments": []})
+        )
+        # conv has no turns, so _handle_waiting_state returns proceed=True immediately
+        phase._state.get_shape_conversation = MagicMock(return_value=None)
+        phase._state.set_shape_conversation = MagicMock()
+        phase._state.increment_session_counter = MagicMock()
+        # _handle_waiting_state: conv has no turns, so proceed=True immediately
+        phase._prs.transition = AsyncMock()
+        phase._prs.post_comment = AsyncMock()
+
+        # _process_finalization calls post_comment + transition + increment
+        await phase._shape_with_runner(task)
+
+        ledger = state.get_convergence_ledger(57)
+        assert ledger is not None, "Ledger must be created when gate is on"
+        assert ledger.stage_state["shape"].last_verdict == "ADVANCE"
+
+    @pytest.mark.asyncio
+    async def test_gate_off_records_no_ledger_on_selection(
+        self, tmp_path: Path
+    ) -> None:
+        """Gate OFF -> no ledger created even when selection is found."""
+        phase, state = _make_shape_phase_with_real_state(
+            tmp_path, convergence_gate_enabled=False
+        )
+        task = Task(id=58, title="Improve onboarding", body="", labels=[])
+        comments = [
+            f"{_SHAPE_OPTIONS_MARKER} for #58\n\n### Direction A: ...",
+            "Direction B please",
+        ]
+        phase._store.enrich_with_comments = AsyncMock(
+            return_value=task.model_copy(update={"comments": comments})
+        )
+
+        await phase._shape_single(task)
+
+        ledger = state.get_convergence_ledger(58)
+        assert ledger is None, "No ledger should be created when gate is off"
+
+    @pytest.mark.asyncio
+    async def test_runner_finalized_with_concerns_records_signatures(
+        self, tmp_path: Path
+    ) -> None:
+        """Gate ON + adversarial agents with HIGH concerns -> signatures recorded."""
+        from datetime import datetime
+
+        from pending_concerns import AdversarialState, Concern
+
+        runner = MagicMock()
+        runner.bind_escalation_deps = MagicMock()
+        runner.run_turn = AsyncMock(
+            return_value=ShapeTurnResult(content="Final content", is_final=True)
+        )
+        phase, state = _make_shape_phase_with_real_state(
+            tmp_path, convergence_gate_enabled=True, shape_runner=runner
+        )
+        task = Task(id=59, title="Build API gateway", body="", labels=[])
+        phase._store.enrich_with_comments = AsyncMock(
+            return_value=task.model_copy(update={"comments": []})
+        )
+        phase._state.get_shape_conversation = MagicMock(return_value=None)
+        phase._state.set_shape_conversation = MagicMock()
+        phase._state.increment_session_counter = MagicMock()
+        phase._prs.transition = AsyncMock()
+        phase._prs.post_comment = AsyncMock()
+
+        # Plant an adversarial state with a HIGH concern via state
+        concern = Concern(
+            id="c1",
+            raised_in_phase="shape",
+            raised_in_stage="shape_challenger",
+            severity="HIGH",
+            concern="Security risk in API design",
+            raised_at=datetime.now(),
+            must_address_by="plan",
+        )
+        adv = AdversarialState(phase="shape", pending_concerns=[concern])
+        # Wire adversarial agents so the block runs, then override get_adversarial_state
+        mock_challenger = MagicMock()
+        phase._challenger_agent = mock_challenger
+        phase._state.get_adversarial_state = MagicMock(return_value=adv)
+        phase._state.set_adversarial_state = MagicMock()
+
+        # Override _run_shape_challenger to do nothing (concern already in adv)
+        phase._run_shape_challenger = AsyncMock()
+
+        await phase._shape_with_runner(task)
+
+        ledger = state.get_convergence_ledger(59)
+        assert ledger is not None
+        assert ledger.stage_state["shape"].last_verdict == "ADVANCE"
+        assert (
+            "Security risk in API design"
+            in ledger.stage_state["shape"].last_finding_signatures
+        )

--- a/tests/test_shape_phase.py
+++ b/tests/test_shape_phase.py
@@ -598,3 +598,68 @@ class TestShapeConvergenceLedger:
             "Security risk in API design"
             in ledger.stage_state["shape"].last_finding_signatures
         )
+
+    @pytest.mark.asyncio
+    async def test_council_consensus_records_advance_verdict(
+        self, tmp_path: Path
+    ) -> None:
+        """Gate ON + council reaches consensus (len(turns)==1 + _council set) ->
+        ledger records 'ADVANCE'.
+
+        Uses a stubbed _run_council_vote returning 1 (consensus) so the
+        council-consensus exit in _shape_with_runner is exercised without
+        driving the full multi-round council logic.
+        """
+        runner = MagicMock()
+        runner.bind_escalation_deps = MagicMock()
+        runner.run_turn = AsyncMock(
+            return_value=ShapeTurnResult(content="Direction proposal", is_final=False)
+        )
+        phase, state = _make_shape_phase_with_real_state(
+            tmp_path, convergence_gate_enabled=True, shape_runner=runner
+        )
+        task = Task(id=60, title="Build dashboard", body="", labels=[])
+        phase._store.enrich_with_comments = AsyncMock(
+            return_value=task.model_copy(update={"comments": []})
+        )
+        phase._state.get_shape_conversation = MagicMock(return_value=None)
+        phase._state.set_shape_conversation = MagicMock()
+        phase._state.increment_session_counter = MagicMock()
+        phase._prs.transition = AsyncMock()
+        phase._prs.post_comment = AsyncMock()
+
+        # Stub _run_council_vote to return 1 (consensus reached)
+        phase._council = MagicMock()  # truthy so the if-branch is taken
+        phase._run_council_vote = AsyncMock(return_value=1)
+
+        await phase._shape_with_runner(task)
+
+        ledger = state.get_convergence_ledger(60)
+        assert ledger is not None, "Ledger must be created when gate is on"
+        assert ledger.stage_state["shape"].last_verdict == "ADVANCE"
+
+    @pytest.mark.asyncio
+    async def test_gate_off_runner_path_records_no_ledger(self, tmp_path: Path) -> None:
+        """Gate OFF + runner exit -> no ledger created even when runner loops back."""
+        runner = MagicMock()
+        runner.bind_escalation_deps = MagicMock()
+        runner.run_turn = AsyncMock(
+            return_value=ShapeTurnResult(content="Turn content", is_final=False)
+        )
+        phase, state = _make_shape_phase_with_real_state(
+            tmp_path, convergence_gate_enabled=False, shape_runner=runner
+        )
+        task = Task(id=61, title="Improve reporting", body="", labels=[])
+        phase._store.enrich_with_comments = AsyncMock(
+            return_value=task.model_copy(update={"comments": []})
+        )
+        phase._state.get_shape_conversation = MagicMock(return_value=None)
+        phase._state.set_shape_conversation = MagicMock()
+        phase._state.increment_session_counter = MagicMock()
+        phase._prs.transition = AsyncMock()
+        phase._prs.post_comment = AsyncMock()
+
+        await phase._shape_with_runner(task)
+
+        ledger = state.get_convergence_ledger(61)
+        assert ledger is None, "No ledger should be created when gate is off"

--- a/tests/test_triage_phase.py
+++ b/tests/test_triage_phase.py
@@ -660,3 +660,78 @@ class TestBugReproducerNotPresentRouting:
         comment = prs.post_comment.call_args.args[1]
         assert "not present" in comment.lower() or "does not exist" in comment.lower()
         prs.transition.assert_not_called()
+
+
+class TestTriageConvergenceLedger:
+    """Triage phase records boundary verdicts into the ConvergenceLedger."""
+
+    @pytest.mark.asyncio
+    async def test_plan_routing_records_advance_verdict_when_gate_on(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Gate ON + issue triaged to 'plan' -> ledger stage_state['triage'].last_verdict == 'ADVANCE'."""
+        config.convergence_gate_enabled = True
+        phase, state, triage, prs, store, _stop = make_triage_phase(config)
+        issue = TaskFactory.create(id=101, title="Add pagination to the API", body="A" * 100)
+
+        triage.evaluate = AsyncMock(
+            return_value=TriageResultFactory.create(
+                issue_number=101,
+                ready=True,
+                clarity_score=9,
+            )
+        )
+        store.get_triageable = supply_once([issue])
+
+        await phase.triage_issues()
+
+        ledger = state.get_convergence_ledger(101)
+        assert ledger is not None, "Ledger must be created when gate is on"
+        assert ledger.stage_state["triage"].last_verdict == "ADVANCE"
+
+    @pytest.mark.asyncio
+    async def test_parked_routing_records_loop_back_verdict_when_gate_on(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Gate ON + issue parked -> ledger stage_state['triage'].last_verdict == 'LOOP_BACK'."""
+        config.convergence_gate_enabled = True
+        phase, state, triage, prs, store, _stop = make_triage_phase(config)
+        issue = TaskFactory.create(id=102, title="Fix the thing", body="")
+
+        triage.evaluate = AsyncMock(
+            return_value=TriageResultFactory.create(
+                issue_number=102,
+                ready=False,
+                reasons=["Body is too short or empty (minimum 50 characters)"],
+            )
+        )
+        store.get_triageable = supply_once([issue])
+
+        await phase.triage_issues()
+
+        ledger = state.get_convergence_ledger(102)
+        assert ledger is not None, "Ledger must be created when gate is on"
+        assert ledger.stage_state["triage"].last_verdict == "LOOP_BACK"
+
+    @pytest.mark.asyncio
+    async def test_gate_off_records_no_ledger(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Gate OFF -> no ledger created, even when issue is triaged to 'plan'."""
+        config.convergence_gate_enabled = False
+        phase, state, triage, prs, store, _stop = make_triage_phase(config)
+        issue = TaskFactory.create(id=103, title="Add export feature", body="A" * 100)
+
+        triage.evaluate = AsyncMock(
+            return_value=TriageResultFactory.create(
+                issue_number=103,
+                ready=True,
+                clarity_score=9,
+            )
+        )
+        store.get_triageable = supply_once([issue])
+
+        await phase.triage_issues()
+
+        ledger = state.get_convergence_ledger(103)
+        assert ledger is None, "No ledger should be created when gate is off"

--- a/tests/test_triage_phase.py
+++ b/tests/test_triage_phase.py
@@ -672,7 +672,9 @@ class TestTriageConvergenceLedger:
         """Gate ON + issue triaged to 'plan' -> ledger stage_state['triage'].last_verdict == 'ADVANCE'."""
         config.convergence_gate_enabled = True
         phase, state, triage, prs, store, _stop = make_triage_phase(config)
-        issue = TaskFactory.create(id=101, title="Add pagination to the API", body="A" * 100)
+        issue = TaskFactory.create(
+            id=101, title="Add pagination to the API", body="A" * 100
+        )
 
         triage.evaluate = AsyncMock(
             return_value=TriageResultFactory.create(
@@ -714,9 +716,7 @@ class TestTriageConvergenceLedger:
         assert ledger.stage_state["triage"].last_verdict == "LOOP_BACK"
 
     @pytest.mark.asyncio
-    async def test_gate_off_records_no_ledger(
-        self, config: HydraFlowConfig
-    ) -> None:
+    async def test_gate_off_records_no_ledger(self, config: HydraFlowConfig) -> None:
         """Gate OFF -> no ledger created, even when issue is triaged to 'plan'."""
         config.convergence_gate_enabled = False
         phase, state, triage, prs, store, _stop = make_triage_phase(config)


### PR DESCRIPTION
## Summary

Phase 2b of two-level convergence (ADR-0096, refines ADR-0094, extends ADR-0095). Rolls the uniform convergence verdict recording out from the Review boundary to the **Triage, Shape, and Plan** boundaries. Each boundary now records an `ADVANCE` / `LOOP_BACK` / `ESCALATE` verdict plus finding signatures into the per-issue `ConvergenceLedger` **after** its existing decision. Still behind `convergence_gate_enabled` (default off), so it ships dark.

**Record, not replace.** No phase's engine changes. The recording is a gated side-write immediately before an existing return; Triage scoring, `ShapeExpertCouncil`, `PlanCouncil`, `SpecJudge`, and `AssumptionSurfacer` are all untouched. When the flag is off, every phase is byte-for-byte unchanged.

## What's in it

- **`record_stage_verdict` helper** (`src/convergence_recording.py`) plus `signatures_from_concerns` (sorted, unique CRITICAL/HIGH concern text). The helper writes `stage_state[stage].last_verdict` + `last_finding_signatures` and persists. It deliberately does **not** call `mark_lap`/`recompute_converged` — laps and `converged` stay Review-owned (single outer-lap anchor, per ADR-0094/0095).
- **Triage recording** — outcome map: `{plan, sentry_noise_closed, already_addressed, epic_decomposed, bug_not_present}` → ADVANCE; `{discover, parked}` → LOOP_BACK; unknown → no record. Signatures `[]` (no adversarial concerns at Triage).
- **Shape recording** — finalized / selection-made / council-consensus → ADVANCE; waiting → LOOP_BACK. Signatures from `adv.pending_concerns` when present.
- **Plan recording** — `success` → ADVANCE; `failed` → LOOP_BACK; `escalated` → ESCALATE; already-satisfied-closed early exit → ADVANCE. Signatures from `adv.pending_concerns` (`adv` is always in scope here).
- **ADR-0096** documenting the record-not-replace boundary model, the review-owned lap invariant, and why the alternatives (replace each engine; let boundaries drive laps) were rejected.

## Two early-return traps caught in review

Both were terminal ADVANCE exits that bypassed the recording call-sites and would have silently dropped a ledger entry. Both were found by the per-task MED reviewers and fixed in-branch:

- **Shape** — the council-consensus exit in `_shape_with_runner` (`_run_council_vote` returns 1) is a terminal ADVANCE; it now records before returning.
- **Plan** — the already-satisfied-closed early return (`_handle_already_satisfied` → closed) leaves `ts_status` at its `"failed"` default but is a forward resolution; it now hard-codes ADVANCE rather than mapping the stale status.

## Test pyramid (all green)

- Unit: `tests/test_convergence_recording.py` (helper), plus per-boundary recording tests in `tests/test_triage_phase.py`, `tests/test_shape_phase.py` (incl. council-consensus + gate-off), `tests/test_plan_phase.py` (`TestPlanConvergenceLedger`: success/failed/escalated/already-satisfied-closed/gate-off).
- Integration: `tests/scenarios/test_convergence_pipeline_mockworld.py` — a real gated `run_pipeline()` drives an issue through live Triage + Plan phase code; the ledger accumulates `triage → ADVANCE` and `plan → ADVANCE` with a non-vacuity probe (no shape phase in `run_pipeline`).
- Full `make quality`: GREEN at the keystone.

## Decisions reviewers should weigh

- **Laps stay Review-owned.** Boundary records are observability + input for the Phase 2d oscillation caretaker; they intentionally do not drive the outer lap. Multiplying `mark_lap` across boundaries was considered and rejected (conflicting lap anchors).
- **Two Plan call-sites are not DRY-merged on purpose** — the early exit hard-codes ADVANCE while the main exit maps `ts_status`; they encode genuinely different verdicts.

## Remaining Phase 2 (subsequent increments)

- 2c: migrate the remaining counters (`auto_agent` / `sandbox_failure_fixer` / `quality_fix`) into the ledger.
- 2d: `ConvergenceOscillationLoop` caretaker consuming the cross-boundary verdict history this PR records.

## Follow-ups (filed, not in this PR)

- Extract a `_record_triage_verdict` helper for the two identical Triage call-sites.
- Dedicated ledger tests for the `bug_not_present` / `discover` / `sentry_noise_closed` Triage paths.
- A sort-order test for `signatures_from_concerns`.

## How it was built

Subagent-driven with blast-radius-scaled review gates: helper LOW (1 reviewer), each boundary MED (2 independent reviewers) + full `make quality`, MockWorld scenario reviewed with a dedicated non-vacuity lens, ADR verified against the implementation, then a final opus whole-branch review. The gates caught the two early-return recording gaps and a fragile orthogonal test assertion before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
