### PR TITLE
Two-level convergence Phase 2c: migrate attempt counters into the ledger

### DIFF
--- a/docs/adr/0097-attempt-counter-migration-to-ledger.md
+++ b/docs/adr/0097-attempt-counter-migration-to-ledger.md
@@ -1,0 +1,92 @@
+# ADR-0097: Attempt counter migration into the ledger (Phase 2c)
+
+- **Status:** Accepted
+- **Date:** 2026-07-01
+- **Refines:** ADR-0094 (two-level convergence: Gate + ConvergenceLedger)
+- **Extends:** ADR-0096 (boundary verdict recording)
+
+## Context
+
+ADR-0094 introduced the `ConvergenceLedger` as the single source of truth for per-issue convergence state. Phase 1 migrated `review_attempts` and `review_blast_radii` from bespoke `StateData` fields into the ledger. Phase 2b (ADR-0096) added cross-boundary verdict recording into `StageRecord.last_verdict`.
+
+Three per-issue attempt counters remained in bespoke storage after Phase 1:
+
+- `StateData.auto_agent_attempts` (an integer field, incremented each time the AutoAgent runner is invoked for an issue)
+- `StateData.sandbox_failure_fixer_attempts` (a dict keyed by PR number, tracking sandbox-fix tries per PR)
+- A per-issue quality-fix count written into `WorkerResultMeta` and read by `retrospective.py`
+
+This split state means the ledger did not hold a complete picture of retry activity, and changes to one counter required reasoning about two storage locations. Phase 2c closes that gap by migrating all three into `ConvergenceLedger.stage_state[<stage>].attempts`.
+
+## Decision
+
+### Move-not-copy, no dual-write
+
+All three counters move into the ledger under named stages. No dual-write phase is introduced. The bespoke storage is deleted at the same time the ledger write is added:
+
+- `auto_agent_attempts` moves to stage `"auto_agent"`.
+- `sandbox_failure_fixer_attempts` (per-PR dict) moves to stage `"sandbox_fix"`, keyed by `str(pr.number)`.
+- The per-issue quality-fix count moves to stage `"quality_fix"`.
+
+The `StateData.auto_agent_attempts` and `StateData.sandbox_failure_fixer_attempts` fields are deleted. `quality_fix_attempts` is removed from the `WorkerResultMeta` TypedDict.
+
+StateTracker accessor names and call signatures are preserved unchanged (all call-sites remain untouched). The accessor bodies now delegate to the ledger rather than to `StateData` fields.
+
+This completes the single-source-of-truth arc that Phase 1 began with `review_attempts` and `review_blast_radii`.
+
+### Serialization and migration cost
+
+`StateData` uses `ConfigDict(extra="ignore")`. Old `state.json` files containing the removed keys (`auto_agent_attempts`, `sandbox_failure_fixer_attempts`) load without error, silently dropping those values. In-flight attempt counters reset to 0 on the first load after deploy.
+
+This is acceptable because attempt counters are transient operational state, not durable data. The outcome matches the Phase 1 `review_attempts` precedent: no data-migration shim is provided, and no shim is needed. An issue that was mid-flight gets a fresh attempt budget, which is the safe direction.
+
+### Sandbox counter keyed by PR number
+
+GitHub PRs and issues share one number namespace per repo. The sandbox-fix loop already passes `pr.number` as the issue identity to the runner and workspace. Keying the sandbox counter's ledger entry by `str(pr.number)` is coherent and cannot collide with a real issue's ledger entry. No PR-to-issue lookup is required.
+
+### quality_fix decision: count moves, within-run cap stays
+
+The cap on quality-fix iterations is enforced within a single worker run by the local `for` loop in `Agent._run_quality_fix_loop`. That loop is untouched by this migration.
+
+Only the per-issue COUNT is moved into the ledger. `implement_phase` writes it via `set_quality_fix_attempts`; `retrospective` reads it from the ledger. The count is per-run, not accumulating across runs. This is a deliberate no-behavior-change choice: the count tracks what happened in the most recent run, which is all `retrospective` needs for its analysis.
+
+The global lifetime aggregate `lifetime_stats.total_quality_fix_rounds` and the `record_stage_retry` helper are unrelated concerns and are left untouched.
+
+### Attempts vs verdicts on StageRecord
+
+This migration writes `StageRecord.attempts` for the `"auto_agent"`, `"sandbox_fix"`, and `"quality_fix"` stages. The Phase 2b boundary recording (ADR-0096) writes `StageRecord.last_verdict` and `last_finding_signatures` for the Triage, Shape, Plan, and Review stages.
+
+The three stages added here are attempt-only slots. No verdict is recorded for them, so `last_verdict` remains `"UNVISITED"` and they play no role in any gated-stage convergence check.
+
+### Always-on storage, not flag-gated
+
+The Gate decision path is behind `convergence_gate_enabled`. Ledger storage is always on, mirroring the Phase 1 split. These counter writes are not conditional on any flag.
+
+## Rules and consequences
+
+1. **Single source of truth for all attempt counters.** No attempt count lives outside the ledger. Adding a new per-issue attempt counter means adding a new stage to the ledger, not a new `StateData` field.
+2. **Accessor signatures are stable.** Call-sites must not be updated when counter storage changes. The accessor layer absorbs storage evolution.
+3. **Fresh budget on deploy.** In-flight attempt counters reset to 0 on the first load after any deploy that removes bespoke fields. Operators should treat in-flight issues as starting fresh attempt budgets after a Phase 2c deploy.
+4. **Sandbox stage key is str(pr.number).** Any code that reads or writes the sandbox-fix attempt count must use `str(pr.number)` as the ledger key. Numeric keys would not match.
+5. **quality_fix count is per-run.** Do not use the ledger count as a cross-run cap or accumulator. It reflects the most recent run's iteration count only.
+
+## Scope (Phase 2c)
+
+This ADR covers the direct migration of three attempt counters into the ledger without helper abstractions, and the MockWorld integration scenario that exercises all three counter paths. Out of scope: Phase 2d's `ConvergenceOscillationLoop` caretaker, which consumes verdict history rather than attempt counts.
+
+## Alternatives considered
+
+1. **Keep bespoke counter dicts in `StateData`.** Rejected. Leaves the ledger as a partial view of per-issue retry state. The whole point of the convergence ledger arc is to consolidate so that a reader of the ledger sees the full picture.
+2. **Migrate `quality_fix` as an accumulating lifetime cap.** Rejected. The within-run cap semantics are production behavior. Changing the count to accumulate across runs would silently tighten the cap for issues that have been processed multiple times, altering escalation behavior without any explicit signal. The safe migration moves the count with identical semantics.
+
+## When to supersede this ADR
+
+Supersede when: a new phase changes attempt counter semantics (for example, introducing cross-run accumulation); the `StageRecord` schema changes what "attempts" means; or a future refactor changes how accessor delegation to the ledger works.
+
+## Source-file citations
+
+- `src/state/_auto_agent.py`: StateTracker accessor for `auto_agent_attempts`, now delegating to the ledger under stage `"auto_agent"`.
+- `src/state/_sandbox_failure_fixer.py`: StateTracker accessor for `sandbox_failure_fixer_attempts`, now delegating to the ledger under stage `"sandbox_fix"`, keyed by `str(pr.number)`.
+- `src/state/_convergence.py`: `set_quality_fix_attempts` and related read accessor, delegating to stage `"quality_fix"`.
+- `src/implement_phase.py`: writes quality-fix count via `set_quality_fix_attempts` at the end of a worker run.
+- `src/retrospective.py`: reads quality-fix count from the ledger for post-run analysis.
+- `tests/scenarios/test_convergence_counter_migration_mockworld.py`: MockWorld integration scenario exercising all three counter migration paths.

--- a/docs/adr/0097-attempt-counter-migration-to-ledger.md
+++ b/docs/adr/0097-attempt-counter-migration-to-ledger.md
@@ -11,7 +11,7 @@ ADR-0094 introduced the `ConvergenceLedger` as the single source of truth for pe
 
 Three per-issue attempt counters remained in bespoke storage after Phase 1:
 
-- `StateData.auto_agent_attempts` (an integer field, incremented each time the AutoAgent runner is invoked for an issue)
+- `StateData.auto_agent_attempts` (a dict keyed by issue number, incremented each time the AutoAgent runner is invoked for an issue)
 - `StateData.sandbox_failure_fixer_attempts` (a dict keyed by PR number, tracking sandbox-fix tries per PR)
 - A per-issue quality-fix count written into `WorkerResultMeta` and read by `retrospective.py`
 
@@ -71,7 +71,7 @@ The Gate decision path is behind `convergence_gate_enabled`. Ledger storage is a
 
 ## Scope (Phase 2c)
 
-This ADR covers the direct migration of three attempt counters into the ledger without helper abstractions, and the MockWorld integration scenario that exercises all three counter paths. Out of scope: Phase 2d's `ConvergenceOscillationLoop` caretaker, which consumes verdict history rather than attempt counts.
+This ADR covers the direct migration of three attempt counters into the ledger without helper abstractions, and an integration scenario that exercises the `sandbox_fix` counter path through the real `SandboxFailureFixerLoop` (representative of the shared accessor-delegation pattern all three migrations use). Out of scope: Phase 2d's `ConvergenceOscillationLoop` caretaker, which consumes verdict history rather than attempt counts.
 
 ## Alternatives considered
 
@@ -89,4 +89,4 @@ Supersede when: a new phase changes attempt counter semantics (for example, intr
 - `src/state/_convergence.py`: `set_quality_fix_attempts` and related read accessor, delegating to stage `"quality_fix"`.
 - `src/implement_phase.py`: writes quality-fix count via `set_quality_fix_attempts` at the end of a worker run.
 - `src/retrospective.py`: reads quality-fix count from the ledger for post-run analysis.
-- `tests/scenarios/test_convergence_counter_migration_mockworld.py`: MockWorld integration scenario exercising all three counter migration paths.
+- `tests/scenarios/test_convergence_counter_migration_mockworld.py`: integration scenario driving the real `SandboxFailureFixerLoop` to prove the `sandbox_fix` counter lands in the ledger through production code (representative of all three migrations' shared delegation pattern).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -128,6 +128,7 @@ ADR and that named test files actually exist.
 | [0094](0094-two-level-convergence-gate-and-ledger.md) | Two-level convergence: Gate + ConvergenceLedger | Accepted |
 | [0095](0095-approve-path-gating-and-converged.md) | Approve-path gating and live convergence (Phase 2a) | Accepted |
 | [0096](0096-boundary-verdict-recording.md) | Boundary verdict recording (Phase 2b) | Accepted |
+| [0097](0097-attempt-counter-migration-to-ledger.md) | Attempt counter migration into the ledger (Phase 2c) | Accepted |
 
 ## Adding a new ADR
 

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-07-01T03:28:59.419712+00:00",
-  "commit_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18",
+  "regenerated_at": "2026-07-01T03:30:37.171148+00:00",
+  "commit_sha": "10546353983dc603fd96dac01c5c4da59514f20b",
   "artifacts": {
     "loops.md": {
-      "source_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18"
+      "source_sha": "10546353983dc603fd96dac01c5c4da59514f20b"
     },
     "ports.md": {
-      "source_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18"
+      "source_sha": "10546353983dc603fd96dac01c5c4da59514f20b"
     },
     "labels.md": {
-      "source_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18"
+      "source_sha": "10546353983dc603fd96dac01c5c4da59514f20b"
     },
     "modules.md": {
-      "source_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18"
+      "source_sha": "10546353983dc603fd96dac01c5c4da59514f20b"
     },
     "events.md": {
-      "source_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18"
+      "source_sha": "10546353983dc603fd96dac01c5c4da59514f20b"
     },
     "adr_xref.md": {
-      "source_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18"
+      "source_sha": "10546353983dc603fd96dac01c5c4da59514f20b"
     },
     "mockworld.md": {
-      "source_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18"
+      "source_sha": "10546353983dc603fd96dac01c5c4da59514f20b"
     },
     "changelog.md": {
-      "source_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18"
+      "source_sha": "10546353983dc603fd96dac01c5c4da59514f20b"
     },
     "coverage_matrix.md": {
-      "source_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18"
+      "source_sha": "10546353983dc603fd96dac01c5c4da59514f20b"
     },
     "functional_areas.md": {
-      "source_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18"
+      "source_sha": "10546353983dc603fd96dac01c5c4da59514f20b"
     },
     "ubiquitous-language.md": {
-      "source_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18"
+      "source_sha": "10546353983dc603fd96dac01c5c4da59514f20b"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18"
+      "source_sha": "10546353983dc603fd96dac01c5c4da59514f20b"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-07-01T01:41:40.928641+00:00",
-  "commit_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9",
+  "regenerated_at": "2026-07-01T03:28:59.419712+00:00",
+  "commit_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18",
   "artifacts": {
     "loops.md": {
-      "source_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9"
+      "source_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18"
     },
     "ports.md": {
-      "source_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9"
+      "source_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18"
     },
     "labels.md": {
-      "source_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9"
+      "source_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18"
     },
     "modules.md": {
-      "source_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9"
+      "source_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18"
     },
     "events.md": {
-      "source_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9"
+      "source_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18"
     },
     "adr_xref.md": {
-      "source_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9"
+      "source_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18"
     },
     "mockworld.md": {
-      "source_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9"
+      "source_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18"
     },
     "changelog.md": {
-      "source_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9"
+      "source_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18"
     },
     "coverage_matrix.md": {
-      "source_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9"
+      "source_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18"
     },
     "functional_areas.md": {
-      "source_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9"
+      "source_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18"
     },
     "ubiquitous-language.md": {
-      "source_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9"
+      "source_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "204a4f99357dea3a81d9d107091f21b692acb4c9"
+      "source_sha": "5e88dcc4ec97a9cfcac9bfc4762837374c8f7c18"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -103,6 +103,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | ADR-0094 | `src.config`, `src.convergence_gate`, `src.models`, `src.review_advisor`, `src.review_phase._phase`, `src.state._convergence` |
 | ADR-0095 | `src.convergence_gate`, `src.models`, `src.review_advisor`, `src.review_phase._phase` |
 | ADR-0096 | `src.convergence_recording`, `src.plan_phase`, `src.shape_phase`, `src.triage_phase` |
+| ADR-0097 | `src.implement_phase`, `src.retrospective`, `src.state._auto_agent`, `src.state._convergence`, `src.state._sandbox_failure_fixer` |
 
 ## Module → ADRs
 
@@ -167,7 +168,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.hf_cli.__main__` | ADR-0036 |
 | `src.hf_cli.supervisor_client` | ADR-0007 |
 | `src.hf_cli.supervisor_service` | ADR-0006, ADR-0007, ADR-0008 |
-| `src.implement_phase` | ADR-0005, ADR-0014, ADR-0024, ADR-0063 |
+| `src.implement_phase` | ADR-0005, ADR-0014, ADR-0024, ADR-0063, ADR-0097 |
 | `src.issue_cache` | ADR-0041 |
 | `src.issue_fetcher` | ADR-0019, ADR-0067 |
 | `src.issue_store` | ADR-0006, ADR-0022, ADR-0041, ADR-0084 |
@@ -211,7 +212,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.repo_wiki` | ADR-0032, ADR-0053, ADR-0061 |
 | `src.repo_wiki_loop` | ADR-0032, ADR-0053 |
 | `src.report_issue_loop` | ADR-0013, ADR-0018, ADR-0045 |
-| `src.retrospective` | ADR-0074 |
+| `src.retrospective` | ADR-0074, ADR-0097 |
 | `src.retrospective_loop` | ADR-0074 |
 | `src.retrospective_queue` | ADR-0074 |
 | `src.review_advisor` | ADR-0059, ADR-0094, ADR-0095 |
@@ -240,8 +241,9 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.stale_issue_loop` | ADR-0072 |
 | `src.state` | ADR-0006, ADR-0013, ADR-0014, ADR-0017, ADR-0024, ADR-0071 |
 | `src.state._adr_audit` | ADR-0056 |
-| `src.state._auto_agent` | ADR-0050 |
-| `src.state._convergence` | ADR-0094 |
+| `src.state._auto_agent` | ADR-0050, ADR-0097 |
+| `src.state._convergence` | ADR-0094, ADR-0097 |
+| `src.state._sandbox_failure_fixer` | ADR-0097 |
 | `src.state._session` | ADR-0021 |
 | `src.telemetry.__init__` | ADR-0055 |
 | `src.telemetry.otel` | ADR-0055 |

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W27
 
+- `1054635` — docs(adr): ADR-0097 attempt counter migration into the ledger (Phase 2c) *(2026-06-30)*
 - `62cd012` — Two-level convergence Phase 2b: boundary verdict recording (Triage/Shape/Plan) (#9677) (#9677) *(2026-06-30)*
 - `e396bad` — Merge origin/staging into Phase1+2a; resolve ADR-0093 collision (convergence ADRs -> 0094/0095), union config + README *(2026-06-30)*
 - `1877391` — feat: loop-fitness scorecard (read-only measurement substrate) (#9672) (#9672) *(2026-06-30)*

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W27
 
+- `62cd012` — Two-level convergence Phase 2b: boundary verdict recording (Triage/Shape/Plan) (#9677) (#9677) *(2026-06-30)*
 - `e396bad` — Merge origin/staging into Phase1+2a; resolve ADR-0093 collision (convergence ADRs -> 0094/0095), union config + README *(2026-06-30)*
 - `1877391` — feat: loop-fitness scorecard (read-only measurement substrate) (#9672) (#9672) *(2026-06-30)*
 - `a642ac1` — docs(adr-0094): soften escalate-parity wording (reject adds oscillation cause) *(2026-06-30)*

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -44,7 +44,7 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 | `ReportIssueLoop` | ✅ [0013, 0018, 0028, 0045] | ✅ [report-issue-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_report_issue_loop.py` | ✅ in catalog | ✅ `s19_report_issue_empty_queue.py` |
 | `RetrospectiveLoop` | ✅ [0074, 0093] | ✅ [architecture-async-control.md] | ✅ loops.md | ✅ README.md | ✅ `test_retrospective_loop.py` | ✅ in catalog | ✅ `s18_retrospective_empty_queue.py` |
 | `RunsGCLoop` | ✅ [0073] | ✅ [architecture-async-control.md] | ✅ loops.md | ✅ README.md | ✅ `test_runs_gc_loop.py` | ✅ in catalog | ✅ `s47_runs_gc_idle_poll.py` |
-| `SandboxFailureFixerLoop` | ✅ [0052, 0063] | ✅ [dark-factory.md] | ✅ loops.md | ✅ README.md | ✅ `test_sandbox_failure_fixer_loop.py` | ✅ in catalog | ✅ `s38_sandbox_fixer_richer_context.py` |
+| `SandboxFailureFixerLoop` | ✅ [0052, 0063, 0097] | ✅ [dark-factory.md] | ✅ loops.md | ✅ README.md | ✅ `test_sandbox_failure_fixer_loop.py` | ✅ in catalog | ✅ `s38_sandbox_fixer_richer_context.py` |
 | `SecurityPatchLoop` | ✅ [0029, 0065] | ✅ [architecture-async-control.md] | ✅ loops.md | ✅ README.md | ✅ `test_security_patch_loop.py` | ✅ in catalog | ✅ `s21_security_patch_no_alerts.py` |
 | `SentryLoop` | ✅ [0055] | ✅ [sentry-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_sentry_loop.py` | ✅ in catalog | ✅ `s42_sentry_ingest_no_credentials.py` |
 | `SkillPromptEvalLoop` | ✅ [0045] | ✅ [skill-prompt-eval-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_skill_prompt_eval_loop.py` | ✅ in catalog | ✅ `s17_skill_prompt_eval_clean_corpus.py` |

--- a/src/implement_phase.py
+++ b/src/implement_phase.py
@@ -586,8 +586,8 @@ class ImplementPhase:
                 f"Error: {result.error or 'none'}",
                 stage=PipelineStage.IMPLEMENT,
             )
+        self._state.set_quality_fix_attempts(issue.id, result.quality_fix_attempts)
         meta: WorkerResultMeta = {
-            "quality_fix_attempts": result.quality_fix_attempts,
             "pre_quality_review_attempts": result.pre_quality_review_attempts,
             "duration_seconds": result.duration_seconds,
             "error": result.error,

--- a/src/models.py
+++ b/src/models.py
@@ -2927,9 +2927,14 @@ class LabelCounts(TypedDict):
 
 
 class WorkerResultMeta(TypedDict, total=False):
-    """Metadata stored by ``StateTracker.set_worker_result_meta``."""
+    """Metadata stored by ``StateTracker.set_worker_result_meta``.
 
-    quality_fix_attempts: int
+    Note: ``quality_fix_attempts`` has been migrated to the convergence ledger
+    (``ConvergenceLedger.stage_state["quality_fix"].attempts``). Use
+    ``StateTracker.set_quality_fix_attempts`` / ``get_convergence_ledger`` to
+    read or write that count.
+    """
+
     pre_quality_review_attempts: int
     duration_seconds: float
     error: str | None

--- a/src/models.py
+++ b/src/models.py
@@ -1957,8 +1957,8 @@ class StateData(BaseModel):
     )
     # Trust fleet — caretaker loops (Plan 5)
     flake_counts: dict[str, int] = Field(default_factory=dict)
+    # NOTE: sandbox_failure_fixer_attempts migrated to convergence_ledgers[str(pr_number)].stage_state["sandbox_fix"].attempts
     # SandboxFailureFixerLoop state
-    sandbox_failure_fixer_attempts: dict[str, int] = Field(default_factory=dict)
     flake_attempts: dict[str, int] = Field(default_factory=dict)
     skill_prompt_last_green: dict[str, str] = Field(default_factory=dict)
     skill_prompt_attempts: dict[str, int] = Field(default_factory=dict)

--- a/src/models.py
+++ b/src/models.py
@@ -1947,7 +1947,7 @@ class StateData(BaseModel):
     # Trust fleet — ContractRefreshLoop (spec §4.2 Task 18)
     contract_refresh_attempts: dict[str, int] = Field(default_factory=dict)
     # Auto-Agent — AutoAgentPreflightLoop (spec §3.6)
-    auto_agent_attempts: dict[str, int] = Field(default_factory=dict)
+    # NOTE: auto_agent_attempts migrated to convergence_ledgers["N"].stage_state["auto_agent"].attempts
     auto_agent_daily_spend: dict[str, float] = Field(default_factory=dict)
     # Trust fleet — TrustFleetSanityLoop (spec §12.1)
     trust_fleet_sanity_attempts: dict[str, int] = Field(default_factory=dict)

--- a/src/retrospective.py
+++ b/src/retrospective.py
@@ -124,7 +124,8 @@ class RetrospectiveCollector:
         )
 
         meta = self._state.get_worker_result_meta(issue_number)
-        quality_fix_rounds = meta.get("quality_fix_attempts", 0)
+        led = self._state.get_convergence_ledger(issue_number)
+        quality_fix_rounds = led.get_attempts("quality_fix") if led else 0
         impl_duration = meta.get("duration_seconds", 0.0)
 
         return RetrospectiveEntry(

--- a/src/state/_auto_agent.py
+++ b/src/state/_auto_agent.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from models import ConvergenceLedger
+
 if TYPE_CHECKING:
     from models import StateData
 
@@ -16,23 +18,24 @@ class AutoAgentStateMixin:
     def save(self) -> None: ...  # provided by CoreMixin
 
     def get_auto_agent_attempts(self, issue: int) -> int:
-        return int(self._data.auto_agent_attempts.get(str(issue), 0))
+        cl = self._data.convergence_ledgers.get(str(issue))
+        return cl.get_attempts("auto_agent") if cl else 0
 
     def bump_auto_agent_attempts(self, issue: int) -> int:
         key = str(issue)
-        current = int(self._data.auto_agent_attempts.get(key, 0))
-        attempts = dict(self._data.auto_agent_attempts)
-        attempts[key] = current + 1
-        self._data.auto_agent_attempts = attempts
+        cl = self._data.convergence_ledgers.get(key)
+        if cl is None:
+            cl = ConvergenceLedger(issue_number=issue)
+            self._data.convergence_ledgers[key] = cl
+        n = cl.increment_attempts("auto_agent")
         self.save()
-        return current + 1
+        return n
 
     def clear_auto_agent_attempts(self, issue: int) -> None:
-        key = str(issue)
-        attempts = dict(self._data.auto_agent_attempts)
-        attempts.pop(key, None)
-        self._data.auto_agent_attempts = attempts
-        self.save()
+        cl = self._data.convergence_ledgers.get(str(issue))
+        if cl is not None and "auto_agent" in cl.stage_state:
+            cl.stage_state["auto_agent"].attempts = 0
+            self.save()
 
     def refund_auto_agent_attempt(self, issue: int) -> int:
         """Decrement the attempt counter by one (floor 0).
@@ -42,17 +45,15 @@ class AutoAgentStateMixin:
         transient outage from consuming the issue's attempt budget and wrongly
         exhausting it to ``human-required`` across repeated outages.
         """
-        key = str(issue)
-        current = int(self._data.auto_agent_attempts.get(key, 0))
-        new_value = max(0, current - 1)
-        attempts = dict(self._data.auto_agent_attempts)
-        if new_value == 0:
-            attempts.pop(key, None)
-        else:
-            attempts[key] = new_value
-        self._data.auto_agent_attempts = attempts
+        cl = self._data.convergence_ledgers.get(str(issue))
+        if cl is None:
+            return 0
+        rec = cl.stage_state.get("auto_agent")
+        if rec is None:
+            return 0
+        rec.attempts = max(0, rec.attempts - 1)
         self.save()
-        return new_value
+        return rec.attempts
 
     def get_auto_agent_daily_spend(self, date_iso: str) -> float:
         return float(self._data.auto_agent_daily_spend.get(date_iso, 0.0))

--- a/src/state/_convergence.py
+++ b/src/state/_convergence.py
@@ -70,6 +70,22 @@ class ConvergenceStateMixin:
         self.save()
         return n
 
+    def set_quality_fix_attempts(self, issue_number: int, count: int) -> None:
+        """Record the per-run quality-fix attempt count for *issue_number* into the ledger."""
+        from models import StageRecord  # noqa: PLC0415
+
+        key = self._key(issue_number)
+        cl = self._data.convergence_ledgers.get(key)
+        if cl is None:
+            cl = ConvergenceLedger(issue_number=issue_number)
+            self._data.convergence_ledgers[key] = cl
+        rec = cl.stage_state.get("quality_fix")
+        if rec is None:
+            cl.stage_state["quality_fix"] = StageRecord(attempts=count)
+        else:
+            rec.attempts = count
+        self.save()
+
     def reset_review_attempts(self, issue_number: int) -> None:
         """Clear the review attempt counter for *issue_number*."""
         cl = self._data.convergence_ledgers.get(self._key(issue_number))

--- a/src/state/_sandbox_failure_fixer.py
+++ b/src/state/_sandbox_failure_fixer.py
@@ -4,11 +4,16 @@ Tracks per-PR auto-fix attempts so the loop can cap retries and escalate
 to ``sandbox-hitl`` when the auto-agent fails to land a fix in
 ``auto_agent_max_attempts`` runs. Keys are stringified PR numbers (matches
 the JSON-friendly storage convention used by the other attempt counters).
+
+NOTE: sandbox_failure_fixer_attempts migrated to
+convergence_ledgers[str(pr_number)].stage_state["sandbox_fix"].attempts
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+
+from models import ConvergenceLedger
 
 if TYPE_CHECKING:
     from models import StateData
@@ -23,22 +28,23 @@ class SandboxFailureFixerStateMixin:
 
     def get_sandbox_failure_fixer_attempts(self, pr_number: int) -> int:
         """Return the current attempt count for *pr_number* (0 if absent)."""
-        return int(self._data.sandbox_failure_fixer_attempts.get(str(pr_number), 0))
+        cl = self._data.convergence_ledgers.get(str(pr_number))
+        return cl.get_attempts("sandbox_fix") if cl else 0
 
     def bump_sandbox_failure_fixer_attempts(self, pr_number: int) -> int:
         """Increment and persist the attempt counter; return the new total."""
         key = str(pr_number)
-        current = int(self._data.sandbox_failure_fixer_attempts.get(key, 0))
-        attempts = dict(self._data.sandbox_failure_fixer_attempts)
-        attempts[key] = current + 1
-        self._data.sandbox_failure_fixer_attempts = attempts
+        cl = self._data.convergence_ledgers.get(key)
+        if cl is None:
+            cl = ConvergenceLedger(issue_number=pr_number)
+            self._data.convergence_ledgers[key] = cl
+        n = cl.increment_attempts("sandbox_fix")
         self.save()
-        return current + 1
+        return n
 
     def clear_sandbox_failure_fixer_attempts(self, pr_number: int) -> None:
         """Drop the counter for *pr_number* (e.g. after PR closure)."""
-        key = str(pr_number)
-        attempts = dict(self._data.sandbox_failure_fixer_attempts)
-        if attempts.pop(key, None) is not None:
-            self._data.sandbox_failure_fixer_attempts = attempts
+        cl = self._data.convergence_ledgers.get(str(pr_number))
+        if cl is not None and "sandbox_fix" in cl.stage_state:
+            cl.stage_state["sandbox_fix"].attempts = 0
             self.save()

--- a/tests/scenarios/test_convergence_counter_migration_mockworld.py
+++ b/tests/scenarios/test_convergence_counter_migration_mockworld.py
@@ -1,0 +1,122 @@
+"""Integration scenario: Phase 2c counter migration into the convergence ledger.
+
+Proves that when SandboxFailureFixerLoop runs _do_work() against a REAL
+StateTracker, the per-PR attempt counter written by the loop flows through
+the production accessor code (bump_sandbox_failure_fixer_attempts) into the
+ConvergenceLedger — not a hand-set value.
+
+This test drives the full _do_work() cycle with a real StateTracker and fake
+port/runner objects to reach the bump at sandbox_failure_fixer_loop.py:166,
+then reads back the ledger via get_convergence_ledger to confirm the counter
+landed in stage_state["sandbox_fix"].attempts.
+
+Rationale: Tasks 1-3 (committed on phase2c) migrated the per-issue counters
+for auto_agent, sandbox_fix, and quality_fix stages out of bespoke StateData
+dicts into the shared ConvergenceLedger. This test is the integration proof
+that the live loop code (not just the mixin unit tests) uses the new path.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from sandbox_failure_fixer_loop import SandboxFailureFixerLoop
+from state import StateTracker
+from tests.helpers import make_bg_loop_deps
+
+pytestmark = pytest.mark.scenario
+
+PR_NUMBER = 42
+
+
+def _make_loop_with_real_tracker(
+    tmp_path,
+    *,
+    prs,
+    runner,
+):
+    """Build a SandboxFailureFixerLoop wired to a real StateTracker.
+
+    Replicates the _make_loop helper from tests/test_sandbox_failure_fixer_loop.py
+    but substitutes the MagicMock state with a real StateTracker backed by a
+    temp-dir state.json.  The loop is built with sandbox_failure_fixer_enabled=True
+    so _do_work() skips the static-config gate and reaches the body.
+    """
+    tracker = StateTracker(state_file=tmp_path / "state.json")
+    deps = make_bg_loop_deps(tmp_path, enabled=True, sandbox_failure_fixer_enabled=True)
+    loop = SandboxFailureFixerLoop(
+        config=deps.config,
+        state=tracker,
+        prs=prs,
+        runner=runner,
+        deps=deps.loop_deps,
+        workspaces=None,
+    )
+    return loop, tracker
+
+
+class TestSandboxFixCounterLandsInLedger:
+    """Full _do_work() drive: bump reaches the real ledger via real loop code.
+
+    The loop must never be hand-set; the ledger must be populated exclusively
+    by the real accessor invoked inside SandboxFailureFixerLoop._do_work().
+    """
+
+    @pytest.mark.asyncio
+    async def test_do_work_increments_sandbox_fix_stage_in_ledger(
+        self, tmp_path
+    ) -> None:
+        """After one _do_work() cycle the ledger records sandbox_fix.attempts >= 1.
+
+        Non-vacuity probe: the 'ledger is not None' assert carries a message
+        that names the exact wiring regression so a future failure is
+        immediately actionable.
+
+        Observed ledger after the run (confirmed in task-4-report):
+            stage_state={"sandbox_fix": StageRecord(attempts=1)}
+        """
+        pr_port = MagicMock()
+        pr_port.list_prs_by_label = AsyncMock(
+            return_value=[
+                SimpleNamespace(number=PR_NUMBER, branch="rc/2026-06-01", labels=[]),
+            ]
+        )
+        pr_port.add_pr_labels = AsyncMock()
+        pr_port.remove_pr_label = AsyncMock()
+        # Fetch helpers called by _build_prompt; return empty strings so the
+        # fallback placeholder text is used — this keeps the test self-contained.
+        pr_port.fetch_ci_failure_logs = AsyncMock(return_value="")
+        pr_port.get_pr_recent_commit_diffs = AsyncMock(return_value="")
+
+        runner = MagicMock()
+        runner.run = AsyncMock(
+            return_value=SimpleNamespace(crashed=False, output_text="ok")
+        )
+
+        loop, tracker = _make_loop_with_real_tracker(
+            tmp_path, prs=pr_port, runner=runner
+        )
+
+        result = await loop._do_work()
+
+        assert result is not None
+        assert result.get("status") == "ok", (
+            f"_do_work returned unexpected status: {result}"
+        )
+
+        # --- non-vacuity probe ---
+        ledger = tracker.get_convergence_ledger(PR_NUMBER)
+        assert ledger is not None, (
+            "no ledger after _do_work — "
+            "bump_sandbox_failure_fixer_attempts did not reach the ledger "
+            "(Phase 2c counter migration wiring regression)"
+        )
+
+        # --- integration assertion: counter flowed through real code ---
+        assert ledger.stage_state["sandbox_fix"].attempts >= 1, (
+            f"expected sandbox_fix.attempts >= 1, got "
+            f"{ledger.stage_state.get('sandbox_fix')}"
+        )

--- a/tests/test_event_payloads.py
+++ b/tests/test_event_payloads.py
@@ -198,25 +198,28 @@ class TestLabelCounts:
 
 
 class TestWorkerResultMeta:
-    """WorkerResultMeta is total=False — all fields are optional."""
+    """WorkerResultMeta is total=False — all fields are optional.
+
+    Note: ``quality_fix_attempts`` has been migrated to the convergence ledger.
+    Use ``StateTracker.set_quality_fix_attempts`` / ``get_convergence_ledger``
+    to read or write that count.
+    """
 
     def test_all_fields(self) -> None:
         meta: WorkerResultMeta = {
-            "quality_fix_attempts": 2,
             "pre_quality_review_attempts": 1,
             "duration_seconds": 120.5,
             "error": None,
             "commits": 3,
         }
-        assert meta["quality_fix_attempts"] == 2
         assert meta["pre_quality_review_attempts"] == 1
         assert meta["duration_seconds"] == 120.5
         assert meta["error"] is None
         assert meta["commits"] == 3
 
     def test_partial_fields(self) -> None:
-        meta: WorkerResultMeta = {"quality_fix_attempts": 1}
-        assert meta["quality_fix_attempts"] == 1
+        meta: WorkerResultMeta = {"pre_quality_review_attempts": 1}
+        assert meta["pre_quality_review_attempts"] == 1
         assert "duration_seconds" not in meta
 
     def test_round_trips_through_state(self, tmp_path: object) -> None:
@@ -228,14 +231,14 @@ class TestWorkerResultMeta:
         tracker = StateTracker(state_file)
 
         meta: WorkerResultMeta = {
-            "quality_fix_attempts": 2,
+            "pre_quality_review_attempts": 2,
             "duration_seconds": 60.0,
             "error": "lint failed",
             "commits": 1,
         }
         tracker.set_worker_result_meta(42, meta)
         loaded = tracker.get_worker_result_meta(42)
-        assert loaded["quality_fix_attempts"] == 2
+        assert loaded["pre_quality_review_attempts"] == 2
         assert loaded["error"] == "lint failed"
 
 

--- a/tests/test_implement_phase.py
+++ b/tests/test_implement_phase.py
@@ -988,10 +988,14 @@ class TestWorkerResultMetaPersistence:
         await phase.run_batch()
 
         meta = phase._state.get_worker_result_meta(42)
-        assert meta["quality_fix_attempts"] == 2
+        assert "quality_fix_attempts" not in meta
         assert meta["pre_quality_review_attempts"] == 3
         assert meta["duration_seconds"] == 150.5
         assert meta["error"] is None
+        # quality_fix count lives in the ledger now
+        led = phase._state.get_convergence_ledger(42)
+        assert led is not None
+        assert led.stage_state["quality_fix"].attempts == 2
 
     @pytest.mark.asyncio
     async def test_worker_result_meta_includes_error(
@@ -1024,6 +1028,65 @@ class TestWorkerResultMetaPersistence:
 
         meta = phase._state.get_worker_result_meta(42)
         assert meta["error"] == "make quality failed"
+
+    @pytest.mark.asyncio
+    async def test_quality_fix_count_recorded_in_ledger(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """quality_fix_attempts should be stored in the convergence ledger."""
+        issue = TaskFactory.create(id=42)
+
+        async def agent_with_qf(
+            issue: Task,
+            wt_path: Path,
+            branch: str,
+            worker_id: int = 0,
+            review_feedback: str = "",
+            prior_failure: str = "",
+        ) -> WorkerResult:
+            return WorkerResultFactory.create(
+                issue_number=issue.id,
+                branch=branch,
+                success=True,
+                workspace_path=str(wt_path),
+                quality_fix_attempts=2,
+            )
+
+        phase, _, _ = make_implement_phase(config, [issue], agent_run=agent_with_qf)
+        await phase.run_batch()
+
+        led = phase._state.get_convergence_ledger(42)
+        assert led is not None
+        assert led.stage_state["quality_fix"].attempts == 2
+
+    @pytest.mark.asyncio
+    async def test_worker_result_meta_no_longer_has_quality_fix_attempts(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """WorkerResultMeta should NOT contain quality_fix_attempts after migration."""
+        issue = TaskFactory.create(id=42)
+
+        async def agent_with_qf(
+            issue: Task,
+            wt_path: Path,
+            branch: str,
+            worker_id: int = 0,
+            review_feedback: str = "",
+            prior_failure: str = "",
+        ) -> WorkerResult:
+            return WorkerResultFactory.create(
+                issue_number=issue.id,
+                branch=branch,
+                success=True,
+                workspace_path=str(wt_path),
+                quality_fix_attempts=2,
+            )
+
+        phase, _, _ = make_implement_phase(config, [issue], agent_run=agent_with_qf)
+        await phase.run_batch()
+
+        meta = phase._state.get_worker_result_meta(42)
+        assert "quality_fix_attempts" not in meta
 
 
 # ---------------------------------------------------------------------------
@@ -1457,8 +1520,12 @@ class TestCommitsPersistedInMeta:
 
         meta = phase._state.get_worker_result_meta(42)
         assert meta["commits"] == 3
-        assert meta["quality_fix_attempts"] == 1
+        assert "quality_fix_attempts" not in meta
         assert meta["duration_seconds"] == 90.0
+        # quality_fix count lives in the ledger now
+        led = phase._state.get_convergence_ledger(42)
+        assert led is not None
+        assert led.stage_state["quality_fix"].attempts == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_retrospective.py
+++ b/tests/test_retrospective.py
@@ -291,11 +291,12 @@ class TestRecord:
         state.set_worker_result_meta(
             42,
             {
-                "quality_fix_attempts": 1,
                 "duration_seconds": 120.5,
                 "error": None,
             },
         )
+        # quality_fix count lives in the ledger now
+        state.set_quality_fix_attempts(42, 1)
 
         review = ReviewResultFactory.create(
             merged=True, fixes_made=False, ci_fix_attempts=0
@@ -367,6 +368,23 @@ class TestRecord:
         data = json.loads(lines[0])
         assert data["quality_fix_rounds"] == 0
         assert data["duration_seconds"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_retrospective_reads_quality_fix_from_ledger(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """quality_fix_rounds in retrospective entry comes from the convergence ledger."""
+        collector, _, state = _make_collector(config, diff_names=["src/foo.py"])
+        # Seed the ledger with 2 quality_fix attempts (new source of truth)
+        state.set_quality_fix_attempts(42, 2)
+
+        review = ReviewResultFactory.create(merged=True)
+        await collector.record(42, 101, review)
+
+        retro_path = config.retrospectives_path
+        lines = retro_path.read_text().strip().splitlines()
+        data = json.loads(lines[0])
+        assert data["quality_fix_rounds"] == 2
 
     @pytest.mark.asyncio
     async def test_record_failure_is_non_blocking(

--- a/tests/test_sandbox_failure_fixer_loop.py
+++ b/tests/test_sandbox_failure_fixer_loop.py
@@ -395,3 +395,45 @@ async def test_dispatch_falls_back_to_repo_root_without_workspace_port(
     kwargs = runner.run.call_args.kwargs
     assert kwargs["worktree_path"] == str(loop._config.repo_root)
     assert kwargs["worktree_path"] != "rc/2026-04-26"
+
+
+# ---------------------------------------------------------------------------
+# Phase 2c convergence-ledger migration tests
+# ---------------------------------------------------------------------------
+
+
+def test_sandbox_attempts_stored_in_ledger(tmp_path: Path) -> None:
+    """After bump, the counter lives in the convergence ledger, not a bespoke field."""
+    from state import StateTracker
+
+    tracker = StateTracker(state_file=tmp_path / "state.json")
+    tracker.bump_sandbox_failure_fixer_attempts(30)
+    ledger = tracker.get_convergence_ledger(30)
+    assert ledger is not None
+    assert ledger.stage_state["sandbox_fix"].attempts == 1
+
+
+def test_old_state_json_with_sandbox_key_loads_clean(tmp_path: Path) -> None:
+    """A state.json with the old 'sandbox_failure_fixer_attempts' key loads without error.
+
+    StateData has extra='ignore', so the stale key is silently dropped. The
+    accessor must then return 0 (not 1) — the old field is not read.
+    """
+    import json
+
+    from models import StateData
+    from state import StateTracker
+
+    old_state: dict = {
+        "sandbox_failure_fixer_attempts": {"30": 1},
+        "convergence_ledgers": {},
+    }
+    # model_validate must not raise
+    data = StateData.model_validate(old_state)
+    assert not hasattr(data, "sandbox_failure_fixer_attempts")
+
+    # Wire it into a tracker via disk so the full load path is exercised.
+    state_file = tmp_path / "state.json"
+    state_file.write_text(json.dumps(old_state))
+    tracker = StateTracker(state_file=state_file)
+    assert tracker.get_sandbox_failure_fixer_attempts(30) == 0

--- a/tests/test_state_auto_agent.py
+++ b/tests/test_state_auto_agent.py
@@ -67,3 +67,39 @@ def test_state_persists_across_load(tmp_path: Path) -> None:
     st2 = _tracker(tmp_path)
     assert st2.get_auto_agent_attempts(8501) == 1
     assert st2.get_auto_agent_daily_spend("2026-04-25") == 5.0
+
+
+def test_auto_agent_attempts_stored_in_ledger(tmp_path: Path) -> None:
+    """After bump, the counter lives in the convergence ledger, not a bespoke field."""
+    st = _tracker(tmp_path)
+    st.bump_auto_agent_attempts(7)
+    ledger = st.get_convergence_ledger(7)
+    assert ledger is not None
+    assert ledger.stage_state["auto_agent"].attempts == 1
+
+
+def test_old_state_json_with_auto_agent_attempts_key_loads_clean(
+    tmp_path: Path,
+) -> None:
+    """A state.json with the old 'auto_agent_attempts' key loads without error.
+
+    StateData has extra='ignore', so the stale key is silently dropped. The
+    accessor must then return 0 (not 2) — the old field is not read.
+    """
+    import json
+
+    from models import StateData
+
+    old_state: dict = {
+        "auto_agent_attempts": {"7": 2},
+        "convergence_ledgers": {},
+    }
+    # model_validate must not raise
+    data = StateData.model_validate(old_state)
+    assert not hasattr(data, "auto_agent_attempts")
+
+    # Wire it into a tracker via disk so the full load path is exercised.
+    state_file = tmp_path / "state.json"
+    state_file.write_text(json.dumps(old_state))
+    tracker = StateTracker(state_file=state_file)
+    assert tracker.get_auto_agent_attempts(7) == 0

--- a/tests/test_state_persistence.py
+++ b/tests/test_state_persistence.py
@@ -167,6 +167,49 @@ class TestReviewAttemptTracking:
 
 
 # ---------------------------------------------------------------------------
+# Quality-fix attempt ledger
+# ---------------------------------------------------------------------------
+
+
+class TestQualityFixLedger:
+    def test_set_quality_fix_attempts_records_in_ledger(self, tmp_path: Path) -> None:
+        tracker = make_tracker(tmp_path)
+        tracker.set_quality_fix_attempts(42, 3)
+        led = tracker.get_convergence_ledger(42)
+        assert led is not None
+        assert led.stage_state["quality_fix"].attempts == 3
+
+    def test_set_quality_fix_attempts_overwrites(self, tmp_path: Path) -> None:
+        tracker = make_tracker(tmp_path)
+        tracker.set_quality_fix_attempts(42, 2)
+        tracker.set_quality_fix_attempts(42, 5)
+        led = tracker.get_convergence_ledger(42)
+        assert led.stage_state["quality_fix"].attempts == 5
+
+    def test_set_quality_fix_attempts_zero(self, tmp_path: Path) -> None:
+        tracker = make_tracker(tmp_path)
+        tracker.set_quality_fix_attempts(42, 0)
+        led = tracker.get_convergence_ledger(42)
+        assert led.stage_state["quality_fix"].attempts == 0
+
+    def test_get_convergence_ledger_returns_zero_when_absent(
+        self, tmp_path: Path
+    ) -> None:
+        tracker = make_tracker(tmp_path)
+        led = tracker.get_convergence_ledger(99)
+        assert led is None
+
+    def test_quality_fix_attempts_persist_across_reload(self, tmp_path: Path) -> None:
+        state_file = tmp_path / "state.json"
+        tracker = StateTracker(state_file)
+        tracker.set_quality_fix_attempts(42, 4)
+
+        tracker2 = StateTracker(state_file)
+        led = tracker2.get_convergence_ledger(42)
+        assert led.stage_state["quality_fix"].attempts == 4
+
+
+# ---------------------------------------------------------------------------
 # Review feedback storage
 # ---------------------------------------------------------------------------
 
@@ -296,7 +339,11 @@ class TestStateDataModel:
 class TestWorkerResultMeta:
     def test_set_and_get_worker_result_meta(self, tmp_path: Path) -> None:
         tracker = make_tracker(tmp_path)
-        meta = {"quality_fix_attempts": 2, "duration_seconds": 120.5, "error": None}
+        meta = {
+            "pre_quality_review_attempts": 2,
+            "duration_seconds": 120.5,
+            "error": None,
+        }
         tracker.set_worker_result_meta(42, meta)
         assert tracker.get_worker_result_meta(42) == meta
 
@@ -307,13 +354,13 @@ class TestWorkerResultMeta:
     def test_set_triggers_save(self, tmp_path: Path) -> None:
         state_file = tmp_path / "state.json"
         tracker = StateTracker(state_file)
-        tracker.set_worker_result_meta(42, {"quality_fix_attempts": 1})
+        tracker.set_worker_result_meta(42, {"pre_quality_review_attempts": 1})
         assert state_file.exists()
 
     def test_persists_across_reload(self, tmp_path: Path) -> None:
         state_file = tmp_path / "state.json"
         tracker = StateTracker(state_file)
-        meta = {"quality_fix_attempts": 3, "duration_seconds": 200.0}
+        meta = {"pre_quality_review_attempts": 3, "duration_seconds": 200.0}
         tracker.set_worker_result_meta(42, meta)
 
         tracker2 = StateTracker(state_file)
@@ -321,16 +368,16 @@ class TestWorkerResultMeta:
 
     def test_multiple_issues_tracked_independently(self, tmp_path: Path) -> None:
         tracker = make_tracker(tmp_path)
-        tracker.set_worker_result_meta(1, {"quality_fix_attempts": 0})
-        tracker.set_worker_result_meta(2, {"quality_fix_attempts": 3})
-        assert tracker.get_worker_result_meta(1) == {"quality_fix_attempts": 0}
-        assert tracker.get_worker_result_meta(2) == {"quality_fix_attempts": 3}
+        tracker.set_worker_result_meta(1, {"pre_quality_review_attempts": 0})
+        tracker.set_worker_result_meta(2, {"pre_quality_review_attempts": 3})
+        assert tracker.get_worker_result_meta(1) == {"pre_quality_review_attempts": 0}
+        assert tracker.get_worker_result_meta(2) == {"pre_quality_review_attempts": 3}
 
     def test_overwrites_previous_meta(self, tmp_path: Path) -> None:
         tracker = make_tracker(tmp_path)
-        tracker.set_worker_result_meta(42, {"quality_fix_attempts": 1})
-        tracker.set_worker_result_meta(42, {"quality_fix_attempts": 5})
-        assert tracker.get_worker_result_meta(42) == {"quality_fix_attempts": 5}
+        tracker.set_worker_result_meta(42, {"pre_quality_review_attempts": 1})
+        tracker.set_worker_result_meta(42, {"pre_quality_review_attempts": 5})
+        assert tracker.get_worker_result_meta(42) == {"pre_quality_review_attempts": 5}
 
     def test_migration_adds_worker_result_meta_to_old_file(
         self, tmp_path: Path

--- a/tests/test_state_tracking.py
+++ b/tests/test_state_tracking.py
@@ -142,7 +142,7 @@ class TestInitialization:
             # auto_agent_attempts migrated to convergence_ledgers (Task 1)
             "auto_agent_daily_spend",
             # SandboxFailureFixerLoop (sandbox-tier scenario testing track)
-            "sandbox_failure_fixer_attempts",
+            # sandbox_failure_fixer_attempts migrated to convergence_ledgers (Task 2)
             # AdrTouchpointAuditorLoop (ADR-0056)
             "adr_audit_cursor",
             "adr_audit_attempts",

--- a/tests/test_state_tracking.py
+++ b/tests/test_state_tracking.py
@@ -139,7 +139,7 @@ class TestInitialization:
             "live_corpus_drift_rollup",
             "live_corpus_escalation_issue",
             # Auto-Agent — AutoAgentPreflightLoop (spec §3.6)
-            "auto_agent_attempts",
+            # auto_agent_attempts migrated to convergence_ledgers (Task 1)
             "auto_agent_daily_spend",
             # SandboxFailureFixerLoop (sandbox-tier scenario testing track)
             "sandbox_failure_fixer_attempts",


### PR DESCRIPTION
## Summary

Phase 2c of two-level convergence (ADR-0097, refines ADR-0094, extends ADR-0096). Migrates the three remaining per-issue attempt counters OUT of bespoke `StateData` storage and INTO the per-issue `ConvergenceLedger`, so the ledger is the single source of truth for attempt tracking. This completes the "single source of truth" arc that Phase 1 began with `review_attempts` / `review_blast_radii`.

**Move-not-copy, no dual-write** ("do not coexist"): each counter's bespoke storage is deleted in the same change that adds the ledger write. `StateTracker` accessor names and signatures are preserved (call-sites untouched); only their bodies now delegate to `ConvergenceLedger.stage_state[<stage>].attempts`.

Ledger storage is always-on (like the Phase 1 counter storage); it is NOT behind `convergence_gate_enabled` (that flag governs the Gate DECISION path, not storage).

## The three migrations

| Counter | Was | Now |
|---|---|---|
| `auto_agent_attempts` | `StateData.auto_agent_attempts` dict (by issue) | ledger stage `"auto_agent"` |
| `sandbox_failure_fixer_attempts` | `StateData.sandbox_failure_fixer_attempts` dict (by PR) | ledger stage `"sandbox_fix"`, keyed by `str(pr.number)` |
| per-issue `quality_fix` count | `WorkerResultMeta["quality_fix_attempts"]` | ledger stage `"quality_fix"` |

The two `StateData` fields are deleted; `quality_fix_attempts` is removed from the `WorkerResultMeta` TypedDict.

## Decisions reviewers should weigh

- **Serialization / fresh budget on deploy.** `StateData` uses `ConfigDict(extra="ignore")`, so old `state.json` files with the removed keys load without error, silently dropping the stale values. In-flight attempt counters reset to 0 (a fresh budget) on first load after deploy. Acceptable for transient operational counters; matches the Phase 1 `review_attempts` precedent (no migration shim). A per-counter serialization test proves old state loads clean and reads 0.
- **Sandbox keyed by PR number.** GitHub PRs and issues share one number namespace per repo, and the loop already treats `pr.number` as the identity, so keying the sandbox ledger by `str(pr.number)` is coherent and cannot collide with a real issue's ledger. No PR→issue lookup.
- **quality_fix: within-run cap unchanged, only the count moved.** The cap on quality-fix iterations stays enforced within a single worker run (`Agent._run_quality_fix_loop` is untouched — `agent.py` is not in this diff). Only the per-issue COUNT moves to the ledger (`implement_phase` writes it, `retrospective` reads it). The count is per-run, NOT accumulating across runs — a deliberate no-behavior-change choice (accumulating would silently tighten the cap and change escalation). The global lifetime aggregate `total_quality_fix_rounds` and `record_stage_retry` are untouched.
- **Attempts vs verdicts on StageRecord.** These migrations write `StageRecord.attempts`; the 2b boundary recording writes `last_verdict`/`last_finding_signatures`. The three new stages are attempt-only slots (no verdict), so they play no role in any gated-stage convergence check.

## Test pyramid (all green)

- Unit (per migration): ledger-storage tests + old-state-loads-clean serialization tests in `tests/test_state_auto_agent.py`, `tests/test_sandbox_failure_fixer_loop.py`, and the quality_fix suite (`tests/test_implement_phase.py`, `tests/test_retrospective.py`, `tests/test_state_persistence.py`). The `test_state_tracking.py` StateData-key enumeration was updated for both removed fields. 4 fallout test files that referenced the removed `WorkerResultMeta` key were updated.
- Integration: `tests/scenarios/test_convergence_counter_migration_mockworld.py` drives the real `SandboxFailureFixerLoop._do_work()` with a real `StateTracker` and confirms the `sandbox_fix` counter lands in the ledger through production code (non-vacuity probe; representative of the shared delegation pattern).
- Full `make quality`: GREEN at the keystone.

## Follow-ups (not in this PR)

- `set_quality_fix_attempts` records unconditionally (even count==0); benign and faithful to the old always-write behavior, but could be conditionalized if ledger compactness matters.
- The `auto_agent` stage is covered by unit tests but not a dedicated integration scenario (it uses the identical delegation pattern the sandbox scenario exercises end-to-end).

## Remaining Phase 2

- 2d: `ConvergenceOscillationLoop` caretaker consuming the cross-boundary verdict history (2b) and, now, the unified attempt counts (2c).

## How it was built

Subagent-driven with blast-radius-scaled review gates. Each migration (HIGH blast radius, touches state serialization) got 2 independent reviewers + full `make quality`; the integration scenario and ADR got focused non-vacuity / accuracy review; then a final opus whole-branch review. The gates confirmed no dual-write, no orphaned readers of the removed keys, and that `agent.py`'s within-run cap is untouched. Controller review caught two ADR factual imprecisions (fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
