### PR TITLE
feat(adr-conformance): dashboard route + panel + e2e (bead advisor-aj83)

### DIFF
--- a/src/dashboard_routes/_conformance_routes.py
+++ b/src/dashboard_routes/_conformance_routes.py
@@ -1,0 +1,64 @@
+"""Conformance route handlers — read-only ADR conformance scorecard endpoint."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from config import HydraFlowConfig
+from dashboard_routes._routes import RouteContext
+
+logger = logging.getLogger("hydraflow.dashboard")
+
+
+def latest_conformance_by_adr(config: HydraFlowConfig) -> dict[str, dict]:
+    """Return the most recent conformance row per adr_id.
+
+    Reads ``<repo_data_root>/metrics/adr_conformance.jsonl`` (the same path
+    ``AdrConformanceLoop._metrics_path()`` persists to) and keeps the row
+    with the maximum ``timestamp`` for each ``adr_id``. Returns ``{}`` when
+    the file is absent or unreadable.
+    """
+    path = config.repo_data_root / "metrics" / "adr_conformance.jsonl"
+    if not path.exists():
+        return {}
+
+    latest: dict[str, dict] = {}
+    try:
+        with open(path) as f:
+            for raw_line in f:
+                stripped = raw_line.strip()
+                if not stripped:
+                    continue
+                try:
+                    row = json.loads(stripped)
+                except json.JSONDecodeError:
+                    logger.debug(
+                        "Skipping corrupt adr_conformance.jsonl line", exc_info=True
+                    )
+                    continue
+                adr_id = row.get("adr_id")
+                if not adr_id:
+                    continue
+                existing = latest.get(adr_id)
+                if existing is None or row.get("timestamp", "") > existing.get(
+                    "timestamp", ""
+                ):
+                    latest[adr_id] = row
+    except OSError:
+        logger.warning("Could not read conformance cache %s", path, exc_info=True)
+        return {}
+
+    return latest
+
+
+def register(router: APIRouter, ctx: RouteContext) -> None:
+    """Register conformance-related routes on *router*."""
+
+    @router.get("/api/adr-conformance")
+    async def get_adr_conformance() -> JSONResponse:
+        """Return the latest conformance row per ADR as JSON."""
+        return JSONResponse(latest_conformance_by_adr(ctx.config))

--- a/src/dashboard_routes/_routes.py
+++ b/src/dashboard_routes/_routes.py
@@ -1884,6 +1884,11 @@ def create_router(
 
     _register_fitness(router, ctx)
 
+    # --- Conformance routes (ADR conformance scorecard read endpoint) ---
+    from dashboard_routes._conformance_routes import register as _register_conformance
+
+    _register_conformance(router, ctx)
+
     # --- Diagnostics routes (factory metrics + trace artifacts) ---
     from dashboard_routes._diagnostics_routes import build_diagnostics_router
 

--- a/src/ui/src/App.jsx
+++ b/src/ui/src/App.jsx
@@ -11,10 +11,11 @@ import { SessionSidebar } from './components/SessionSidebar'
 import { AtlasExplorer } from './components/atlas/AtlasExplorer'
 import { ProjectView } from './components/ProjectView'
 import { LoopFitnessPanel } from './components/LoopFitnessPanel'
+import { AdrConformancePanel } from './components/AdrConformancePanel'
 import { theme } from './theme'
 import { canonicalRepoSlug } from './constants'
 
-const TABS = ['issues', 'hitl', 'outcomes', 'atlas', 'loop-fitness', 'system']
+const TABS = ['issues', 'hitl', 'outcomes', 'atlas', 'loop-fitness', 'adr-conformance', 'system']
 
 const TAB_LABELS = {
   issues: 'Work Stream',
@@ -22,6 +23,7 @@ const TAB_LABELS = {
   hitl: 'HITL',
   atlas: 'Atlas',
   'loop-fitness': 'Loop Fitness',
+  'adr-conformance': 'ADR Conformance',
   system: 'System',
 }
 
@@ -275,6 +277,7 @@ function AppContent() {
           )}
           {activeTab === 'atlas' && <AtlasExplorer />}
           {activeTab === 'loop-fitness' && <LoopFitnessPanel />}
+          {activeTab === 'adr-conformance' && <AdrConformancePanel />}
           {activeTab === 'system' && (
             <SystemPanel
               backgroundWorkers={backgroundWorkers}

--- a/src/ui/src/components/AdrConformancePanel.jsx
+++ b/src/ui/src/components/AdrConformancePanel.jsx
@@ -1,0 +1,246 @@
+import React from 'react'
+import { theme } from '../theme'
+import { useHydraFlow } from '../context/HydraFlowContext'
+
+const OUTCOME_STYLES = {
+  pass: 'badgePass',
+  fail: 'badgeFail',
+  unresolved: 'badgeUnresolved',
+  manual: 'badgeManual',
+  skipped: 'badgeSkipped',
+}
+
+function OutcomeBadge({ outcome }) {
+  const styleKey = OUTCOME_STYLES[outcome] || 'badgeUnresolved'
+  return (
+    <span
+      style={styles[styleKey]}
+      data-testid={`adr-conformance-outcome-badge-${outcome}`}
+    >
+      {outcome}
+    </span>
+  )
+}
+
+function ChecksTable({ checks }) {
+  if (!checks || checks.length === 0) return null
+  return (
+    <div style={styles.checksTable} data-testid="adr-conformance-checks">
+      {checks.map((check, idx) => (
+        <div key={`${check.check}-${idx}`} style={styles.checkRow}>
+          <span style={styles.checkName}>{check.check}</span>
+          <span style={styles.checkOutcome} data-testid={`adr-conformance-check-outcome-${check.outcome}`}>
+            {check.outcome}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function AdrRow({ adrId, row }) {
+  return (
+    <div style={styles.row} data-testid={`adr-conformance-row-${adrId}`}>
+      <div style={styles.rowHeader}>
+        <span style={styles.adrId} data-testid={`adr-conformance-id-${adrId}`}>
+          {adrId}
+        </span>
+        <span style={styles.kindBadge}>{row.kind}</span>
+      </div>
+      <div style={styles.rowMeta}>
+        <div style={styles.metaItem}>
+          <span style={styles.metaLabel}>outcome</span>
+          <OutcomeBadge outcome={row.outcome} />
+        </div>
+        <div style={styles.metaItem}>
+          <span style={styles.metaLabel}>checks</span>
+          <span style={styles.metaValue}>{row.checks?.length ?? 0}</span>
+        </div>
+      </div>
+      <ChecksTable checks={row.checks} />
+    </div>
+  )
+}
+
+export function AdrConformancePanel() {
+  const { adrConformance } = useHydraFlow()
+
+  const entries = Object.entries(adrConformance || {})
+    .sort(([a], [b]) => a.localeCompare(b))
+
+  if (entries.length === 0) {
+    return (
+      <div style={styles.container} data-testid="adr-conformance-panel-root">
+        <div style={styles.empty}>No ADR conformance data available yet.</div>
+      </div>
+    )
+  }
+
+  return (
+    <div style={styles.container} data-testid="adr-conformance-panel-root">
+      <div style={styles.header}>
+        <h2 style={styles.title}>ADR Conformance</h2>
+        <p style={styles.subtitle}>
+          Per-ADR enforcement outcomes, sorted by ADR id. Reflects the latest conformance run.
+        </p>
+      </div>
+      <div style={styles.rows} data-testid="adr-conformance-rows">
+        {entries.map(([adrId, row]) => (
+          <AdrRow key={adrId} adrId={adrId} row={row} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+const styles = {
+  container: {
+    flex: 1,
+    overflowY: 'auto',
+    padding: 20,
+  },
+  header: {
+    marginBottom: 20,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: 700,
+    color: theme.textBright,
+    margin: 0,
+    marginBottom: 6,
+  },
+  subtitle: {
+    fontSize: 12,
+    color: theme.textMuted,
+    margin: 0,
+  },
+  rows: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 12,
+  },
+  row: {
+    border: `1px solid ${theme.border}`,
+    borderRadius: 8,
+    padding: 16,
+    background: theme.surface,
+  },
+  rowHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 10,
+    marginBottom: 10,
+  },
+  adrId: {
+    fontSize: 14,
+    fontWeight: 600,
+    color: theme.textBright,
+    fontFamily: 'monospace',
+  },
+  kindBadge: {
+    fontSize: 10,
+    fontWeight: 600,
+    color: theme.accent,
+    background: theme.accentSubtle,
+    borderRadius: 4,
+    padding: '2px 8px',
+    textTransform: 'uppercase',
+    letterSpacing: '0.05em',
+  },
+  rowMeta: {
+    display: 'flex',
+    gap: 24,
+    flexWrap: 'wrap',
+    marginBottom: 8,
+  },
+  metaItem: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 2,
+  },
+  metaLabel: {
+    fontSize: 10,
+    color: theme.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: '0.05em',
+  },
+  metaValue: {
+    fontSize: 14,
+    fontWeight: 600,
+    color: theme.textBright,
+  },
+  badgePass: {
+    fontSize: 11,
+    fontWeight: 600,
+    color: theme.green,
+    background: theme.greenSubtle,
+    borderRadius: 4,
+    padding: '2px 8px',
+  },
+  badgeFail: {
+    fontSize: 11,
+    fontWeight: 600,
+    color: theme.red,
+    background: theme.redSubtle,
+    borderRadius: 4,
+    padding: '2px 8px',
+  },
+  badgeUnresolved: {
+    fontSize: 11,
+    fontWeight: 600,
+    color: theme.textMuted,
+    background: theme.mutedSubtle,
+    borderRadius: 4,
+    padding: '2px 8px',
+    border: `1px dashed ${theme.border}`,
+  },
+  badgeManual: {
+    fontSize: 11,
+    fontWeight: 600,
+    color: theme.yellow,
+    background: theme.yellowSubtle,
+    borderRadius: 4,
+    padding: '2px 8px',
+  },
+  badgeSkipped: {
+    fontSize: 11,
+    fontWeight: 600,
+    color: theme.textMuted,
+    background: theme.mutedSubtle,
+    borderRadius: 4,
+    padding: '2px 8px',
+  },
+  checksTable: {
+    marginTop: 8,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 3,
+    background: theme.surfaceInset,
+    borderRadius: 6,
+    padding: '8px 12px',
+  },
+  checkRow: {
+    display: 'flex',
+    gap: 12,
+    alignItems: 'baseline',
+    justifyContent: 'space-between',
+  },
+  checkName: {
+    fontSize: 11,
+    color: theme.textMuted,
+    fontFamily: 'monospace',
+    flexShrink: 1,
+    overflowWrap: 'anywhere',
+  },
+  checkOutcome: {
+    fontSize: 11,
+    color: theme.text,
+    fontFamily: 'monospace',
+    flexShrink: 0,
+  },
+  empty: {
+    fontSize: 13,
+    color: theme.textMuted,
+    padding: 20,
+  },
+}

--- a/src/ui/src/components/__tests__/AdrConformancePanel.test.jsx
+++ b/src/ui/src/components/__tests__/AdrConformancePanel.test.jsx
@@ -1,0 +1,172 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+const mockUseHydraFlow = vi.fn()
+
+vi.mock('../../context/HydraFlowContext', () => ({
+  useHydraFlow: (...args) => mockUseHydraFlow(...args),
+}))
+
+const { AdrConformancePanel } = await import('../AdrConformancePanel')
+
+function defaultContext(overrides = {}) {
+  return {
+    adrConformance: {},
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  mockUseHydraFlow.mockReturnValue(defaultContext())
+})
+
+describe('AdrConformancePanel', () => {
+  it('shows empty state when adrConformance is empty', () => {
+    render(<AdrConformancePanel />)
+    expect(screen.getByTestId('adr-conformance-panel-root')).toBeInTheDocument()
+    expect(screen.getByText('No ADR conformance data available yet.')).toBeInTheDocument()
+  })
+
+  it('shows empty state when adrConformance is null', () => {
+    mockUseHydraFlow.mockReturnValue(defaultContext({ adrConformance: null }))
+    render(<AdrConformancePanel />)
+    expect(screen.getByText('No ADR conformance data available yet.')).toBeInTheDocument()
+  })
+
+  it('renders per-ADR rows with adr_id, kind, outcome, and check count', () => {
+    mockUseHydraFlow.mockReturnValue(defaultContext({
+      adrConformance: {
+        'ADR-0100': {
+          adr_id: 'ADR-0100',
+          kind: 'enforced',
+          outcome: 'pass',
+          checks: [
+            { check: 'pytest tests/test_adr_conformance.py', outcome: 'pass', duration_s: 1.2, detail: null },
+          ],
+          timestamp: '2026-06-30T00:00:00Z',
+        },
+      },
+    }))
+    render(<AdrConformancePanel />)
+    expect(screen.getByTestId('adr-conformance-row-ADR-0100')).toBeInTheDocument()
+    expect(screen.getByTestId('adr-conformance-id-ADR-0100')).toBeInTheDocument()
+    expect(screen.getByText('enforced')).toBeInTheDocument()
+    expect(screen.getByTestId('adr-conformance-outcome-badge-pass')).toBeInTheDocument()
+    expect(screen.getByText('1')).toBeInTheDocument()
+  })
+
+  it('renders manual and decision-of-record kinds', () => {
+    mockUseHydraFlow.mockReturnValue(defaultContext({
+      adrConformance: {
+        'ADR-0042': {
+          adr_id: 'ADR-0042',
+          kind: 'manual',
+          outcome: 'manual',
+          checks: [],
+          timestamp: '2026-06-30T00:00:00Z',
+        },
+        'ADR-0001': {
+          adr_id: 'ADR-0001',
+          kind: 'decision-of-record',
+          outcome: 'skipped',
+          checks: [],
+          timestamp: '2026-06-30T00:00:00Z',
+        },
+      },
+    }))
+    render(<AdrConformancePanel />)
+    expect(screen.getAllByText('manual').length).toBeGreaterThan(0)
+    expect(screen.getByText('decision-of-record')).toBeInTheDocument()
+    expect(screen.getByTestId('adr-conformance-outcome-badge-manual')).toBeInTheDocument()
+    expect(screen.getByTestId('adr-conformance-outcome-badge-skipped')).toBeInTheDocument()
+  })
+
+  it('color-codes fail and unresolved outcomes distinctly from pass', () => {
+    mockUseHydraFlow.mockReturnValue(defaultContext({
+      adrConformance: {
+        'ADR-0002': {
+          adr_id: 'ADR-0002',
+          kind: 'enforced',
+          outcome: 'fail',
+          checks: [],
+          timestamp: '2026-06-30T00:00:00Z',
+        },
+        'ADR-0003': {
+          adr_id: 'ADR-0003',
+          kind: 'enforced',
+          outcome: 'unresolved',
+          checks: [],
+          timestamp: '2026-06-30T00:00:00Z',
+        },
+        'ADR-0004': {
+          adr_id: 'ADR-0004',
+          kind: 'enforced',
+          outcome: 'pass',
+          checks: [],
+          timestamp: '2026-06-30T00:00:00Z',
+        },
+      },
+    }))
+    render(<AdrConformancePanel />)
+    const failBadge = screen.getByTestId('adr-conformance-outcome-badge-fail')
+    const unresolvedBadge = screen.getByTestId('adr-conformance-outcome-badge-unresolved')
+    const passBadge = screen.getByTestId('adr-conformance-outcome-badge-pass')
+    expect(failBadge.style.color).not.toBe(passBadge.style.color)
+    expect(unresolvedBadge.style.color).not.toBe(passBadge.style.color)
+  })
+
+  it('sorts rows by adr_id alphabetically', () => {
+    mockUseHydraFlow.mockReturnValue(defaultContext({
+      adrConformance: {
+        'ADR-0100': { adr_id: 'ADR-0100', kind: 'enforced', outcome: 'pass', checks: [], timestamp: '2026-06-30T00:00:00Z' },
+        'ADR-0001': { adr_id: 'ADR-0001', kind: 'enforced', outcome: 'pass', checks: [], timestamp: '2026-06-30T00:00:00Z' },
+        'ADR-0042': { adr_id: 'ADR-0042', kind: 'enforced', outcome: 'pass', checks: [], timestamp: '2026-06-30T00:00:00Z' },
+      },
+    }))
+    render(<AdrConformancePanel />)
+    const rows = screen.getByTestId('adr-conformance-rows')
+    const rowElements = rows.querySelectorAll('[data-testid^="adr-conformance-row-"]')
+    const ids = Array.from(rowElements).map(el => el.getAttribute('data-testid').replace('adr-conformance-row-', ''))
+    expect(ids).toEqual(['ADR-0001', 'ADR-0042', 'ADR-0100'])
+  })
+
+  it('renders individual check names and outcomes', () => {
+    mockUseHydraFlow.mockReturnValue(defaultContext({
+      adrConformance: {
+        'ADR-0100': {
+          adr_id: 'ADR-0100',
+          kind: 'enforced',
+          outcome: 'fail',
+          checks: [
+            { check: 'make quality', outcome: 'fail', duration_s: 3.4, detail: 'boom' },
+            { check: 'pytest tests/test_x.py', outcome: 'pass', duration_s: 0.5, detail: null },
+          ],
+          timestamp: '2026-06-30T00:00:00Z',
+        },
+      },
+    }))
+    render(<AdrConformancePanel />)
+    const checksEl = screen.getByTestId('adr-conformance-checks')
+    expect(checksEl).toBeInTheDocument()
+    expect(checksEl.textContent).toContain('make quality')
+    expect(checksEl.textContent).toContain('pytest tests/test_x.py')
+  })
+
+  it('renders zero checks as "0", not blank', () => {
+    mockUseHydraFlow.mockReturnValue(defaultContext({
+      adrConformance: {
+        'ADR-0007': {
+          adr_id: 'ADR-0007',
+          kind: 'decision-of-record',
+          outcome: 'skipped',
+          checks: [],
+          timestamp: '2026-06-30T00:00:00Z',
+        },
+      },
+    }))
+    render(<AdrConformancePanel />)
+    const row = screen.getByTestId('adr-conformance-row-ADR-0007')
+    expect(row.textContent).toContain('0')
+  })
+})

--- a/src/ui/src/components/__tests__/App.test.jsx
+++ b/src/ui/src/components/__tests__/App.test.jsx
@@ -233,10 +233,10 @@ describe('Config warning banner', () => {
 })
 
 describe('Main tab bar', () => {
-  it('has exactly 6 main tabs including Atlas and Loop Fitness', async () => {
+  it('has exactly 7 main tabs including Atlas, Loop Fitness, and ADR Conformance', async () => {
     const { default: App } = await import('../../App')
     render(<App />)
-    const tabLabels = ['Work Stream', 'HITL', 'Outcomes', 'Atlas', 'Loop Fitness', 'System']
+    const tabLabels = ['Work Stream', 'HITL', 'Outcomes', 'Atlas', 'Loop Fitness', 'ADR Conformance', 'System']
     const tabContainer = screen.getByTestId('main-tabs')
     expect(tabContainer.childElementCount).toBe(tabLabels.length)
     for (const label of tabLabels) {

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -57,6 +57,7 @@ export const initialState = {
   troubleshooting: null,
   trackedReports: [],
   loopFitness: {},
+  adrConformance: {},
   // True when the orchestrator backend is wired to Fake adapters (sandbox tier).
   // Set from /api/control/status. Drives the persistent MOCKWORLD MODE banner.
   mockworldActive: false,
@@ -547,6 +548,8 @@ export function reducer(state, action) {
 
     case 'LOOP_FITNESS':
       return { ...state, loopFitness: action.data }
+    case 'ADR_CONFORMANCE':
+      return { ...state, adrConformance: action.data }
 
     case 'metrics_update':
       return {
@@ -1036,6 +1039,13 @@ export function HydraFlowProvider({ children }) {
     fetchWithRepo('/api/loop-fitness')
       .then(r => r.json())
       .then(data => dispatch({ type: 'LOOP_FITNESS', data }))
+      .catch(() => {})
+  }, [fetchWithRepo])
+
+  const fetchAdrConformance = useCallback(() => {
+    fetchWithRepo('/api/adr-conformance')
+      .then(r => r.json())
+      .then(data => dispatch({ type: 'ADR_CONFORMANCE', data }))
       .catch(() => {})
   }, [fetchWithRepo])
 
@@ -1618,6 +1628,7 @@ export function HydraFlowProvider({ children }) {
       fetchGithubMetrics()
       fetchMetricsHistory()
       fetchLoopFitness()
+      fetchAdrConformance()
       fetchPipeline()
       fetchPipelineStats()
       fetchEpics()
@@ -1653,6 +1664,9 @@ export function HydraFlowProvider({ children }) {
         }
         if (event.type === 'loop_fitness_update') {
           fetchLoopFitness()
+        }
+        if (event.type === 'adr_conformance_update') {
+          fetchAdrConformance()
         }
         // queue_update no longer triggers a pipeline fetch: the QUEUE_UPDATE
         // storm is the source of the REST-poll thrash. The authoritative
@@ -1695,7 +1709,7 @@ export function HydraFlowProvider({ children }) {
       console.warn('[HydraFlow] WebSocket error; awaiting close for reconnect', err)
     }
     wsRef.current = ws
-  }, [state.selectedRepoSlug, applyRepoParam, fetchLifetimeStats, fetchHitlItems, fetchGithubMetrics, fetchMetricsHistory, fetchLoopFitness, fetchPipeline, fetchPipelineStats, fetchEpics, fetchSessions, fetchRepos, fetchRuntimes, fetchWithRepo])
+  }, [state.selectedRepoSlug, applyRepoParam, fetchLifetimeStats, fetchHitlItems, fetchGithubMetrics, fetchMetricsHistory, fetchLoopFitness, fetchAdrConformance, fetchPipeline, fetchPipelineStats, fetchEpics, fetchSessions, fetchRepos, fetchRuntimes, fetchWithRepo])
 
   useEffect(() => {
     const poll = () => {

--- a/tests/scenarios/test_adr_conformance_e2e.py
+++ b/tests/scenarios/test_adr_conformance_e2e.py
@@ -1,9 +1,10 @@
 """End-to-end test for AdrConformanceLoop (ADR-0100).
 
-Exercises the full producer path with real I/O (no mocks-of-mocks):
+Exercises the full producer-to-route path with real I/O (no mocks-of-mocks):
   producer tick → adr_conformance.jsonl persisted → jsonl read back off disk
   and re-parsed via ``AdrConformance.model_validate_json`` → real EventBus
-  carries the ``ADR_CONFORMANCE_UPDATE`` event.
+  carries the ``ADR_CONFORMANCE_UPDATE`` event → ``latest_conformance_by_adr()``
+  route helper serves the persisted data back out.
 
 Convention mirrored: tests/scenarios/test_fitness_scorecard_e2e.py — real
 ``EventBus``, real ``HydraFlowConfig``, real ``StateTracker``/``DedupStore``/
@@ -23,12 +24,12 @@ Task 17 scenario's ``_build_loop`` helper.
 The added value over Task 17's scenario test is the **round-trip**: rows
 are not just asserted present in the jsonl file, they are read back off
 disk and re-parsed through the real Pydantic model, catching
-serialization/schema bugs that a write-only assertion would miss.
-
-Out of scope (intentionally, per the task brief): a dashboard READ-route
-e2e analogous to the fitness sibling's ``latest_fitness_by_worker``
-assertion. The ADR-conformance dashboard panel/route is a separate,
-deferred follow-up — there is no equivalent route to exercise yet.
+serialization/schema bugs that a write-only assertion would miss. The
+route-helper assertion (mirroring the fitness e2e's
+``latest_fitness_by_worker`` check) closes out the previously-deferred gap:
+now that ``dashboard_routes._conformance_routes.latest_conformance_by_adr``
+exists, this test proves the full producer→persist→route read path, not
+just producer→persist.
 """
 
 from __future__ import annotations
@@ -43,6 +44,7 @@ from adr_conformance_loop import AdrConformanceLoop
 from adr_index import ADRIndex
 from base_background_loop import LoopDeps
 from config import HydraFlowConfig
+from dashboard_routes._conformance_routes import latest_conformance_by_adr
 from dedup_store import DedupStore
 from events import EventBus, EventType
 from mockworld.fakes import FakeConformanceRunner, FakeGitHub
@@ -121,6 +123,11 @@ async def test_adr_conformance_e2e(tmp_path) -> None:
        the on-disk schema is loadable, not just writable.
     3. An ADR_CONFORMANCE_UPDATE event was published on the real EventBus
        with per-ADR outcomes in the payload.
+    4. ``latest_conformance_by_adr(config)`` — the dashboard read route's
+       helper — returns the latest row per ADR straight off the jsonl the
+       loop just wrote, with the expected adr_id/kind/outcome. This is the
+       producer→persist→route link the fitness e2e's
+       ``latest_fitness_by_worker`` assertion exercises for its own loop.
     """
     repo_root = _seed_repo(tmp_path)
 
@@ -197,3 +204,19 @@ async def test_adr_conformance_e2e(tmp_path) -> None:
     assert payload_by_adr["ADR-0049"]["outcome"] == "fail"
     assert payload_by_adr["ADR-0052"]["outcome"] == "pass"
     assert payload_by_adr["ADR-0050"]["outcome"] == "skipped"
+
+    # ── 4. Route helper returns the latest row per ADR, reading the same jsonl ─
+    # This is the end-to-end link: persisted jsonl → route helper → served data.
+    # `config` here is the exact HydraFlowConfig the loop ticked against, so
+    # `latest_conformance_by_adr` reads `config.repo_data_root / "metrics" /
+    # "adr_conformance.jsonl"` — the same path asserted at `jsonl_path` above.
+    latest = latest_conformance_by_adr(config)
+
+    assert latest["ADR-0049"]["kind"] == "enforced"
+    assert latest["ADR-0049"]["outcome"] == "fail"
+
+    assert latest["ADR-0052"]["kind"] == "enforced"
+    assert latest["ADR-0052"]["outcome"] == "pass"
+
+    assert latest["ADR-0050"]["kind"] == "decision-of-record"
+    assert latest["ADR-0050"]["outcome"] == "skipped"

--- a/tests/test_conformance_routes.py
+++ b/tests/test_conformance_routes.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from adr_conformance import AdrConformance, CheckOutcome, ConformanceKind
+from file_util import append_jsonl
+from tests.helpers import ConfigFactory
+
+
+def _metrics_path(config):
+    return config.repo_data_root / "metrics" / "adr_conformance.jsonl"
+
+
+def test_latest_conformance_per_adr(tmp_path) -> None:
+    config = ConfigFactory.create(repo_root=tmp_path / "repo")
+    old = AdrConformance(
+        adr_id="0100",
+        kind=ConformanceKind.ENFORCED,
+        outcome=CheckOutcome.FAIL,
+        checks=[],
+        timestamp=datetime(2026, 6, 1, tzinfo=UTC),
+    )
+    new = AdrConformance(
+        adr_id="0100",
+        kind=ConformanceKind.ENFORCED,
+        outcome=CheckOutcome.PASS,
+        checks=[],
+        timestamp=datetime(2026, 6, 30, tzinfo=UTC),
+    )
+    other = AdrConformance(
+        adr_id="0042",
+        kind=ConformanceKind.MANUAL,
+        outcome=CheckOutcome.MANUAL,
+        checks=[],
+        timestamp=datetime(2026, 6, 15, tzinfo=UTC),
+    )
+    path = _metrics_path(config)
+    append_jsonl(path, old.model_dump_json())
+    append_jsonl(path, new.model_dump_json())
+    append_jsonl(path, other.model_dump_json())
+
+    from dashboard_routes._conformance_routes import latest_conformance_by_adr
+
+    latest = latest_conformance_by_adr(config)
+    assert latest["0100"]["outcome"] == "pass"  # newest wins
+    assert latest["0042"]["outcome"] == "manual"
+
+
+def test_latest_conformance_missing_file_returns_empty(tmp_path) -> None:
+    config = ConfigFactory.create(repo_root=tmp_path / "repo")
+
+    from dashboard_routes._conformance_routes import latest_conformance_by_adr
+
+    assert latest_conformance_by_adr(config) == {}
+
+
+def test_latest_conformance_tolerates_corrupt_line(tmp_path) -> None:
+    config = ConfigFactory.create(repo_root=tmp_path / "repo")
+    good = AdrConformance(
+        adr_id="0100",
+        kind=ConformanceKind.ENFORCED,
+        outcome=CheckOutcome.PASS,
+        checks=[],
+        timestamp=datetime(2026, 6, 30, tzinfo=UTC),
+    )
+    path = _metrics_path(config)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as f:
+        f.write("{not valid json\n")
+    append_jsonl(path, good.model_dump_json())
+
+    from dashboard_routes._conformance_routes import latest_conformance_by_adr
+
+    latest = latest_conformance_by_adr(config)
+    assert latest["0100"]["outcome"] == "pass"


### PR DESCRIPTION
Deferred dashboard surface for ADR-0100 (PR #9684). Adds the conformance read-route + `latest_conformance_by_adr` helper (mirrors `_fitness_routes`), the `AdrConformancePanel` UI + App wiring (mirrors `LoopFitnessPanel`), and an e2e asserting the full producer→persist→route read path. make quality green (16679); UI production build + 1162 UI tests green; whole-branch review Approved.

Not included: the docker Tier-C browser run — the sandbox container needs a generic `/seed/scenario.json` harness fixture (unrelated to this feature) and could not be brought up here; `advisor-aj83` stays open for that sub-item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)