### PR TITLE
fix(adr-conformance): three follow-ups from the ADR-0051 fresh-eyes review

### DIFF
--- a/src/adr_conformance_loop.py
+++ b/src/adr_conformance_loop.py
@@ -210,7 +210,13 @@ class AdrConformanceLoop(BaseBackgroundLoop):
         self, conf: AdrConformance, rename_match: str
     ) -> None:
         """File a dedup'd issue proposing a rename — the loop does NOT edit
-        the ADR file itself; a human/pipeline applies the computed rename."""
+        the ADR file itself; a human/pipeline applies the computed rename.
+
+        Deliberately bypasses the attempt budget/escalation path: a rename
+        has one clear fix, so the same idempotent proposal (deduped by its
+        stable title via ``find_existing_issue``) is re-filed until the ADR
+        is repointed — it never escalates to HITL (ADR-0100 split-class
+        model)."""
         title = f"ADR conformance: {conf.adr_id} check may have been renamed"
         body = (
             "## ADR conformance — proposed repoint\n\n"

--- a/src/adr_reviewer.py
+++ b/src/adr_reviewer.py
@@ -63,6 +63,10 @@ def _write_adr_decision(
 _STATUS_RE = re.compile(r"\*\*Status:\*\*\s*(\w+)", re.IGNORECASE)
 _ENFORCEMENT_LINE_RE = re.compile(r"^\*\*Enforcement:\*\*", re.MULTILINE)
 _STATUS_LINE_RE = re.compile(r"^(\*\*Status:\*\*[^\n]*)$", re.MULTILINE)
+# Fallback anchor for the `## Status` H2 heading form (13 ADRs on disk, e.g.
+# ADR-0053): capture the heading plus its value line so the injection lands
+# under the value, as its own paragraph.
+_STATUS_H2_BLOCK_RE = re.compile(r"^(##\s+Status\s*\n+[^\n]+)$", re.MULTILINE)
 
 
 def _ensure_enforcement_line(content: str) -> str:
@@ -88,8 +92,14 @@ def _ensure_enforcement_line(content: str) -> str:
     """
     if _ENFORCEMENT_LINE_RE.search(content):
         return content
-    return _STATUS_LINE_RE.sub(
-        r"\1\n**Enforcement:** decision-of-record", content, count=1
+    if _STATUS_LINE_RE.search(content):
+        return _STATUS_LINE_RE.sub(
+            r"\1\n**Enforcement:** decision-of-record", content, count=1
+        )
+    # `## Status` H2 heading form: previously a silent no-op — the ADR then
+    # failed the ratchet the moment it flipped to Accepted.
+    return _STATUS_H2_BLOCK_RE.sub(
+        r"\1\n\n**Enforcement:** decision-of-record", content, count=1
     )
 
 

--- a/tests/test_adr_conformance_coverage.py
+++ b/tests/test_adr_conformance_coverage.py
@@ -145,6 +145,32 @@ def _accepted():
     return [a for a in scan_adr_directory(ADR_DIR) if a.status == "Accepted"]
 
 
+# Detects an `**Enforced by:**` line that IS present in the file even though
+# parse_enforced_by returned zero checks — the bulleted-list footgun:
+# adr_index._ENFORCED_BY_RE deliberately stops its capture at the first
+# markdown bullet, so `**Enforced by:**\n- pytest:...` parses to (). The
+# ratchet already fails on that (enforced + no checks), but without this
+# diagnosis the error message blames a *missing* line and sends the author
+# hunting the wrong cause.
+_ENFORCED_BY_PRESENT_RE = re.compile(r"^\*\*Enforced by:\*\*", re.MULTILINE)
+
+
+def _diagnose_enforced_without_checks(number: int, text: str) -> str:
+    """Message for an `enforced` ADR whose parsed checks came back empty:
+    distinguish "line absent" from "line present but in the bulleted-list
+    form the parser rejects"."""
+    if _ENFORCED_BY_PRESENT_RE.search(text):
+        return (
+            f"ADR-{number:04d}: enforced, and an **Enforced by:** line exists "
+            "but parsed to zero checks — likely the bulleted-list form "
+            "(`**Enforced by:**` followed by `- pytest:...` bullets), which "
+            "the parser rejects. Put each check on its own unbulleted line "
+            "after **Enforced by:** (see ADR-0049/0053 for the sanctioned "
+            "multi-check form)."
+        )
+    return f"ADR-{number:04d}: enforced but no Enforced-by"
+
+
 def test_every_adr_file_parses():
     """No silent skips: every docs/adr/*.md file with an ADR heading must
     come back from scan_adr_directory. This is the regression test for the
@@ -232,7 +258,9 @@ def test_enforced_adrs_name_resolvable_nonmutating_checks():
         if a.number in _GRANDFATHERED or a.enforcement != "enforced":
             continue
         if not a.enforced_by:
-            problems.append(f"ADR-{a.number:04d}: enforced but no Enforced-by")
+            files = sorted(ADR_DIR.glob(f"{a.number:04d}-*.md"))
+            text = files[0].read_text() if files else ""
+            problems.append(_diagnose_enforced_without_checks(a.number, text))
             continue
         for chk in a.enforced_by:
             if chk.kind == "prose":
@@ -257,6 +285,26 @@ def test_manual_adrs_have_a_process_pointer():
         and not a.enforced_by
     ]
     assert not offenders, f"manual ADRs missing an Enforced-by pointer: {offenders}"
+
+
+def test_diagnosis_names_the_bulleted_form_when_line_is_present():
+    text = (
+        "# ADR-0999: Example\n\n"
+        "**Status:** Accepted\n"
+        "**Enforcement:** enforced\n"
+        "**Enforced by:**\n"
+        "- pytest:tests/test_a.py::test_x\n"
+        "- pytest:tests/test_b.py::test_y\n"
+    )
+    msg = _diagnose_enforced_without_checks(999, text)
+    assert "bulleted-list form" in msg
+    assert "own unbulleted line" in msg
+
+
+def test_diagnosis_reports_plain_absence_when_line_is_missing():
+    text = "# ADR-0999: Example\n\n**Status:** Accepted\n**Enforcement:** enforced\n"
+    msg = _diagnose_enforced_without_checks(999, text)
+    assert msg == "ADR-0999: enforced but no Enforced-by"
 
 
 def test_grandfather_only_shrinks():

--- a/tests/test_adr_reviewer_enforced_by.py
+++ b/tests/test_adr_reviewer_enforced_by.py
@@ -52,3 +52,20 @@ def test_no_status_line_leaves_content_untouched() -> None:
     content = "# ADR-0099: Malformed\n\nNo status line present.\n"
     result = _ensure_enforcement_line(content)
     assert result == content
+
+
+def test_injects_under_h2_status_heading() -> None:
+    """ADRs using the ``## Status`` H2 form (13 exist on disk, e.g.
+    ADR-0053) must also get the injection — previously the bold-inline
+    anchor made this a silent no-op and the ADR failed the ratchet on
+    acceptance."""
+    content = (
+        "# ADR-0099: Test ADR\n\n## Status\n\nAccepted\n\n## Context\n\nSomething.\n"
+    )
+    result = _ensure_enforcement_line(content)
+    assert "**Enforcement:** decision-of-record" in result
+    # Must land after the status value, before the next section.
+    status_idx = result.index("Accepted")
+    enforcement_idx = result.index("**Enforcement:**")
+    context_idx = result.index("## Context")
+    assert status_idx < enforcement_idx < context_idx


### PR DESCRIPTION
## What

Follow-ups from the fresh-eyes production-readiness review (ADR-0051 convergence pass) of the ADR-0100 conformance feature. Reviewer verdict was **converged / nothing material** — these are the actionable Minors + the cheap half of one Important:

1. **Ratchet diagnosis for the bulleted-list footgun** (`tests/test_adr_conformance_coverage.py`): `_ENFORCED_BY_RE` deliberately stops at markdown bullets, so `**Enforced by:**` followed by `- pytest:...` bullets parses to zero checks. The ratchet already failed loudly on that, but the message ('enforced but no Enforced-by') blamed a *missing* line and sent the author hunting the wrong cause. Now: if the line is present but parsed empty, the error names the bulleted-form pitfall and the sanctioned own-line format. Helper + 2 unit tests.
2. **`_ensure_enforcement_line` H2-status fallback** (`src/adr_reviewer.py`): the injector only anchored on bold-inline `**Status:**`; for the `## Status` H2 form (13 ADRs on disk) it was a silent no-op, so a bot-authored H2-form ADR would fail the ratchet the moment it flipped to Accepted. TDD'd — the red run reproduced the no-op.
3. **REPOINT attempt-budget comment** (`src/adr_conformance_loop.py`): documents that `_file_repoint_issue` deliberately bypasses the attempt budget / never escalates (ADR-0100 split-class model; idempotent re-file deduped by stable title).

## Not in this PR

- **Metrics-jsonl retention** (reviewer's Important #1 + timestamp-ordering Minor): the append-forever pattern is shared with `fitness_report.py` — needs a repo-wide retention decision, tracked as bead `advisor-sqsv`.
- Reviewer's Minor #5 (dangling doc refs) was a false positive — the wording it suggested is already in the files.

## Verification

- `pytest tests/test_adr_reviewer_enforced_by.py tests/test_adr_conformance_coverage.py tests/test_adr_conformance_loop.py` → 28 passed
- Fresh pyright on touched files: 0 errors; ruff check + format clean
- Full `make quality` running locally in parallel; CI runs the identical gate here

🤖 Generated with [Claude Code](https://claude.com/claude-code)