### PR TITLE
fix(audit-ci): restore main history for P5.6/P10.3 and reset baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,13 +297,21 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          # P5.6 (`git log origin/main`) and P10.3 (fix-commit history since
+          # the baseline) read real git history. The default depth-1 checkout
+          # made both `git log` calls fail, silently degrading two principles
+          # to NA in CI. Full history keeps them honest; the clone stays well
+          # inside this job's 5-minute timeout.
+          fetch-depth: 0
       - name: Resolve origin HEAD
         # actions/checkout leaves refs/remotes/origin/HEAD unset on PR
         # checkouts (which are a merge commit, not a fetched branch).
         # P5.5 (branch-protection probe) needs origin/HEAD to detect the
         # default branch, so fetch main explicitly and point HEAD at it.
+        # No --depth here: P5.6 walks the last 100 commits of origin/main.
         run: |
-          git fetch --no-tags --depth=1 origin main:refs/remotes/origin/main
+          git fetch --no-tags origin main:refs/remotes/origin/main
           git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
       - uses: astral-sh/setup-uv@v4
         with:

--- a/.hydraflow-audit-baseline
+++ b/.hydraflow-audit-baseline
@@ -1,6 +1,9 @@
 # Principles-audit baseline. The P10.3 check (regression-test discipline)
-# scans fix commits between this SHA and HEAD; commits before this point
-# are excluded as historical drift predating the rule's adoption.
+# scans fix commits after this point — a commit SHA or an ISO date/timestamp;
+# commits before it are excluded as historical drift predating the rule's
+# adoption. Dates become `git log --since=` filters (branch-independent);
+# SHAs become a `<sha>..HEAD` range and must be an ancestor of every branch
+# the audit runs on.
 #
 # History:
 # - 2026-05-02 d0d18382: ADR-0044 + the P3/P10 audit framework began
@@ -23,4 +26,17 @@
 #      baseline is reset to the current adoption point — accurate
 #      forward-enforcement starts here. Pre-fix historical drift is
 #      excluded as designed.
-97005928
+#
+# Reset 2026-07-02 (bead advisor-vm0r): the CI `audit` job had been running
+# on a depth-1 checkout with a depth-1 fetch of main, so `git log
+# <baseline>..HEAD` could not resolve the baseline SHA and P5.6 could not
+# see a main ref — BOTH checks silently degraded to NA in CI. Enforcement
+# was not real since that regression (same failure shape as the 2026-06-12
+# reset). The checkout is fixed (fetch-depth: 0, un-shallowed main fetch);
+# the baseline resets to the fix's ship time so accurate forward-enforcement
+# restarts here. A timestamp rather than a SHA because the audit runs
+# against PR merge commits on staging AND against main: RC promotion means
+# no recent SHA is an ancestor of both (the newest common ancestor is the
+# last RC merge, which predates 13 uncovered fix commits), while a
+# timestamp is branch-independent.
+2026-07-02T21:00:00Z

--- a/scripts/hydraflow_audit/checks/p10_tdd.py
+++ b/scripts/hydraflow_audit/checks/p10_tdd.py
@@ -104,6 +104,28 @@ def _skip_module(path: Path) -> bool:
 
 _FIX_COMMIT_RE = re.compile(r"^(fix|bugfix|bug)[\(:]", re.IGNORECASE)
 _BASELINE_FILE = ".hydraflow-audit-baseline"
+# ISO date (2026-07-02) or timestamp (2026-07-02T21:00:00Z). Anything else
+# in the baseline file is treated as a commit-ish.
+_DATE_BASELINE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}([T ].+)?$")
+
+
+def _baseline_selector(baseline: str) -> str:
+    """Turn the declared baseline into a ``git log`` selector argument.
+
+    Dates become ``--since=`` filters, which are branch-independent: they
+    work on PR merge commits into staging AND on main, with no requirement
+    that the baseline commit be an ancestor of HEAD (squash-based RC
+    promotion means no post-promotion staging SHA ever is). Bare dates get
+    an explicit midnight because git's approxidate fills missing
+    time-of-day fields from the *current* clock — ``--since=2026-07-02``
+    run at 14:00 silently excludes that morning's commits. Anything
+    non-date-shaped is treated as a commit-ish range start.
+    """
+    if not _DATE_BASELINE_RE.match(baseline):
+        return f"{baseline}..HEAD"
+    if "T" in baseline or " " in baseline:
+        return f"--since={baseline}"
+    return f"--since={baseline}T00:00:00"
 
 
 @register("P10.3")
@@ -125,7 +147,7 @@ def _bug_fixes_land_with_regression_tests(ctx: CheckContext) -> Finding:  # noqa
     baseline = _read_baseline(ctx.root)
     git_args = ["git", "log", "--no-merges", "-n", "50", "--format=%H%x09%s"]
     if baseline is not None:
-        git_args.append(f"{baseline}..HEAD")
+        git_args.append(_baseline_selector(baseline))
     try:
         result = subprocess.run(
             git_args,
@@ -144,7 +166,12 @@ def _bug_fixes_land_with_regression_tests(ctx: CheckContext) -> Finding:  # noqa
         for line in result.stdout.splitlines()
         if "\t" in line and _FIX_COMMIT_RE.match(line.split("\t", 1)[1])
     ]
-    scope = f"since baseline {baseline[:7]}" if baseline else "last 50 commits"
+    if baseline is None:
+        scope = "last 50 commits"
+    elif _DATE_BASELINE_RE.match(baseline):
+        scope = f"since baseline {baseline}"
+    else:
+        scope = f"since baseline {baseline[:7]}"
     if not fix_commits:
         return finding(
             "P10.3", Status.PASS, f"no fix/bug commits {scope} — nothing to audit"
@@ -172,7 +199,8 @@ def _bug_fixes_land_with_regression_tests(ctx: CheckContext) -> Finding:  # noqa
         "P10.3",
         Status.WARN,
         f"{len(missing)}/{len(fix_commits)} fix commits {scope} without a regression test ({sample}) — "
-        "set .hydraflow-audit-baseline to a post-adoption commit to exclude historical drift",
+        "set .hydraflow-audit-baseline to a post-adoption commit or ISO date "
+        "to exclude historical drift",
     )
 
 

--- a/scripts/hydraflow_audit/checks/p5_ci.py
+++ b/scripts/hydraflow_audit/checks/p5_ci.py
@@ -285,11 +285,45 @@ def _detect_github_slug(root: Path) -> str | None:
     return match.group(1)
 
 
+def _resolve_main_history_ref(root: Path) -> str | None:
+    """Return a rev that reaches main's history: local ``main`` or ``origin/main``.
+
+    CI checks out PRs as a detached merge commit with no local ``main``
+    branch; the audit workflow fetches ``refs/remotes/origin/main``
+    explicitly. Git's refname shorthand never resolves bare ``main`` to
+    ``refs/remotes/origin/main`` (only ``refs/remotes/main`` would match),
+    so ``git log main`` fails there. Probe candidates explicitly and fall
+    back to the remote-tracking ref.
+    """
+    for candidate in ("main", "origin/main", "master", "origin/master"):
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--verify", "--quiet", f"{candidate}^{{commit}}"],
+                check=False,
+                cwd=root,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            return None
+        if result.returncode == 0:
+            return candidate
+    return None
+
+
 @register("P5.6")
 def _no_direct_pushes_to_main(ctx: CheckContext) -> Finding:
     """Warn when recent main-branch history has commits not reached via merge."""
     if not (ctx.root / ".git").exists():
         return finding("P5.6", Status.NA, "not a git repo — cannot inspect history")
+    main_ref = _resolve_main_history_ref(ctx.root)
+    if main_ref is None:
+        return finding(
+            "P5.6",
+            Status.NA,
+            "no main/master ref (local or origin) — cannot inspect history",
+        )
     try:
         result = subprocess.run(
             [
@@ -297,7 +331,7 @@ def _no_direct_pushes_to_main(ctx: CheckContext) -> Finding:
                 "log",
                 "--no-merges",
                 "--first-parent",
-                "main",
+                main_ref,
                 "-n",
                 "100",
                 "--format=%H %s",
@@ -311,7 +345,7 @@ def _no_direct_pushes_to_main(ctx: CheckContext) -> Finding:
     except (subprocess.TimeoutExpired, OSError):
         return finding("P5.6", Status.NA, "git log timed out — skipping")
     if result.returncode != 0:
-        return finding("P5.6", Status.NA, "git log failed — skipping (no main branch?)")
+        return finding("P5.6", Status.NA, f"git log {main_ref} failed — skipping")
     lines = [line for line in result.stdout.splitlines() if line.strip()]
     # Squash-merge workflows leave non-merge commits on main, but each one
     # still went through a PR — GitHub appends `(#NNN)` to the subject.

--- a/tests/regressions/test_audit_ci_main_history.py
+++ b/tests/regressions/test_audit_ci_main_history.py
@@ -1,0 +1,74 @@
+"""Regression: the Principles Audit CI job must see main-branch history.
+
+Bead advisor-vm0r: the ``audit`` job ran on the actions/checkout default
+(depth-1) and fetched ``origin/main`` with ``--depth=1``. P5.6
+(``git log ... main``: no local ``main`` ref existed, and bare ``main``
+never resolves to ``refs/remotes/origin/main``) and P10.3
+(``git log <baseline>..HEAD``: the baseline SHA was outside the shallow
+clone) both failed and silently degraded to NA, so two git-history
+principles were unenforced in CI.
+
+These tests pin the workflow shape and baseline format that keep the two
+checks live:
+
+1. the audit job's checkout uses ``fetch-depth: 0``;
+2. the explicit main fetch is not shallow (no ``--depth``);
+3. ``.hydraflow-audit-baseline`` holds a date/timestamp baseline that
+   P10.3 turns into a branch-independent ``--since`` selector (a SHA
+   baseline would have to be an ancestor of both staging and main, which
+   RC-promotion squashing makes impossible to keep fresh).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _audit_job_steps() -> list[dict]:
+    ci = yaml.safe_load(
+        (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    )
+    return ci["jobs"]["audit"]["steps"]
+
+
+def test_audit_job_checkout_fetches_full_history() -> None:
+    checkout = next(
+        step
+        for step in _audit_job_steps()
+        if "actions/checkout" in str(step.get("uses", ""))
+    )
+    assert checkout.get("with", {}).get("fetch-depth") == 0, (
+        "audit job checkout must use fetch-depth: 0 — a shallow checkout "
+        "makes P5.6/P10.3 silently degrade to NA"
+    )
+
+
+def test_audit_job_main_fetch_is_not_shallow() -> None:
+    resolve = next(
+        step for step in _audit_job_steps() if step.get("name") == "Resolve origin HEAD"
+    )
+    run = resolve["run"]
+    assert "--depth" not in run, (
+        "the explicit main fetch must not be shallow — P5.6 walks the last "
+        "100 commits of origin/main"
+    )
+    assert "origin main:refs/remotes/origin/main" in run
+    assert "symbolic-ref" in run  # P5.5 needs origin/HEAD
+
+
+def test_baseline_is_a_branch_independent_date_baseline() -> None:
+    from scripts.hydraflow_audit.checks.p10_tdd import (
+        _DATE_BASELINE_RE,
+        _read_baseline,
+    )
+
+    baseline = _read_baseline(REPO_ROOT)
+    assert baseline is not None, ".hydraflow-audit-baseline missing or empty"
+    assert _DATE_BASELINE_RE.match(baseline), (
+        f"baseline {baseline!r} is SHA-shaped; the audit runs on staging PR "
+        "merge commits AND on main, and no fresh SHA is an ancestor of both"
+    )

--- a/tests/test_hydraflow_audit_p10_checks.py
+++ b/tests/test_hydraflow_audit_p10_checks.py
@@ -146,6 +146,44 @@ def test_na_outside_git(tmp_path: Path) -> None:
     assert _run("P10.3", _ctx(tmp_path)).status is Status.NA
 
 
+def test_future_date_baseline_excludes_all_fix_commits(tmp_path: Path) -> None:
+    """A date baseline uses --since, so no ancestry/SHA resolution is needed."""
+    _git_init(tmp_path)
+    _git_commit(tmp_path, "fix: old drift", {"src/a.py": "def f(): return 1\n"})
+    _write(tmp_path / ".hydraflow-audit-baseline", "# rule adopted\n2099-01-01\n")
+    result = _run("P10.3", _ctx(tmp_path))
+    assert result.status is Status.PASS
+    assert "no fix/bug commits" in (result.message or "")
+    assert "2099-01-01" in (result.message or "")
+
+
+def test_past_date_baseline_counts_newer_fix_commits(tmp_path: Path) -> None:
+    _git_init(tmp_path)
+    _git_commit(tmp_path, "fix: typo", {"src/a.py": "def f(): return 1\n"})
+    _write(tmp_path / ".hydraflow-audit-baseline", "2020-01-01\n")
+    assert _run("P10.3", _ctx(tmp_path)).status is Status.WARN
+
+
+def test_timestamp_baseline_supported(tmp_path: Path) -> None:
+    _git_init(tmp_path)
+    _git_commit(tmp_path, "fix: typo", {"src/a.py": "def f(): return 1\n"})
+    _write(tmp_path / ".hydraflow-audit-baseline", "2099-01-01T00:00:00Z\n")
+    result = _run("P10.3", _ctx(tmp_path))
+    assert result.status is Status.PASS
+    assert "no fix/bug commits" in (result.message or "")
+
+
+def test_baseline_selector_pins_midnight_on_bare_dates() -> None:
+    """git approxidate fills missing time-of-day from the CURRENT clock, so a
+    bare --since=<date> run in the afternoon would exclude that morning's
+    commits; the selector must pin midnight explicitly."""
+    from scripts.hydraflow_audit.checks.p10_tdd import _baseline_selector
+
+    assert _baseline_selector("2026-07-02") == "--since=2026-07-02T00:00:00"
+    assert _baseline_selector("2026-07-02T21:00:00Z") == "--since=2026-07-02T21:00:00Z"
+    assert _baseline_selector("97005928") == "97005928..HEAD"
+
+
 # --- P10.4 ----------------------------------------------------------------
 
 

--- a/tests/test_hydraflow_audit_p5_checks.py
+++ b/tests/test_hydraflow_audit_p5_checks.py
@@ -248,3 +248,49 @@ def test_git_log_warns_when_no_pr_attribution(tmp_path: Path) -> None:
 
 def test_git_log_na_outside_repo(tmp_path: Path) -> None:
     assert _run("P5.6", _ctx(tmp_path)).status is Status.NA
+
+
+def test_git_log_falls_back_to_origin_main_when_local_main_absent(
+    tmp_path: Path,
+) -> None:
+    """CI checks out a detached PR merge commit with only origin/main fetched.
+
+    Bare ``main`` never resolves to ``refs/remotes/origin/main`` under git's
+    refname shorthand, so P5.6 must probe the remote-tracking ref explicitly
+    instead of degrading to NA (bead advisor-vm0r).
+    """
+    _git_init_with_commits(
+        tmp_path,
+        [f"feat: thing {i} (#{1000 + i})" for i in range(5)],
+    )
+    subprocess.run(
+        ["git", "update-ref", "refs/remotes/origin/main", "HEAD"],
+        cwd=tmp_path,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "checkout", "-q", "--detach"], cwd=tmp_path, check=True, env=_git_env()
+    )
+    subprocess.run(
+        ["git", "branch", "-q", "-D", "main"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    result = _run("P5.6", _ctx(tmp_path))
+    assert result.status is Status.PASS
+
+
+def test_git_log_na_when_no_main_ref_anywhere(tmp_path: Path) -> None:
+    subprocess.run(["git", "init", "-q", "-b", "trunk"], cwd=tmp_path, check=True)
+    (tmp_path / "f.txt").write_text("x", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, env=_git_env())
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "feat: seed (#1)"],
+        cwd=tmp_path,
+        check=True,
+        env=_git_env(),
+    )
+    result = _run("P5.6", _ctx(tmp_path))
+    assert result.status is Status.NA
+    assert "no main/master ref" in (result.message or "")


### PR DESCRIPTION
## Root cause (bead advisor-vm0r)

The `audit` job ("Principles Audit") ran on the `actions/checkout@v4` default — a **depth-1 shallow checkout** — and its "Resolve origin HEAD" step fetched main with `--depth=1`. Two audit checks depend on real git history and both silently degraded to NA:

- **P5.6** (no direct pushes to main): runs `git log --first-parent main`. The CI checkout is a detached PR merge commit with **no local `main` ref**, and git's refname shorthand never resolves bare `main` to `refs/remotes/origin/main` — so `git log` failed and the check reported "git log failed — skipping (no main branch?)".
- **P10.3** (bug fixes land with regression tests): runs `git log <baseline>..HEAD`. The baseline SHA in `.hydraflow-audit-baseline` was outside the depth-1 clone, so `git log` failed and the check reported "git log failed".

Result: two git-history principles were unenforced in CI, invisibly — the job stayed green.

## Fix

1. **ci.yml `audit` job**: `fetch-depth: 0` on the checkout, and dropped `--depth=1` from the explicit main fetch (the fetch + `symbolic-ref` step stays — P5.5 needs `origin/HEAD`). Full history keeps the checks honest and stays well inside the job's 5-minute timeout.
2. **P5.6** now resolves the history ref explicitly (`main` → `origin/main` → `master` → `origin/master`) instead of hard-requiring a local `main`; NA only when no candidate exists anywhere.
3. **P10.3** now implements the ISO-date baseline its docstring already promised: date-shaped baselines become `--since=` filters. Bare dates pin an explicit midnight, because git's approxidate fills missing time-of-day from the *current* clock (`--since=2026-07-02` run at 14:00 silently excludes that morning's commits).

## Baseline reset (`.hydraflow-audit-baseline` → `2026-07-02T21:00:00Z`)

Per the file's own documented convention (same rationale as the 2026-06-12 reset): the check was silently NA in CI since the shallow-checkout regression, so enforcement wasn't real; accurate forward-enforcement restarts at the fix's ship time. A dated History entry in the file records this.

**Why a timestamp, not a SHA** (the task's decision point): the audit runs against PR merge commits on staging AND against main, so a SHA baseline must be an ancestor of both. The newest such commit is `git merge-base origin/main origin/staging` = `7e78adc2` (the last RC promotion, 2026-06-20) — but 13 of the 14 fix commits since it lack regression tests, so any valid SHA baseline turns the job red on historical drift the check was never actually enforcing. A `--since` timestamp is branch-independent (no ancestry requirement at all), which is strictly more robust here. The SHA path still works for repos that use it.

## Verification

- Local `make audit` exits 0: `P5 PASS 10/10`, `P10 PASS 5/5`, total `PASS 91 WARN 0 FAIL 0 NA 5`.
  - `P5.6 PASS — 1 commits without PR attribution in last 100`
  - `P10.3 PASS — no fix/bug commits since baseline 2026-07-02T21:00:00Z — nothing to audit`
- Unit tests: P5.6 origin/main fallback + no-main NA; P10.3 date/timestamp baselines + midnight pinning. Regression test (`tests/regressions/test_audit_ci_main_history.py`) pins the workflow shape (fetch-depth 0, non-shallow main fetch) and the date-shaped baseline.
- `ruff check`, `ruff format --check`, `pyright` clean on all touched Python files.

**CI is the proof**: the shallow-checkout environment can't be fully simulated locally. The real evidence is this PR's own Principles Audit job — with main history present, P5.6 and P10.3 must report real PASS results instead of "git log failed" NA. Check the job log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
