### PR TITLE
fix(adr-conformance): bound jsonl growth + fix timestamp string-compare bug

### DIFF
--- a/src/adr_conformance_loop.py
+++ b/src/adr_conformance_loop.py
@@ -134,11 +134,24 @@ class AdrConformanceLoop(BaseBackgroundLoop):
         return self._config.repo_data_root / "metrics" / "adr_conformance.jsonl"
 
     def _persist_jsonl(self, results: list[AdrConformance]) -> None:
-        from file_util import append_jsonl  # noqa: PLC0415
+        """Append this tick's rows, then compact to the latest row per adr_id.
+
+        The metrics jsonl has snapshot semantics — the dashboard route
+        (``latest_conformance_by_adr``) serves only the newest row per
+        ``adr_id`` — so after every tick the file is compacted to exactly one
+        row per Accepted ADR, bounding its size at #ADRs rows instead of
+        leaking ~#ADRs rows per tick forever. Append-then-compact (rather
+        than merge-and-rewrite) keeps ``append_jsonl``'s crash-safe fsync and
+        ADR-0085 secret scrubbing on the write path; the compaction rewrite
+        is atomic (``os.replace``), and this loop is the file's only writer,
+        so the dashboard reader never observes a torn file.
+        """
+        from file_util import append_jsonl, compact_jsonl_latest_by_key  # noqa: PLC0415
 
         path = self._metrics_path()
         for conf in results:
             append_jsonl(path, conf.model_dump_json())
+        compact_jsonl_latest_by_key(path, key="adr_id", ts_key="timestamp")
 
     def _issue_title(self, conf: AdrConformance) -> str:
         return f"ADR conformance: {conf.adr_id} is {conf.outcome.value}"

--- a/src/dashboard_routes/_conformance_routes.py
+++ b/src/dashboard_routes/_conformance_routes.py
@@ -10,6 +10,7 @@ from fastapi.responses import JSONResponse
 
 from config import HydraFlowConfig
 from dashboard_routes._routes import RouteContext
+from file_util import is_newer_timestamp
 
 logger = logging.getLogger("hydraflow.dashboard")
 
@@ -19,8 +20,13 @@ def latest_conformance_by_adr(config: HydraFlowConfig) -> dict[str, dict]:
 
     Reads ``<repo_data_root>/metrics/adr_conformance.jsonl`` (the same path
     ``AdrConformanceLoop._metrics_path()`` persists to) and keeps the row
-    with the maximum ``timestamp`` for each ``adr_id``. Returns ``{}`` when
-    the file is absent or unreadable.
+    with the maximum ``timestamp`` for each ``adr_id``. Timestamps are
+    compared as parsed datetimes via ``file_util.is_newer_timestamp`` (the
+    same rule the loop's compact-on-write uses), never as strings — Pydantic
+    serializes ``...56Z`` vs ``...56.000001Z`` and lexically ``.`` < ``Z``
+    would sort the newer row first. Rows with unparseable timestamps are
+    treated as oldest; they never crash the route. Returns ``{}`` when the
+    file is absent or unreadable.
     """
     path = config.repo_data_root / "metrics" / "adr_conformance.jsonl"
     if not path.exists():
@@ -44,8 +50,8 @@ def latest_conformance_by_adr(config: HydraFlowConfig) -> dict[str, dict]:
                 if not adr_id:
                     continue
                 existing = latest.get(adr_id)
-                if existing is None or row.get("timestamp", "") > existing.get(
-                    "timestamp", ""
+                if existing is None or is_newer_timestamp(
+                    row.get("timestamp"), existing.get("timestamp")
                 ):
                     latest[adr_id] = row
     except OSError:

--- a/src/file_util.py
+++ b/src/file_util.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import contextlib
 import fcntl
+import json
 import logging
 import os
 import shutil
 import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager
+from datetime import UTC, datetime
 from pathlib import Path
 
 from secret_scrub import scrub_secrets
@@ -55,6 +57,93 @@ def append_jsonl(path: Path, data: str) -> None:
         f.write(scrub_secrets(data) + "\n")
         f.flush()
         os.fsync(f.fileno())
+
+
+def _parse_row_timestamp(value: object) -> datetime | None:
+    """Parse an ISO-8601 timestamp value from a jsonl row; ``None`` if unparseable.
+
+    ``datetime.fromisoformat`` on Python 3.11+ accepts both serialization
+    forms Pydantic emits for UTC datetimes (``...56Z`` when microseconds are
+    0, ``...56.000001Z`` otherwise). Naive datetimes are assumed UTC so
+    comparisons against aware ones never raise ``TypeError``.
+    """
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def is_newer_timestamp(candidate: object, existing: object) -> bool:
+    """Return True when *candidate* is a strictly newer timestamp than *existing*.
+
+    The shared "parse ts, latest-wins" rule for jsonl rows — used by both
+    ``compact_jsonl_latest_by_key`` and the dashboard conformance route so
+    the two can't drift. Timestamps are compared as parsed datetimes, never
+    as strings: Pydantic serializes whole-second UTC datetimes as ``...56Z``
+    but sub-second ones as ``...56.000001Z``, and lexically ``.`` < ``Z``
+    would sort the newer row first. Unparseable/missing timestamps are
+    treated as oldest: an unparseable *candidate* is never newer, and a
+    parseable *candidate* always beats an unparseable *existing*. Equal
+    timestamps are not newer (the first row seen wins).
+    """
+    cand = _parse_row_timestamp(candidate)
+    if cand is None:
+        return False
+    exist = _parse_row_timestamp(existing)
+    if exist is None:
+        return True
+    return cand > exist
+
+
+def compact_jsonl_latest_by_key(path: Path, *, key: str, ts_key: str) -> None:
+    """Rewrite jsonl *path* in place, keeping only the newest row per *key*.
+
+    Retention policy for **snapshot-semantics** jsonl files — files where
+    only the latest row per key is ever served (e.g.
+    ``metrics/adr_conformance.jsonl``, ADR-0100's gitignored scratch state).
+    Do NOT use on trend-semantics files (e.g. ``fitness.jsonl``) where row
+    history is load-bearing.
+
+    Rows are JSON objects, one per line. For each distinct value of *key*
+    the row whose *ts_key* is latest per ``is_newer_timestamp`` survives,
+    preserving first-seen key order. Blank lines, corrupt/non-object lines,
+    and rows missing *key* are dropped without raising (the same tolerance
+    as the dashboard read path). The rewrite goes through ``atomic_write``
+    (tempfile in the same directory + ``os.replace``), so a concurrent
+    reader sees either the old or the new complete file, never a torn one.
+    A missing file is a no-op.
+    """
+    if not path.exists():
+        return
+
+    kept: dict[str, tuple[str, object]] = {}  # key value -> (raw line, ts value)
+    with open(path, encoding="utf-8") as f:
+        for raw_line in f:
+            stripped = raw_line.strip()
+            if not stripped:
+                continue
+            try:
+                row = json.loads(stripped)
+            except json.JSONDecodeError:
+                logger.debug(
+                    "Dropping corrupt jsonl line during compaction of %s", path
+                )
+                continue
+            if not isinstance(row, dict):
+                continue
+            key_value = row.get(key)
+            if not key_value:
+                continue
+            existing = kept.get(str(key_value))
+            if existing is None or is_newer_timestamp(row.get(ts_key), existing[1]):
+                kept[str(key_value)] = (stripped, row.get(ts_key))
+
+    atomic_write(path, "".join(f"{line}\n" for line, _ts in kept.values()))
 
 
 @contextmanager

--- a/tests/test_adr_conformance_loop.py
+++ b/tests/test_adr_conformance_loop.py
@@ -257,6 +257,34 @@ async def test_tick_persists_jsonl_files_issue_on_fail_and_emits_event(
     assert outcomes["ADR-0051"] == "unresolved"
 
 
+async def test_jsonl_compacted_to_latest_row_per_adr_across_ticks(
+    loop_fixture,
+) -> None:
+    """The metrics jsonl has snapshot semantics (the dashboard serves only the
+    latest row per adr_id), so after each tick it must contain exactly one row
+    per ADR — bounded by #ADRs, not leaking ~#ADRs rows per tick forever.
+    The surviving row must carry the SECOND tick's outcome."""
+    loop, fakes = loop_fixture
+    await run_tick(loop)
+    # Flip the failing check to PASS so tick 2's rows are distinguishable.
+    fakes.runner._outcomes["make:conformance-fail-fixture"] = CheckOutcome.PASS
+
+    await run_tick(loop)
+
+    jsonl_path = fakes.metrics_dir / "adr_conformance.jsonl"
+    rows = [json.loads(line) for line in jsonl_path.read_text().strip().splitlines()]
+    by_adr: dict[str, dict] = {}
+    for row in rows:
+        assert row["adr_id"] not in by_adr, (
+            f"duplicate row for {row['adr_id']} — compaction did not run"
+        )
+        by_adr[row["adr_id"]] = row
+    assert len(rows) == 3  # exactly one row per ADR fixture
+    assert by_adr["ADR-0049"]["outcome"] == "pass"  # tick 2's outcome, not tick 1's
+    assert by_adr["ADR-0050"]["outcome"] == "skipped"
+    assert by_adr["ADR-0051"]["outcome"] == "unresolved"
+
+
 async def test_decision_of_record_never_remediated(loop_fixture) -> None:
     loop, fakes = loop_fixture
     await run_tick(loop)

--- a/tests/test_conformance_routes.py
+++ b/tests/test_conformance_routes.py
@@ -54,6 +54,73 @@ def test_latest_conformance_missing_file_returns_empty(tmp_path) -> None:
     assert latest_conformance_by_adr(config) == {}
 
 
+def test_latest_conformance_microsecond_boundary_newer_row_wins(tmp_path) -> None:
+    """Regression: Pydantic serializes whole-second datetimes as '...56Z' but
+    sub-second ones as '...56.000001Z'; lexically '.' < 'Z', so a STRING
+    comparison would wrongly keep the whole-second (older) row. Timestamps
+    must be compared as parsed datetimes."""
+    config = ConfigFactory.create(repo_root=tmp_path / "repo")
+    older = AdrConformance(
+        adr_id="0100",
+        kind=ConformanceKind.ENFORCED,
+        outcome=CheckOutcome.FAIL,
+        checks=[],
+        timestamp=datetime(2026, 6, 30, 12, 0, 56, tzinfo=UTC),  # ...56Z
+    )
+    newer = AdrConformance(
+        adr_id="0100",
+        kind=ConformanceKind.ENFORCED,
+        outcome=CheckOutcome.PASS,
+        checks=[],
+        timestamp=datetime(2026, 6, 30, 12, 0, 56, 1, tzinfo=UTC),  # ...56.000001Z
+    )
+    path = _metrics_path(config)
+    append_jsonl(path, older.model_dump_json())
+    append_jsonl(path, newer.model_dump_json())
+
+    from dashboard_routes._conformance_routes import latest_conformance_by_adr
+
+    latest = latest_conformance_by_adr(config)
+    assert latest["0100"]["outcome"] == "pass"  # the truly-newer row
+
+
+def test_latest_conformance_unparseable_timestamp_treated_as_oldest(tmp_path) -> None:
+    """A row with a garbage timestamp must never beat a parseable row (a
+    string comparison would rank 'not-a-timestamp' > '2026-...'), and a key
+    whose only row has a garbage timestamp is still served, never a crash."""
+    import json
+
+    config = ConfigFactory.create(repo_root=tmp_path / "repo")
+    valid = AdrConformance(
+        adr_id="0100",
+        kind=ConformanceKind.ENFORCED,
+        outcome=CheckOutcome.PASS,
+        checks=[],
+        timestamp=datetime(2026, 6, 30, tzinfo=UTC),
+    )
+    path = _metrics_path(config)
+    append_jsonl(path, valid.model_dump_json())
+    # Appended AFTER the valid row so string comparison would pick it.
+    append_jsonl(
+        path,
+        json.dumps(
+            {"adr_id": "0100", "outcome": "fail", "timestamp": "not-a-timestamp"}
+        ),
+    )
+    append_jsonl(
+        path,
+        json.dumps(
+            {"adr_id": "0042", "outcome": "manual", "timestamp": "not-a-timestamp"}
+        ),
+    )
+
+    from dashboard_routes._conformance_routes import latest_conformance_by_adr
+
+    latest = latest_conformance_by_adr(config)
+    assert latest["0100"]["outcome"] == "pass"  # garbage ts never wins
+    assert latest["0042"]["outcome"] == "manual"  # sole garbage-ts row still served
+
+
 def test_latest_conformance_tolerates_corrupt_line(tmp_path) -> None:
     config = ConfigFactory.create(repo_root=tmp_path / "repo")
     good = AdrConformance(

--- a/tests/test_file_util.py
+++ b/tests/test_file_util.py
@@ -1,15 +1,23 @@
-"""Tests for file_util helpers: atomic_write, append_jsonl, file_lock, rotate_backups."""
+"""Tests for file_util helpers: atomic_write, append_jsonl, file_lock,
+rotate_backups, compact_jsonl_latest_by_key, is_newer_timestamp."""
 
 from __future__ import annotations
 
 import fcntl
+import json
 import os
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from file_util import append_jsonl, atomic_write, file_lock
+from file_util import (
+    append_jsonl,
+    atomic_write,
+    compact_jsonl_latest_by_key,
+    file_lock,
+    is_newer_timestamp,
+)
 
 
 class TestAtomicWrite:
@@ -203,3 +211,139 @@ class TestRotateBackups:
         assert Path(f"{target}.bak").read_text() == "v2"
         # With count=1, the old .bak (now .bak.1) is the oldest allowed
         assert Path(f"{target}.bak.1").read_text() == "v1"
+
+
+class TestIsNewerTimestamp:
+    def test_microsecond_row_is_newer_than_whole_second_row(self) -> None:
+        """Regression: lexically '.' < 'Z', so a STRING comparison would sort
+        '...56.000001Z' before '...56Z' — but it is one microsecond NEWER."""
+        assert is_newer_timestamp("2026-06-30T12:00:56.000001Z", "2026-06-30T12:00:56Z")
+        assert not is_newer_timestamp(
+            "2026-06-30T12:00:56Z", "2026-06-30T12:00:56.000001Z"
+        )
+
+    def test_plainly_newer_and_older(self) -> None:
+        assert is_newer_timestamp("2026-06-30T00:00:00Z", "2026-06-01T00:00:00Z")
+        assert not is_newer_timestamp("2026-06-01T00:00:00Z", "2026-06-30T00:00:00Z")
+
+    def test_equal_timestamps_are_not_newer(self) -> None:
+        assert not is_newer_timestamp("2026-06-30T00:00:00Z", "2026-06-30T00:00:00Z")
+
+    def test_unparseable_candidate_is_never_newer(self) -> None:
+        assert not is_newer_timestamp("not-a-timestamp", "2026-06-30T00:00:00Z")
+        assert not is_newer_timestamp(None, "2026-06-30T00:00:00Z")
+
+    def test_parseable_candidate_beats_unparseable_existing(self) -> None:
+        assert is_newer_timestamp("2026-06-30T00:00:00Z", "not-a-timestamp")
+        assert is_newer_timestamp("2026-06-30T00:00:00Z", None)
+
+    def test_both_unparseable_is_not_newer(self) -> None:
+        assert not is_newer_timestamp("garbage", "also-garbage")
+
+    def test_naive_datetime_assumed_utc(self) -> None:
+        # Must not raise TypeError comparing naive vs aware.
+        assert is_newer_timestamp("2026-06-30T00:00:01", "2026-06-30T00:00:00Z")
+
+
+def _row(key: str, ts: str, marker: str) -> str:
+    return json.dumps({"adr_id": key, "timestamp": ts, "marker": marker})
+
+
+class TestCompactJsonlLatestByKey:
+    def test_keeps_only_latest_row_per_key(self, tmp_path: Path) -> None:
+        target = tmp_path / "metrics.jsonl"
+        append_jsonl(target, _row("0100", "2026-06-01T00:00:00Z", "old"))
+        append_jsonl(target, _row("0042", "2026-06-15T00:00:00Z", "only"))
+        append_jsonl(target, _row("0100", "2026-06-30T00:00:00Z", "new"))
+
+        compact_jsonl_latest_by_key(target, key="adr_id", ts_key="timestamp")
+
+        rows = [json.loads(line) for line in target.read_text().splitlines()]
+        by_key = {row["adr_id"]: row for row in rows}
+        assert len(rows) == 2
+        assert by_key["0100"]["marker"] == "new"
+        assert by_key["0042"]["marker"] == "only"
+
+    def test_microsecond_boundary_latter_is_newer(self, tmp_path: Path) -> None:
+        """'...56Z' vs '...56.000001Z': the LATTER is newer despite lexically
+        sorting first ('.' < 'Z') — compaction must compare parsed datetimes."""
+        target = tmp_path / "metrics.jsonl"
+        append_jsonl(target, _row("0100", "2026-06-30T12:00:56Z", "whole-second"))
+        append_jsonl(target, _row("0100", "2026-06-30T12:00:56.000001Z", "microsecond"))
+
+        compact_jsonl_latest_by_key(target, key="adr_id", ts_key="timestamp")
+
+        rows = [json.loads(line) for line in target.read_text().splitlines()]
+        assert len(rows) == 1
+        assert rows[0]["marker"] == "microsecond"
+
+    def test_corrupt_and_blank_lines_dropped_without_raising(
+        self, tmp_path: Path
+    ) -> None:
+        target = tmp_path / "metrics.jsonl"
+        with open(target, "w", encoding="utf-8") as f:
+            f.write("{not valid json\n")
+            f.write("\n")
+            f.write('["not", "an", "object"]\n')
+            f.write(_row("0100", "2026-06-30T00:00:00Z", "good") + "\n")
+
+        compact_jsonl_latest_by_key(target, key="adr_id", ts_key="timestamp")
+
+        rows = [json.loads(line) for line in target.read_text().splitlines()]
+        assert len(rows) == 1
+        assert rows[0]["marker"] == "good"
+
+    def test_rows_missing_key_dropped(self, tmp_path: Path) -> None:
+        target = tmp_path / "metrics.jsonl"
+        append_jsonl(target, json.dumps({"timestamp": "2026-06-30T00:00:00Z"}))
+        append_jsonl(target, _row("0100", "2026-06-30T00:00:00Z", "keyed"))
+
+        compact_jsonl_latest_by_key(target, key="adr_id", ts_key="timestamp")
+
+        rows = [json.loads(line) for line in target.read_text().splitlines()]
+        assert len(rows) == 1
+        assert rows[0]["adr_id"] == "0100"
+
+    def test_unparseable_timestamp_treated_as_oldest(self, tmp_path: Path) -> None:
+        target = tmp_path / "metrics.jsonl"
+        # Appended AFTER the valid row; a string comparison would rank
+        # "not-a-timestamp" > "2026-..." and wrongly keep the garbage row.
+        append_jsonl(target, _row("0100", "2026-06-30T00:00:00Z", "valid"))
+        append_jsonl(target, _row("0100", "not-a-timestamp", "garbage"))
+        # A key whose ONLY row has a garbage timestamp still survives.
+        append_jsonl(target, _row("0042", "not-a-timestamp", "sole-garbage"))
+
+        compact_jsonl_latest_by_key(target, key="adr_id", ts_key="timestamp")
+
+        rows = [json.loads(line) for line in target.read_text().splitlines()]
+        by_key = {row["adr_id"]: row for row in rows}
+        assert by_key["0100"]["marker"] == "valid"
+        assert by_key["0042"]["marker"] == "sole-garbage"
+
+    def test_result_file_parses_fully(self, tmp_path: Path) -> None:
+        target = tmp_path / "metrics.jsonl"
+        for i in range(10):
+            append_jsonl(
+                target, _row(f"{i % 3:04d}", f"2026-06-{i + 1:02d}T00:00:00Z", str(i))
+            )
+
+        compact_jsonl_latest_by_key(target, key="adr_id", ts_key="timestamp")
+
+        for line in target.read_text().splitlines():
+            json.loads(line)  # every surviving line is complete, valid JSON
+
+    def test_rewrites_atomically_via_os_replace(self, tmp_path: Path) -> None:
+        target = tmp_path / "metrics.jsonl"
+        append_jsonl(target, _row("0100", "2026-06-01T00:00:00Z", "old"))
+        append_jsonl(target, _row("0100", "2026-06-30T00:00:00Z", "new"))
+
+        with patch("file_util.os.replace", wraps=os.replace) as mock_replace:
+            compact_jsonl_latest_by_key(target, key="adr_id", ts_key="timestamp")
+            mock_replace.assert_called_once()
+            args = mock_replace.call_args[0]
+            assert str(args[1]) == str(target)
+
+    def test_missing_file_is_noop(self, tmp_path: Path) -> None:
+        target = tmp_path / "missing.jsonl"
+        compact_jsonl_latest_by_key(target, key="adr_id", ts_key="timestamp")
+        assert not target.exists()


### PR DESCRIPTION
## Findings (fresh-eyes production review, both verified)

**1. Unbounded growth of `metrics/adr_conformance.jsonl`.**
`AdrConformanceLoop._persist_jsonl` appended one row per Accepted ADR per tick (~60 rows/tick) via `append_jsonl`, forever. The dashboard route `latest_conformance_by_adr` (`GET /api/adr-conformance`) then read and parsed the **entire** file on every request, keeping only the latest row per `adr_id`. Slow disk leak plus an O(file) hot read path.

**2. Timestamp string-comparison bug in `latest_conformance_by_adr`.**
It picked the latest row per ADR by comparing timestamp **strings**. Pydantic serializes a `datetime` as `...56Z` when microseconds are 0 but `...56.000001Z` otherwise; lexically `.` < `Z`, so `...56.000001Z` sorted **before** `...56Z` — the newer row lost. Unreachable today (rows within a tick share a timestamp; ticks are far apart) but latent and wrong.

## Retention policy: compact-on-write to latest-per-key (snapshot semantics)

The conformance jsonl has **snapshot semantics** — only the latest row per `adr_id` is ever served — so the policy is compact-on-write:

- `_persist_jsonl` now **appends then compacts** to exactly one row per `adr_id` after each tick. Append-then-compact (rather than merge-and-rewrite) keeps `append_jsonl`'s crash-safe fsync and ADR-0085 secret scrubbing on the write path; the compaction rewrite is atomic. End state after each tick: one row per Accepted ADR, file size bounded by #ADRs.
- New generic helper `file_util.compact_jsonl_latest_by_key(path, *, key, ts_key)`: reads existing rows (tolerant of corrupt/blank/non-object/keyless lines, same tolerance as the route), keeps the newest row per `key`, and rewrites atomically via the existing `atomic_write` (`tempfile` in the same dir + `os.replace`).
- ADR-0100 explicitly calls this jsonl "gitignored scratch state," so compaction is sanctioned.

## Timestamp fix — shared helper so route and compaction can't drift

New `file_util.is_newer_timestamp(candidate, existing)` is the single "parse ts, latest-wins" rule used by **both** the route and the compaction helper. It parses via `datetime.fromisoformat` (Python 3.11 handles the trailing `Z` in both `...56Z` and `...56.000001Z` forms), assumes UTC for any naive datetime, and treats an unparseable/missing timestamp as **oldest** — so the route never crashes on a bad row, and a garbage timestamp never beats a real one.

## fitness.jsonl deliberately NOT migrated

`fitness_report.py` / `fitness.jsonl` are untouched. Fitness rows have **trend semantics** — their history is load-bearing (the scorecard plots it over time), so compacting to latest-per-key would destroy data. The new `compact_jsonl_latest_by_key` helper is generic and available for future snapshot-semantics adopters, but must not be pointed at trend files.

## Concurrency

The loop is the **only** writer (single async loop, sequential ticks); the dashboard is a reader. `atomic_write` uses `os.replace`, so a concurrent `GET` reads either the old or the new **complete** file, never a torn one. No locking needed.

## Tests (written red-first where behavior changed)

- `tests/test_file_util.py` — `is_newer_timestamp` (microsecond-boundary ordering, unparseable-as-oldest, naive-as-UTC, equal-not-newer) and `compact_jsonl_latest_by_key` (latest-per-key survives, corrupt/blank/keyless lines dropped without raising, microsecond boundary, unparseable-ts-as-oldest, atomic `os.replace`, result parses fully, missing-file no-op).
- `tests/test_adr_conformance_loop.py` — after two ticks over the same ADRs, the jsonl holds exactly one row per `adr_id` carrying the second tick's outcome.
- `tests/test_conformance_routes.py` — microsecond-boundary case returns the truly-newer row; unparseable timestamp treated as oldest and never crashes.
- Existing `tests/scenarios/test_adr_conformance_e2e.py` stays green (its assertions are on latest rows, which compaction preserves).
- Full `make quality` green: **16705 passed**, ruff check/format clean, pyright 0 errors.

> Human review recommended before merge (autonomy floor is not a merge gate, but flagging per review discipline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)