### PR TITLE
fix(adr-conformance): scenario test for jsonl compaction (fixes staging Scenario Tests red)

### DIFF
--- a/tests/scenarios/test_adr_conformance_scenario.py
+++ b/tests/scenarios/test_adr_conformance_scenario.py
@@ -278,11 +278,15 @@ class TestAdrConformanceScenario:
         for event in conformance_events:
             assert len(event.data["results"]) == 3
 
-        # jsonl accumulates 3 rows per tick (append-only ledger).
+        # jsonl is compacted to the latest row per adr_id each tick (snapshot
+        # semantics, bead advisor-sqsv) — bounded at one row per ADR, not an
+        # append-only ledger. Two ticks over three ADRs → three rows (one per
+        # adr_id carrying the second tick's outcome), not six.
         jsonl_path = config.repo_data_root / "metrics" / "adr_conformance.jsonl"
         rows = [
             json.loads(line)
             for line in jsonl_path.read_text().splitlines()
             if line.strip()
         ]
-        assert len(rows) == 6
+        assert len(rows) == 3
+        assert {r["adr_id"] for r in rows} == {"ADR-0049", "ADR-0050", "ADR-0051"}


### PR DESCRIPTION
## Why staging is red

The staging CI run on tip `2d1dc8be` failed: `Scenario Tests` → `test_second_tick_does_not_double_file` asserted `len(rows) == 6` but got 3.

Bead advisor-sqsv (#9698) intentionally changed `_persist_jsonl` to compact the jsonl to the latest row per `adr_id` each tick (snapshot semantics, bounded file). So two ticks over three ADRs now yield **3 rows (one per adr_id), not 6 (append-only)**. The scenario test encoded the old append-only behavior.

**Why it wasn't caught pre-merge:** `make quality` (which #9698 ran green, 16705 tests) does **not** include `make scenario-loops` — that's a separate CI job. The compaction change's scenario fallout slipped through that gap.

## Fix

Update the assertion to encode the compaction invariant — exactly 3 rows, one per adr_id (`ADR-0049`/`0050`/`0051`) — instead of a bare append count. The test's real intent (issue dedup holds across ticks, 2 conformance events) was unaffected and still passes.

## Verification

- `pytest tests/scenarios/ -m scenario_loops` → **139 passed** (was 138 passed + 1 failed).
- ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)