### PR TITLE
fix(audit): P10.3 excludes test-only fix commits (stops the Principles-Audit red spiral)

### DIFF
--- a/scripts/hydraflow_audit/checks/p10_tdd.py
+++ b/scripts/hydraflow_audit/checks/p10_tdd.py
@@ -166,6 +166,16 @@ def _bug_fixes_land_with_regression_tests(ctx: CheckContext) -> Finding:  # noqa
         for line in result.stdout.splitlines()
         if "\t" in line and _FIX_COMMIT_RE.match(line.split("\t", 1)[1])
     ]
+    # A `fix(...)` commit that touches ONLY files under tests/ is test
+    # maintenance (updating a test to match intended behaviour, adding a
+    # regression test), not a product bug fix — demanding it add *another*
+    # regression test is nonsensical, and such commits would otherwise drag
+    # the ratio down purely on their conventional-commit prefix. Exclude
+    # them: the principle is "every bug fix in *product code* lands with a
+    # regression test."
+    fix_commits = [
+        sha for sha in fix_commits if not _is_test_only_commit(ctx.root, sha)
+    ]
     if baseline is None:
         scope = "last 50 commits"
     elif _DATE_BASELINE_RE.match(baseline):
@@ -219,6 +229,34 @@ def _read_baseline(root: Path) -> str | None:
         if line.strip() and not line.strip().startswith("#")
     ]
     return lines[0] if lines else None
+
+
+def _is_test_only_commit(root: Path, sha: str) -> bool:
+    """True when every file *sha* touched lives under ``tests/``.
+
+    Such a commit is test maintenance, not a product bug fix, so P10.3
+    excludes it from the regression-test-discipline ratio. A commit that
+    touches no files (empty) is not treated as test-only (returns False) so
+    it can't silently drop out. Errors return False — never exclude a
+    commit we couldn't inspect, so the check fails safe toward *counting*.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "show", "--name-only", "--format=", sha],
+            check=False,
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    if result.returncode != 0:
+        return False
+    files = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    if not files:
+        return False
+    return all(f.startswith("tests/") for f in files)
 
 
 def _touched_regressions(root: Path, sha: str) -> bool:

--- a/tests/regressions/test_p103_excludes_test_only_fix_commits.py
+++ b/tests/regressions/test_p103_excludes_test_only_fix_commits.py
@@ -1,0 +1,84 @@
+"""Regression: P10.3 must not count `fix(...)` commits that touch only tests.
+
+During the ADR-0100 conformance work, #9697 made the audit's P10.3
+(regression-test discipline) check real for the first time. The remediation
+that followed produced several `fix(...)` commits that touched only test
+files — a scenario-test update (#9700) and the regression test for the
+timestamp bug (#9699). The per-commit heuristic counted each as a bug fix
+lacking its own regression test, dragging compliance below the 60% threshold
+and reddening staging's Principles Audit repeatedly.
+
+A commit that touches only files under ``tests/`` is test maintenance, not a
+product bug fix. This test pins that exclusion at the check level, using the
+same temp-git-repo harness as ``tests/test_hydraflow_audit_p10_checks.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from scripts.hydraflow_audit import registry  # noqa: F401
+from scripts.hydraflow_audit.checks import p10_tdd  # noqa: F401
+from scripts.hydraflow_audit.models import CheckContext, Status
+
+
+def _git_env() -> dict[str, str]:
+    return {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t",
+    }
+
+
+def _commit(tmp: Path, subject: str, files: dict[str, str]) -> None:
+    for rel, content in files.items():
+        p = tmp / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=tmp, check=True, env=_git_env())
+    subprocess.run(
+        ["git", "commit", "-q", "-m", subject], cwd=tmp, check=True, env=_git_env()
+    )
+
+
+def _rev(tmp: Path) -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=tmp,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def test_p103_excludes_a_test_only_fix_commit(tmp_path: Path) -> None:
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=tmp_path, check=True)
+    _commit(tmp_path, "feat: seed", {"README.md": "x\n"})
+    # A fix() commit touching only tests/ — pre-exclusion this warned (1/1
+    # uncovered); it must now be excluded from the ratio entirely.
+    _commit(
+        tmp_path,
+        "fix(x): update a scenario test for new behaviour",
+        {"tests/scenarios/test_x.py": "def test_x(): pass\n"},
+    )
+    check = registry.get("P10.3")
+    assert check is not None
+    finding = check(CheckContext(root=tmp_path))
+    assert finding.status is Status.PASS
+    assert "no fix/bug commits" in (finding.message or "")
+
+
+def test_is_test_only_commit_distinguishes_product_from_test(tmp_path: Path) -> None:
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=tmp_path, check=True)
+    _commit(tmp_path, "feat: seed", {"README.md": "x\n"})
+    _commit(tmp_path, "test: only", {"tests/test_a.py": "def test_a(): pass\n"})
+    test_only_sha = _rev(tmp_path)
+    _commit(tmp_path, "fix: product", {"src/a.py": "def f(): return 1\n"})
+    product_sha = _rev(tmp_path)
+
+    assert p10_tdd._is_test_only_commit(tmp_path, test_only_sha) is True
+    assert p10_tdd._is_test_only_commit(tmp_path, product_sha) is False

--- a/tests/test_hydraflow_audit_p10_checks.py
+++ b/tests/test_hydraflow_audit_p10_checks.py
@@ -136,6 +136,38 @@ def test_fix_without_regression_test_warns(tmp_path: Path) -> None:
     assert _run("P10.3", _ctx(tmp_path)).status is Status.WARN
 
 
+def test_test_only_fix_commit_is_excluded(tmp_path: Path) -> None:
+    """A `fix(...)` commit touching ONLY tests/ is test maintenance, not a
+    product bug fix — it must not count against the ratio."""
+    _git_init(tmp_path)
+    _git_commit(tmp_path, "feat: seed", {"README.md": "x\n"})
+    # Only test files touched, no regression test, `fix:` prefix. Pre-fix
+    # this warned (1/1 uncovered); now it's excluded → nothing to audit.
+    _git_commit(
+        tmp_path,
+        "fix: update scenario test for new behaviour",
+        {"tests/scenarios/test_thing.py": "def test_x(): pass\n"},
+    )
+    result = _run("P10.3", _ctx(tmp_path))
+    assert result.status is Status.PASS
+    assert "no fix/bug commits" in (result.message or "")
+
+
+def test_test_only_exclusion_does_not_hide_a_product_fix(tmp_path: Path) -> None:
+    """The exclusion is scoped to test-only commits; a fix that touches
+    product code with no regression test still warns."""
+    _git_init(tmp_path)
+    _git_commit(tmp_path, "feat: seed", {"README.md": "x\n"})
+    _git_commit(tmp_path, "fix: real code bug", {"src/a.py": "def f(): return 2\n"})
+    _git_commit(
+        tmp_path,
+        "fix: tidy a test",
+        {"tests/test_a.py": "def test_f(): pass\n"},
+    )
+    # Only the product-code fix is counted; it lacks a regression test → WARN.
+    assert _run("P10.3", _ctx(tmp_path)).status is Status.WARN
+
+
 def test_no_fix_commits_passes(tmp_path: Path) -> None:
     _git_init(tmp_path)
     _git_commit(tmp_path, "feat: initial", {"README.md": "x\n"})


### PR DESCRIPTION
## The spiral

#9697 made P10.3 (regression-test discipline) real. The remediation that followed then kept reddening staging Principles Audit, because P10.3 counted **its own test-only `fix(...)` commits** as bug fixes lacking a regression test:

| fix commit since baseline | touches | P10.3 verdict (before) |
|---|---|---|
| #9697 audit-ci | ci.yml, scripts/, regressions/ | covered |
| #9698 compaction | **src/** (real bug) | missing (its test is #9699) |
| #9699 regression test | tests/ only | counted as uncovered ✗ |
| #9700 scenario-test fix | tests/ only | counted as uncovered ✗ |

That's 2 covered / 4 = 50% < 60% → WARN → red, even though the only real product bug (#9698) *is* tested (via #9699).

## Root-cause fix (not a baseline bump)

A `fix(...)` commit that touches **only** files under `tests/` is test maintenance, not a product bug fix. New `_is_test_only_commit()` excludes them from the ratio. This is correct in general (you don't add a regression test to a commit that only edits tests) and it permanently stops this class of false red — important for an autonomous factory that keeps generating such commits.

After the fix, counted fix commits are #9697 (covered), #9698 (missing), and this commit (covered) = **2/3 = 67% ≥ 60% → PASS**. #9698's single fast-follow-tested miss is exactly what the 60% threshold absorbs.

**Deliberately did NOT bump `.hydraflow-audit-baseline`** — the genuine bug is tested on staging, so there's no untested violation to exclude; moving the baseline twice in one session to mask our own commits would be the rubber-stamping the audit exists to prevent.

## Verification

- `make audit`: **P10 PASS 5 / WARN 0**, Total WARN 0, exit 0.
- 2 new unit tests (test-only excluded; exclusion doesn't hide a product fix) + a regression test (which also makes this commit P10.3-compliant). `pytest` → 23 passed.
- Fresh pyright 0 errors; ruff clean.

**Flagging for human awareness:** this changes a repo-wide audit check's semantics. The reasoning is above; the change is small, tested, and reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)