### PR TITLE
fix(adr-conformance): bulleted Enforced-by lists + scenario-loops in make quality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -357,6 +357,7 @@ quality: deps lint-ul
 		$(UV) pyright && echo "[typecheck OK]" & \
 		$(UV) bandit -c pyproject.toml -r . --severity-level medium && echo "[security OK]" & \
 		PYTHONPATH=src $(UV) pytest tests/ && echo "[tests OK]" & \
+		PYTHONPATH=src $(UV) pytest tests/scenarios/ -m scenario_loops -q && echo "[scenarios OK]" & \
 		wait_result=0; \
 		for job in $$(jobs -p); do wait $$job || wait_result=1; done; \
 		exit $$wait_result; \

--- a/src/adr_index.py
+++ b/src/adr_index.py
@@ -144,6 +144,37 @@ def parse_enforced_by(block: str) -> tuple[Check, ...]:
     return tuple(checks)
 
 
+_BULLET_RE = re.compile(r"^[-*]\s+(.*)$")
+
+
+def _parse_bulleted_enforced_by(text: str, start: int) -> tuple[Check, ...]:
+    """Collect a bulleted `**Enforced by:**` list into typed checks.
+
+    Scans the lines after *start* (the end of the `**Enforced by:**` marker).
+    A bullet whose content (after the ``-``/``*`` marker) begins with
+    ``pytest:`` or ``make:`` is a typed check; the first bullet that is NOT a
+    typed check, or the first non-bullet/blank line once checks have begun,
+    ends the list. This keeps unrelated sibling bullets (e.g. ``- **Spec:**``)
+    from being absorbed, matching the inline path's safety.
+    """
+    checks: list[Check] = []
+    for raw_line in text[start:].splitlines():
+        stripped = raw_line.strip()
+        if not stripped:
+            if checks:
+                break
+            continue  # skip the blank between the marker line and the list
+        m = _BULLET_RE.match(stripped)
+        if not m:
+            break  # a non-bullet line ends the list
+        item = m.group(1).strip().rstrip(",").strip()
+        if item.startswith("pytest:") or item.startswith("make:"):
+            checks.extend(parse_enforced_by(item))
+        else:
+            break  # a non-check bullet (e.g. `- **Spec:**`) ends the list
+    return tuple(checks)
+
+
 def _normalize_enforcement(raw: str) -> str:
     low = raw.strip().lower()
     return low if low in _KNOWN_ENFORCEMENT else "unknown"
@@ -226,6 +257,15 @@ def parse_adr_file(path: Path) -> ADR:
     enforcement = _normalize_enforcement(enf_match.group(1)) if enf_match else "unknown"
     eb_match = _ENFORCED_BY_RE.search(text)
     enforced_by = parse_enforced_by(eb_match.group(1)) if eb_match else ()
+    if eb_match and not enforced_by:
+        # Bulleted form: `**Enforced by:**` on its own line followed by
+        # `- pytest:...` / `- make:...` bullets. _ENFORCED_BY_RE deliberately
+        # stops its inline capture at the first bullet (to avoid swallowing
+        # unrelated sibling frontmatter bullets), so the inline group is empty
+        # here. Collect the immediately-following bullets that ARE typed
+        # checks; stop at the first bullet that isn't (preserving the same
+        # sibling-bullet safety the inline path has).
+        enforced_by = _parse_bulleted_enforced_by(text, eb_match.end())
 
     return ADR(
         number=number,

--- a/tests/test_adr_index_conformance_parse.py
+++ b/tests/test_adr_index_conformance_parse.py
@@ -84,6 +84,81 @@ def test_enforced_by_stops_at_next_bullet_not_just_blank_line(tmp_path):
     )
 
 
+def test_bulleted_enforced_by_list_is_parsed(tmp_path):
+    """Idiomatic markdown bulleted **Enforced by:** lists parse to typed
+    checks, not zero. The inline capture stops at the first bullet, so a
+    dedicated fallback collects the immediately-following typed-check
+    bullets (bead advisor-z7o9)."""
+    adr = parse_adr_file(
+        _write(
+            tmp_path,
+            (
+                "# ADR-0099: X\n\n**Status:** Accepted\n"
+                "**Enforcement:** enforced\n"
+                "**Enforced by:**\n"
+                "- pytest:tests/test_x.py::test_a\n"
+                "- pytest:tests/test_y.py::test_b\n"
+                "\n## Context\n\nc\n"
+            ),
+        )
+    )
+    assert adr.enforced_by == (
+        Check(
+            kind="pytest",
+            target="tests/test_x.py::test_a",
+            raw="pytest:tests/test_x.py::test_a",
+        ),
+        Check(
+            kind="pytest",
+            target="tests/test_y.py::test_b",
+            raw="pytest:tests/test_y.py::test_b",
+        ),
+    )
+
+
+def test_bulleted_fallback_stops_at_non_check_bullet(tmp_path):
+    """A non-check bullet after **Enforced by:** (e.g. a sibling
+    `- **Spec:**`) must NOT be absorbed as a check — the fallback stops at
+    the first bullet that isn't a typed check, preserving the same
+    sibling-bullet safety the inline path has."""
+    adr = parse_adr_file(
+        _write(
+            tmp_path,
+            (
+                "# ADR-0099: X\n\n**Status:** Accepted\n"
+                "**Enforcement:** manual\n"
+                "**Enforced by:**\n"
+                "- **Spec:** docs/superpowers/x.md\n\n## Context\n\nc\n"
+            ),
+        )
+    )
+    assert adr.enforced_by == ()
+
+
+def test_bulleted_fallback_stops_at_first_non_check_after_valid_checks(tmp_path):
+    """Once the typed-check bullets end, a following non-check bullet ends
+    the list rather than being swallowed."""
+    adr = parse_adr_file(
+        _write(
+            tmp_path,
+            (
+                "# ADR-0099: X\n\n**Status:** Accepted\n"
+                "**Enforcement:** enforced\n"
+                "**Enforced by:**\n"
+                "- pytest:tests/test_x.py::test_a\n"
+                "- **Spec:** docs/superpowers/x.md\n\n## Context\n\nc\n"
+            ),
+        )
+    )
+    assert adr.enforced_by == (
+        Check(
+            kind="pytest",
+            target="tests/test_x.py::test_a",
+            raw="pytest:tests/test_x.py::test_a",
+        ),
+    )
+
+
 def test_manual_prose_is_one_check_per_line_not_comma_split():
     # commas inside manual prose must NOT fragment
     checks = parse_enforced_by("branch protection review, per PR checklist\n")


### PR DESCRIPTION
Two gap fixes from the ADR-0100 fitness-function review (beads advisor-z7o9, advisor-6o64).

## 1. Parser accepts bulleted `**Enforced by:**` lists (advisor-z7o9)

The idiomatic markdown form parsed to **zero** checks:
```
**Enforced by:**
- pytest:tests/test_x.py::test_a
- pytest:tests/test_y.py::test_b
```
`_ENFORCED_BY_RE` deliberately stops its inline capture at the first bullet (so it can't swallow unrelated sibling frontmatter bullets like `- **Spec:**`), which left the bulleted list unparsed. #9694 made this *fail loudly*; this makes it *parse correctly*. New `_parse_bulleted_enforced_by` collects immediately-following **typed-check** bullets and stops at the first non-check bullet — preserving the exact sibling-bullet safety the inline path has (covered by a dedicated test).

## 2. `make quality` runs the scenario_loops suite (advisor-6o64)

`make quality`'s `pytest tests/` **deselects** `scenario_loops` (pyproject addopts `-m "not ... scenario_loops ..."`), so the MockWorld loop scenarios never ran locally. That's precisely how #9698's compaction change shipped green on `make quality` but red on the CI **Scenario Tests** job. Added as a 4th parallel job in the `quality` recipe. Closes the green-locally-red-in-CI gap.

## Verification

- `pytest tests/test_adr_index_conformance_parse.py tests/test_adr_index.py` → 21 passed (incl. new bulleted-form + safety tests).
- `make -n quality` parses; scenario_loops job present.
- Fresh pyright 0 errors; ruff clean.

## Context (separate, tracked)

The marquee gap — a **watched enablement** of `AdrConformanceLoop` — is bead `advisor-qqyo`. A dry-run of the loop against the real 68-ADR corpus (53 pass / 8 manual / 4 decision-of-record / 3 false-positive fail) found the runner mis-maps marker-gated + sandbox-only pytest citations to FAIL, so enabling now would file 3 spurious issues. That runner-robustness fix is the real enablement gate and is being tackled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)