### PR TITLE
chore(audit): advance P10.3 baseline past the ADR-0100 remediation burst

### DIFF
--- a/.hydraflow-audit-baseline
+++ b/.hydraflow-audit-baseline
@@ -39,4 +39,21 @@
 # no recent SHA is an ancestor of both (the newest common ancestor is the
 # last RC merge, which predates 13 uncovered fix commits), while a
 # timestamp is branch-independent.
-2026-07-02T21:00:00Z
+#
+# Reset 2026-07-03 (bead advisor-qqyo): reactivating P10.3 on 2026-07-02
+# made it real for the first time in weeks, and the ADR-0100 remediation
+# burst that immediately followed produced several product-code `fix(...)`
+# commits whose regression tests landed in a SEPARATE fast-follow PR (squash
+# -per-PR splits the fix from its test), which the per-commit heuristic
+# cannot attribute. Every fix in the burst IS tested — enumerated so this
+# reset provably hides no untested work:
+#   - de1ae975 (#9698, jsonl compaction/timestamp) -> tested by
+#     tests/regressions/test_conformance_jsonl_timestamp_ordering.py (#9699)
+#   - 584ed70b (#9702, bulleted Enforced-by parser) -> tested by
+#     tests/test_adr_index_conformance_parse.py
+#   - 66982195 (#9703, conformance-runner robustness) -> tested by
+#     tests/test_adr_conformance_runner_subprocess.py
+# The discipline (every bug fix has a regression test) is met in substance;
+# the 40% ratio was a per-commit-attribution artifact, not untested drift.
+# Forward-enforcement restarts here.
+2026-07-03T21:51:00Z


### PR DESCRIPTION
Restores staging Principles Audit to green (bead advisor-qqyo).

## Why

Reactivating P10.3 on 2026-07-02 made the regression-test-discipline check real for the first time in weeks. The ADR-0100 remediation burst that immediately followed produced product-code fix commits whose regression tests landed in **separate fast-follow PRs** (squash-per-PR splits the fix from its test), which P10.3's per-commit heuristic can't attribute. Ratio stuck at 2 covered / 5 = 40%.

**Every fix in the burst IS tested** (enumerated in the baseline file so this provably hides no untested work):

| fix commit | tested by |
|---|---|
| de1ae975 (#9698 jsonl compaction/timestamp) | tests/regressions/test_conformance_jsonl_timestamp_ordering.py (#9699) |
| 584ed70b (#9702 bulleted parser) | tests/test_adr_index_conformance_parse.py |
| 66982195 (#9703 runner robustness) | tests/test_adr_conformance_runner_subprocess.py |

The discipline is met in substance; the 40% was a per-commit-attribution artifact. I can't raise the ratio legitimately (no bugs left to fix; regression-test-only commits are excluded by the rule added in #9701), so advancing the baseline — exactly what the mechanism documents for this case (cf. the 2026-06-12 and #9697 resets) — is the honest resolution.

This reverses the 'no bump' stance from earlier in the session; it was surfaced and approved before landing, because the situation changed (1 rescuable miss then vs 3 tested-but-split misses now).

## Verification

- make audit: P10 PASS 5 / WARN 0, Total WARN 0, exit 0.
- Committed as chore(...) so the baseline-setter isn't itself a counted fix commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)