### PR TITLE
feat(adr-conformance): enable AdrConformanceLoop by default

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -3019,8 +3019,13 @@ class HydraFlowConfig(BaseModel):
         description="Deploy-time kill-switch for AdrTouchpointAuditorLoop.",
     )
     adr_conformance_loop_enabled: bool = Field(
-        default=False,
-        description="Deploy-time kill-switch for AdrConformanceLoop (ADR-0100).",
+        default=True,
+        description=(
+            "Deploy-time kill-switch for AdrConformanceLoop (ADR-0100). "
+            "Enabled by default (like sibling caretaker loops) after a dry-run "
+            "against the full ADR corpus confirmed zero false-positive issue "
+            "filing; set False to disable."
+        ),
     )
     ci_monitor_loop_enabled: bool = Field(
         default=True,

--- a/tests/scenarios/test_adr_conformance_scenario.py
+++ b/tests/scenarios/test_adr_conformance_scenario.py
@@ -5,7 +5,7 @@ builder (Task 11) against a seeded ADR fixture directory, a real
 ``ADRIndex``/``StateTracker``/``DedupStore`` on ``tmp_path``, and
 ``world.github`` (``FakeGitHub``) as the ``PRManager`` write surface.
 
-``config.adr_conformance_loop_enabled`` defaults to ``False`` and is not a
+``config.adr_conformance_loop_enabled`` defaults to ``True`` and is not a
 named ``ConfigFactory.create`` param (unlike e.g.
 ``sandbox_failure_fixer_enabled``) — matching the direct-construction
 pattern documented in ``tests/scenarios/test_sandbox_failure_fixer_scenario.py``
@@ -117,8 +117,8 @@ def _build_loop(world: MockWorld, repo_root: Path):
     """Construct AdrConformanceLoop via the Task 11 catalog builder.
 
     Direct construction (not ``world.run_with_loops``): the catalog has no
-    config-enable seam for ``adr_conformance_loop_enabled`` (defaults
-    False, and isn't a named ``ConfigFactory.create`` kwarg), and
+    config-enable seam for ``adr_conformance_loop_enabled`` (isn't a
+    named ``ConfigFactory.create`` kwarg), and
     ``run_with_loops`` would also leave ``data_root`` at its unsafe
     ``Path(".")`` default. Mirrors ``test_sandbox_failure_fixer_scenario.py``.
     """

--- a/tests/test_adr_conformance_state.py
+++ b/tests/test_adr_conformance_state.py
@@ -22,7 +22,9 @@ def state_tracker(tmp_path: Path) -> StateTracker:
 
 def test_config_defaults():
     c = HydraFlowConfig()
-    assert c.adr_conformance_loop_enabled is False
+    # Enabled by default (ADR-0100) once proven safe — a dry-run against the
+    # full ADR corpus filed zero false-positive issues (bead advisor-qqyo).
+    assert c.adr_conformance_loop_enabled is True
     assert c.adr_conformance_interval == 86400
 
 


### PR DESCRIPTION
Final step of bead advisor-qqyo: turn the measured contract on.

## What

Flip `adr_conformance_loop_enabled` default `False`→`True`, matching sibling caretaker loops (`ci_monitor`, `branch_protection_auditor`, `gate_activator`, all default `True`).

## Why it's safe

A dry-run of `evaluate_adrs` against the **full 68-ADR corpus** with the real runner (post the #9703 robustness fix) produced:

```
56 pass · 8 manual · 4 decision-of-record · 0 drift   →   WOULD_FILE_ISSUES=0
```

So on the current corpus the loop files **zero** issues. It stays bounded: one open remediation issue per ADR (state rollup), a per-ADR attempt budget before escalation, and the `enabled_cb('adr_conformance')` kill switch (ADR-0049/0100). No ADR decision mandated off-by-default — `False` was rollout caution, now discharged by the dry-run evidence.

## Verification

- Config-defaults test updated to assert `True`; two stale scenario docstrings corrected.
- The loop was already registered in the orchestrator (only `_do_work` was gated), so loop-count / wiring-completeness tests are unaffected — verified (`test_orchestrator_loops`, `test_loop_wiring_completeness`, `test_loop_count_matches_adr0001`, `test_sandbox_main_smoke` all green).
- Conformance loop/state/scenario suites green; fresh pyright 0 errors; ruff clean.

## After merge

First production ticks will file 0 issues (all conformant today); the loop then measures drift going forward. Bead advisor-qqyo closes once a first live tick confirms sensible behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)