### PR TITLE
fix(config): sync adr_conformance env-override default (fixes staging Tests red)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -481,7 +481,7 @@ _ENV_BOOL_OVERRIDES: list[tuple[str, str, bool]] = [
     (
         "adr_conformance_loop_enabled",
         "HYDRAFLOW_ADR_CONFORMANCE_LOOP_ENABLED",
-        False,
+        True,
     ),
     ("ci_monitor_loop_enabled", "HYDRAFLOW_CI_MONITOR_LOOP_ENABLED", True),
     (

--- a/tests/regressions/test_adr_conformance_enable_default_two_writers.py
+++ b/tests/regressions/test_adr_conformance_enable_default_two_writers.py
@@ -1,0 +1,26 @@
+"""Regression: adr_conformance_loop_enabled has two writers of its default.
+
+#9705 enabled AdrConformanceLoop by default by flipping the pydantic Field
+default False->True, but the value is ALSO recorded in config._ENV_BOOL_OVERRIDES
+(the env-var override table). Only the Field was updated, so the two drifted
+and three tests in test_config_env.py failed — reddening staging's Tests job.
+
+This pins the specific invariant for this flag: the env-override table's
+recorded default must equal the pydantic field default, and both must be
+True (enabled). The general drift guard lives in
+``test_config_env.py::test_override_table_defaults_match_field_defaults``;
+this is the incident-specific pin.
+"""
+
+from __future__ import annotations
+
+from config import _ENV_BOOL_OVERRIDES, HydraFlowConfig
+
+
+def test_adr_conformance_enable_default_is_true_and_consistent():
+    field_default = HydraFlowConfig().adr_conformance_loop_enabled
+    assert field_default is True
+
+    table = {attr: default for attr, _env, default in _ENV_BOOL_OVERRIDES}
+    assert "adr_conformance_loop_enabled" in table
+    assert table["adr_conformance_loop_enabled"] == field_default


### PR DESCRIPTION
## Why staging Tests is red

#9705 enabled AdrConformanceLoop by flipping the pydantic Field default False→True. That value has a **second writer** — `config._ENV_BOOL_OVERRIDES` (the env-var override table) — which I did not update. `test_config_env.py` has a two-writers drift guard (`test_override_table_defaults_match_field_defaults`) that correctly caught it; 3 checks failed → Tests red → CI Gate red.

Principles Audit and Scenario Tests stayed green; only Tests broke.

## Fix

- Set the `_ENV_BOOL_OVERRIDES` entry for `adr_conformance_loop_enabled` to `True` so both writers agree.
- Add `tests/regressions/test_adr_conformance_enable_default_two_writers.py` pinning this flag's field↔table consistency.

## Verification

- `pytest tests/test_config_env.py` → 773 passed (was 3 failing).
- `make audit`: P10 PASS 5 / WARN 0 (this fix commit carries its regression test, so P10.3 stays green).
- ruff + pyright clean.

Lesson logged: a config-default change has two writers here; the config-env suite must be run for such changes (my targeted run missed it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)