### PR TITLE
fix(adr-conformance): harden mutating-make-target detection; pin make-rename safety

### DIFF
--- a/src/adr_conformance.py
+++ b/src/adr_conformance.py
@@ -74,8 +74,81 @@ MUTATING_MAKE_TARGETS: frozenset[str] = frozenset(
 _PARAM_SUFFIX_RE = re.compile(r"\[.*\]$")
 
 
-def is_mutating(check: Check) -> bool:
-    return check.kind == "make" and check.target in MUTATING_MAKE_TARGETS
+# High-confidence mutation signals scanned in a make target's recipe. Chosen
+# to be unambiguous — a read-only check (pytest, arch-check, lint-check,
+# `git diff`/`git log`) never contains these — so the recipe scan hardens the
+# denylist toward fail-CLOSED (an unknown target that writes to the repo/remote
+# is caught) without false-flagging legitimate side-effect-free checks.
+_RECIPE_MUTATION_SIGNALS: tuple[str, ...] = (
+    "git commit",
+    "git push",
+    "git add",
+    "git checkout",
+    "git reset",
+    "git rm",
+    "git mv",
+    "git stash",
+    "git merge",
+    "git rebase",
+    "git tag",
+    "git apply",
+    "gh pr create",
+    "gh pr merge",
+    "gh issue create",
+    "gh release",
+    "sed -i",
+    "pip install",
+    "uv sync",
+    "npm install",
+    "npm ci",
+)
+
+
+def _make_recipe(repo_root: Path, target: str) -> str:
+    """Return the recipe body of a Makefile *target* (its tab-indented lines).
+
+    A make recipe is the contiguous run of tab-prefixed lines following the
+    ``target:`` line; it ends at the first non-tab line. Returns "" when the
+    Makefile or target is absent.
+    """
+    makefile = repo_root / "Makefile"
+    if not makefile.is_file():
+        return ""
+    target_re = re.compile(rf"^{re.escape(target)}\s*:")
+    recipe: list[str] = []
+    in_target = False
+    for line in makefile.read_text().splitlines():
+        if target_re.match(line):
+            in_target = True
+            continue
+        if in_target:
+            if line.startswith("\t"):
+                recipe.append(line)
+            else:
+                break
+    return "\n".join(recipe)
+
+
+def _recipe_mutates(repo_root: Path, target: str) -> bool:
+    recipe = _make_recipe(repo_root, target)
+    return any(sig in recipe for sig in _RECIPE_MUTATION_SIGNALS)
+
+
+def is_mutating(check: Check, repo_root: Path | None = None) -> bool:
+    """True when a make check has side effects and so may not be `enforced`.
+
+    Two layers: the ``MUTATING_MAKE_TARGETS`` denylist (authoritative for
+    known-mutating targets whose mutation isn't visible in the recipe text,
+    e.g. ``arch-regen`` writing files via a python entrypoint), plus — when
+    *repo_root* is given — a recipe scan for high-confidence mutation commands.
+    The scan closes the denylist's fail-open gap: a NEW mutating target that
+    isn't listed is still caught if its recipe pushes/commits/opens PRs/etc.
+    """
+    if check.kind != "make":
+        return False
+    if check.target in MUTATING_MAKE_TARGETS:
+        return True
+    return repo_root is not None and _recipe_mutates(repo_root, check.target)
 
 
 def _module_level_name_defined(tree: ast.Module, wanted: str) -> bool:

--- a/tests/regressions/test_conformance_make_target_safety.py
+++ b/tests/regressions/test_conformance_make_target_safety.py
@@ -1,0 +1,59 @@
+"""Regression: ADR-conformance make-target safety (beads advisor-xz82/w6zf).
+
+xz82 — the MUTATING_MAKE_TARGETS denylist failed OPEN: a make target not on
+the list was treated as side-effect-free and could be cited as an `enforced`
+check, then executed by the loop. is_mutating now also scans the target's
+Makefile recipe for high-confidence mutation commands, so an unlisted target
+that pushes/commits/opens PRs is caught.
+
+w6zf — make-target renames are intentionally NOT auto-repointed: a make
+target's identity is its name (no content signal to match), so a guessed
+REPOINT would be unsafe. classify_remediation routes an UNRESOLVED make
+check (no rename match) to FILE_ISSUE, never REPOINT.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from adr_conformance import (
+    AdrConformance,
+    CheckOutcome,
+    ConformanceKind,
+    is_mutating,
+)
+from adr_conformance_remediation import RemediationAction, classify_remediation
+from adr_index import Check
+
+
+def test_unlisted_mutating_make_target_is_caught_by_recipe_scan(tmp_path: Path):
+    (tmp_path / "Makefile").write_text(
+        "release:\n\t@echo cutting release\n\tgh pr create --fill\n\tgit push --tags\n"
+    )
+    check = Check("make", "release", "make:release")
+    # Not on the denylist, so denylist-only misses it...
+    assert is_mutating(check) is False
+    # ...but the recipe scan (with repo_root, as the ratchet passes) catches it.
+    assert is_mutating(check, tmp_path) is True
+
+
+def _unresolved_make_conf():
+    # Minimal conformance object with the .outcome classify_remediation reads.
+    return AdrConformance(
+        adr_id="ADR-0099",
+        kind=ConformanceKind.ENFORCED,
+        outcome=CheckOutcome.UNRESOLVED,
+        checks=[],
+        timestamp=datetime(2026, 7, 4, tzinfo=UTC),
+    )
+
+
+def test_unresolved_make_target_never_repoints():
+    # rename_match is None for make targets (the loop's _detect_rename only
+    # inspects pytest checks) -> must route to FILE_ISSUE, never REPOINT.
+    decision = classify_remediation(
+        _unresolved_make_conf(), rename_match=None, attempts=0
+    )
+    assert decision.action is RemediationAction.FILE_ISSUE
+    assert decision.action is not RemediationAction.REPOINT

--- a/tests/test_adr_conformance_coverage.py
+++ b/tests/test_adr_conformance_coverage.py
@@ -339,7 +339,7 @@ def test_enforced_adrs_name_resolvable_nonmutating_checks():
                 problems.append(
                     f"ADR-{a.number:04d}: prose check under enforced ({chk.raw!r})"
                 )
-            elif is_mutating(chk):
+            elif is_mutating(chk, REPO):
                 problems.append(
                     f"ADR-{a.number:04d}: mutating target {chk.target!r} not allowed"
                 )

--- a/tests/test_adr_conformance_loop.py
+++ b/tests/test_adr_conformance_loop.py
@@ -18,11 +18,17 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
 
-from adr_conformance import CheckOutcome
+from adr_conformance import (
+    AdrConformance,
+    CheckOutcome,
+    CheckResult,
+    ConformanceKind,
+)
 from adr_conformance_loop import AdrConformanceLoop
 from adr_index import ADRIndex
 from base_background_loop import LoopDeps
@@ -365,6 +371,31 @@ async def test_unresolved_with_ambiguous_rename_still_files_plain_issue(
         for title, _body, _labels in fakes.pr.created_issues
         if "ADR-0051" in title
     )
+
+
+def test_detect_rename_returns_none_for_unresolved_make_target(loop_fixture) -> None:
+    """Make-target renames are never auto-detected (bead advisor-w6zf).
+
+    A make target's identity IS its name — unlike a pytest node, which keeps
+    its function/class name when it moves files, a renamed make target offers
+    no content signal to match, so any guessed REPOINT would be unsafe. An
+    UNRESOLVED make check therefore yields no rename and routes to FILE_ISSUE
+    (then ESCALATE by recurrence). This is conservative-by-design, not a gap:
+    _detect_rename only ever inspects pytest: checks.
+    """
+    loop, _ = loop_fixture
+    conf = AdrConformance(
+        adr_id="ADR-0099",
+        kind=ConformanceKind.ENFORCED,
+        outcome=CheckOutcome.UNRESOLVED,
+        checks=[
+            CheckResult(
+                check="make:some-renamed-target", outcome=CheckOutcome.UNRESOLVED
+            )
+        ],
+        timestamp=datetime(2026, 7, 4, tzinfo=UTC),
+    )
+    assert loop._detect_rename(conf) is None
 
 
 async def test_pass_clears_attempt_counter(loop_fixture) -> None:

--- a/tests/test_adr_conformance_resolve.py
+++ b/tests/test_adr_conformance_resolve.py
@@ -36,6 +36,37 @@ def test_mutating_targets_flagged():
     assert "lint-ul" in MUTATING_MAKE_TARGETS
 
 
+def test_recipe_scan_flags_unlisted_mutating_target(tmp_path):
+    # A target NOT in the denylist but whose recipe pushes to the remote must
+    # be caught when repo_root is supplied (fail-closed hardening, bead
+    # advisor-xz82). Without repo_root the denylist alone can't see it.
+    (tmp_path / "Makefile").write_text(
+        "publish:\n\t@echo building\n\tgit push origin main\n"
+    )
+    danger = Check("make", "publish", "make:publish")
+    assert is_mutating(danger, tmp_path) is True
+    assert is_mutating(danger) is False  # denylist-only can't see the recipe
+
+
+def test_recipe_scan_does_not_flag_readonly_target(tmp_path):
+    # A read-only check target (pytest, git diff) must NOT be flagged — the
+    # signals are chosen to avoid false positives that would block a valid ADR.
+    (tmp_path / "Makefile").write_text(
+        "verify:\n\tpytest tests/ -q\n\tgit diff --exit-code\n"
+    )
+    assert is_mutating(Check("make", "verify", "make:verify"), tmp_path) is False
+
+
+def test_recipe_scan_reads_only_the_named_targets_recipe(tmp_path):
+    # A mutating command in a DIFFERENT target must not bleed into the scan of
+    # a safe target (recipe ends at the first non-tab line).
+    (tmp_path / "Makefile").write_text(
+        "safe:\n\tpytest tests/ -q\n\nrelease:\n\tgit push\n"
+    )
+    assert is_mutating(Check("make", "safe", "make:safe"), tmp_path) is False
+    assert is_mutating(Check("make", "release", "make:release"), tmp_path) is True
+
+
 def test_pytest_class_method_resolves_when_direct_child(tmp_path):
     (tmp_path / "tests").mkdir()
     (tmp_path / "tests" / "t.py").write_text(


### PR DESCRIPTION
The two remaining ADR-0100 gap beads (both P2). One is a real fail-open fix; the other turned out to be conservative-by-design, so it's pinned + documented rather than "implemented".

## advisor-xz82 — harden mutating-make-target detection (real fix)

`MUTATING_MAKE_TARGETS` was a denylist that **failed open**: a make target not on the list was treated as side-effect-free, so it could be cited as an `enforced` check, pass the ratchet, and then be executed by the loop.

`is_mutating(check, repo_root)` now also scans the target's Makefile recipe for high-confidence mutation commands (`git commit/push/add/checkout/reset/rm/mv/...`, `gh pr/issue create`, `sed -i`, `pip/uv/npm install`). The ratchet passes `REPO`, so an unlisted target that writes to the repo or remote is caught pre-merge. Signals are deliberately unambiguous — a read-only check (pytest, `arch-check`, `git diff`) never contains them — so this hardens toward fail-**closed** without false-flagging valid checks. Verified the existing enforced targets (`trust-contracts`, `arch-check`) are still allowed.

## advisor-w6zf — make-target rename→REPOINT (working as designed)

Make-target renames are intentionally **not** auto-repointed. A make target's identity *is* its name — unlike a pytest node, which keeps its function/class name when it moves files, so `find_renamed_pytest_node` can match it. A renamed make target offers no content signal, so any guessed REPOINT would violate the code's own "ambiguity is reached by recurrence, not guessed" rule. An UNRESOLVED make check correctly routes to FILE_ISSUE → ESCALATE.

Rather than build unreliable fuzzy matching, this pins the safety invariant: a `_detect_rename` test (returns `None` for a make check) + a regression test (`classify_remediation` never REPOINTs an UNRESOLVED make check).

## Verification

- 35 touched-suite tests pass (resolve + loop + coverage ratchet + new regression file).
- `make audit`: P1/P10 clean, WARN 0; existing enforced make targets not newly flagged; this fix commit carries its regression test so P10.3 stays green.
- ruff + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
