### PR TITLE
test(steering): real s52 Docker e2e (/pause→flow=paused) + allowlist-from-env — closes #9710

### DIFF
--- a/docker-compose.sandbox.yml
+++ b/docker-compose.sandbox.yml
@@ -46,6 +46,15 @@ services:
       # is 60 s regardless of this env var.
       HYDRAFLOW_CONVERGENCE_OSCILLATION_INTERVAL: "5"
       HYDRAFLOW_CONVERGENCE_OSCILLATION_LOOP_ENABLED: "true"
+      # HumanSteeringLoop (ADR-0099 #4, s52). human_steering_enabled is
+      # already default-on (src/config.py) but is set explicitly here for
+      # clarity. The allowlist defaults to [] (honors nobody, safe-by-
+      # default) so s52's seeded /pause comment needs its author explicitly
+      # allow-listed here — "steer-bot" must match the login s52 seeds the
+      # /pause comment from (tests/sandbox_scenarios/scenarios/
+      # s52_human_steering_directive.py).
+      HYDRAFLOW_HUMAN_STEERING_ENABLED: "true"
+      HYDRAFLOW_HUMAN_STEERING_AUTHORIZED_USERS: "steer-bot"
     volumes:
       - ./tests/sandbox_scenarios/seeds:/seed:ro
     networks: [sandbox]

--- a/src/config.py
+++ b/src/config.py
@@ -4060,6 +4060,13 @@ def _apply_env_overrides(config: HydraFlowConfig) -> None:
         if parsed:
             object.__setattr__(config, "lite_plan_labels", parsed)
 
+    # Human-steering authorized users (comma-separated list, special-case)
+    env_steering_users = os.environ.get("HYDRAFLOW_HUMAN_STEERING_AUTHORIZED_USERS")
+    if env_steering_users is not None and config.human_steering_authorized_users == []:
+        parsed = [u.strip() for u in env_steering_users.split(",") if u.strip()]
+        if parsed:
+            object.__setattr__(config, "human_steering_authorized_users", parsed)
+
     # Docker resource limit overrides (validated fields handled manually
     # because str/int overrides need format/bounds validation that
     # the data-driven tables don't provide)

--- a/src/mockworld/fakes/fake_llm.py
+++ b/src/mockworld/fakes/fake_llm.py
@@ -7,6 +7,7 @@ success result is returned.
 
 from __future__ import annotations
 
+import asyncio
 from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -122,6 +123,8 @@ class _FakePlannerRunner(_ScriptedRunner):
         **_unused: Any,
     ) -> Any:
         _ = (worker_id, research_context)
+        if self._parent.plan_hold_seconds:
+            await asyncio.sleep(self._parent.plan_hold_seconds)
         issue_number = getattr(task, "id", getattr(task, "number", 0))
         if not self._parent._consume_budget(issue_number):
             return PlanResultFactory.create(
@@ -385,6 +388,12 @@ class FakeLLM:
         self._advisor = _FakeAdvisorRunner()
         # ADR-0063 phase-level scripted outcomes (W3a/W3b/W4/W5).
         self._phase_scripts = _FakePhaseScripts()
+        # Artificial real-time delay (seconds) _FakePlannerRunner.plan()
+        # awaits before returning. Defaults to 0.0 (no-op) — set via
+        # MockWorldSeed.plan_hold_seconds by sandbox_main.py for scenarios
+        # that need a sustained, real wall-clock "active" window (see
+        # MockWorldSeed.plan_hold_seconds docstring for why).
+        self.plan_hold_seconds: float = 0.0
 
     def script_triage(self, issue_number: int, results: list[Any]) -> None:
         self.triage_runner.add_script(

--- a/src/mockworld/sandbox_main.py
+++ b/src/mockworld/sandbox_main.py
@@ -198,6 +198,9 @@ async def main() -> None:
     # the seed.scripts payload. Without this, the sandbox would attempt
     # real LLM calls and fail under the air-gapped network.
     fake_llm = FakeLLM()
+    # Defaults to 0.0 (no-op) — see MockWorldSeed.plan_hold_seconds docstring
+    # for why a scenario (e.g. s52_human_steering_directive) might set this.
+    fake_llm.plan_hold_seconds = seed.plan_hold_seconds
     for phase, by_issue in seed.scripts.items():
         for issue_number, results in by_issue.items():
             getattr(fake_llm, f"script_{phase}")(issue_number, results)

--- a/src/mockworld/seed.py
+++ b/src/mockworld/seed.py
@@ -88,6 +88,21 @@ class MockWorldSeed:
     # ("failure", "<run_url>") to drive the red-CI path.
     main_branch_ci_status: tuple[str, str] = ("success", "")
 
+    # Artificial real-time delay (seconds) inside FakePlannerRunner.plan()
+    # before it returns. Defaults to 0.0 (no-op — every existing scenario's
+    # FakeLLM timing is unaffected). A scenario that needs an issue to stay
+    # inside the real IssueStore "active" window (store_lifecycle's
+    # mark_active/mark_complete bracket, populated while PlanPhase awaits
+    # this call) for a sustained, real wall-clock duration — rather than the
+    # near-instantaneous default — sets this to a positive value. See
+    # s52_human_steering_directive.py, which needs HumanSteeringLoop's
+    # 60-second-interval tick to reliably observe the issue as active;
+    # without an artificial hold the plan-fails-forever tight loop's actual
+    # active window is only milliseconds long even though it dominates the
+    # loop logically, making a live snapshot miss it far more often than a
+    # naive duty-cycle estimate would suggest.
+    plan_hold_seconds: float = 0.0
+
     def to_json(self) -> str:
         """Serialize to JSON for cross-process transfer."""
         return json.dumps(asdict(self), indent=2)

--- a/tests/sandbox_scenarios/scenarios/s52_human_steering_directive.py
+++ b/tests/sandbox_scenarios/scenarios/s52_human_steering_directive.py
@@ -29,38 +29,58 @@ lambda *_: 60)`` overrides every caretaker's interval, per s51's precedent).
 ``lambda: list(store.get_active_issues().keys())`` — the ``FakeIssueStore``
 active set that ``store_lifecycle`` (``phase_utils.py``) populates via
 ``mark_active`` on phase entry and clears via ``mark_complete`` on phase
-exit. A phase that completes instantly (the Fakes have no artificial
-latency) holds that window open for a single event-loop tick — far too
-narrow to reliably coincide with a 60-second caretaker cadence if the issue
-is only driven through the pipeline once.
+exit.
 
-s51 (``s51_convergence_oscillation.py``) solves the identical timing problem
-for ``ConvergenceOscillationLoop`` by driving the issue into a state where a
-phase orchestrator's ``_polling_loop`` (``orchestrator.py``) keeps
-re-entering ``store_lifecycle`` in a tight loop with no sleep between
-iterations: ``_polling_loop`` only sleeps ``poll_interval`` when
-``did_work`` is falsy (``if did_work: continue`` — no sleep). Scripting plan
-to fail (``{"success": False}``) makes ``plan_issues()`` keep returning a
-non-empty (truthy) result every iteration — PlanPhase records the failure,
-skips the label swap (the issue stays on ``hydraflow-plan``), and the plan
-loop immediately re-polls and reprocesses the same issue, over and over,
-for the lifetime of the scenario run. That keeps the issue flickering
-active/inactive at effectively the event-loop's own cadence rather than
-once every ``poll_interval`` (30 s default), so ``HumanSteeringLoop``'s
-60-second tick has continuous opportunities to observe it as active over
-the scenario's run.
+s51 (``s51_convergence_oscillation.py``) keeps its issue perpetually
+cycling through a phase orchestrator's ``_polling_loop`` (``orchestrator.py``)
+tight retry (``if did_work: continue`` — no sleep between iterations, since
+plan scripted to fail forever never runs out of "work"). This scenario
+reuses that same "plan fails forever" vehicle for the same reason (keep
+the issue perpetually re-entering ``store_lifecycle`` rather than settling
+into a terminal state) — but a tight retry loop alone is NOT sufficient
+here. Measured empirically against a live Docker sandbox: even though the
+issue is nominally "active" for ~90%+ of the *logical* iterations of the
+tight loop, each individual ``mark_active``-to-``mark_complete`` window is
+only a few milliseconds of *real* wall-clock time (the Fakes have no
+artificial latency), while the gap between one ``mark_complete`` and the
+next ``mark_active`` — though tiny in absolute terms — is where
+``HumanSteeringLoop``'s tick lands far more often than the duty-cycle ratio
+would predict (roughly 1 hit in ~300 tries when temporarily sampled at a
+much faster interval than 60 s). A production deployment never hits this:
+real LLM/planning calls take real seconds, so the active window's absolute
+duration dwarfs a 60-second sampling interval. The sandbox's instant Fakes
+break that assumption.
 
-This scenario reuses that same "plan fails forever" vehicle, simplified to
-skip the discover/shape detour s51 needs for its oscillation ledger (not
-relevant here): triage scripts ``ready=True`` (default ``clarity_score=10``
-clears the discovery gate) so the issue routes straight from
-``hydraflow-find`` to ``hydraflow-plan`` in one triage pass, then plan fails
-forever. This also keeps the Tier-1 in-process parity check
-(``test_sandbox_parity.py``, which for ``loops_enabled=None`` runs a
+The fix is ``MockWorldSeed.plan_hold_seconds`` (``src/mockworld/seed.py``):
+an opt-in artificial ``asyncio.sleep`` inside ``_FakePlannerRunner.plan()``
+(``src/mockworld/fakes/fake_llm.py``) that extends the plan call's real
+wall-clock duration while ``store_lifecycle`` still holds the issue
+``mark_active``. Defaults to ``0.0`` (a no-op skip, not even an
+``await asyncio.sleep(0)`` call) so every other scenario's FakeLLM timing
+is completely unaffected. This scenario sets it to a few seconds — long
+enough that the "active" window's absolute duration comfortably dominates
+any single 60-second sampling tick, closing the gap a purely-logical tight
+retry loop leaves open.
+
+Scripting plan to fail (``{"success": False}``) makes ``plan_issues()``
+keep returning a non-empty (truthy) result every iteration — PlanPhase
+records the failure, skips the label swap (the issue stays on
+``hydraflow-plan``), and the plan loop immediately re-polls and reprocesses
+the same issue, over and over, for the lifetime of the scenario run, each
+pass now held open for ``plan_hold_seconds`` real seconds.
+
+This scenario also skips the discover/shape detour s51 needs for its
+oscillation ledger (not relevant here): triage scripts ``ready=True``
+(default ``clarity_score=10`` clears the discovery gate) so the issue
+routes straight from ``hydraflow-find`` to ``hydraflow-plan`` in one triage
+pass, then plan fails forever. This keeps the Tier-1 in-process parity
+check (``test_sandbox_parity.py``, which for ``loops_enabled=None`` runs a
 *single-shot* ``MockWorld.run_pipeline()`` — triage once, then plan once,
-no repeated cycling) satisfied: it asserts the issue's ``final_stage !=
-"triage"``, which requires the seed's single-shot outcome be a plan result,
-not merely a ``discover``-routed issue that ``run_pipeline`` never revisits.
+no repeated cycling, and no ``plan_hold_seconds`` delay since that harness
+never touches ``sandbox_main.py``'s ``FakeLLM`` wiring) satisfied: it
+asserts the issue's ``final_stage != "triage"``, which requires the seed's
+single-shot outcome be a plan result, not merely a ``discover``-routed
+issue that ``run_pipeline`` never revisits.
 
 ----------------------------------------------------------------------
 ALLOWLIST-FROM-ENV
@@ -107,9 +127,10 @@ _AUTHORIZED_LOGIN = "steer-bot"  # MUST match docker-compose.sandbox.yml's
 
 def seed() -> MockWorldSeed:
     """Seed a /pause comment from the allow-listed login and keep the issue
-    perpetually active via the "plan fails forever" tight-loop recipe (see
-    module docstring) so HumanSteeringLoop's 60-second tick has continuous
-    opportunities to observe the issue as active.
+    perpetually active via the "plan fails forever" tight-loop recipe, held
+    open for a real ``plan_hold_seconds`` duration each pass (see module
+    docstring) so HumanSteeringLoop's 60-second tick reliably observes the
+    issue as active.
     """
     return MockWorldSeed(
         # loops_enabled=None: all caretaker loops run (including
@@ -169,6 +190,14 @@ def seed() -> MockWorldSeed:
         # 60-second tick ample opportunity against the continuously-active
         # issue.
         cycles_to_run=16,
+        # Hold each plan pass open for 3 real seconds (see module docstring
+        # for why a tight retry loop alone isn't sufficient with the Fakes'
+        # instant-by-default timing). 3s comfortably dominates the
+        # millisecond-scale iteration overhead that otherwise makes the
+        # active window's absolute duration far shorter than its logical
+        # share of the loop would suggest, while staying well under the
+        # 60-second caretaker tick and the 120-second assertion timeout.
+        plan_hold_seconds=3.0,
     )
 
 
@@ -178,9 +207,11 @@ async def assert_outcome(api, page) -> None:
 
     Polls with a generous 120-second timeout so the 60-second caretaker
     tick (sandbox interval_cb override) has time to land while the issue is
-    active (the plan-failure tight loop keeps re-opening that window — see
-    module docstring) and the state write to propagate through the
-    StateTracker before the deadline.
+    active. The plan-failure tight loop keeps re-opening the active window,
+    and ``plan_hold_seconds`` (see module docstring and ``seed()``) holds
+    each pass open for a real 3 seconds, so a 60-second-interval tick
+    reliably samples a moment when the issue is genuinely active rather
+    than racing a millisecond-scale window.
     """
     _ = page  # UI interaction not needed for this caretaker assertion
 

--- a/tests/sandbox_scenarios/scenarios/s52_human_steering_directive.py
+++ b/tests/sandbox_scenarios/scenarios/s52_human_steering_directive.py
@@ -1,89 +1,92 @@
-"""s52 - HumanSteeringLoop emits worker status; seeds a real /pause directive.
+"""s52 — HumanSteeringLoop: seeded /pause directive actuates to flow=paused.
 
-Golden path: the sandbox runtime starts the real ``HumanSteeringLoop`` and
-ticks it against an issue carrying a seeded ``/pause`` comment (Task 5's
-``MockWorldSeed.comments`` — no longer synthetic, no idle-only poll). The
-worker-status heartbeat proves the loop is registered, started, and ticking
-in the real Docker stack. The sensing/directive-parsing semantics (comment ->
-parsed directive -> persisted ``SteeringState``) are covered end-to-end at
-the MockWorld layer in ``tests/scenarios/test_human_steering_scenario.py``
-(Task 8/12), including the Task 1 authorization allowlist and the
-actuator-decision seam (``human_steering.apply_steering`` /
-``fenced_steering_guidance``).
+This scenario exercises the real ``HumanSteeringLoop`` caretaker (ADR-0099
+surface #4) end-to-end inside the docker sandbox. It seeds a real ``/pause``
+comment (via ``MockWorldSeed.comments`` — see ``FakeGitHub.from_seed`` ->
+``add_seeded_comment``) from a login that is explicitly allow-listed via
+``HYDRAFLOW_HUMAN_STEERING_AUTHORIZED_USERS`` (docker-compose.sandbox.yml),
+drives the issue through the real pipeline so it becomes "active" in
+``FakeIssueStore`` (the set ``HumanSteeringLoop``'s ``active_issues_cb``
+reads), and asserts via ``/api/state`` that the persisted
+``StateData.human_steering`` entry for the issue shows ``flow == "paused"``.
 
-----------------------------------------------------------------------
-WHAT TASK 5 AND TASK 4 UNBLOCKED, AND WHAT'S STILL MISSING
-----------------------------------------------------------------------
-The previous version of this scenario listed two missing harness
-capabilities. Both are now *mostly* resolved:
-
-1. Seeding a comment onto a sandboxed issue: SOLVED. ``MockWorldSeed.comments``
-   (src/mockworld/seed.py) now carries per-issue ``{login, body, created_at}``
-   entries, and ``FakeGitHub.from_seed`` (src/mockworld/fakes/fake_github.py)
-   calls ``add_seeded_comment`` for each one, which appends a structured
-   ``FakeComment`` (str subclass carrying real ``login``/``created_at``) to
-   ``FakeIssue.comments``. ``list_issue_comments`` reads those fields back out
-   as the `{"user": {"login": ...}, "body": ..., "created_at": ...}` shape
-   ``human_steering.parse_directives`` consumes. This scenario now seeds a
-   real ``/pause`` comment from an authorized login via that path (below) —
-   the same mechanism ``sandbox_main.py`` uses to build the shared
-   ``FakeGitHub`` the whole sandbox orchestrator runs against.
-
-2. Making the seeded issue "active" enough to be sensed: SOLVED by Task 4.
-   ``HumanSteeringLoop``'s ``active_issues_cb`` is wired in
-   ``service_registry.py`` (the same factory ``sandbox_main.py`` calls) to
-   ``lambda: list(store.get_active_issues().keys())`` — the full-pipeline
-   active-issue set, not the narrower implement/review/HITL-in-flight set.
-   ``store`` in the sandbox is a real ``FakeIssueStore``, whose
-   ``get_active_issues()`` returns whatever ``mark_active()`` populated.
-   Driving the seeded issue through even one real phase (e.g. triage, via
-   ``loops_enabled=None`` so phase orchestrators run) marks it active, which
-   is sufficient for ``HumanSteeringLoop`` to fetch its comments.
-
-3. STILL MISSING: enabling the feature itself. ``human_steering_enabled``
-   defaults to ``False`` (src/config.py) and — unlike, say,
-   ``HYDRAFLOW_CONVERGENCE_OSCILLATION_LOOP_ENABLED`` (a real, working env
-   override for a different caretaker) — it has no entry in
-   ``_ENV_BOOL_OVERRIDES`` (src/config.py), so there is no
-   ``HYDRAFLOW_HUMAN_STEERING_ENABLED`` env var docker-compose.sandbox.yml
-   could set, and ``MockWorldSeed`` has no generic config-override field a
-   scenario could use instead. Adding either is a ``src/config.py`` (and
-   possibly ``docker-compose.sandbox.yml``) change — outside this task's
-   scope (seeding + scenario-assertion upgrades only). Without
-   ``human_steering_enabled=True``, ``HumanSteeringLoop._do_work`` always
-   early-returns ``{"status": "config_disabled"}`` before it ever calls
-   ``list_issue_comments`` or touches ``StateData.human_steering`` — so a
-   real ``/api/state`` ``flow == "paused"`` assertion is NOT reachable in
-   this Docker sandbox today, no matter what gets seeded.
+The sensing/directive-parsing semantics (comment -> parsed directive ->
+persisted ``SteeringState``, the Task 1 authorization allowlist, and the
+actuator-decision seam ``human_steering.apply_steering`` /
+``fenced_steering_guidance``) are covered end-to-end at the MockWorld layer
+in ``tests/scenarios/test_human_steering_scenario.py``. This scenario's job
+is narrower and complementary: prove the real caretaker, running inside the
+real Docker orchestrator against the real dashboard API, actually persists
+that outcome where an operator (or CI) can observe it.
 
 ----------------------------------------------------------------------
-WHAT THIS SCENARIO ASSERTS INSTEAD (real, not pure smoke)
+WHY THE ISSUE NEEDS TO BE "ACTIVE" WHEN THE LOOP TICKS (not just once)
 ----------------------------------------------------------------------
-Rather than leave this an idle no-comment poll, the seed now attaches a real
-``/pause`` comment from an authorized-looking login to the issue (exercising
-the Task 5 seeding path end-to-end through ``sandbox_main.py`` ->
-``FakeGitHub.from_seed`` -> ``add_seeded_comment``), and drives the issue
-through triage so it becomes active in ``FakeIssueStore`` (Task 4's
-active-set). ``assert_outcome`` still asserts the worker-status heartbeat
-(``BACKGROUND_WORKER_STATUS`` with ``worker == "human_steering"``), which
-fires regardless of ``human_steering_enabled`` (``BaseBackgroundLoop.
-_execute_cycle`` publishes it whenever ``_do_work()`` returns, including the
-``config_disabled`` early return) — proving Docker/UI/wiring, exactly as
-before. It ALSO asserts, via ``/api/state``, that ``StateData.human_steering``
-for the issue is still the unset default (no ``flow: "paused"``) BECAUSE the
-feature is off — an explicit, named assertion of the current gated state
-rather than silence, so a future PR that adds the missing env override (item
-3 above) has a failing assertion here pointing at exactly what to flip to
-``"paused"``.
+``HumanSteeringLoop._do_work`` snapshots ``active_issues_cb()`` once per
+tick (every 60 s in the sandbox — ``WorkerRegistryCallbacks(get_interval=
+lambda *_: 60)`` overrides every caretaker's interval, per s51's precedent).
+``active_issues_cb`` is wired in ``service_registry.py`` to
+``lambda: list(store.get_active_issues().keys())`` — the ``FakeIssueStore``
+active set that ``store_lifecycle`` (``phase_utils.py``) populates via
+``mark_active`` on phase entry and clears via ``mark_complete`` on phase
+exit. A phase that completes instantly (the Fakes have no artificial
+latency) holds that window open for a single event-loop tick — far too
+narrow to reliably coincide with a 60-second caretaker cadence if the issue
+is only driven through the pipeline once.
 
-If a future task adds ``human_steering_enabled`` to ``_ENV_BOOL_OVERRIDES``
-and a ``HYDRAFLOW_HUMAN_STEERING_ENABLED`` env line in
-docker-compose.sandbox.yml, this scenario should drop the "still disabled"
-assertion and replace it with
-``payload["human_steering"][str(issue_number)]["flow"] == "paused"``
-(``StateData.human_steering`` is a real Pydantic field, already present in
-the ``/api/state`` payload today, unfiltered — this is the same
-``to_dict()`` / ``model_dump()`` route s51 uses for ``convergence_ledgers``).
+s51 (``s51_convergence_oscillation.py``) solves the identical timing problem
+for ``ConvergenceOscillationLoop`` by driving the issue into a state where a
+phase orchestrator's ``_polling_loop`` (``orchestrator.py``) keeps
+re-entering ``store_lifecycle`` in a tight loop with no sleep between
+iterations: ``_polling_loop`` only sleeps ``poll_interval`` when
+``did_work`` is falsy (``if did_work: continue`` — no sleep). Scripting plan
+to fail (``{"success": False}``) makes ``plan_issues()`` keep returning a
+non-empty (truthy) result every iteration — PlanPhase records the failure,
+skips the label swap (the issue stays on ``hydraflow-plan``), and the plan
+loop immediately re-polls and reprocesses the same issue, over and over,
+for the lifetime of the scenario run. That keeps the issue flickering
+active/inactive at effectively the event-loop's own cadence rather than
+once every ``poll_interval`` (30 s default), so ``HumanSteeringLoop``'s
+60-second tick has continuous opportunities to observe it as active over
+the scenario's run.
+
+This scenario reuses that same "plan fails forever" vehicle, simplified to
+skip the discover/shape detour s51 needs for its oscillation ledger (not
+relevant here): triage scripts ``ready=True`` (default ``clarity_score=10``
+clears the discovery gate) so the issue routes straight from
+``hydraflow-find`` to ``hydraflow-plan`` in one triage pass, then plan fails
+forever. This also keeps the Tier-1 in-process parity check
+(``test_sandbox_parity.py``, which for ``loops_enabled=None`` runs a
+*single-shot* ``MockWorld.run_pipeline()`` — triage once, then plan once,
+no repeated cycling) satisfied: it asserts the issue's ``final_stage !=
+"triage"``, which requires the seed's single-shot outcome be a plan result,
+not merely a ``discover``-routed issue that ``run_pipeline`` never revisits.
+
+----------------------------------------------------------------------
+ALLOWLIST-FROM-ENV
+----------------------------------------------------------------------
+``human_steering_authorized_users`` defaults to ``[]`` (honors nobody, safe
+default-on for ``human_steering_enabled``). ``HYDRAFLOW_HUMAN_STEERING_
+AUTHORIZED_USERS`` (comma-separated, special-cased in
+``_apply_env_overrides`` the same way ``HYDRAFLOW_LITE_PLAN_LABELS``
+populates ``lite_plan_labels``) is set to ``"steer-bot"`` in
+docker-compose.sandbox.yml. ``_AUTHORIZED_LOGIN`` below MUST match that
+value — this scenario seeds its ``/pause`` comment from that exact login so
+the sensor's allowlist check (``human_steering.parse_directives``) actually
+honors it.
+
+----------------------------------------------------------------------
+WHAT THIS SCENARIO ASSERTS
+----------------------------------------------------------------------
+Via ``/api/state``: ``StateData.human_steering[str(issue_number)].flow ==
+"paused"`` — the real caretaker loop parsed the seeded ``/pause`` comment
+from the allow-listed login and persisted the paused flow, unfiltered,
+exactly as ``StateData`` (a real Pydantic field) serializes it
+(``to_dict()`` / ``model_dump()`` — the same route s51 uses for
+``convergence_ledgers``). This is the terminal proof for ADR-0103's
+human-steering directive path: Docker + real config gate + real allowlist
++ real sensor loop + real dashboard API, not a MockWorld-layer unit
+assertion.
 """
 
 from __future__ import annotations
@@ -92,32 +95,45 @@ from mockworld.seed import MockWorldSeed
 
 NAME = "s52_human_steering_directive"
 DESCRIPTION = (
-    "HumanSteeringLoop ticks against an issue carrying a seeded /pause "
-    "comment and emits worker status; the directive itself is inert until "
-    "human_steering_enabled gets an env override (documented gap)."
+    "Seeded /pause from an allow-listed login actuates through the real "
+    "HumanSteeringLoop; /api/state shows the issue's human_steering "
+    "flow == 'paused'."
 )
 
 _ISSUE_NUMBER = 1
-_AUTHORIZED_LOGIN = "sandbox-operator"
+_AUTHORIZED_LOGIN = "steer-bot"  # MUST match docker-compose.sandbox.yml's
+# HYDRAFLOW_HUMAN_STEERING_AUTHORIZED_USERS value.
 
 
 def seed() -> MockWorldSeed:
+    """Seed a /pause comment from the allow-listed login and keep the issue
+    perpetually active via the "plan fails forever" tight-loop recipe (see
+    module docstring) so HumanSteeringLoop's 60-second tick has continuous
+    opportunities to observe the issue as active.
+    """
     return MockWorldSeed(
-        loops_enabled=["human_steering"],
+        # loops_enabled=None: all caretaker loops run (including
+        # human_steering — gated off unless human_steering_enabled, which
+        # is default-on) AND phase orchestrators run regardless (they use a
+        # separate BGWorkerManager gate — see s51's
+        # _build_caretaker_enabled_cb docstring). Required so triage/plan
+        # actually process the issue and mark_active/mark_complete populate
+        # FakeIssueStore.get_active_issues().
+        loops_enabled=None,
         issues=[
             {
                 "number": _ISSUE_NUMBER,
-                "title": "steer me",
-                "body": "issue body for the human-steering sandbox scenario",
-                "labels": ["in-progress"],
+                "title": "Investigate recurring churn in auth module",
+                "body": (
+                    "The auth module changes have been cycling through "
+                    "planning without converging."
+                ),
+                "labels": ["hydraflow-find"],
             }
         ],
-        # Task 5 seeding: a real /pause comment from a named login, exercised
-        # through the same FakeGitHub.from_seed -> add_seeded_comment path
-        # sandbox_main.py wires the whole orchestrator against. Inert today
-        # because human_steering_enabled has no env override (see module
-        # docstring item 3) — HumanSteeringLoop._do_work short-circuits on
-        # the config gate before ever calling list_issue_comments.
+        # A real /pause comment from the allow-listed login, seeded through
+        # the same FakeGitHub.from_seed -> add_seeded_comment path
+        # sandbox_main.py wires the whole orchestrator against.
         comments={
             _ISSUE_NUMBER: [
                 {
@@ -127,53 +143,70 @@ def seed() -> MockWorldSeed:
                 }
             ]
         },
-        cycles_to_run=2,
+        scripts={
+            # ready=True (default clarity_score=10 clears the discovery
+            # gate) routes the issue straight from hydraflow-find to
+            # hydraflow-plan in one triage pass (no discover/shape detour —
+            # keeps the Tier-1 single-shot run_pipeline() parity check
+            # satisfied; see module docstring).
+            "triage": {_ISSUE_NUMBER: [{"ready": True}]},
+            # Plan fails forever: PlanPhase sets ts_status="failed", skips
+            # the label swap (issue stays on hydraflow-plan), and the plan
+            # polling loop immediately re-polls (did_work is truthy) with no
+            # sleep — see module docstring. This is what keeps the issue
+            # perpetually active for HumanSteeringLoop to observe. FakeLLM's
+            # last-scripted-entry-repeats semantics mean this single
+            # {"success": False} entry keeps being returned indefinitely.
+            "plan": {_ISSUE_NUMBER: [{"success": False}]},
+        },
+        # cycles_to_run is used by the Tier-1 in-process parity test
+        # (test_sandbox_parity.py). With loops_enabled=None that harness
+        # runs MockWorld.run_pipeline() (single-shot phase orchestration,
+        # not the background-loop path) and only asserts generic pipeline
+        # progress — it does not exercise HumanSteeringLoop's tick timing,
+        # which is Docker-only (Tier 2). The Tier-2 Docker sandbox runs
+        # until assert_outcome's polling timeout, giving the caretaker's
+        # 60-second tick ample opportunity against the continuously-active
+        # issue.
+        cycles_to_run=16,
     )
 
 
 async def assert_outcome(api, page) -> None:
-    """Verify the worker-status heartbeat, and that steering stays inert
-    while ``human_steering_enabled`` remains dark-by-default with no env
-    override wired (see module docstring)."""
+    """Assert HumanSteeringLoop actuated the seeded /pause into a persisted
+    paused flow, visible via /api/state.
+
+    Polls with a generous 120-second timeout so the 60-second caretaker
+    tick (sandbox interval_cb override) has time to land while the issue is
+    active (the plan-failure tight loop keeps re-opening that window — see
+    module docstring) and the state write to propagate through the
+    StateTracker before the deadline.
+    """
     _ = page  # UI interaction not needed for this caretaker assertion
 
-    events_payload = await api.wait_until(
-        "/api/events",
-        lambda payload: any(
-            isinstance(payload, list)
-            and event.get("type") == "background_worker_status"
-            and event.get("data", {}).get("worker") == "human_steering"
-            for event in (payload if isinstance(payload, list) else [])
-        ),
-        timeout=60.0,
+    def _paused(payload: object) -> bool:
+        if not isinstance(payload, dict):
+            return False
+        human_steering = payload.get("human_steering")
+        if not isinstance(human_steering, dict):
+            return False
+        entry = human_steering.get(str(_ISSUE_NUMBER))
+        return isinstance(entry, dict) and entry.get("flow") == "paused"
+
+    state_payload = await api.wait_until(
+        "/api/state",
+        _paused,
+        timeout=120.0,
     )
 
-    worker_events = [
-        event
-        for event in events_payload
-        if event.get("type") == "background_worker_status"
-        and event.get("data", {}).get("worker") == "human_steering"
-    ]
-    assert len(worker_events) >= 1, (
-        "Expected at least one human_steering worker-status event; "
-        f"got none. All events: {events_payload!r}"
-    )
-
-    # Named, explicit assertion of the current gated reality (not silence):
-    # the seeded /pause comment exists on the issue (Task 5 seeding worked),
-    # but StateData.human_steering for this issue is untouched because
-    # human_steering_enabled defaults False and nothing in this sandbox flips
-    # it. If a future PR wires HYDRAFLOW_HUMAN_STEERING_ENABLED (see module
-    # docstring item 3), this assertion is the one to replace with
-    # `flow == "paused"`.
-    state_payload = await api.get("/api/state")
-    assert isinstance(state_payload, dict)
     human_steering = state_payload.get("human_steering") or {}
     entry = human_steering.get(str(_ISSUE_NUMBER))
-    assert entry is None or entry.get("flow") in (None, "running"), (
-        "human_steering_enabled has no env override in this sandbox yet, so "
-        "the seeded /pause must NOT have been actuated into a persisted "
-        f"paused flow; got entry={entry!r}. If this now shows "
-        "flow == 'paused', the env-override gap (module docstring item 3) "
-        "has been closed — upgrade this assertion accordingly."
+    assert isinstance(entry, dict), (
+        f"expected a human_steering entry for issue #{_ISSUE_NUMBER}; "
+        f"got human_steering={human_steering!r}"
+    )
+    assert entry.get("flow") == "paused", (
+        "HumanSteeringLoop should have parsed the seeded /pause comment "
+        f"from the allow-listed login {_AUTHORIZED_LOGIN!r} and persisted "
+        f"flow == 'paused'; got entry={entry!r}"
     )

--- a/tests/scenarios/fakes/test_fake_llm.py
+++ b/tests/scenarios/fakes/test_fake_llm.py
@@ -51,6 +51,42 @@ class TestFakeLLMScriptedResults:
         assert r1.success is False
         assert r2.success is True
 
+    async def test_plan_hold_seconds_default_is_a_noop(self):
+        """Default plan_hold_seconds=0.0 must not introduce any real delay
+        (every existing scenario's FakeLLM timing must stay unaffected)."""
+        import time
+
+        from mockworld.fakes.fake_llm import FakeLLM
+
+        llm = FakeLLM()
+        assert llm.plan_hold_seconds == 0.0
+
+        task = TaskFactory.create(id=1)
+        start = time.monotonic()
+        await llm.planners.plan(task)
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 0.1
+
+    async def test_plan_hold_seconds_delays_plan_call(self):
+        """A scenario opting into plan_hold_seconds (e.g. s52) gets a real
+        artificial delay before plan() returns — this is what extends the
+        real wall-clock duration IssueStore.mark_active holds the issue
+        active for, so a slow-interval sampler reliably observes it."""
+        import time
+
+        from mockworld.fakes.fake_llm import FakeLLM
+
+        llm = FakeLLM()
+        llm.plan_hold_seconds = 0.2
+
+        task = TaskFactory.create(id=1)
+        start = time.monotonic()
+        await llm.planners.plan(task)
+        elapsed = time.monotonic() - start
+
+        assert elapsed >= 0.2
+
     async def test_implement_returns_scripted_worker_result(self):
         from mockworld.fakes.fake_llm import FakeLLM
 

--- a/tests/test_config_env.py
+++ b/tests/test_config_env.py
@@ -472,6 +472,67 @@ class TestEnvVarOverrideTable:
             )
 
 
+class TestHumanSteeringAuthorizedUsersEnvOverride:
+    """HYDRAFLOW_HUMAN_STEERING_AUTHORIZED_USERS (comma-separated list, special-case)."""
+
+    def test_default_is_empty_list(self, tmp_path: Path) -> None:
+        cfg = HydraFlowConfig(
+            repo_root=tmp_path,
+            workspace_base=tmp_path / "wt",
+            state_file=tmp_path / "s.json",
+        )
+        assert cfg.human_steering_authorized_users == []
+
+    def test_env_var_override_applies_when_at_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(
+            "HYDRAFLOW_HUMAN_STEERING_AUTHORIZED_USERS", "steer-bot,octocat"
+        )
+        cfg = HydraFlowConfig(
+            repo_root=tmp_path,
+            workspace_base=tmp_path / "wt",
+            state_file=tmp_path / "s.json",
+        )
+        assert cfg.human_steering_authorized_users == ["steer-bot", "octocat"]
+
+    def test_env_var_override_strips_whitespace_and_drops_empties(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(
+            "HYDRAFLOW_HUMAN_STEERING_AUTHORIZED_USERS", " steer-bot , , octocat "
+        )
+        cfg = HydraFlowConfig(
+            repo_root=tmp_path,
+            workspace_base=tmp_path / "wt",
+            state_file=tmp_path / "s.json",
+        )
+        assert cfg.human_steering_authorized_users == ["steer-bot", "octocat"]
+
+    def test_explicit_value_overrides_env_var(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HYDRAFLOW_HUMAN_STEERING_AUTHORIZED_USERS", "steer-bot")
+        cfg = HydraFlowConfig(
+            human_steering_authorized_users=["custom-user"],
+            repo_root=tmp_path,
+            workspace_base=tmp_path / "wt",
+            state_file=tmp_path / "s.json",
+        )
+        assert cfg.human_steering_authorized_users == ["custom-user"]
+
+    def test_env_var_all_whitespace_leaves_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HYDRAFLOW_HUMAN_STEERING_AUTHORIZED_USERS", "  ,  ")
+        cfg = HydraFlowConfig(
+            repo_root=tmp_path,
+            workspace_base=tmp_path / "wt",
+            state_file=tmp_path / "s.json",
+        )
+        assert cfg.human_steering_authorized_users == []
+
+
 class TestOtelConfigFields:
     def test_config_otel_defaults(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_mockworld_seed.py
+++ b/tests/test_mockworld_seed.py
@@ -15,6 +15,7 @@ def test_default_seed_is_empty() -> None:
     assert seed.scripts == {}
     assert seed.cycles_to_run == 4
     assert seed.loops_enabled is None
+    assert seed.plan_hold_seconds == 0.0
 
 
 def test_seed_round_trips_through_json() -> None:
@@ -37,6 +38,16 @@ def test_seed_json_is_valid_json() -> None:
     raw = seed.to_json()
     parsed = json.loads(raw)
     assert parsed["issues"] == [{"number": 1}]
+
+
+def test_seed_round_trips_plan_hold_seconds_through_json() -> None:
+    """Back-compat default (0.0) round-trips; a scenario-set value survives too."""
+    original = MockWorldSeed(plan_hold_seconds=3.0)
+
+    parsed = MockWorldSeed.from_json(original.to_json())
+
+    assert parsed == original
+    assert parsed.plan_hold_seconds == 3.0
 
 
 def test_default_seed_has_empty_advisor_scripts() -> None:


### PR DESCRIPTION
Completes the final open item of **#9710** (item 5's real Docker e2e). The four before-enable items + the MockWorld real assertion landed in #9711; this finishes the sandbox-tier proof.

## What

- **Allowlist-from-env** (`src/config.py`) — `HYDRAFLOW_HUMAN_STEERING_AUTHORIZED_USERS` (comma-separated) populates `human_steering_authorized_users`, mirroring the existing `HYDRAFLOW_LITE_PLAN_LABELS` list-from-env pattern (default-guarded). Tested in `test_config_env.py`.
- **`s52` upgraded** from wiring-smoke to a REAL assertion: seeds a `/pause` from the allow-listed `steer-bot` login, drives the issue through triage→plan, and asserts via `/api/state` that `human_steering["1"].flow == "paused"` — a genuine Docker + real config gate + real allowlist + real sensor loop + real dashboard-API proof for ADR-0103.
- **`MockWorldSeed.plan_hold_seconds`** (opt-in, default `0.0`) — fixes a Docker-only timing race: with the Fakes' instant processing, each "active" window was milliseconds, so the 60s sensor tick almost always missed it. Holding each plan pass open 3 real seconds gives the sampler a reliable window. Zero effect on any other scenario (production LLM calls take real seconds, so the race can't occur there).

## Verification

- Tier-1 parity + `test_config_env` + broad related suites: green (703 via fast filter).
- **Tier-2 real Docker: PASSED on two consecutive runs** (~55s each) — the first run caught the timing race (a real finding, fixed via `plan_hold_seconds`), then two clean passes.

Small test/config increment on the already-whole-branch-reviewed feature (#9711); CI is the gate. This closes the #9710 test pyramid (unit + MockWorld scenario + real sandbox e2e).

Closes #9710

🤖 Generated with [Claude Code](https://claude.com/claude-code)