### PR TITLE
feat(auto-tighten): cross-tick open-PR dedup probe

### DIFF
--- a/src/auto_tighten/pr_author.py
+++ b/src/auto_tighten/pr_author.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 
 from auto_tighten.models import ConfirmedTightening
 
 
 class TighteningPrAuthor:
-    def __init__(self, *, repo_root: Path, base: str, opener=None) -> None:
+    def __init__(
+        self,
+        *,
+        repo_root: Path,
+        base: str,
+        opener=None,
+        open_pr_exists: Callable[[str], bool] | None = None,
+    ) -> None:
         self._root = repo_root
         self._base = base
         if opener is None:
@@ -14,19 +22,27 @@ class TighteningPrAuthor:
 
             opener = open_automated_pr_async
         self._opener = opener
+        # Cross-tick dedup: skip opening when a tightening PR for this exact
+        # floor is already open. Defaults to "no dedup" so unit tests that do
+        # not wire it behave unchanged; production wires a gh probe.
+        self._open_pr_exists = open_pr_exists or (lambda _branch: False)
 
     async def open(self, ct: ConfirmedTightening) -> str | None:
-        """Open the tightening PR, returning its URL or ``None`` on failure.
+        """Open the tightening PR, returning its URL or ``None`` on skip/failure.
 
-        Passes ``raise_on_failure=False`` to the opener: a failed open (e.g.
-        a duplicate branch head because the prior tick's PR is still open,
-        or a no-diff) must resolve to a benign hold, not an exception. Cross-
-        tick dedup on "PR already open" isn't wired yet (needs real ``gh``
-        wiring) — until then, this is what keeps a stuck PR from spamming an
-        error event every tick. The caller (``AutoTightenLoop._do_work``)
-        already treats a falsy return as "no tightening this tick."
+        Cross-tick dedup: if a tightening PR for this exact floor is already
+        open (same branch head), skip before touching the working tree, so a
+        stuck or slow-to-merge PR does not redo worktree and push work every
+        tick. Also passes ``raise_on_failure=False`` to the opener so any
+        residual failure (a race, a no-diff) resolves to a benign hold, not an
+        exception. The caller (``AutoTightenLoop._do_work``) treats a falsy
+        return as "no tightening this tick."
         """
         from auto_pr import _sanitize_branch_for_path  # noqa: PLC0415
+
+        branch = f"auto-tighten/{_sanitize_branch_for_path(ct.dedup_key)}"
+        if self._open_pr_exists(branch):
+            return None
 
         files = []
         for edit in ct.file_edits:
@@ -34,7 +50,6 @@ class TighteningPrAuthor:
             p.parent.mkdir(parents=True, exist_ok=True)
             p.write_text(edit.new_text)
             files.append(p)
-        branch = f"auto-tighten/{_sanitize_branch_for_path(ct.dedup_key)}"
         result = await self._opener(
             repo_root=self._root,
             branch=branch,

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -520,6 +520,43 @@ def make_gh_merged_pr_lister(
     return _list_merged_prs
 
 
+def make_gh_open_pr_exists(
+    config: HydraFlowConfig, *, runner: GhRunner = run_gh_command
+) -> Callable[[str], bool]:
+    """Build the open-PR probe ``TighteningPrAuthor`` uses for cross-tick dedup.
+
+    Returns True when a PR is already open for ``branch`` (its head), so the
+    loop skips re-opening a tightening PR whose prior tick's PR has not merged.
+    Fails open (returns False on any ``gh`` error): a probe failure must not
+    block a legitimate tightening, and a genuine duplicate-head open still
+    resolves to a benign hold downstream via ``raise_on_failure=False``.
+    """
+
+    def _open_pr_exists(branch: str) -> bool:
+        proc = runner(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--head",
+                branch,
+                "--state",
+                "open",
+                "--json",
+                "number",
+            ],
+            cwd=config.repo_root,
+        )
+        if proc.returncode != 0:
+            return False
+        try:
+            return bool(json.loads(proc.stdout))
+        except (json.JSONDecodeError, TypeError):
+            return False
+
+    return _open_pr_exists
+
+
 def build_state_tracker(config: HydraFlowConfig) -> StateTracker:
     """Construct a file-backed ``StateTracker``."""
     return StateTracker(config.state_file)
@@ -1460,7 +1497,9 @@ def build_services(
             list_merged_prs=make_gh_merged_pr_lister(config)
         ),
         pr_author=TighteningPrAuthor(
-            repo_root=config.repo_root, base=config.base_branch()
+            repo_root=config.repo_root,
+            base=config.base_branch(),
+            open_pr_exists=make_gh_open_pr_exists(config),
         ),
         observation_store=ObservationStore(_auto_tighten_metrics / "tighten.jsonl"),
     )

--- a/tests/auto_tighten/test_pr_author.py
+++ b/tests/auto_tighten/test_pr_author.py
@@ -118,3 +118,68 @@ async def test_branch_name_sanitized_for_unsafe_dedup_key(tmp_path):
     dynamic_segment = branch[len("auto-tighten/") :]
     assert "/" not in dynamic_segment
     assert " " not in dynamic_segment
+
+
+async def test_open_skips_when_pr_already_open(tmp_path):
+    # Cross-tick dedup: a tightening PR for this floor is already open, so
+    # skip without calling the opener or writing to the working tree.
+    edit_path = tmp_path / "pyproject.toml"
+    opener_called = False
+
+    async def fake_opener(**kwargs):
+        nonlocal opener_called
+        opener_called = True
+
+        class R:
+            pr_url = "https://gh/pr/1"
+
+        return R()
+
+    author = TighteningPrAuthor(
+        repo_root=tmp_path,
+        base="staging",
+        opener=fake_opener,
+        open_pr_exists=lambda _branch: True,
+    )
+    ct = ConfirmedTightening(
+        ratchet_id="coverage",
+        floor=77.0,
+        file_edits=[FileEdit(path=str(edit_path), new_text="fail_under = 77\n")],
+        dedup_key="coverage:77.0",
+        evidence="PR #11",
+    )
+    url = await author.open(ct)
+    assert url is None
+    assert opener_called is False
+    assert not edit_path.exists()  # working tree untouched by a skipped open
+
+
+async def test_open_proceeds_when_open_pr_exists_false(tmp_path):
+    (tmp_path / "pyproject.toml").write_text("fail_under = 70\n")
+
+    async def fake_opener(**kwargs):
+        class R:
+            pr_url = "https://gh/pr/3"
+
+        return R()
+
+    author = TighteningPrAuthor(
+        repo_root=tmp_path,
+        base="staging",
+        opener=fake_opener,
+        open_pr_exists=lambda _branch: False,
+    )
+    ct = ConfirmedTightening(
+        ratchet_id="coverage",
+        floor=77.0,
+        file_edits=[
+            FileEdit(
+                path=str(tmp_path / "pyproject.toml"), new_text="fail_under = 77\n"
+            )
+        ],
+        dedup_key="coverage:77.0",
+        evidence="PR #11",
+    )
+    url = await author.open(ct)
+    assert url == "https://gh/pr/3"
+    assert (tmp_path / "pyproject.toml").read_text() == "fail_under = 77\n"

--- a/tests/test_service_registry.py
+++ b/tests/test_service_registry.py
@@ -591,3 +591,44 @@ class TestAutoTightenGhClosures:
 
         lister = make_gh_merged_pr_lister(config, runner=fake_runner)
         assert lister("2026-06-01T00:00:00Z") == []
+
+    def test_open_pr_exists_true_and_probes_the_head_branch(
+        self, config: HydraFlowConfig
+    ) -> None:
+        from service_registry import make_gh_open_pr_exists
+
+        captured = {}
+
+        def fake_runner(cmd, *, cwd):
+            captured["cmd"] = cmd
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout='[{"number": 42}]', stderr=""
+            )
+
+        probe = make_gh_open_pr_exists(config, runner=fake_runner)
+        assert probe("auto-tighten/coverage-77.0") is True
+        assert "--head" in captured["cmd"]
+        assert "auto-tighten/coverage-77.0" in captured["cmd"]
+
+    def test_open_pr_exists_false_when_none_listed(
+        self, config: HydraFlowConfig
+    ) -> None:
+        from service_registry import make_gh_open_pr_exists
+
+        def fake_runner(cmd, *, cwd):
+            return subprocess.CompletedProcess(cmd, 0, stdout="[]", stderr="")
+
+        probe = make_gh_open_pr_exists(config, runner=fake_runner)
+        assert probe("auto-tighten/coverage-77.0") is False
+
+    def test_open_pr_exists_fails_open_on_nonzero_exit(
+        self, config: HydraFlowConfig
+    ) -> None:
+        # A gh error must not block a legitimate tightening: fail open (False).
+        from service_registry import make_gh_open_pr_exists
+
+        def fake_runner(cmd, *, cwd):
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="boom")
+
+        probe = make_gh_open_pr_exists(config, runner=fake_runner)
+        assert probe("auto-tighten/coverage-77.0") is False


### PR DESCRIPTION
## What

Closes the one deferred pre-enable follow-up from ADR-0104 / PR #9713 (the auto-tightening ratchet loop, already merged and enabled on staging).

`TighteningPrAuthor` now takes an injected `open_pr_exists` probe and **skips before touching the working tree** when a tightening PR for this exact floor (same branch head) is already open. That stops a stuck or slow-to-merge PR from redoing worktree+push work every tick. Wired via `make_gh_open_pr_exists` (`gh pr list --head <branch> --state open`), which **fails open**: a probe error never blocks a legitimate tightening, and a genuine duplicate-head open still resolves to a benign hold via `raise_on_failure=False`.

Default is no-dedup, so existing callers/tests are unchanged; only the service-registry wiring turns it on.

## Tests

- `test_pr_author`: skip-when-open (no opener call, working tree untouched) + proceed-when-not-open.
- `test_service_registry`: `make_gh_open_pr_exists` true/false/fail-open, and that it probes `--head <branch>`.
- `make quality` green.

## Safety

Unchanged: the monotone-tighten invariant still holds; this only removes redundant churn on an already-open PR. No effect on what gets tightened or merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)