### PR TITLE
feat(loops): stalled-loop auto-restart — restart-first dead-man-switches (closes #9650 class)

### DIFF
--- a/src/base_background_loop.py
+++ b/src/base_background_loop.py
@@ -124,6 +124,14 @@ class BaseBackgroundLoop(abc.ABC):
         self._timeout_cb = deps.timeout_cb
         self._run_on_startup = run_on_startup
         self._trigger_event = asyncio.Event()
+        # When the current run() task started. Heartbeats only refresh at
+        # cycle COMPLETION, so after a credit-pause resume / orchestrator
+        # restart a freshly created task carries a stale persisted heartbeat;
+        # the stall sweep uses max(heartbeat, run_started_at) so it never
+        # false-restarts a healthy in-flight first cycle. Every task-creation
+        # path (startup, crash restart, credit resume, restart verb) funnels
+        # through run(), making this the single stamp point.
+        self._run_started_at: datetime | None = None
 
     @property
     def name(self) -> str:
@@ -363,6 +371,7 @@ class BaseBackgroundLoop(abc.ABC):
 
     async def run(self) -> None:
         """Run the background worker loop until the stop event is set."""
+        self._run_started_at = datetime.now(UTC)
         # Run immediately if configured, or if cycles were missed during downtime
         if self._run_on_startup or self._should_run_catchup():
             try:

--- a/src/bg_worker_manager.py
+++ b/src/bg_worker_manager.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Any, cast
 from models import BackgroundWorkerState
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
     from base_background_loop import BaseBackgroundLoop
     from config import HydraFlowConfig
     from state import StateTracker
@@ -33,6 +35,9 @@ class BGWorkerManager:
         self._bg_worker_states: dict[str, BackgroundWorkerState] = {}
         self._bg_worker_enabled: dict[str, bool] = {}
         self._bg_worker_intervals: dict[str, int] = {}
+        # Injected post-ctor by the orchestrator (chicken-and-egg with the
+        # supervisor's task dict) — mirrors HealthMonitor's set_bg_workers.
+        self._restart_cb: Callable[[str], Awaitable[bool]] | None = None
         self._seed_default_disabled_workers()
 
     @property
@@ -92,6 +97,54 @@ class BGWorkerManager:
             return False
         loop.trigger()
         return True
+
+    def set_restart_cb(self, cb: Callable[[str], Awaitable[bool]]) -> None:
+        """Inject the orchestrator's restart verb (post-ctor wiring)."""
+        self._restart_cb = cb
+
+    async def restart(self, name: str) -> bool:
+        """Cancel-and-recreate a loop task via the orchestrator's restart verb.
+
+        ``trigger`` wakes a *sleeping* loop; it cannot unstick one wedged on
+        an ``await`` mid-cycle. ``restart`` can — HealthMonitorLoop's
+        restart-first stall policy uses it before escalating to a human.
+        Returns ``False`` when unwired (minimal fixtures) or unknown *name*.
+        """
+        if self._restart_cb is None:
+            return False
+        return await self._restart_cb(name)
+
+    def registered_loop_names(self) -> set[str]:
+        """Names of workers backed by a registered ``BaseBackgroundLoop``.
+
+        Pipeline phases, the store poller, and other non-loop workers are
+        absent — their supervision semantics differ (no interval/watchdog
+        contract), so stall sweeps must not touch them.
+        """
+        return set(self._bg_loop_registry)
+
+    def cycle_timeout(self, name: str) -> int:
+        """Effective per-cycle watchdog bound for *name* (#9556 semantics).
+
+        Falls back to ``loop_watchdog_default_seconds`` for names without a
+        registered ``BaseBackgroundLoop``.
+        """
+        loop = self._bg_loop_registry.get(name)
+        if loop is None:
+            return self._config.loop_watchdog_default_seconds
+        return loop._cycle_timeout_seconds()
+
+    def run_started_at(self, name: str) -> datetime | None:
+        """When *name*'s current ``run()`` task started — ``None`` if unknown.
+
+        Stall sweeps compare against ``max(heartbeat, run_started_at)`` so a
+        freshly (re)created task with a stale persisted heartbeat (post
+        credit-pause / orchestrator restart) is never false-restarted.
+        """
+        loop = self._bg_loop_registry.get(name)
+        if loop is None:
+            return None
+        return loop._run_started_at
 
     def _restore_intervals(self, intervals: dict[str, int]) -> None:
         """Bulk-restore interval overrides (used during startup recovery)."""

--- a/src/health_monitor_loop.py
+++ b/src/health_monitor_loop.py
@@ -69,6 +69,27 @@ _SANITY_STALL_MULTIPLIER = 3
 # loop did no real work.
 _SANITY_NOOP_STREAK_THRESHOLD = 3
 
+# Dedup marker recording that the restart-first path already cancelled and
+# recreated the sanity loop for the current stall event — the next stall
+# tick escalates to an issue instead of restart-thrashing. Cleared with the
+# stall dedup key on recovery.
+_SANITY_RESTART_KEY = "health_monitor:trust_fleet_sanity:restart-attempted"
+
+# Generic stall sweep across registry loops: a heartbeat older than
+# multiplier × interval + cycle_timeout means the loop task is wedged
+# outside its watchdog window. The cycle_timeout term keeps a legitimately
+# long LLM cycle (heartbeat only refreshes between cycles) from being
+# false-restarted.
+_WORKER_STALL_MULTIPLIER = 3
+
+# Loops excluded from the generic sweep. trust_fleet_sanity has its own
+# §12.1 dead-man-switch above (with G5 no-op detection the generic sweep
+# lacks); double coverage would double-restart and double-file.
+# health_monitor runs the sweep itself — self-cancelling mid-cycle (stale
+# persisted heartbeat after long orchestrator downtime) is harm without
+# benefit, and a truly wedged health_monitor can't sweep itself anyway.
+_WORKER_STALL_EXCLUDED = frozenset({"trust_fleet_sanity", "health_monitor"})
+
 # ---------------------------------------------------------------------------
 # Trend metrics
 # ---------------------------------------------------------------------------
@@ -356,6 +377,12 @@ class HealthMonitorLoop(BaseBackgroundLoop):
             "health_monitor_wiki_stall",
             config.data_root / "dedup" / "health_monitor_wiki_stall.json",
         )
+        # Generic loop-stall sweep markers (restart-attempted / issue-filed
+        # per worker per stall event); cleared on that worker's recovery.
+        self._worker_stall_dedup = DedupStore(
+            "health_monitor_worker_stall",
+            config.data_root / "dedup" / "health_monitor_worker_stall.json",
+        )
 
     def set_bg_workers(self, bg_workers: BGWorkerManager) -> None:
         """Late-binding for the post-ctor BGWorkerManager wiring."""
@@ -395,6 +422,13 @@ class HealthMonitorLoop(BaseBackgroundLoop):
             await self._check_wiki_freshness()
         except Exception:  # noqa: BLE001
             logger.debug("wiki-freshness check failed", exc_info=True)
+
+        # Generic stall sweep: restart-first for any silent registry loop.
+        # Deliberately unwrapped (unlike the grandfathered sibling checks
+        # above): a sweep failure propagates to the base cycle handler,
+        # which owns credit/auth classification and surfaces a visible
+        # cycle error instead of a debug line — the tick retries.
+        await self._check_worker_staleness()
 
         metrics = compute_trend_metrics(
             self._outcomes_path, self._scores_path, self._failures_path
@@ -1057,23 +1091,60 @@ class HealthMonitorLoop(BaseBackgroundLoop):
             if self._sanity_noop_streak >= _SANITY_NOOP_STREAK_THRESHOLD:
                 noop_tripped = True
             else:
-                # Recovery — sanity loop ticking with real work. Close any open
-                # stall issue and clear dedup so a future stall files fresh
-                # (#9359 issue-hygiene).
+                # Loop is ticking again. Close any open stall issue and clear
+                # its dedup key (#9359 issue-hygiene) — a persistent no-op
+                # re-escalates via the streak.
                 if dedup_key in filed_keys:
                     await self._close_issues_by_label(
                         prs,
                         "sanity-loop-stalled",
-                        "trust_fleet_sanity is ticking with real work again — "
-                        "auto-closing.",
+                        "trust_fleet_sanity is ticking again — auto-closing.",
                     )
-                    self._sanity_stall_dedup.set_all(filed_keys - {dedup_key})
+                # Only re-arm restart-first on GENUINE recovery (real work).
+                # workers_scanned == 0 with streak < threshold is a no-op
+                # streak still building — clearing the marker there would
+                # restart a persistent no-op every 3 ticks forever with
+                # escalation permanently bypassed.
+                cleared = {dedup_key}
+                if workers_scanned > 0:
+                    cleared.add(_SANITY_RESTART_KEY)
+                if filed_keys & cleared:
+                    self._sanity_stall_dedup.set_all(filed_keys - cleared)
                 return
         else:
+            # Young-task window: heartbeats only refresh at cycle COMPLETION,
+            # so a freshly recreated task (restart-first tick, credit-pause
+            # resume, orchestrator restart) still carries the stale heartbeat
+            # while its first cycle is in flight. Neither recovered (clearing
+            # the restart marker here would break restart-once-then-escalate:
+            # a wedged loop would be restarted every threshold window forever)
+            # nor actionable — wait until the task itself outlives the
+            # threshold without heartbeating.
+            started_at = bg_workers.run_started_at("trust_fleet_sanity")
+            if (
+                started_at is not None
+                and (datetime.now(UTC) - started_at).total_seconds() < threshold_s
+            ):
+                return
             # Stale-heartbeat path — counter remains as last seen; no-op
             # streak may or may not be set, but we file the stale-stall
             # variant of the issue regardless.
             self._sanity_noop_streak = 0
+        # Restart-first (dark-factory): before paging a human, try the
+        # restart verb once per stall event. A wedged task is cancelled and
+        # recreated; escalation waits one more threshold window. When the
+        # verb is unwired (minimal fixtures / restart returns False) fall
+        # through to filing immediately — pre-restart behavior.
+        if _SANITY_RESTART_KEY not in filed_keys:
+            restarted = await bg_workers.restart("trust_fleet_sanity")
+            if restarted:
+                logger.warning(
+                    "trust_fleet_sanity stalled — auto-restarted "
+                    "(restart-first; escalation deferred one threshold window)"
+                )
+                self._sanity_noop_streak = 0
+                self._sanity_stall_dedup.set_all(filed_keys | {_SANITY_RESTART_KEY})
+                return
         # Heartbeat-stale or no-op-streak path: file (or dedup-skip).
         if dedup_key in filed_keys:
             # Already filed for the current stall event; wait for recovery
@@ -1111,7 +1182,10 @@ class HealthMonitorLoop(BaseBackgroundLoop):
             f"- Interval: "
             f"`{self._config.trust_fleet_sanity_interval}s`\n"
             f"- Enabled: `True`\n"
-            f"- Workers scanned (last tick): `{workers_scanned}`\n\n"
+            f"- Workers scanned (last tick): `{workers_scanned}`\n"
+            f"- Auto-restart attempted: "
+            f"`{_SANITY_RESTART_KEY in filed_keys}` "
+            f"(restart-first did not clear the stall)\n\n"
             f"### Operator playbook\n"
             f"1. Check orchestrator logs for the `trust_fleet_sanity` "
             f"loop task (look for uncaught exceptions on the run task).\n"
@@ -1130,6 +1204,142 @@ class HealthMonitorLoop(BaseBackgroundLoop):
         )
         filed_keys = self._sanity_stall_dedup.get()
         self._sanity_stall_dedup.set_all(filed_keys | {dedup_key})
+
+    async def _check_worker_staleness(self) -> None:
+        """Generic restart-first stall sweep across registry loops.
+
+        Third leg of loop supervision: the per-cycle watchdog (#9556)
+        bounds a cycle that hangs, the supervisor restarts a loop that
+        raises — but a loop that goes *silent* (task wedged outside the
+        watchdog window) shows only as a stale heartbeat (#9650). Restart
+        it once per stall event; escalate with a ``loop-stalled`` issue
+        only when the restart didn't clear it. Recovery auto-closes the
+        issue (title-filtered — the label is shared across loops) and
+        clears both markers so a future stall restarts fresh.
+
+        Threshold is ``_WORKER_STALL_MULTIPLIER × interval +
+        cycle_timeout`` so a legitimately long LLM cycle (heartbeat only
+        refreshes between cycles) is never false-restarted. Non-registry
+        workers (pipeline phases, store poller) are out of scope — their
+        supervision semantics differ. Silent no-op when deps are missing
+        (minimal scenario fixtures), mirroring the §12.1 check.
+        """
+        state = self._state
+        bg_workers = self._bg_workers
+        prs = self._prs
+        # ``getattr`` guard: __new__-bypassed test scaffolding constructs
+        # this loop without the ctor (see PR #8460 post-mortem).
+        dedup = getattr(self, "_worker_stall_dedup", None)
+        if state is None or bg_workers is None or prs is None or dedup is None:
+            return
+
+        heartbeats = state.get_worker_heartbeats()
+        registered = bg_workers.registered_loop_names()
+        enabled_flags = getattr(bg_workers, "worker_enabled", {})
+        keys = dedup.get()
+        now = datetime.now(UTC)
+        for name, hb in heartbeats.items():
+            if name in _WORKER_STALL_EXCLUDED or name not in registered:
+                continue
+            if not enabled_flags.get(name, True):
+                continue
+            last_run_iso = hb.get("last_run") if isinstance(hb, dict) else None
+            if not last_run_iso:
+                continue
+            try:
+                last_run = datetime.fromisoformat(last_run_iso.replace("Z", "+00:00"))
+            except ValueError:
+                continue
+            if last_run.tzinfo is None:
+                last_run = last_run.replace(tzinfo=UTC)
+            elapsed_s = (now - last_run).total_seconds()
+            interval_s = bg_workers.get_interval(name)
+            threshold_s = (
+                _WORKER_STALL_MULTIPLIER * interval_s + bg_workers.cycle_timeout(name)
+            )
+            restart_key = f"health_monitor:worker-stall:restart:{name}"
+            filed_key = f"health_monitor:worker-stall:filed:{name}"
+            if elapsed_s < threshold_s:
+                # Recovery — close this worker's stall issue (if filed)
+                # and clear markers so a future stall restarts fresh.
+                if filed_key in keys:
+                    # Delimited needle (": {name} ") — a bare name would
+                    # also match prefix siblings (stale_issue ⊂
+                    # stale_issue_gc) and close the wrong loop's issue.
+                    await self._close_issues_by_label(
+                        prs,
+                        "loop-stalled",
+                        f"`{name}` is heartbeating again — auto-closing.",
+                        title_contains=f": {name} ",
+                    )
+                if keys & {restart_key, filed_key}:
+                    keys = keys - {restart_key, filed_key}
+                    dedup.set_all(keys)
+                continue
+            # Young-task window: heartbeats only refresh at cycle
+            # COMPLETION, so a freshly recreated task (restart-first tick,
+            # credit-pause resume, orchestrator restart) still carries the
+            # stale heartbeat while its first cycle is in flight. Neither
+            # recovered (clearing markers here would break restart-once-
+            # then-escalate: a wedged loop would restart every threshold
+            # window forever) nor actionable — wait until the task itself
+            # outlives the threshold without heartbeating.
+            started_at = bg_workers.run_started_at(name)
+            if (
+                started_at is not None
+                and (now - started_at).total_seconds() < threshold_s
+            ):
+                continue
+            # Stale. Restart-first: one restart per stall event; escalation
+            # waits one more sweep. Falls through to filing when the verb
+            # is unwired (returns False).
+            if restart_key not in keys:
+                restarted = await bg_workers.restart(name)
+                if restarted:
+                    logger.warning(
+                        "Loop %r stalled (%.0fs > %.0fs) — auto-restarted "
+                        "(restart-first; escalation deferred one sweep)",
+                        name,
+                        elapsed_s,
+                        threshold_s,
+                    )
+                    keys = keys | {restart_key}
+                    dedup.set_all(keys)
+                    continue
+            if filed_key in keys:
+                # Already filed for the current stall event.
+                continue
+            title = (
+                f"loop-stalled: {name} silent for {int(elapsed_s)}s "
+                f"(threshold {int(threshold_s)}s)"
+            )
+            body = (
+                f"## Background loop dead-man-switch tripped\n\n"
+                f"`{name}` has not heartbeated in `{int(elapsed_s)}s`, "
+                f"exceeding `{_WORKER_STALL_MULTIPLIER} × interval + "
+                f"cycle_timeout` = `{int(threshold_s)}s`.\n\n"
+                f"- Last heartbeat: `{last_run_iso}`\n"
+                f"- Interval: `{interval_s}s`\n"
+                f"- Watchdog bound: `{bg_workers.cycle_timeout(name)}s`\n"
+                f"- Auto-restart attempted: `{restart_key in keys}` "
+                f"(restart-first did not clear the stall)\n\n"
+                f"### Operator playbook\n"
+                f"1. Check orchestrator logs for the `{name}` loop task "
+                f"(look for a wedged await outside the cycle watchdog).\n"
+                f"2. Restart the orchestrator (`systemctl restart "
+                f"hydraflow` or equivalent).\n"
+                f"3. If the loop stalls repeatedly, flip its kill-switch "
+                f"in the **System** tab and file a HydraFlow bug report.\n\n"
+                f"_Auto-filed by HydraFlow `health_monitor` (generic "
+                f"loop-stall dead-man-switch)._"
+            )
+            await prs.create_issue(
+                title,
+                body,
+                ["hydraflow-find", "loop-stalled"],
+            )
+            keys = keys | {filed_key}
+            dedup.set_all(keys)
 
     async def _check_wiki_freshness(self) -> None:
         """Dead-man-switch for `RepoWikiLoop` via `docs/wiki/log.jsonl` mtime.
@@ -1211,11 +1421,17 @@ class HealthMonitorLoop(BaseBackgroundLoop):
         self._wiki_stall_dedup.set_all(filed_keys | {dedup_key})
 
     async def _close_issues_by_label(
-        self, prs: PRPort, label: str, comment: str
+        self,
+        prs: PRPort,
+        label: str,
+        comment: str,
+        *,
+        title_contains: str | None = None,
     ) -> None:
         """Close every open issue carrying *label* when a dead-man-switch
         recovers (#9359). Titles embed elapsed-time so they can't be found by
-        title; the label is the stable handle."""
+        title; the label is the stable handle. ``title_contains`` narrows to
+        one worker's issues when the label is shared (generic stall sweep)."""
         try:
             issues = await prs.list_issues_by_label(label)
         except Exception:  # noqa: BLE001
@@ -1228,6 +1444,10 @@ class HealthMonitorLoop(BaseBackgroundLoop):
         for issue in issues:
             number = issue.get("number")
             if not number:
+                continue
+            if title_contains is not None and title_contains not in str(
+                issue.get("title", "")
+            ):
                 continue
             await prs.post_comment(number, comment)
             await prs.close_issue(number)

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -128,6 +128,9 @@ class HydraFlowOrchestrator:
         self._session_issue_results: dict[int, bool] = {}
         # Loop tasks (set by _supervise_loops for stop() to cancel)
         self._loop_tasks: dict[str, asyncio.Task[None]] = {}
+        # Loop factories (retained by _supervise_loops so restart_loop_task
+        # can cancel-and-recreate a silently-stalled loop task)
+        self._loop_factories: dict[str, Callable[[], Coroutine[Any, Any, None]]] = {}
         # Strong references for fire-and-forget background tasks (#6513) —
         # without this the GC can collect the Task before it completes.
         self._deferred_tasks: set[asyncio.Task[None]] = set()
@@ -215,6 +218,9 @@ class HydraFlowOrchestrator:
             "fitness_scorecard": svc.fitness_scorecard_loop,
         }
         self._bg_workers = BGWorkerManager(config, self._state, bg_loop_registry)
+        # The restart verb reads self._loop_tasks/_loop_factories lazily, so
+        # binding it here (before _supervise_loops populates them) is safe.
+        self._bg_workers.set_restart_cb(self.restart_loop_task)
         svc.fitness_scorecard_loop.set_loops(bg_loop_registry)
         # Loops that need a reference to BGWorkerManager cannot take one
         # at construction time (chicken-and-egg: BGWorkerManager takes the
@@ -1114,6 +1120,41 @@ class HydraFlowOrchestrator:
             factory_fn(), name=f"hydraflow-{loop_name}"
         )
 
+    async def restart_loop_task(self, name: str) -> bool:
+        """Cancel a (possibly silently-stalled) loop task and start a fresh one.
+
+        The restart verb behind ``BGWorkerManager.restart`` — used by
+        HealthMonitorLoop's restart-first stall policy. The supervisor only
+        wakes on task *completion*, so a loop blocked forever on an ``await``
+        is invisible to it; this cancels the wedged task and recreates it
+        from the factory retained by :meth:`_supervise_loops`.
+
+        The replacement is registered in ``self._loop_tasks`` *synchronously*
+        after ``cancel()`` (no await between) so the supervisor's identity
+        check sees old task and replacement atomically.
+
+        Deliberately does NOT await the old task's drain: that await would
+        deliver — and a suppress would swallow — the *caller's* own
+        cancellation (e.g. the health-monitor work task being cancelled by
+        a credit-pause shutdown), letting the staleness sweep escape its
+        one cancel and spawn rogue loop tasks against an exhausted billing
+        signal. The supervisor drains the cancelled old task through its
+        done-set via the identity check; cancelled tasks emit no
+        never-retrieved warnings.
+
+        Returns ``False`` for unknown names or before supervision started.
+        """
+        old = self._loop_tasks.get(name)
+        factory = self._loop_factories.get(name)
+        if old is None or factory is None:
+            return False
+        old.cancel()
+        self._loop_tasks[name] = asyncio.create_task(
+            factory(), name=f"hydraflow-{name}"
+        )
+        logger.info("Loop %r restarted via restart_loop_task", name)
+        return True
+
     async def _handle_loop_exception(
         self,
         name: str,
@@ -1219,6 +1260,7 @@ class HydraFlowOrchestrator:
         known_worker_names = {n for n, _ in loop_factories}
         self._state_restorer.prune_stale_disabled_workers(known_worker_names)
         self._state_restorer.prune_stale_worker_states(known_worker_names)
+        self._loop_factories = dict(loop_factories)
         tasks: dict[str, asyncio.Task[None]] = {}
         for name, factory in loop_factories:
             tasks[name] = asyncio.create_task(factory(), name=f"hydraflow-{name}")
@@ -1232,6 +1274,24 @@ class HydraFlowOrchestrator:
                 for task in done:
                     name = task.get_name().removeprefix("hydraflow-")
                     if self._stop_event.is_set():
+                        break
+                    if tasks.get(name) is not task:
+                        # Externally restarted (restart_loop_task) — the
+                        # replacement is already registered and supervised;
+                        # this is the drained old task. Calling .exception()
+                        # on it would raise CancelledError here.
+                        continue
+                    if task.cancelled():
+                        # Cancelled outside shutdown and not replaced —
+                        # crash-equivalent; recreate to maintain supervision.
+                        logger.warning(
+                            "Loop %r was cancelled unexpectedly — restarting",
+                            name,
+                        )
+                        factory_fn = dict(loop_factories)[name]
+                        tasks[name] = asyncio.create_task(
+                            factory_fn(), name=f"hydraflow-{name}"
+                        )
                         break
                     exc = task.exception()
                     if exc is not None:

--- a/src/prep.py
+++ b/src/prep.py
@@ -133,6 +133,7 @@ HYDRAFLOW_LITERAL_LABELS: tuple[tuple[str, str, str], ...] = (
     ("issue-cost-spike", "e4e669", "Per-issue cost spike detected"),
     ("arch-knowledge", "e4e669", "Architecture-knowledge coverage gap"),
     ("sanity-loop-stalled", "e4e669", "Sanity loop stalled (dead-man switch)"),
+    ("loop-stalled", "e4e669", "Background loop stalled (dead-man switch)"),
     ("wiki-stale", "e4e669", "Wiki freshness dead-man switch fired"),
     ("onboarding-blocked", "e4e669", "Onboarding/auto-agent preflight blocked"),
     ("cultural-check", "e4e669", "Principles cultural-check audit label"),

--- a/tests/scenarios/catalog/loop_registrations.py
+++ b/tests/scenarios/catalog/loop_registrations.py
@@ -94,7 +94,20 @@ def _build_pr_unsticker(ports: dict[str, Any], config: Any, deps: Any) -> Any:
 def _build_health_monitor(ports: dict[str, Any], config: Any, deps: Any) -> Any:
     from health_monitor_loop import HealthMonitorLoop  # noqa: PLC0415
 
-    return HealthMonitorLoop(config=config, deps=deps, prs=ports["github"])
+    # ``state`` powers the dead-man-switch heartbeat reads; ``bg_workers``
+    # (seeded via seed_ports) powers the restart-first stall sweep. Both
+    # checks silently no-op when their deps are absent, so plain
+    # health-monitor scenarios are unaffected.
+    loop = HealthMonitorLoop(
+        config=config,
+        deps=deps,
+        prs=ports["github"],
+        state=ports.get("state"),
+    )
+    bg_workers = ports.get("bg_workers")
+    if bg_workers is not None:
+        loop.set_bg_workers(bg_workers)
+    return loop
 
 
 def _build_workspace_gc(ports: dict[str, Any], config: Any, deps: Any) -> Any:

--- a/tests/scenarios/test_loop_stall_restart_scenario.py
+++ b/tests/scenarios/test_loop_stall_restart_scenario.py
@@ -1,0 +1,80 @@
+"""Scenario: loop-stall restart-first control flow through MockWorld.
+
+A registry loop goes silent → health monitor restarts it (no human paged);
+still silent next sweep → exactly one `loop-stalled` escalation; heartbeat
+recovers → the issue auto-closes and the markers re-arm. Dedup markers
+persist across loop re-instantiation (DedupStore files), which each
+`run_with_loops` call exercises by rebuilding the loop from the catalog.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from bg_worker_manager import BGWorkerManager
+from models import BackgroundWorkerState
+from tests.scenarios.fakes.mock_world import MockWorld
+from tests.scenarios.helpers.loop_port_seeding import seed_ports
+
+pytestmark = pytest.mark.scenario_loops
+
+
+def _heartbeat(name: str, age_seconds: int) -> BackgroundWorkerState:
+    stamp = (datetime.now(UTC) - timedelta(seconds=age_seconds)).isoformat()
+    return BackgroundWorkerState(name=name, status="ok", last_run=stamp, details={})
+
+
+class TestLoopStallRestartFirst:
+    async def test_restart_then_escalate_then_recover(self, tmp_path):
+        world = MockWorld(tmp_path)
+        state = world.harness.state
+        state.set_bg_worker_state("workspace_gc", _heartbeat("workspace_gc", 99_999))
+
+        restart_calls: list[str] = []
+
+        async def restart_cb(name: str) -> bool:
+            restart_calls.append(name)
+            return True
+
+        stalled_loop = MagicMock()
+        stalled_loop._get_default_interval.return_value = 600
+        stalled_loop._cycle_timeout_seconds.return_value = 100
+        # A real loop stamps this in run(); a MagicMock would auto-create a
+        # non-datetime mock and break the max(heartbeat, run_started_at) math.
+        stalled_loop._run_started_at = None
+        bg_workers = BGWorkerManager(
+            world.harness.config, state, {"workspace_gc": stalled_loop}
+        )
+        bg_workers.set_restart_cb(restart_cb)
+        seed_ports(world, bg_workers=bg_workers)
+
+        # Sweep 1 — stale: restart-first, nobody paged.
+        await world.run_with_loops(["health_monitor"], cycles=1)
+        assert restart_calls == ["workspace_gc"]
+        assert await world.github.list_issues_by_label("loop-stalled") == []
+
+        # Sweep 2 — restart didn't clear it: exactly one escalation,
+        # no restart-thrash.
+        await world.run_with_loops(["health_monitor"], cycles=1)
+        stalled = await world.github.list_issues_by_label("loop-stalled")
+        assert len(stalled) == 1
+        assert "workspace_gc" in stalled[0]["title"]
+        assert restart_calls == ["workspace_gc"]
+
+        # Sweep 3 — dedup holds: still exactly one issue.
+        await world.run_with_loops(["health_monitor"], cycles=1)
+        assert len(await world.github.list_issues_by_label("loop-stalled")) == 1
+
+        # Recovery — fresh heartbeat: auto-close + re-arm.
+        state.set_bg_worker_state("workspace_gc", _heartbeat("workspace_gc", 5))
+        await world.run_with_loops(["health_monitor"], cycles=1)
+        assert await world.github.list_issues_by_label("loop-stalled") == []
+
+        # A later fresh stall restarts again instead of escalating.
+        state.set_bg_worker_state("workspace_gc", _heartbeat("workspace_gc", 88_888))
+        await world.run_with_loops(["health_monitor"], cycles=1)
+        assert restart_calls == ["workspace_gc", "workspace_gc"]
+        assert await world.github.list_issues_by_label("loop-stalled") == []

--- a/tests/test_base_background_loop.py
+++ b/tests/test_base_background_loop.py
@@ -90,6 +90,19 @@ def _make_stub(
 
 class TestBaseBackgroundLoopRun:
     @pytest.mark.asyncio
+    async def test_run__stamps_run_started_at(self, tmp_path: Path) -> None:
+        """run() records when the current task started — the stall sweep
+        uses max(heartbeat, run_started_at) so a freshly (re)created task
+        with a stale persisted heartbeat (post credit-pause / restart)
+        isn't false-restarted mid-first-cycle."""
+        loop, _stop = _make_stub(tmp_path)
+        assert loop._run_started_at is None
+
+        await loop.run()
+
+        assert loop._run_started_at is not None
+
+    @pytest.mark.asyncio
     async def test_run__calls_do_work_and_reports_success(self, tmp_path: Path) -> None:
         """The loop calls _do_work and reports success via status_cb and bus."""
         loop, _stop = _make_stub(tmp_path, work_fn=lambda: {"count": 5})

--- a/tests/test_bg_worker_manager.py
+++ b/tests/test_bg_worker_manager.py
@@ -264,3 +264,71 @@ class TestRestoreMethods:
         manager.update_status("x", "ok")
         manager.update_status("y", "idle")
         assert manager._known_worker_state_names() == {"x", "y"}
+
+
+class TestRestart:
+    @pytest.mark.asyncio
+    async def test_restart_without_cb_returns_false(
+        self, manager: BGWorkerManager
+    ) -> None:
+        assert await manager.restart("workspace_gc") is False
+
+    @pytest.mark.asyncio
+    async def test_restart_delegates_to_cb(self, manager: BGWorkerManager) -> None:
+        calls: list[str] = []
+
+        async def cb(name: str) -> bool:
+            calls.append(name)
+            return True
+
+        manager.set_restart_cb(cb)
+        assert await manager.restart("workspace_gc") is True
+        assert calls == ["workspace_gc"]
+
+    @pytest.mark.asyncio
+    async def test_restart_propagates_cb_false(self, manager: BGWorkerManager) -> None:
+        async def cb(name: str) -> bool:  # noqa: ARG001
+            return False
+
+        manager.set_restart_cb(cb)
+        assert await manager.restart("unknown_loop") is False
+
+
+class TestRegisteredLoopNames:
+    def test_returns_registry_keys(self, config: HydraFlowConfig, state: Any) -> None:
+        mgr = BGWorkerManager(config, state, {"a": MagicMock(), "b": MagicMock()})
+        assert mgr.registered_loop_names() == {"a", "b"}
+
+    def test_empty_registry(self, manager: BGWorkerManager) -> None:
+        assert manager.registered_loop_names() == set()
+
+
+class TestRunStartedAt:
+    def test_delegates_to_registered_loop(
+        self, config: HydraFlowConfig, state: Any
+    ) -> None:
+        from datetime import UTC, datetime
+
+        stamp = datetime(2026, 7, 7, 12, 0, 0, tzinfo=UTC)
+        fake_loop = MagicMock()
+        fake_loop._run_started_at = stamp
+        mgr = BGWorkerManager(config, state, {"myloop": fake_loop})
+        assert mgr.run_started_at("myloop") == stamp
+
+    def test_unknown_name_returns_none(self, manager: BGWorkerManager) -> None:
+        assert manager.run_started_at("nope") is None
+
+
+class TestCycleTimeout:
+    def test_delegates_to_registered_loop(
+        self, config: HydraFlowConfig, state: Any
+    ) -> None:
+        fake_loop = MagicMock()
+        fake_loop._cycle_timeout_seconds.return_value = 1234
+        mgr = BGWorkerManager(config, state, {"myloop": fake_loop})
+        assert mgr.cycle_timeout("myloop") == 1234
+
+    def test_unknown_name_uses_watchdog_default(
+        self, manager: BGWorkerManager, config: HydraFlowConfig
+    ) -> None:
+        assert manager.cycle_timeout("nope") == config.loop_watchdog_default_seconds

--- a/tests/test_health_monitor_sanity_stall.py
+++ b/tests/test_health_monitor_sanity_stall.py
@@ -27,6 +27,10 @@ def hm_env(tmp_path: Path):
     state.get_worker_heartbeats.return_value = {}
     bg_workers = MagicMock()
     bg_workers.worker_enabled = {"trust_fleet_sanity": True}
+    bg_workers.run_started_at.return_value = None
+    # Default: restart verb unavailable (unwired cb) — the dead-man-switch
+    # falls through to filing immediately, preserving pre-restart behavior.
+    bg_workers.restart = AsyncMock(return_value=False)
     prs = AsyncMock()
     prs.create_issue = AsyncMock(return_value=17)
     prs.list_issues_by_label = AsyncMock(return_value=[])
@@ -223,3 +227,173 @@ async def test_recovery_closes_open_stall_issue(hm_env) -> None:
     )
     await hm._check_sanity_loop_staleness()
     prs.close_issue.assert_awaited_once_with(91)
+
+
+@pytest.mark.asyncio
+async def test_stall_restart_first_defers_issue(hm_env) -> None:
+    """Restart-first: when the restart verb succeeds, the first stall tick
+    restarts the loop instead of paging a human."""
+    hm, state, bg_workers, prs = hm_env
+    bg_workers.restart = AsyncMock(return_value=True)
+    stale = (datetime.now(UTC) - timedelta(seconds=2400)).isoformat()
+    state.get_worker_heartbeats.return_value = {
+        "trust_fleet_sanity": {"status": "ok", "last_run": stale, "details": {}},
+    }
+    await hm._check_sanity_loop_staleness()
+    bg_workers.restart.assert_awaited_once_with("trust_fleet_sanity")
+    prs.create_issue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_still_stale_after_restart_files_issue_once(hm_env) -> None:
+    """A stall that survives its restart escalates — one issue, one restart."""
+    hm, state, bg_workers, prs = hm_env
+    bg_workers.restart = AsyncMock(return_value=True)
+    stale = (datetime.now(UTC) - timedelta(seconds=2400)).isoformat()
+    state.get_worker_heartbeats.return_value = {
+        "trust_fleet_sanity": {"status": "ok", "last_run": stale, "details": {}},
+    }
+    await hm._check_sanity_loop_staleness()  # restart tick
+    await hm._check_sanity_loop_staleness()  # still stale — file
+    await hm._check_sanity_loop_staleness()  # dedup — no refile
+    assert bg_workers.restart.await_count == 1
+    assert prs.create_issue.await_count == 1
+    body = prs.create_issue.await_args.args[1]
+    assert "Auto-restart attempted" in body
+
+
+@pytest.mark.asyncio
+async def test_recovery_clears_restart_marker(hm_env) -> None:
+    """Recovery clears the restart marker so a future stall restarts again."""
+    hm, state, bg_workers, prs = hm_env
+    bg_workers.restart = AsyncMock(return_value=True)
+    stale = (datetime.now(UTC) - timedelta(seconds=2400)).isoformat()
+    state.get_worker_heartbeats.return_value = {
+        "trust_fleet_sanity": {"status": "ok", "last_run": stale, "details": {}},
+    }
+    await hm._check_sanity_loop_staleness()
+    assert bg_workers.restart.await_count == 1
+    # Recovery — fresh heartbeat with real work.
+    recent = (datetime.now(UTC) - timedelta(seconds=60)).isoformat()
+    state.get_worker_heartbeats.return_value = {
+        "trust_fleet_sanity": {
+            "status": "ok",
+            "last_run": recent,
+            "details": {"workers_scanned": 5},
+        },
+    }
+    await hm._check_sanity_loop_staleness()
+    prs.create_issue.assert_not_awaited()
+    # New stall — restart fires again instead of escalating.
+    stale2 = (datetime.now(UTC) - timedelta(seconds=3000)).isoformat()
+    state.get_worker_heartbeats.return_value = {
+        "trust_fleet_sanity": {"status": "ok", "last_run": stale2, "details": {}},
+    }
+    await hm._check_sanity_loop_staleness()
+    assert bg_workers.restart.await_count == 2
+    prs.create_issue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_restart_unavailable_files_immediately(hm_env) -> None:
+    """When the restart verb is unwired (False), behavior matches the
+    pre-restart contract: file on the first stall tick."""
+    hm, state, bg_workers, prs = hm_env
+    stale = (datetime.now(UTC) - timedelta(seconds=2400)).isoformat()
+    state.get_worker_heartbeats.return_value = {
+        "trust_fleet_sanity": {"status": "ok", "last_run": stale, "details": {}},
+    }
+    await hm._check_sanity_loop_staleness()
+    bg_workers.restart.assert_awaited_once_with("trust_fleet_sanity")
+    prs.create_issue.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_young_sanity_task_with_stale_heartbeat_not_flagged(hm_env) -> None:
+    """Post credit-pause: a just-recreated sanity task with a pre-pause
+    heartbeat must not be restarted or escalated mid-first-cycle."""
+    hm, state, bg_workers, prs = hm_env
+    bg_workers.restart = AsyncMock(return_value=True)
+    bg_workers.run_started_at.return_value = datetime.now(UTC) - timedelta(seconds=30)
+    stale = (datetime.now(UTC) - timedelta(seconds=99_999)).isoformat()
+    state.get_worker_heartbeats.return_value = {
+        "trust_fleet_sanity": {"status": "ok", "last_run": stale, "details": {}},
+    }
+    await hm._check_sanity_loop_staleness()
+    bg_workers.restart.assert_not_awaited()
+    prs.create_issue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sanity_restart_once_contract_survives_young_task_window(
+    hm_env,
+) -> None:
+    """The young-task window after a sanity restart must not clear
+    _SANITY_RESTART_KEY — that would restart a broken sanity loop every
+    threshold window forever instead of escalating once."""
+    hm, state, bg_workers, prs = hm_env
+    bg_workers.restart = AsyncMock(return_value=True)
+    stale = (datetime.now(UTC) - timedelta(seconds=99_999)).isoformat()
+    state.get_worker_heartbeats.return_value = {
+        "trust_fleet_sanity": {"status": "ok", "last_run": stale, "details": {}},
+    }
+    await hm._check_sanity_loop_staleness()  # restart tick
+    assert bg_workers.restart.await_count == 1
+    # Recreated task's first cycle in flight — heartbeat still stale.
+    bg_workers.run_started_at.return_value = datetime.now(UTC) - timedelta(seconds=30)
+    await hm._check_sanity_loop_staleness()
+    prs.create_issue.assert_not_awaited()
+    # Task aged past threshold without heartbeating — escalate, not restart.
+    bg_workers.run_started_at.return_value = datetime.now(UTC) - timedelta(
+        seconds=5_000
+    )
+    await hm._check_sanity_loop_staleness()
+    assert bg_workers.restart.await_count == 1
+    prs.create_issue.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_noop_restart_marker_survives_streak_rebuild(hm_env) -> None:
+    """After a noop-tripped restart, streak-rebuild ticks (workers_scanned=0,
+    streak 1-2) must NOT clear the restart marker — the loop is no-oping,
+    not recovered. Clearing there restarts a persistent no-op every 3 ticks
+    forever with escalation permanently bypassed."""
+    hm, state, bg_workers, prs = hm_env
+    bg_workers.restart = AsyncMock(return_value=True)
+    recent = (datetime.now(UTC) - timedelta(seconds=120)).isoformat()
+    state.get_worker_heartbeats.return_value = {
+        "trust_fleet_sanity": {
+            "status": "ok",
+            "last_run": recent,
+            "details": {"workers_scanned": 0},
+        },
+    }
+    for _ in range(3):
+        await hm._check_sanity_loop_staleness()
+    assert bg_workers.restart.await_count == 1  # noop restart fired
+    prs.create_issue.assert_not_awaited()
+    # Streak rebuilds (ticks 4-6); marker must survive so tick 6 escalates.
+    for _ in range(3):
+        await hm._check_sanity_loop_staleness()
+    assert bg_workers.restart.await_count == 1  # no restart-thrash
+    prs.create_issue.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_noop_streak_also_restarts_first(hm_env) -> None:
+    """The G5 no-op-streak stall variant gets the same restart-first path."""
+    hm, state, bg_workers, prs = hm_env
+    bg_workers.restart = AsyncMock(return_value=True)
+    recent = (datetime.now(UTC) - timedelta(seconds=120)).isoformat()
+    state.get_worker_heartbeats.return_value = {
+        "trust_fleet_sanity": {
+            "status": "ok",
+            "last_run": recent,
+            "details": {"workers_scanned": 0},
+        },
+    }
+    await hm._check_sanity_loop_staleness()
+    await hm._check_sanity_loop_staleness()
+    await hm._check_sanity_loop_staleness()  # streak hits 3 — restart, no issue
+    bg_workers.restart.assert_awaited_once_with("trust_fleet_sanity")
+    prs.create_issue.assert_not_awaited()

--- a/tests/test_health_monitor_worker_stall.py
+++ b/tests/test_health_monitor_worker_stall.py
@@ -1,0 +1,283 @@
+"""Generic stall sweep: restart-first dead-man-switch for any registry loop.
+
+The per-cycle watchdog (#9556) bounds a cycle that hangs; the supervisor
+restarts a loop that raises. A loop that goes *silent* shows only as a stale
+heartbeat — the sweep restarts it once per stall event and escalates with a
+`loop-stalled` issue only when the restart didn't clear it (#9650).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from config import HydraFlowConfig
+from health_monitor_loop import HealthMonitorLoop
+
+
+def _hb(age_seconds: int) -> dict:
+    stamp = (datetime.now(UTC) - timedelta(seconds=age_seconds)).isoformat()
+    return {"status": "ok", "last_run": stamp, "details": {}}
+
+
+@pytest.fixture
+def hm_env(tmp_path: Path):
+    from dedup_store import DedupStore
+
+    cfg = HydraFlowConfig(data_root=tmp_path, repo="hydra/hydraflow")
+    state = MagicMock()
+    state.get_worker_heartbeats.return_value = {}
+    bg_workers = MagicMock()
+    bg_workers.worker_enabled = {}
+    bg_workers.registered_loop_names.return_value = {"workspace_gc"}
+    # interval 600s, watchdog bound 100s → threshold = 3×600 + 100 = 1900s
+    bg_workers.get_interval.return_value = 600
+    bg_workers.cycle_timeout.return_value = 100
+    bg_workers.run_started_at.return_value = None
+    bg_workers.restart = AsyncMock(return_value=True)
+    prs = AsyncMock()
+    prs.create_issue = AsyncMock(return_value=17)
+    prs.list_issues_by_label = AsyncMock(return_value=[])
+    hm = HealthMonitorLoop.__new__(HealthMonitorLoop)
+    hm._config = cfg
+    hm._state = state
+    hm._bg_workers = bg_workers
+    hm._prs = prs
+    hm._worker_stall_dedup = DedupStore(
+        "hm_worker_stall_test",
+        tmp_path / "dedup" / "hm_worker_stall_test.json",
+    )
+    return hm, state, bg_workers, prs
+
+
+@pytest.mark.asyncio
+async def test_healthy_loop_untouched(hm_env) -> None:
+    hm, state, bg_workers, prs = hm_env
+    state.get_worker_heartbeats.return_value = {"workspace_gc": _hb(60)}
+    await hm._check_worker_staleness()
+    bg_workers.restart.assert_not_awaited()
+    prs.create_issue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stale_loop_restarted_not_escalated(hm_env) -> None:
+    hm, state, bg_workers, prs = hm_env
+    state.get_worker_heartbeats.return_value = {"workspace_gc": _hb(2400)}
+    await hm._check_worker_staleness()
+    bg_workers.restart.assert_awaited_once_with("workspace_gc")
+    prs.create_issue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_still_stale_after_restart_files_once(hm_env) -> None:
+    hm, state, bg_workers, prs = hm_env
+    state.get_worker_heartbeats.return_value = {"workspace_gc": _hb(2400)}
+    await hm._check_worker_staleness()  # restart tick
+    await hm._check_worker_staleness()  # still stale — file
+    await hm._check_worker_staleness()  # dedup — no refile
+    assert bg_workers.restart.await_count == 1
+    assert prs.create_issue.await_count == 1
+    title, body, labels = prs.create_issue.await_args.args
+    assert "workspace_gc" in title
+    assert "loop-stalled" in title
+    assert "Auto-restart attempted" in body
+    assert "hydraflow-find" in labels
+    assert "loop-stalled" in labels
+
+
+@pytest.mark.asyncio
+async def test_recovery_closes_own_issue_and_clears_markers(hm_env) -> None:
+    hm, state, bg_workers, prs = hm_env
+    state.get_worker_heartbeats.return_value = {"workspace_gc": _hb(2400)}
+    await hm._check_worker_staleness()  # restart
+    await hm._check_worker_staleness()  # file
+    assert prs.create_issue.await_count == 1
+    # Recovery. Two open loop-stalled issues exist; only workspace_gc's
+    # may be closed (title filter — the label is shared across loops).
+    prs.list_issues_by_label = AsyncMock(
+        return_value=[
+            {"number": 91, "title": "loop-stalled: workspace_gc silent for 2400s"},
+            {"number": 92, "title": "loop-stalled: repo_wiki silent for 9999s"},
+        ]
+    )
+    state.get_worker_heartbeats.return_value = {"workspace_gc": _hb(30)}
+    await hm._check_worker_staleness()
+    prs.close_issue.assert_awaited_once_with(91)
+    # A fresh stall gets a fresh restart (markers cleared).
+    state.get_worker_heartbeats.return_value = {"workspace_gc": _hb(3000)}
+    await hm._check_worker_staleness()
+    assert bg_workers.restart.await_count == 2
+    assert prs.create_issue.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_long_llm_cycle_bound_prevents_false_restart(hm_env) -> None:
+    hm, state, bg_workers, prs = hm_env
+    # A LONG_LLM_CYCLE loop mid-cycle: heartbeat 2400s old but the loop's
+    # watchdog bound is 4h — threshold 3×600+14400 = 16200s. Healthy.
+    bg_workers.cycle_timeout.return_value = 14400
+    state.get_worker_heartbeats.return_value = {"workspace_gc": _hb(2400)}
+    await hm._check_worker_staleness()
+    bg_workers.restart.assert_not_awaited()
+    prs.create_issue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_disabled_worker_skipped(hm_env) -> None:
+    hm, state, bg_workers, prs = hm_env
+    bg_workers.worker_enabled = {"workspace_gc": False}
+    state.get_worker_heartbeats.return_value = {"workspace_gc": _hb(99999)}
+    await hm._check_worker_staleness()
+    bg_workers.restart.assert_not_awaited()
+    prs.create_issue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_trust_fleet_sanity_owned_by_specific_check(hm_env) -> None:
+    hm, state, bg_workers, prs = hm_env
+    bg_workers.registered_loop_names.return_value = {"trust_fleet_sanity"}
+    state.get_worker_heartbeats.return_value = {"trust_fleet_sanity": _hb(99999)}
+    await hm._check_worker_staleness()
+    bg_workers.restart.assert_not_awaited()
+    prs.create_issue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unregistered_worker_skipped(hm_env) -> None:
+    hm, state, bg_workers, prs = hm_env
+    state.get_worker_heartbeats.return_value = {"pipeline_poller": _hb(99999)}
+    await hm._check_worker_staleness()
+    bg_workers.restart.assert_not_awaited()
+    prs.create_issue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_restart_unavailable_files_immediately(hm_env) -> None:
+    hm, state, bg_workers, prs = hm_env
+    bg_workers.restart = AsyncMock(return_value=False)
+    state.get_worker_heartbeats.return_value = {"workspace_gc": _hb(2400)}
+    await hm._check_worker_staleness()
+    bg_workers.restart.assert_awaited_once_with("workspace_gc")
+    prs.create_issue.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_recovery_close_does_not_match_prefix_sibling(hm_env) -> None:
+    """`stale_issue` recovering must not close `stale_issue_gc`'s stall issue
+    (nor clear its markers) — the registry's only prefix pair; a bare
+    substring title match would hit both."""
+    hm, state, bg_workers, prs = hm_env
+    bg_workers.registered_loop_names.return_value = {
+        "stale_issue",
+        "stale_issue_gc",
+    }
+    hm._worker_stall_dedup.set_all(
+        {
+            "health_monitor:worker-stall:restart:stale_issue",
+            "health_monitor:worker-stall:filed:stale_issue",
+            "health_monitor:worker-stall:restart:stale_issue_gc",
+            "health_monitor:worker-stall:filed:stale_issue_gc",
+        }
+    )
+    prs.list_issues_by_label = AsyncMock(
+        return_value=[
+            {
+                "number": 71,
+                "title": "loop-stalled: stale_issue silent for 2400s (threshold 1900s)",
+            },
+            {
+                "number": 72,
+                "title": "loop-stalled: stale_issue_gc silent for 2400s "
+                "(threshold 1900s)",
+            },
+        ]
+    )
+    state.get_worker_heartbeats.return_value = {
+        "stale_issue": _hb(30),  # recovered
+        "stale_issue_gc": _hb(99_999),  # still stalled
+    }
+    await hm._check_worker_staleness()
+    closed = {c.args[0] for c in prs.close_issue.await_args_list}
+    assert closed == {71}
+    # The sibling's markers must survive its neighbor's recovery.
+    keys = hm._worker_stall_dedup.get()
+    assert "health_monitor:worker-stall:filed:stale_issue_gc" in keys
+    assert "health_monitor:worker-stall:restart:stale_issue_gc" in keys
+
+
+@pytest.mark.asyncio
+async def test_health_monitor_never_self_restarts(hm_env) -> None:
+    """The sweep runs inside health_monitor — self-cancelling mid-cycle
+    (e.g. stale persisted heartbeat after long orchestrator downtime) is
+    harm without benefit; a truly wedged health_monitor can't sweep anyway."""
+    hm, state, bg_workers, prs = hm_env
+    bg_workers.registered_loop_names.return_value = {"health_monitor"}
+    state.get_worker_heartbeats.return_value = {"health_monitor": _hb(99_999)}
+    await hm._check_worker_staleness()
+    bg_workers.restart.assert_not_awaited()
+    prs.create_issue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_young_task_with_stale_heartbeat_not_restarted(hm_env) -> None:
+    """Post credit-pause / orchestrator restart: the persisted heartbeat is
+    stale but the current task was just created — heartbeats only refresh at
+    cycle COMPLETION, so restarting here would cancel a healthy in-flight
+    first cycle (wasted LLM spend) and could file false issues."""
+    hm, state, bg_workers, prs = hm_env
+    bg_workers.run_started_at.return_value = datetime.now(UTC) - timedelta(seconds=30)
+    state.get_worker_heartbeats.return_value = {"workspace_gc": _hb(99_999)}
+    await hm._check_worker_staleness()
+    bg_workers.restart.assert_not_awaited()
+    prs.create_issue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_old_task_with_stale_heartbeat_still_restarted(hm_env) -> None:
+    """A task that has been running past the threshold without completing a
+    cycle IS wedged — run_started_at must not mask genuine stalls."""
+    hm, state, bg_workers, prs = hm_env
+    bg_workers.run_started_at.return_value = datetime.now(UTC) - timedelta(
+        seconds=99_999
+    )
+    state.get_worker_heartbeats.return_value = {"workspace_gc": _hb(99_999)}
+    await hm._check_worker_staleness()
+    bg_workers.restart.assert_awaited_once_with("workspace_gc")
+
+
+@pytest.mark.asyncio
+async def test_restart_once_contract_survives_young_task_window(hm_env) -> None:
+    """The young-task window after a restart must NOT read as recovery:
+    clearing the restart marker there turns 'restart once, then escalate'
+    into 'restart forever, never escalate' for a genuinely wedged loop."""
+    hm, state, bg_workers, prs = hm_env
+    state.get_worker_heartbeats.return_value = {"workspace_gc": _hb(99_999)}
+    await hm._check_worker_staleness()  # restart tick
+    assert bg_workers.restart.await_count == 1
+    # Recreated task's first cycle in flight — heartbeat still stale.
+    bg_workers.run_started_at.return_value = datetime.now(UTC) - timedelta(seconds=30)
+    await hm._check_worker_staleness()
+    assert bg_workers.restart.await_count == 1
+    prs.create_issue.assert_not_awaited()
+    assert (
+        "health_monitor:worker-stall:restart:workspace_gc"
+        in hm._worker_stall_dedup.get()
+    )
+    # Task aged past threshold without ever heartbeating — wedged for real.
+    bg_workers.run_started_at.return_value = datetime.now(UTC) - timedelta(
+        seconds=5_000
+    )
+    await hm._check_worker_staleness()
+    assert bg_workers.restart.await_count == 1  # escalate, don't re-restart
+    prs.create_issue.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_missing_deps_is_silent_noop(hm_env) -> None:
+    hm, _state, bg_workers, prs = hm_env
+    hm._bg_workers = None  # minimal scenario fixtures omit the injection
+    await hm._check_worker_staleness()
+    prs.create_issue.assert_not_awaited()

--- a/tests/test_orchestrator_loop_restart.py
+++ b/tests/test_orchestrator_loop_restart.py
@@ -1,0 +1,171 @@
+"""Tests for Orchestrator.restart_loop_task — the stalled-loop restart verb.
+
+A silently-stalled loop task never completes, so ``_supervise_loops`` never
+sees it (its ``asyncio.wait`` only wakes on task completion). The restart
+verb cancels the stalled task and replaces it from the retained factory;
+the supervisor must tolerate the externally-cancelled old task draining
+through its done-set without raising ``CancelledError``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+
+if TYPE_CHECKING:
+    from config import HydraFlowConfig
+from orchestrator import HydraFlowOrchestrator
+from tests.helpers import mock_fetcher_noop
+
+
+class TestRestartLoopTask:
+    @pytest.mark.asyncio
+    async def test_unknown_name_returns_false(self, config: HydraFlowConfig) -> None:
+        """Unknown loop names (or pre-supervision calls) are a no-op False."""
+        orch = HydraFlowOrchestrator(config)
+        assert await orch.restart_loop_task("no-such-loop") is False
+
+    @pytest.mark.asyncio
+    async def test_cancels_stalled_task_and_replaces_it(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """The old task is cancelled and a fresh one from the factory
+        takes its slot in _loop_tasks."""
+        orch = HydraFlowOrchestrator(config)
+        started = asyncio.Event()
+
+        async def stuck_loop() -> None:
+            started.set()
+            await asyncio.Event().wait()  # silent stall — never returns
+
+        orch._loop_factories = {"stuck": stuck_loop}
+        old = asyncio.create_task(stuck_loop(), name="hydraflow-stuck")
+        orch._loop_tasks = {"stuck": old}
+        await started.wait()
+
+        try:
+            assert await orch.restart_loop_task("stuck") is True
+            await asyncio.gather(old, return_exceptions=True)
+            assert old.cancelled()
+            replacement = orch._loop_tasks["stuck"]
+            assert replacement is not old
+            assert not replacement.done()
+        finally:
+            for task in orch._loop_tasks.values():
+                task.cancel()
+            await asyncio.gather(*orch._loop_tasks.values(), return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_missing_factory_returns_false(self, config: HydraFlowConfig) -> None:
+        """A task without a retained factory cannot be restarted."""
+        orch = HydraFlowOrchestrator(config)
+
+        async def stuck_loop() -> None:
+            await asyncio.Event().wait()
+
+        old = asyncio.create_task(stuck_loop(), name="hydraflow-stuck")
+        orch._loop_tasks = {"stuck": old}
+        orch._loop_factories = {}
+        try:
+            assert await orch.restart_loop_task("stuck") is False
+            assert not old.cancelled()
+        finally:
+            old.cancel()
+            await asyncio.gather(old, return_exceptions=True)
+
+
+class TestRestartDoesNotDrainOldTask:
+    @pytest.mark.asyncio
+    async def test_restart_returns_without_awaiting_slow_cancellation(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """restart_loop_task must NOT await the old task: that await would
+        deliver (and suppress) the CALLER's own cancellation during a
+        credit-pause shutdown, letting the staleness sweep escape its one
+        cancel and spawn rogue loop tasks against an exhausted billing
+        signal. The supervisor's identity check drains the old task."""
+        orch = HydraFlowOrchestrator(config)
+        release = asyncio.Event()
+
+        async def stubborn_loop() -> None:
+            try:
+                await asyncio.Event().wait()
+            finally:
+                await release.wait()  # slow cancellation drain
+
+        orch._loop_factories = {"stubborn": stubborn_loop}
+        old = asyncio.create_task(stubborn_loop(), name="hydraflow-stubborn")
+        orch._loop_tasks = {"stubborn": old}
+        await asyncio.sleep(0)
+        try:
+            result = await asyncio.wait_for(
+                orch.restart_loop_task("stubborn"), timeout=1
+            )
+            assert result is True
+            assert not old.done()  # still draining — restart didn't block
+        finally:
+            release.set()
+            orch._loop_tasks["stubborn"].cancel()
+            await asyncio.gather(
+                old, orch._loop_tasks["stubborn"], return_exceptions=True
+            )
+
+
+class TestSupervisorExternalRestartHardening:
+    @pytest.mark.asyncio
+    async def test_supervisor_survives_external_restart(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Restarting a stalled loop mid-supervision must not blow up
+        _supervise_loops when the cancelled old task drains through its
+        asyncio.wait done-set (Task.exception() raises CancelledError)."""
+        orch = HydraFlowOrchestrator(config)
+        orch._svc.prs.ensure_labels_exist = AsyncMock()  # type: ignore[method-assign]
+        mock_fetcher_noop(orch)
+
+        implement_calls = 0
+
+        async def stalling_then_stopping() -> None:
+            nonlocal implement_calls
+            implement_calls += 1
+            if implement_calls == 1:
+                await asyncio.Event().wait()  # silent stall
+                return
+            # Post-restart invocation: wind the orchestrator down.
+            orch._stop_event.set()
+
+        orch._implement_loop = stalling_then_stopping  # type: ignore[method-assign]
+
+        orch._svc.triager.triage_issues = AsyncMock(return_value=0)  # type: ignore[method-assign]
+        orch._svc.planner_phase.plan_issues = AsyncMock(return_value=[])  # type: ignore[method-assign]
+        orch._svc.store.get_reviewable = lambda _max_count: []  # type: ignore[method-assign]
+        orch._svc.store.start = AsyncMock()  # type: ignore[method-assign]
+
+        async def instant_sleep(seconds: int) -> None:  # noqa: ARG001
+            await asyncio.sleep(0)
+
+        orch._sleep_or_stop = instant_sleep  # type: ignore[method-assign]
+
+        run_task = asyncio.create_task(orch.run())
+        try:
+            # Wait for the implement loop to enter its stall.
+            for _ in range(200):
+                if implement_calls >= 1:
+                    break
+                await asyncio.sleep(0.01)
+            assert implement_calls == 1
+
+            assert await orch.restart_loop_task("implement") is True
+
+            # The supervisor must keep running and supervise the
+            # replacement task, whose second invocation stops the run.
+            await asyncio.wait_for(run_task, timeout=10)
+        finally:
+            if not run_task.done():
+                run_task.cancel()
+                await asyncio.gather(run_task, return_exceptions=True)
+
+        assert implement_calls == 2

--- a/tests/test_pr_manager_core.py
+++ b/tests/test_pr_manager_core.py
@@ -1778,6 +1778,7 @@ async def test_ensure_labels_exist_uses_config_label_names(config, event_bus, tm
         "issue-cost-spike",
         "arch-knowledge",
         "sanity-loop-stalled",
+        "loop-stalled",
         "wiki-stale",
         "onboarding-blocked",
         "cultural-check",


### PR DESCRIPTION
## Summary

A silently-stalled background loop now gets automatically cancelled and restarted before any human is paged; escalation fires only when the restart doesn't clear the stall. This closes the third supervision gap: the watchdog (#9594) bounds cycles that **hang**, the supervisor restarts loops that **raise**, but a loop that went **silent** (task wedged outside the watchdog window) only got an issue filed — #9650 sat as a 5h trust_fleet_sanity stall with a sticky note.

## Layers

- **Orchestrator**: `restart_loop_task(name)` — cancel + synchronous replace from retained factories. Supervisor done-loop hardened: skips externally-replaced tasks (identity check) and treats unexpected cancellation as crash-equivalent. (Latent prod hazard fixed: `Task.exception()` on a cancelled task *raises* `CancelledError` inside `_supervise_loops`.)
- **BGWorkerManager**: `restart` (injected-callback, mirrors `set_bg_workers`), `cycle_timeout`, `registered_loop_names`, `run_started_at` — control-plane surface for the sweeps.
- **HealthMonitorLoop**: restart-first policy on the §12.1 sanity dead-man-switch **and** a new generic stale-worker sweep over registry loops. Three-state logic per worker: genuinely recovered (close issue, clear markers) / young task in-flight (heartbeats only refresh at cycle *completion* — no action after credit-pause resume or orchestrator restart) / wedged (one restart per stall event, then a `loop-stalled` escalation). Threshold `3×interval + cycle_timeout` is immune to legitimately long LLM cycles.

## Review convergence (ADR-0051)

Five fresh-eyes passes; each of the first four found one real bug class, all fixed with pinned regression tests:
1. Drain-await in the restart verb suppressed the *caller's* cancellation during credit-pause shutdown (rogue tasks vs exhausted billing signal).
2. Bare-substring recovery close hit the registry's prefix pair (`stale_issue` ⊂ `stale_issue_gc`) — now a delimited title needle.
3. Credit-pause resume false-restarted healthy first cycles → `run_started_at` stamped in `BaseBackgroundLoop.run()` (single choke point).
4. Two marker-state-machine escapes where non-recovery states re-armed the restart marker — turning "restart once, then escalate" into "restart forever, page nobody."

Pass 5: **CONVERGED** — full state-machine trace, no material findings.

## Testing

- Unit: 30+ new tests across orchestrator restart/supervisor hardening, BGWorkerManager verbs, both dead-man-switches (incl. restart-once contract, young-task window, noop-streak marker preservation, prefix-sibling close).
- MockWorld scenario: stale heartbeat → restart (nobody paged) → still stale → exactly one `loop-stalled` escalation → recovery → auto-close + re-arm; real `BGWorkerManager` delegation; marker persistence across loop re-instantiation.
- Sandbox e2e: N/A — in-process asyncio orchestration, no docker/UI/label-routing surface.
- Gates: `make quality` green (16,392 passed), `make scenario`/`scenario-loops` green (335 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)