### PR TITLE
fix(config): env-combo role choices survive the group cascade (fixes #9717)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -3842,8 +3842,15 @@ def _apply_env_overrides(config: HydraFlowConfig) -> None:
             )
             raise ValueError(msg)
         object.__setattr__(config, tool_field, tool)
+        # Register as explicitly-set: object.__setattr__ bypasses Pydantic's
+        # fields-set tracking, so without this the group cascade in
+        # _apply_profile_overrides treats the field as untouched and — when
+        # the env value equals the field default — silently overwrites the
+        # operator's per-role choice (#9717).
+        config.__pydantic_fields_set__.add(tool_field)
         if model:  # empty model only for "inherit"
             object.__setattr__(config, model_field, model)
+            config.__pydantic_fields_set__.add(model_field)
 
     # Data-driven env var overrides (Literal-typed fields)
     for field, env_key in _ENV_LITERAL_OVERRIDES:

--- a/tests/regressions/test_issue_9717.py
+++ b/tests/regressions/test_issue_9717.py
@@ -1,0 +1,62 @@
+"""Issue #9717: env-combo role model clobbered by the group cascade.
+
+``_apply_env_overrides`` sets combo env vars via ``object.__setattr__``,
+which bypasses ``__pydantic_fields_set__``; ``_apply_profile_overrides``
+then sees the field as non-explicit and — when the env-set value equals the
+field default — the BACKGROUND/SYSTEM cascade silently overwrites the
+operator's explicit per-role choice.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from config import HydraFlowConfig
+
+
+def test_explicit_report_issue_combo_survives_background_cascade() -> None:
+    """The original report: HYDRAFLOW_REPORT_ISSUE=claude:opus (== defaults)
+    + HYDRAFLOW_BACKGROUND=claude:sonnet must keep report_issue on opus."""
+    with patch.dict(
+        os.environ,
+        {
+            "HYDRAFLOW_REPORT_ISSUE": "claude:opus",
+            "HYDRAFLOW_BACKGROUND": "claude:sonnet",
+        },
+        clear=False,
+    ):
+        cfg = HydraFlowConfig()
+        assert cfg.report_issue_tool == "claude"
+        assert cfg.report_issue_model == "opus"
+        # The cascade must still reach roles WITHOUT an explicit combo.
+        assert cfg.sentry_model == "sonnet"
+        assert cfg.adr_review_model == "sonnet"
+
+
+def test_explicit_planner_combo_survives_system_cascade() -> None:
+    """Same class under the SYSTEM cascade: planner_model default is opus."""
+    with patch.dict(
+        os.environ,
+        {
+            "HYDRAFLOW_PLANNER": "claude:opus",
+            "HYDRAFLOW_SYSTEM": "claude:sonnet",
+        },
+        clear=False,
+    ):
+        cfg = HydraFlowConfig()
+        assert cfg.planner_tool == "claude"
+        assert cfg.planner_model == "opus"
+        # Non-explicit system-family roles still cascade.
+        assert cfg.review_model == "sonnet"
+
+
+def test_combo_env_fields_registered_as_explicit() -> None:
+    """Combo-set fields must land in __pydantic_fields_set__ — that is the
+    signal _apply_profile_overrides uses to respect operator choices."""
+    with patch.dict(
+        os.environ, {"HYDRAFLOW_REPORT_ISSUE": "claude:opus"}, clear=False
+    ):
+        cfg = HydraFlowConfig()
+        assert "report_issue_tool" in cfg.__pydantic_fields_set__
+        assert "report_issue_model" in cfg.__pydantic_fields_set__


### PR DESCRIPTION
## Summary

`HYDRAFLOW_<ROLE>=tool:model` combo env vars were applied via `object.__setattr__`, which bypasses Pydantic's `__pydantic_fields_set__` tracking. `_apply_profile_overrides` therefore saw those fields as untouched — and whenever the env-set value happened to equal the field default (`HYDRAFLOW_REPORT_ISSUE=claude:opus`, default `opus`), the BACKGROUND/SYSTEM cascade silently overwrote the operator's explicit per-role choice.

First observed in the 2026-06 factory cost audit ("report_issue .env combo silently clobbered by BACKGROUND cascade"); verified still live at HEAD before fixing. Applies to every `_ENV_COMBO_OVERRIDES` role under both cascades.

## Fix

Register combo-env-set tool/model fields in `config.__pydantic_fields_set__` (7 lines in the combo loop) — the cascade's `explicit_fields` guard now respects them, while roles *without* an explicit combo still receive the cascaded value.

Safety verified: the only other `fields_set` consumer (`_resolve_persistence_paths`, state_file/event_log_path) runs *before* env overrides and shares no fields; `HydraFlowConfig` is not frozen; no `exclude_unset` serialization anywhere in `src/`; SYSTEM/BACKGROUND source fields are read by value, never via `fields_set`.

## Testing

- `tests/regressions/test_issue_9717.py` — the exact reported scenario (report_issue + BACKGROUND), the SYSTEM-cascade variant (planner), and the fields-set mechanism invariant. All three verified RED before the fix.
- Full `make quality` green; config suites (277 tests) green.
- Fresh-eyes review: CONVERGED on pass 1.

Fixes #9717

🤖 Generated with [Claude Code](https://claude.com/claude-code)