### PR TITLE
feat(implement): diverse-retry directive on cycling retries (Fix C1)

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -169,8 +169,13 @@ Run through this checklist before your final commit:
         prior_failure: str = "",
         bead_mapping: dict[str, str] | None = None,
         human_guidance: str = "",
+        attempt_number: int = 0,
     ) -> WorkerResult:
         """Run the implementation agent for *task*.
+
+        ``attempt_number`` is the 1-based issue attempt this run represents
+        (0 = unknown); on cycling retries it feeds the diverse-retry
+        directive in the prior-failure prompt section.
 
         Returns a :class:`WorkerResult` with success/failure info.
         """
@@ -202,6 +207,7 @@ Run through this checklist before your final commit:
                 prior_failure=prior_failure,
                 bead_mapping=bead_mapping,
                 human_guidance=human_guidance,
+                attempt_number=attempt_number,
             )
             transcript = await self._execute(
                 cmd,
@@ -579,6 +585,7 @@ Run through this checklist before your final commit:
         prior_failure: str = "",
         bead_mapping: dict[str, str] | None = None,
         human_guidance: str = "",
+        attempt_number: int = 0,
     ) -> tuple[str, dict[str, object]]:
         """Build the implementation prompt and pruning stats."""
         builder = PromptBuilder()
@@ -644,11 +651,27 @@ Run through this checklist before your final commit:
                 label="Prior failure",
             )
             builder.record_history("Prior failure", raw_prior_failure, prior_failure)
+            # Diverse-retry: the attempt budget is 3 near-identical tries
+            # against the same wall unless the retry is told to pivot. The
+            # directive rides the prior-failure section only — review-feedback
+            # retries (which suppress prior_failure) keep their own framing.
+            attempt_line = (
+                f"This is attempt {attempt_number} of "
+                f"{self._config.max_issue_attempts}; the budget exhausts "
+                f"after that and a human is paged. "
+                if attempt_number >= 1
+                else ""
+            )
             prior_failure_section = (
                 f"\n\n## Prior Attempt Failure\n\n"
                 f"Your previous implementation attempt failed with the following error. "
                 f"Avoid repeating the same mistake:\n\n"
-                f"```\n{prior_failure}\n```"
+                f"```\n{prior_failure}\n```\n\n"
+                f"{attempt_line}"
+                f"Do NOT retry the same approach: first diagnose why the "
+                f"previous attempt failed, then take a materially different "
+                f"strategy — a different design, different files, or a "
+                f"different diagnosis of the root cause."
             )
 
         comments_section = ""

--- a/src/implement_phase.py
+++ b/src/implement_phase.py
@@ -676,6 +676,9 @@ class ImplementPhase:
             "review_feedback": review_feedback,
             "prior_failure": prior_failure,
             "human_guidance": human_guidance,
+            # Diverse-retry: the agent frames its strategy-delta directive
+            # as "attempt N of M" (rendered only when prior_failure is set).
+            "attempt_number": self._state.get_issue_attempts(issue.id),
         }
         if bead_mapping:
             run_kwargs["bead_mapping"] = bead_mapping

--- a/tests/test_agent_advanced.py
+++ b/tests/test_agent_advanced.py
@@ -619,3 +619,53 @@ class TestPriorFailureInPrompt:
         prompt, _ = await runner._build_prompt_with_stats(issue, prior_failure="")
 
         assert "## Prior Attempt Failure" not in prompt
+
+    @pytest.mark.asyncio
+    async def test_retry_includes_attempt_count_and_strategy_delta(
+        self, config, event_bus: EventBus
+    ) -> None:
+        """Diverse-retry: without a strategy-delta directive the attempt
+        budget burns three near-identical tries against the same wall."""
+        runner = AgentRunner(config, event_bus)
+        issue = TaskFactory.create()
+
+        prompt, _ = await runner._build_prompt_with_stats(
+            issue,
+            prior_failure="pytest: 3 failed in tests/test_x.py",
+            attempt_number=2,
+        )
+
+        assert f"attempt 2 of {config.max_issue_attempts}" in prompt
+        assert "materially different strategy" in prompt
+
+    @pytest.mark.asyncio
+    async def test_no_strategy_delta_without_prior_failure(
+        self, config, event_bus: EventBus
+    ) -> None:
+        """The directive rides the prior-failure section — a fresh first
+        attempt (or a review-feedback retry) must not carry it."""
+        runner = AgentRunner(config, event_bus)
+        issue = TaskFactory.create()
+
+        prompt, _ = await runner._build_prompt_with_stats(
+            issue, prior_failure="", attempt_number=2
+        )
+
+        assert "materially different strategy" not in prompt
+
+    @pytest.mark.asyncio
+    async def test_unknown_attempt_number_omits_count(
+        self, config, event_bus: EventBus
+    ) -> None:
+        """attempt_number=0 (caller didn't thread it) keeps the legacy
+        section without a bogus 'attempt 0 of N' line."""
+        runner = AgentRunner(config, event_bus)
+        issue = TaskFactory.create()
+
+        prompt, _ = await runner._build_prompt_with_stats(
+            issue, prior_failure="boom", attempt_number=0
+        )
+
+        assert "## Prior Attempt Failure" in prompt
+        assert "attempt 0" not in prompt
+        assert "materially different strategy" in prompt

--- a/tests/test_implement_phase.py
+++ b/tests/test_implement_phase.py
@@ -508,6 +508,49 @@ class TestWorktreeCreationFailure:
         assert captured_prior_failure == ["Previous attempt failed"]
 
     @pytest.mark.asyncio
+    async def test_cycling_retry_threads_attempt_number(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Diverse-retry: the agent needs the attempt count to frame its
+        strategy-delta directive ('attempt N of M')."""
+        from state import StateTracker
+
+        issue = TaskFactory.create(id=99)
+        state = StateTracker(config.state_file)
+        state.set_worker_result_meta(99, {"error": "Previous attempt failed"})
+        state.increment_issue_attempts(99)
+
+        captured_attempts: list[int] = []
+
+        async def capturing_agent(
+            issue: Task,
+            wt_path: Path,
+            branch: str,
+            worker_id: int = 0,
+            review_feedback: str = "",
+            prior_failure: str = "",
+            attempt_number: int = 0,
+        ) -> WorkerResult:
+            captured_attempts.append(attempt_number)
+            return WorkerResultFactory.create(
+                issue_number=issue.id,
+                success=True,
+                workspace_path=str(wt_path),
+            )
+
+        phase, _mock_wt, _ = make_implement_phase(
+            config, [issue], agent_run=capturing_agent
+        )
+        wt_path = config.workspace_path_for_issue(99)
+        wt_path.mkdir(parents=True, exist_ok=True)
+        phase._state = state
+
+        await phase.run_batch()
+
+        # Setup incremented once; run_batch increments again → attempt 2.
+        assert captured_attempts == [2]
+
+    @pytest.mark.asyncio
     async def test_review_feedback_resets_worktree_to_main(
         self, config: HydraFlowConfig
     ) -> None:

--- a/tests/test_implement_spec_reviewer.py
+++ b/tests/test_implement_spec_reviewer.py
@@ -432,6 +432,7 @@ class TestSpecReviewFeedsNextAttempt:
             prior_failure: str = "",
             bead_mapping: dict[str, str] | None = None,
             human_guidance: str = "",
+            attempt_number: int = 0,
         ) -> WorkerResult:
             captured.append(prior_failure)
             return WorkerResultFactory.create(
@@ -480,6 +481,7 @@ class TestSpecReviewFeedsNextAttempt:
             prior_failure: str = "",
             bead_mapping: dict[str, str] | None = None,
             human_guidance: str = "",
+            attempt_number: int = 0,
         ) -> WorkerResult:
             captured.append(prior_failure)
             return WorkerResultFactory.create(


### PR DESCRIPTION
## Summary

The 3-attempt implement budget burned near-identical tries: retries carried the prior error but no framing. The prior-failure prompt section now includes **"This is attempt N of {max_issue_attempts}; the budget exhausts after that and a human is paged"** plus an explicit strategy-delta directive — diagnose why the previous attempt failed, then take a materially different strategy (different design, different files, or a different root-cause diagnosis).

Scope notes:
- Rides the prior-failure section only. Review-feedback retries (which suppress `prior_failure` by design) keep their own framing; preflight already has per-playbook divergence language (ADR-0063 W1) and renders prior attempts from its audit store — verified before building, so this fills the one genuine gap.
- `attempt_number` threads `implement_phase` → `AgentRunner.run` → `_build_prompt_with_stats`; `0` = unknown (legacy callers) omits the count line. Increment-before-read ordering verified (`_check_attempt_cap` always precedes `_run_implementation`).
- Intake widening to plain HITL issues (C2) needs an ADR-0050 amendment — split to #9721 with the design constraints.

## Review + gates

- Fresh-eyes review: **CONVERGED** pass 1 (caller compatibility incl. MockWorld fakes and the kwargs-absorbing test helper; increment ordering; no injection surface — both values are integers from state/config; no review-feedback leakage; negligible prompt-budget impact).
- `make quality` green (17k tests), `make audit` green (91 PASS / 0 WARN).
- MockWorld scenario layer N/A: prompt-composition change, no label/control-flow surface (unit layer per the established scoping precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)