### PR TITLE
feat(cost): soft-throttle band before the hard-cap kill (Fix I)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,45 +1,45 @@
 {
-  "regenerated_at": "2026-07-07T16:58:31.398978+00:00",
-  "commit_sha": "69bf32e2fa2d0977024d6d6640a8e94040bbd93f",
+  "regenerated_at": "2026-07-08T07:00:50.159534+00:00",
+  "commit_sha": "c267c12e757f33766f0fe0673d091f34ffa4d530",
   "artifacts": {
     "loops.md": {
-      "source_sha": "69bf32e2fa2d0977024d6d6640a8e94040bbd93f"
+      "source_sha": "c267c12e757f33766f0fe0673d091f34ffa4d530"
     },
     "ports.md": {
-      "source_sha": "69bf32e2fa2d0977024d6d6640a8e94040bbd93f"
+      "source_sha": "c267c12e757f33766f0fe0673d091f34ffa4d530"
     },
     "labels.md": {
-      "source_sha": "69bf32e2fa2d0977024d6d6640a8e94040bbd93f"
+      "source_sha": "c267c12e757f33766f0fe0673d091f34ffa4d530"
     },
     "modules.md": {
-      "source_sha": "69bf32e2fa2d0977024d6d6640a8e94040bbd93f"
+      "source_sha": "c267c12e757f33766f0fe0673d091f34ffa4d530"
     },
     "events.md": {
-      "source_sha": "69bf32e2fa2d0977024d6d6640a8e94040bbd93f"
+      "source_sha": "c267c12e757f33766f0fe0673d091f34ffa4d530"
     },
     "adr_xref.md": {
-      "source_sha": "69bf32e2fa2d0977024d6d6640a8e94040bbd93f"
+      "source_sha": "c267c12e757f33766f0fe0673d091f34ffa4d530"
     },
     "mockworld.md": {
-      "source_sha": "69bf32e2fa2d0977024d6d6640a8e94040bbd93f"
+      "source_sha": "c267c12e757f33766f0fe0673d091f34ffa4d530"
     },
     "changelog.md": {
-      "source_sha": "69bf32e2fa2d0977024d6d6640a8e94040bbd93f"
+      "source_sha": "c267c12e757f33766f0fe0673d091f34ffa4d530"
     },
     "coverage_matrix.md": {
-      "source_sha": "69bf32e2fa2d0977024d6d6640a8e94040bbd93f"
+      "source_sha": "c267c12e757f33766f0fe0673d091f34ffa4d530"
     },
     "adr-conformance.md": {
-      "source_sha": "69bf32e2fa2d0977024d6d6640a8e94040bbd93f"
+      "source_sha": "c267c12e757f33766f0fe0673d091f34ffa4d530"
     },
     "functional_areas.md": {
-      "source_sha": "69bf32e2fa2d0977024d6d6640a8e94040bbd93f"
+      "source_sha": "c267c12e757f33766f0fe0673d091f34ffa4d530"
     },
     "ubiquitous-language.md": {
-      "source_sha": "69bf32e2fa2d0977024d6d6640a8e94040bbd93f"
+      "source_sha": "c267c12e757f33766f0fe0673d091f34ffa4d530"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "69bf32e2fa2d0977024d6d6640a8e94040bbd93f"
+      "source_sha": "c267c12e757f33766f0fe0673d091f34ffa4d530"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,16 +6,11 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W28
 
-- `69bf32e` — feat(auto-tighten): enable AutoTightenLoop by default (actuation e2e-verified) *(2026-07-07)*
-- `924cd79` — docs(adr): ADR-0104 auto-tightening ratchet *(2026-07-07)*
+- `4768add` — feat(auto-tighten): auto-tightening ratchet loop (coverage floor, ADR-0104) (#9713) (#9713) *(2026-07-07)*
 
 ## 2026-W27
 
-- `9c7d77b` — feat(auto-tighten): wire loop into registry/orchestrator/dashboard + gh closures *(2026-07-05)*
-- `e147f67` — feat(auto-tighten): AutoTightenLoop caretaker loop *(2026-07-05)*
-- `a8e53c6` — refactor(auto-tighten): rename RatchetPort to RatchetAdapter (not a hexagonal Port) *(2026-07-05)*
-- `476469c` — feat(auto-tighten): add RatchetPort protocol *(2026-07-05)*
-- `59c88c0` — feat(auto-tighten): add core models *(2026-07-05)*
+- `a963f8f` — feat(steering): enable human-steering by default (#9710 enable-readiness, all 6 phases + allowlist) (#9711) (#9711) *(2026-07-05)*
 - `83cf489` — feat(steering): continuous human-on-the-loop steering channel (ADR-0103, control surface #4) (#9709) (#9709) *(2026-07-04)*
 - `ef22341` — Convergence hardening: real lap signatures, ledger lifecycle, caretaker guards (#9693) (#9706) (#9706) *(2026-07-04)*
 - `ed627b8` — docs(adr): backfill Enforcement for all 59 grandfathered ADRs (drain grandfather set to ∅) (#9696) (#9696) *(2026-07-02)*
@@ -480,10 +475,6 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 ## 2026-W16
 
 - `03cb313` — Phase 0: regression tests + CI prep for staging/RC workflow (#7518) (#7518) *(2026-04-18)*
-
-## 2026-W15
-
-- `6e18c3b` — Issue cache: append-only JSONL mirror with typed record API (#6429) (#6429) *(2026-04-08)*
 
 
 <!-- arch:generated -->

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -20,7 +20,7 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 | `ContractRefreshLoop` | ✅ [0045, 0047] | ✅ [contract-refresh-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_contract_refresh_loop.py` | ✅ in catalog | ✅ `s30_contract_refresh_clean.py` |
 | `ConvergenceOscillationLoop` | ✅ [0096, 0097, 0098] | ❌ | ✅ loops.md | ❌ | ✅ `test_convergence_oscillation_loop.py` | ✅ in catalog | ✅ `s51_convergence_oscillation.py` |
 | `CorpusLearningLoop` | ✅ [0045] | ✅ [corpus-learning-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_corpus_learning_loop.py` | ✅ in catalog | ✅ `s22_corpus_learning_no_escape_issues.py` |
-| `CostBudgetWatcherLoop` | ✅ [0054] | ✅ [architecture.md] | ✅ loops.md | ✅ README.md | ✅ `test_cost_budget_watcher_loop.py` | ✅ in catalog | ✅ `s26_cost_budget_watcher_unlimited.py` |
+| `CostBudgetWatcherLoop` | ✅ [0054] | ✅ [architecture.md, dark-factory.md] | ✅ loops.md | ✅ README.md | ✅ `test_cost_budget_watcher_loop.py` | ✅ in catalog | ✅ `s26_cost_budget_watcher_unlimited.py` |
 | `DependabotMergeLoop` | ✅ [0054, 0057, 0058] | ✅ [dependabot-merge-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_dependabot_merge_loop.py` | ✅ in catalog | ✅ `s09_dependabot_auto_merge.py` |
 | `DiagnosticLoop` | ✅ [0050] | ✅ [diagnostic-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_diagnostic_loop.py` | ✅ in catalog | ✅ `s05_hitl_after_review_exhaustion.py` |
 | `DiagramLoop` | ✅ [0001, 0093] | ✅ [diagram-loop.md, patterns.md] | ✅ loops.md | ✅ README.md | ✅ `test_diagram_loop.py` | ✅ in catalog | ✅ `s34_diagram_loop_no_changes.py` |

--- a/docs/wiki/dark-factory.md
+++ b/docs/wiki/dark-factory.md
@@ -255,6 +255,19 @@ has merge conflicts" if main moved during CI. The `--auto` flag is the
 ideal recipe but only works if the repo enables it; otherwise, monitor
 CI completion and manually merge.
 
+### 4.7 Cost-watcher operator-override windows
+
+CostBudgetWatcherLoop takes authorship of two reversible actions — the
+hard-cap **kill** (`set_enabled False`) and the soft-band **throttle**
+(interval stretch, `cost_throttled_workers` priors). In both cases an
+operator change made *inside the window* is silently superseded on
+recovery: a worker manually disabled after we killed it gets re-enabled;
+an interval changed mid-throttle is overwritten by the pre-throttle
+value (None → cleared to the loop default). Detecting either would need
+an event log keyed on (name, source, timestamp) for every control-plane
+write. Accepted trade-off: the windows are short (band crossings move at
+rolling-24h speed) and recovery restores the pre-window operator intent.
+
 ## §5 — Verifying the contract is honored
 
 Auto-discovery tests that fail when a load-bearing convention is broken:

--- a/src/bg_worker_manager.py
+++ b/src/bg_worker_manager.py
@@ -142,6 +142,18 @@ class BGWorkerManager:
         self._bg_worker_intervals[name] = seconds
         self._state.set_worker_intervals(dict(self._bg_worker_intervals))
 
+    def clear_interval(self, name: str) -> None:
+        """Remove a dynamic interval override and persist (no-op if absent).
+
+        The loop falls back to its own ``_get_default_interval()`` — used by
+        the cost-throttle recovery path to undo a stretch the operator never
+        asked for.
+        """
+        if name not in self._bg_worker_intervals:
+            return
+        del self._bg_worker_intervals[name]
+        self._state.set_worker_intervals(dict(self._bg_worker_intervals))
+
     def get_interval(self, name: str) -> int:
         """Return the effective interval for a background worker.
 

--- a/src/config.py
+++ b/src/config.py
@@ -409,6 +409,7 @@ _ENV_FLOAT_RATIO_OVERRIDES: list[tuple[str, str, float]] = [
     ("visual_warn_threshold", "HYDRAFLOW_VISUAL_WARN_THRESHOLD", 0.05),
     ("visual_fail_threshold", "HYDRAFLOW_VISUAL_FAIL_THRESHOLD", 0.15),
     ("loop_anomaly_tick_error_ratio", "HYDRAFLOW_LOOP_ANOMALY_TICK_ERROR_RATIO", 0.2),
+    ("cost_throttle_ratio", "HYDRAFLOW_COST_THROTTLE_RATIO", 0.8),
 ]
 
 _ENV_BOOL_OVERRIDES: list[tuple[str, str, bool]] = [
@@ -1317,6 +1318,18 @@ class HydraFlowConfig(BaseModel):
             "Soft daily cost budget (USD). When the last-24h machinery "
             "cost exceeds this, ReportIssueLoop files a hydraflow-find "
             "issue with label cost-budget-exceeded. None disables the check."
+        ),
+    )
+    cost_throttle_ratio: float = Field(
+        default=0.8,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Fraction of daily_cost_budget_usd at which CostBudgetWatcherLoop "
+            "starts soft-throttling caretaker loops (interval-stretch) before "
+            "the hard-cap kill. 0 disables throttling; no effect when "
+            "daily_cost_budget_usd is None. "
+            "Env: HYDRAFLOW_COST_THROTTLE_RATIO."
         ),
     )
     issue_cost_alert_usd: float | None = Field(

--- a/src/cost_budget_watcher_loop.py
+++ b/src/cost_budget_watcher_loop.py
@@ -44,6 +44,10 @@ logger = logging.getLogger(__name__)
 
 _KILL_SWITCH_ENV = "HYDRAFLOW_DISABLE_COST_BUDGET_WATCHER"
 _ISSUE_TITLE = "[cost-budget] daily cap exceeded"
+# Soft-throttle interval stretch applied in the band
+# [cap * cost_throttle_ratio, cap]. Fixed module constant (not a knob):
+# the point is a coarse degrade-before-kill, not a tunable SLA.
+_THROTTLE_MULTIPLIER = 4
 # Curated list of loops the watcher gates. The watcher itself is NOT in
 # this set — it must keep running to detect recovery. Pipeline loops
 # (triage/plan/implement/review) are also out — their gating is via
@@ -150,6 +154,9 @@ class CostBudgetWatcherLoop(BaseBackgroundLoop):
         await self._close_issue_if_open(cap=cap, total=total)
 
         if previously_killed:
+            # Revived loops come back into the CURRENT band: if spend is
+            # still in the throttle band, the next tick stretches them —
+            # revive-throttled, not revive-full-cadence.
             await self._reenable_caretakers(previously_killed)
             return {
                 "action": "recovered",
@@ -158,7 +165,82 @@ class CostBudgetWatcherLoop(BaseBackgroundLoop):
                 "reenabled_count": len(previously_killed),
             }
 
+        # Soft-throttle band: a cost-killed loop is a blind spot, so degrade
+        # BEFORE the hard cap — stretch caretaker intervals to shed spend
+        # while keeping every detector alive.
+        ratio = self._config.cost_throttle_ratio
+        throttled_priors = dict(self._state.get_cost_throttled_workers() or {})
+        if ratio and total >= cap * ratio:
+            newly = self._throttle_caretakers(throttled_priors)
+            return {
+                "action": "throttled",
+                "cap": cap,
+                "total": total,
+                "threshold": cap * ratio,
+                "throttled_count": len(throttled_priors),
+                "newly_throttled": newly,
+            }
+
+        if throttled_priors:
+            self._restore_throttled_intervals(throttled_priors)
+            return {
+                "action": "unthrottled",
+                "cap": cap,
+                "total": total,
+                "restored_count": len(throttled_priors),
+            }
+
         return {"action": "ok", "cap": cap, "total": total}
+
+    def _throttle_caretakers(self, priors: dict[str, int | None]) -> int:
+        """Stretch every un-throttled target's interval; save the prior override.
+
+        Idempotent across ticks: workers already in *priors* are skipped, so
+        the multiplier never compounds. The saved value is the operator's
+        pre-throttle override (None = there was none) for exact restore.
+        """
+        newly = 0
+        for name in _TARGET_WORKERS:
+            if name in priors:
+                continue
+            prior_override = self._bg_workers.worker_intervals.get(name)
+            base = self._bg_workers.get_interval(name)
+            self._bg_workers.set_interval(name, base * _THROTTLE_MULTIPLIER)
+            priors[name] = prior_override
+            newly += 1
+        if newly:
+            self._state.set_cost_throttled_workers(priors)
+            logger.warning(
+                "CostBudgetWatcher: soft-throttled %d caretaker loop(s) "
+                "(interval x%d) — spend entered the throttle band",
+                newly,
+                _THROTTLE_MULTIPLIER,
+            )
+        return newly
+
+    def _restore_throttled_intervals(self, priors: dict[str, int | None]) -> None:
+        """Undo the throttle: restore PRE-THROTTLE overrides, clear ours.
+
+        **Known gotcha:** if the operator changed a worker's interval via
+        the UI *during* the throttle window, that change is silently lost
+        here — we restore the value in effect before the throttle was
+        applied (None = no override, so ``clear_interval`` falls back to
+        the loop default). Detecting a mid-throttle operator change would
+        need an event log keyed on (name, source, timestamp). Mirrors the
+        ``_reenable_caretakers`` kill-window gotcha; both documented in
+        dark-factory.md as the cost-watcher operator-override gotcha.
+        """
+        for name, prior in priors.items():
+            if prior is None:
+                self._bg_workers.clear_interval(name)
+            else:
+                self._bg_workers.set_interval(name, prior)
+        self._state.set_cost_throttled_workers({})
+        logger.info(
+            "CostBudgetWatcher: spend left the throttle band — restored "
+            "%d caretaker interval(s)",
+            len(priors),
+        )
 
     async def _kill_caretakers(self, previously_killed: set[str]) -> set[str]:
         """Disable every _TARGET_WORKERS member; persist the set we touched."""

--- a/src/models.py
+++ b/src/models.py
@@ -2007,6 +2007,16 @@ class StateData(BaseModel):
             "Preserved across restart."
         ),
     )
+    cost_throttled_workers: dict[str, int | None] = Field(
+        default_factory=dict,
+        description=(
+            "Workers interval-stretched by CostBudgetWatcherLoop in the "
+            "soft-throttle band (spend >= cap * cost_throttle_ratio). Maps "
+            "worker name to its PRE-throttle interval override (None = the "
+            "operator had none), so recovery restores exactly. Preserved "
+            "across restart."
+        ),
+    )
     interrupted_issues: dict[str, str] = Field(default_factory=dict)
     last_reviewed_shas: dict[str, str] = Field(default_factory=dict)
     pending_reports: list[PendingReport] = Field(default_factory=list)

--- a/src/state/_worker.py
+++ b/src/state/_worker.py
@@ -107,6 +107,15 @@ class WorkerStateMixin:
         self._data.cost_budget_killed_workers = sorted(names)
         self.save()
 
+    def get_cost_throttled_workers(self) -> dict[str, int | None]:
+        """Workers interval-stretched by the cost watcher → pre-throttle override."""
+        return dict(self._data.cost_throttled_workers)
+
+    def set_cost_throttled_workers(self, priors: dict[str, int | None]) -> None:
+        """Persist the throttle map (empty dict = nothing throttled)."""
+        self._data.cost_throttled_workers = dict(priors)
+        self.save()
+
     # --- background worker states ---
 
     def get_worker_heartbeats(self) -> dict[str, PersistedWorkerHeartbeat]:

--- a/tests/test_bg_worker_manager.py
+++ b/tests/test_bg_worker_manager.py
@@ -264,3 +264,17 @@ class TestRestoreMethods:
         manager.update_status("x", "ok")
         manager.update_status("y", "idle")
         assert manager._known_worker_state_names() == {"x", "y"}
+
+
+class TestClearInterval:
+    def test_removes_override_and_persists(self, manager: BGWorkerManager) -> None:
+        manager.set_interval("memory_sync", 99)
+        manager.clear_interval("memory_sync")
+        assert manager.get_interval("memory_sync") == (
+            manager._config.memory_sync_interval
+        )
+        assert "memory_sync" not in manager._state.get_worker_intervals()
+
+    def test_missing_override_is_noop(self, manager: BGWorkerManager) -> None:
+        manager.clear_interval("never_set")
+        assert "never_set" not in manager._state.get_worker_intervals()

--- a/tests/test_config_cost_budget_fields.py
+++ b/tests/test_config_cost_budget_fields.py
@@ -46,3 +46,14 @@ def test_negative_value_rejected() -> None:
 
     with pytest.raises(ValidationError):
         HydraFlowConfig(daily_cost_budget_usd=-1.0)
+
+
+def test_cost_throttle_ratio_defaults_to_0_8() -> None:
+    cfg = HydraFlowConfig()
+    assert cfg.cost_throttle_ratio == pytest.approx(0.8)
+
+
+def test_cost_throttle_ratio_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("HYDRAFLOW_COST_THROTTLE_RATIO", "0.5")
+    cfg = HydraFlowConfig()
+    assert cfg.cost_throttle_ratio == pytest.approx(0.5)

--- a/tests/test_cost_budget_watcher_loop.py
+++ b/tests/test_cost_budget_watcher_loop.py
@@ -24,8 +24,11 @@ def _make_loop(cap: float | None = None) -> CostBudgetWatcherLoop:
     config = MagicMock()
     config.daily_cost_budget_usd = cap
     config.cost_budget_watcher_loop_enabled = True
+    # Throttle off by default; throttle tests opt in via _make_throttle_loop.
+    config.cost_throttle_ratio = 0.0
     state = MagicMock()
     state.get_cost_budget_killed_workers.return_value = set()
+    state.get_cost_throttled_workers.return_value = {}
     pr_manager = AsyncMock()
     deps = MagicMock()
     loop = CostBudgetWatcherLoop(
@@ -60,3 +63,86 @@ async def test_under_cap_returns_ok() -> None:
     assert result["action"] == "ok"
     assert result["cap"] == 50.0
     assert result["total"] == 20.0
+
+
+def _make_throttle_loop(
+    cap: float = 50.0,
+    ratio: float = 0.8,
+    total: float = 45.0,
+    priors: dict | None = None,
+    intervals: dict | None = None,
+):
+    loop = _make_loop(cap=cap)
+    loop._config.cost_throttle_ratio = ratio
+    loop._state.get_cost_throttled_workers.return_value = dict(priors or {})
+    bg = loop._bg_workers
+    bg.worker_intervals = dict(intervals or {})
+    bg.get_interval.return_value = 600
+    return loop, total
+
+
+@pytest.mark.asyncio
+async def test_throttle_band_stretches_intervals_and_saves_priors() -> None:
+    """cap*ratio <= spend <= cap → stretch every target's interval, saving
+    the pre-throttle override (None = operator had none) for exact restore."""
+    loop, total = _make_throttle_loop(intervals={"repo_wiki": 900})
+    with patch("cost_budget_watcher_loop.build_rolling_24h") as mock_build:
+        mock_build.return_value = {"total": {"cost_usd": total}}
+        result = await loop._do_work()  # noqa: SLF001
+    assert result["action"] == "throttled"
+    loop._bg_workers.set_interval.assert_any_call("repo_wiki", 2400)
+    loop._bg_workers.set_interval.assert_any_call("flake_tracker", 2400)
+    priors = loop._state.set_cost_throttled_workers.call_args.args[0]
+    assert priors["repo_wiki"] == 900  # operator override preserved
+    assert priors["flake_tracker"] is None  # no override before throttle
+
+
+@pytest.mark.asyncio
+async def test_throttle_is_idempotent_across_ticks() -> None:
+    """Already-throttled workers must not be re-stretched (compounding 4x)."""
+    from cost_budget_watcher_loop import _TARGET_WORKERS
+
+    all_priors = dict.fromkeys(_TARGET_WORKERS)
+    loop, total = _make_throttle_loop(priors=all_priors)
+    with patch("cost_budget_watcher_loop.build_rolling_24h") as mock_build:
+        mock_build.return_value = {"total": {"cost_usd": total}}
+        result = await loop._do_work()  # noqa: SLF001
+    assert result["action"] == "throttled"
+    loop._bg_workers.set_interval.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_recovery_below_band_restores_intervals() -> None:
+    """Below cap*ratio: operator overrides restored, throttle-only overrides
+    cleared entirely, state emptied."""
+    loop, _ = _make_throttle_loop(priors={"repo_wiki": 900, "flake_tracker": None})
+    with patch("cost_budget_watcher_loop.build_rolling_24h") as mock_build:
+        mock_build.return_value = {"total": {"cost_usd": 10.0}}
+        result = await loop._do_work()  # noqa: SLF001
+    assert result["action"] == "unthrottled"
+    loop._bg_workers.set_interval.assert_called_once_with("repo_wiki", 900)
+    loop._bg_workers.clear_interval.assert_called_once_with("flake_tracker")
+    loop._state.set_cost_throttled_workers.assert_called_once_with({})
+
+
+@pytest.mark.asyncio
+async def test_over_cap_still_kills_without_touching_throttle() -> None:
+    """The hard cap keeps its kill contract; throttle state survives so
+    revived loops come back throttled, not full-cadence."""
+    loop, _ = _make_throttle_loop(priors={"repo_wiki": None})
+    with patch("cost_budget_watcher_loop.build_rolling_24h") as mock_build:
+        mock_build.return_value = {"total": {"cost_usd": 60.0}}
+        result = await loop._do_work()  # noqa: SLF001
+    assert result["action"] == "killed"
+    loop._bg_workers.set_interval.assert_not_called()
+    loop._bg_workers.clear_interval.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ratio_zero_disables_throttling() -> None:
+    loop, total = _make_throttle_loop(ratio=0.0)
+    with patch("cost_budget_watcher_loop.build_rolling_24h") as mock_build:
+        mock_build.return_value = {"total": {"cost_usd": total}}
+        result = await loop._do_work()  # noqa: SLF001
+    assert result["action"] == "ok"
+    loop._bg_workers.set_interval.assert_not_called()

--- a/tests/test_cost_budget_watcher_scenario.py
+++ b/tests/test_cost_budget_watcher_scenario.py
@@ -19,9 +19,11 @@ def _build_loop(*, cap: float | None = None):
         find_existing_issue=AsyncMock(return_value=0),
         create_issue=AsyncMock(return_value=0),
     )
+    config.cost_throttle_ratio = 0.0  # throttle tests opt in explicitly
     state = MagicMock()
     state.get_cost_budget_killed_workers = MagicMock(return_value=set())
     state.set_cost_budget_killed_workers = MagicMock()
+    state.get_cost_throttled_workers = MagicMock(return_value={})
     state.get_disabled_workers = MagicMock(return_value=set())
     deps = MagicMock()
     # Construct without bg_workers (chicken-and-egg per HealthMonitorLoop /
@@ -186,3 +188,44 @@ async def test_under_cap_no_close_when_no_open_issue() -> None:
         mock_rolling.return_value = {"total": {"cost_usd": 3.0}}
         await loop._do_work()
     pr.close_issue.assert_not_awaited()
+
+
+async def test_throttle_lifecycle_band_then_recovery() -> None:
+    """Full soft-throttle lifecycle: spend enters the band (stretch, priors
+    saved), stays (idempotent), drops below (exact restore) — detectors
+    stay ALIVE the whole time (no set_enabled calls)."""
+    loop, bg, pr, state = _build_loop(cap=10.0)
+    loop._config.cost_throttle_ratio = 0.8
+    bg.worker_intervals = {"repo_wiki": 900}
+    bg.get_interval = MagicMock(return_value=900)
+    priors_store: dict = {}
+    state.get_cost_throttled_workers = MagicMock(side_effect=lambda: dict(priors_store))
+    state.set_cost_throttled_workers = MagicMock(
+        side_effect=lambda p: (priors_store.clear(), priors_store.update(p))
+    )
+
+    with patch("cost_budget_watcher_loop.build_rolling_24h") as mock_rolling:
+        # Tick 1 — enter the band.
+        mock_rolling.return_value = {"total": {"cost_usd": 9.0}}
+        r1 = await loop._do_work()
+        assert r1["action"] == "throttled"
+        assert r1["newly_throttled"] > 0
+        bg.set_interval.assert_any_call("repo_wiki", 3600)
+        assert priors_store["repo_wiki"] == 900
+
+        # Tick 2 — still in the band: no re-stretch.
+        bg.set_interval.reset_mock()
+        r2 = await loop._do_work()
+        assert r2["action"] == "throttled"
+        assert r2["newly_throttled"] == 0
+        bg.set_interval.assert_not_called()
+
+        # Tick 3 — spend fell below the band: exact restore.
+        mock_rolling.return_value = {"total": {"cost_usd": 2.0}}
+        r3 = await loop._do_work()
+        assert r3["action"] == "unthrottled"
+        bg.set_interval.assert_any_call("repo_wiki", 900)
+        assert priors_store == {}
+
+    # The whole lifecycle never killed anything.
+    bg.set_enabled.assert_not_called()

--- a/tests/test_restart_resume.py
+++ b/tests/test_restart_resume.py
@@ -298,3 +298,24 @@ class TestCostBudgetKilledWorkersPersistence:
             "watcher_killed_a",
             "watcher_killed_b",
         }
+
+
+class TestCostThrottledWorkersState:
+    def test_round_trips_priors_including_none(self, tmp_path: Path) -> None:
+        from state import StateTracker
+
+        st = StateTracker(tmp_path / "state.json")
+        st.set_cost_throttled_workers({"repo_wiki": 900, "flake_tracker": None})
+        reloaded = StateTracker(tmp_path / "state.json")
+        assert reloaded.get_cost_throttled_workers() == {
+            "repo_wiki": 900,
+            "flake_tracker": None,
+        }
+
+    def test_clearable(self, tmp_path: Path) -> None:
+        from state import StateTracker
+
+        st = StateTracker(tmp_path / "state.json")
+        st.set_cost_throttled_workers({"repo_wiki": None})
+        st.set_cost_throttled_workers({})
+        assert st.get_cost_throttled_workers() == {}

--- a/tests/test_state_tracking.py
+++ b/tests/test_state_tracking.py
@@ -53,6 +53,7 @@ class TestInitialization:
             "ci_monitor_settings",
             "ci_monitor_tracked_failures",
             "cost_budget_killed_workers",
+            "cost_throttled_workers",
             "default_disabled_workers_seeded",
             "disabled_workers",
             "epic_states",


### PR DESCRIPTION
## Summary

A cost-killed loop is a blind spot — and blind spots are how six-day dead-letter escalations happen. At spend ≥ `cap × cost_throttle_ratio` (new config field, default 0.8, `HYDRAFLOW_COST_THROTTLE_RATIO`, 0 disables) the CostBudgetWatcherLoop now stretches every `_TARGET_WORKERS` interval ×4 instead of waiting for the cap: every detector stays alive at reduced cadence. The hard-cap kill contract is unchanged, and loops revived from a kill re-enter the *current* band — revive-throttled, not revive-full-cadence.

## Mechanics

- **Exact restore**: the pre-throttle override (`None` = operator had none) persists per worker in new StateData field `cost_throttled_workers`; recovery below the band restores operator overrides and clears throttle-only ones via new `BGWorkerManager.clear_interval`. Idempotent across ticks (no ×4 compounding — priors membership is the guard).
- Fixed `_THROTTLE_MULTIPLIER = 4` module constant (coarse degrade-before-kill, not a tunable SLA).
- Env override rides `_ENV_FLOAT_RATIO_OVERRIDES` (tuple default == Field default per the #9432 invariant).

## Review + gates

- Fresh-eyes review: one material finding — the restore path silently supersedes mid-throttle operator interval changes (same class as the documented kill-window gotcha). Fixed as documented behavior: explicit docstring + new dark-factory.md §4.7 covering BOTH operator-override windows (also fulfilling `_reenable_caretakers`' previously-stale doc promise). Everything else traced clean: compounding guard, restart-persistence coherence, env semantics, kill-path interaction.
- `make quality` green (17k tests incl. state-keys pin + curated-drift after arch-regen), audit 91 PASS / 0 WARN, scenario suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)