### PR TITLE
fix(scaffold): bring scaffold_loop up to the current ratchets (13 wiring sites)

### DIFF
--- a/docs/wiki/dark-factory.md
+++ b/docs/wiki/dark-factory.md
@@ -283,10 +283,22 @@ scaffold scripts that generate boilerplate with all the conventions
 correct, conformance tests that catch contract drift, pre-commit checks
 that block the most common omissions.
 
-See ADR-0051 (when written) for the formal "iterative production-readiness
-review" process and the planned infrastructure improvements
-(`BaseSubprocessRunner`, `scripts/scaffold-loop.py`, auto-PRPort
-conformance, subagent-verify wrapper, pre-commit arch-regen).
+See ADR-0051 for the formal "iterative production-readiness review"
+process. The infrastructure improvements this section originally planned
+have since SHIPPED — check for the current state before rebuilding any of
+them (two 2026-07 sessions nearly did):
+
+- `BaseSubprocessRunner` (`src/runners/base_subprocess_runner.py`, #8446)
+  — auto-applies `reraise_on_credit_or_bug` + telemetry ordering.
+- `scripts/scaffold_loop.py` + `scripts/scaffold_templates/` (#8448) —
+  atomic five-checkpoint patcher; template kept current with the ratchets
+  (kill-switch gate order, `loop_fitness` override).
+- Conformance ratchets: `tests/test_loop_wiring_completeness.py`,
+  `tests/test_loop_fitness_completeness.py`,
+  `tests/test_loop_kill_switch_completeness.py`, Port↔Fake signature
+  conformance (#8446).
+
+Still open: subagent-verify wrapper, pre-commit arch-regen.
 
 ## Onboarding a foreign managed repo
 

--- a/scripts/scaffold_loop.py
+++ b/scripts/scaffold_loop.py
@@ -19,7 +19,7 @@ asks `Apply? [y/N]`. Use `--apply` to skip the prompt (for CI).
 The script:
 1. Refuses to run on a dirty working tree.
 2. Renders three new files from scripts/scaffold_templates/.
-3. Patches the ten wiring sites (models.py, state/__init__.py, config.py,
+3. Patches the thirteen wiring sites (models.py, state/__init__.py, config.py,
    service_registry.py, orchestrator.py, ui constants, _common.py,
    scenario catalog, functional_areas.yml, tests/helpers.py). The spec's
    "five-checkpoint" terminology refers to the original wiring categories;
@@ -197,7 +197,7 @@ def _compute_patches(names: dict[str, str], description: str) -> list[tuple[Path
             f"    {snake}_loop: {pascal}Loop\n",
         )
     construction = (
-        f"    {snake}_loop = {pascal}Loop(  # noqa: F841\n"
+        f"    {snake}_loop = {pascal}Loop(\n"
         f"        config=config,\n"
         f"        state=state,\n"
         f"        deps=loop_deps,\n"
@@ -278,6 +278,29 @@ def _compute_patches(names: dict[str, str], description: str) -> list[tuple[Path
         )
     patches.append((common_path, common_text))
 
+    # 7b. src/dashboard_routes/_control_routes.py — _bg_worker_defs.
+    # Required by tests/test_loop_wiring_completeness.py
+    # (TestBgWorkerDefsParity) — caught missing on the first scaffold
+    # dogfood (detector_calibration).
+    ctrl_path = REPO_ROOT / "src/dashboard_routes/_control_routes.py"
+    ctrl_text = ctrl_path.read_text()
+    # Anchor after a stable caretaker entry, NOT the list head — the
+    # first seven entries are pipeline workers pinned by
+    # tests/test_bg_worker_status.py (detector_calibration dogfood finding).
+    defs_marker = '        "wiki_rot_detector",\n'
+    if defs_marker in ctrl_text:
+        entry = (
+            f"    (\n"
+            f'        "{snake}",\n'
+            f'        "{name_title}",\n'
+            f'        "{description}",\n'
+            f"    ),\n"
+        )
+        anchor_end = ctrl_text.index(defs_marker)
+        anchor_end = ctrl_text.index("),\n", anchor_end) + len("),\n")
+        ctrl_text = ctrl_text[:anchor_end] + entry + ctrl_text[anchor_end:]
+    patches.append((ctrl_path, ctrl_text))
+
     # 8. tests/scenarios/catalog/loop_registrations.py — _build_NAME + _BUILDERS.
     cat_path = REPO_ROOT / "tests/scenarios/catalog/loop_registrations.py"
     cat_text = cat_path.read_text()
@@ -302,6 +325,34 @@ def _compute_patches(names: dict[str, str], description: str) -> list[tuple[Path
             f'    "{snake}": _build_{snake},',
         )
     patches.append((cat_path, cat_text))
+
+    # 8b. tests/orchestrator_integration_utils.py — fake ServiceRegistry attr.
+    # A new loop missing here AttributeErrors every orchestrator integration
+    # test (detector_calibration dogfood finding).
+    fake_svc_path = REPO_ROOT / "tests/orchestrator_integration_utils.py"
+    fake_svc_text = fake_svc_path.read_text()
+    fake_marker = "    services.wiki_rot_detector_loop = FakeBackgroundLoop()\n"
+    if fake_marker in fake_svc_text:
+        fake_svc_text = fake_svc_text.replace(
+            fake_marker,
+            fake_marker + f"    services.{snake}_loop = FakeBackgroundLoop()\n",
+            1,
+        )
+    patches.append((fake_svc_path, fake_svc_text))
+
+    # 8c. tests/test_state_tracking.py — StateData keys pin. The scaffold
+    # adds {snake}_attempts to StateData (site 1), so the pin must learn it
+    # (detector_calibration dogfood finding).
+    keys_pin_path = REPO_ROOT / "tests/test_state_tracking.py"
+    keys_pin_text = keys_pin_path.read_text()
+    pin_marker = '"cost_budget_killed_workers",\n'
+    if pin_marker in keys_pin_text:
+        keys_pin_text = keys_pin_text.replace(
+            pin_marker,
+            pin_marker + f'            "{snake}_attempts",\n',
+            1,
+        )
+    patches.append((keys_pin_path, keys_pin_text))
 
     # 9. docs/arch/functional_areas.yml — append to the autonomy area's loops list.
     fa_path = REPO_ROOT / "docs/arch/functional_areas.yml"

--- a/scripts/scaffold_templates/loop.py.j2
+++ b/scripts/scaffold_templates/loop.py.j2
@@ -11,6 +11,7 @@ from typing import Any
 
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import HydraFlowConfig
+from loop_fitness import Confidence, FitnessContext, FitnessKind, LoopFitness
 
 logger = logging.getLogger("hydraflow.{{ snake }}")
 
@@ -35,6 +36,25 @@ class {{ pascal }}Loop(BaseBackgroundLoop):
 
     def _get_default_interval(self) -> int:
         return self._config.{{ snake }}_interval
+
+    def loop_fitness(self, ctx: FitnessContext) -> LoopFitness:
+        """HOUSEKEEPING fitness (no normalized objective yet).
+
+        Required override — new loops are NOT grandfathered by
+        tests/test_loop_fitness_completeness.py. When this loop gains a
+        measurable objective, switch to FitnessKind.SCORED with real
+        components. Must stay PURE over ``ctx`` — no network, no clock,
+        no mutable ``self`` state (the deferred optimizer replays history
+        through it).
+        """
+        return LoopFitness(
+            worker_name=self._worker_name,
+            kind=FitnessKind.HOUSEKEEPING,
+            components={},
+            sample_count=0,
+            confidence=Confidence.INSUFFICIENT_DATA,
+            timestamp=ctx.window_end,
+        )
 
     async def _do_work(self) -> dict[str, Any] | None:
         # ADR-0049 in-body kill-switch (universal mandate).

--- a/tests/test_scaffold_loop.py
+++ b/tests/test_scaffold_loop.py
@@ -92,3 +92,108 @@ def test_names_helper_produces_expected_variants() -> None:
     assert names["upper"] == "BLARG_MONITOR"
     # `today` is dynamic — just check it's set.
     assert names["today"]
+
+
+def test_loop_template_defines_loop_fitness_override(
+    fixture_names: dict[str, str],
+) -> None:
+    """New loops are NOT grandfathered by test_loop_fitness_completeness —
+    a scaffolded loop without a loop_fitness override fails the ratchet on
+    its very first CI run. The template must emit one (HOUSEKEEPING
+    default; scored loops customize)."""
+    import ast
+    from importlib import import_module
+
+    scaffold_loop = import_module("scaffold_loop")
+    rendered = scaffold_loop._render_templates(fixture_names, "Fixture description.")
+    loop_path = next(p for p in rendered if p.name == "fixture_loop_loop.py")
+    content = rendered[loop_path]
+
+    tree = ast.parse(content)
+    cls = next(n for n in tree.body if isinstance(n, ast.ClassDef))
+    names = {
+        n.name
+        for n in cls.body
+        if isinstance(n, ast.FunctionDef | ast.AsyncFunctionDef)
+    }
+    assert "loop_fitness" in names
+    assert "FitnessKind.HOUSEKEEPING" in content
+    assert "worker_name=self._worker_name" in content or (
+        f'worker_name="{fixture_names["snake"]}"' in content
+    )
+
+
+def test_patch_plan_covers_bg_worker_defs(fixture_names: dict[str, str]) -> None:
+    """The wiring-completeness ratchet (TestBgWorkerDefsParity) requires every
+    registry loop in dashboard _bg_worker_defs — caught missing on the first
+    scaffold dogfood (detector_calibration)."""
+    from importlib import import_module
+
+    scaffold_loop = import_module("scaffold_loop")
+    patches = scaffold_loop._compute_patches(fixture_names, "Fixture description.")
+    control_routes = next(
+        (text for path, text in patches if path.name == "_control_routes.py"),
+        None,
+    )
+    assert control_routes is not None
+    assert '"fixture_loop",' in control_routes
+    assert "Fixture Loop" in control_routes
+    # NOT at the list head: the first seven defs are pipeline workers
+    # pinned by tests/test_bg_worker_status.py.
+    assert (
+        not control_routes.split("_bg_worker_defs = [", 1)[1]
+        .lstrip()
+        .startswith('(\n        "fixture_loop"')
+    )
+
+
+def test_patch_plan_covers_fake_service_registry(
+    fixture_names: dict[str, str],
+) -> None:
+    """tests/orchestrator_integration_utils.py builds a fake ServiceRegistry;
+    a new loop missing there AttributeErrors every orchestrator integration
+    test (caught on the detector_calibration dogfood)."""
+    from importlib import import_module
+
+    scaffold_loop = import_module("scaffold_loop")
+    patches = scaffold_loop._compute_patches(fixture_names, "Fixture description.")
+    fake_svc = next(
+        (
+            text
+            for path, text in patches
+            if path.name == "orchestrator_integration_utils.py"
+        ),
+        None,
+    )
+    assert fake_svc is not None
+    assert "services.fixture_loop_loop = FakeBackgroundLoop()" in fake_svc
+
+
+def test_patch_plan_covers_state_keys_pin(fixture_names: dict[str, str]) -> None:
+    """tests/test_state_tracking.py pins StateData keys; the scaffold adds
+    a {snake}_attempts field, so it must add the pin entry too (caught on
+    the detector_calibration dogfood)."""
+    from importlib import import_module
+
+    scaffold_loop = import_module("scaffold_loop")
+    patches = scaffold_loop._compute_patches(fixture_names, "Fixture description.")
+    pin = next(
+        (text for path, text in patches if path.name == "test_state_tracking.py"),
+        None,
+    )
+    assert pin is not None
+    assert '"fixture_loop_attempts",' in pin
+
+
+def test_registry_patch_emits_no_f841_noqa(fixture_names: dict[str, str]) -> None:
+    """The constructed loop variable IS used (ServiceRegistry return), so the
+    suppression is dead weight — and the disturbance ratchet blocks new
+    noqa keys per file (detector_calibration dogfood finding)."""
+    from importlib import import_module
+
+    scaffold_loop = import_module("scaffold_loop")
+    patches = scaffold_loop._compute_patches(fixture_names, "Fixture description.")
+    registry = next(
+        text for path, text in patches if path.name == "service_registry.py"
+    )
+    assert "FixtureLoopLoop(  # noqa: F841" not in registry


### PR DESCRIPTION
## Summary

Dogfooding the scaffold on a real new loop (DetectorCalibrationLoop, follow-up PR) surfaced that it had drifted behind the conventions the completeness ratchets now enforce:

- **Template**: emits the required `loop_fitness` override (HOUSEKEEPING default with the SCORED upgrade note) — `test_loop_fitness_completeness` does NOT grandfather new loops, so a scaffolded loop failed the ratchet on its first CI run.
- **Patcher +3 sites** (10 → 13): `_bg_worker_defs` in `_control_routes.py` (TestBgWorkerDefsParity), the fake ServiceRegistry in `tests/orchestrator_integration_utils.py` (a missing attr AttributeErrors every orchestrator integration test), and the StateData keys pin in `tests/test_state_tracking.py` (the scaffold adds `{snake}_attempts`).
- **Docs**: dark-factory.md §6 still listed `BaseSubprocessRunner`, `scaffold-loop.py`, and the conformance ratchets as "planned" — all shipped long ago (#8446/#8448); two sessions this week nearly rebuilt them from the stale list. Now marked SHIPPED with pointers; the genuinely-open items (subagent-verify wrapper, pre-commit arch-regen) kept.

Golden tests pin the template invariants and every new patch-plan entry.

## Gates
`make quality` green ×3 (once per commit), audit 91 PASS / 0 WARN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)