### PR TITLE
feat(audit-chain): crash-window self-healing + writer resilience (convergence findings 1,2,4,8)

### DIFF
--- a/src/approval_records.py
+++ b/src/approval_records.py
@@ -58,7 +58,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 import subprocess_util
@@ -125,6 +125,19 @@ def _login(actor: Any) -> str:
     return ""
 
 
+def _parse_merged_at(value: Any) -> datetime | None:
+    """Parse gh's ISO-8601 ``mergedAt`` (``...Z``); ``None`` if unparseable."""
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed
+
+
 class ApprovalRecordReconciler:
     """Idempotent post-hoc reconciler: merged PR → chained approval record.
 
@@ -155,7 +168,15 @@ class ApprovalRecordReconciler:
             for number in (entry.get("number") for entry in merged)
             if isinstance(number, int)
         }
-        todo = sorted(scanned - recorded)
+        # Retention interplay (CH-1): pruning deletes old approval records,
+        # but old PRs re-enter the sort:updated-desc window whenever they are
+        # labeled/commented. Evidence the operator chose to expire must not
+        # be re-minted with a fresh timestamp, so retention-expired merges
+        # never enter todo. The continuity check below still uses the FULL
+        # scanned set: an expired-but-not-yet-pruned recorded PR remains a
+        # valid continuity anchor.
+        fresh = self._filter_retention_expired(merged)
+        todo = sorted(fresh - recorded)
         # Continuity check: with every scanned PR unrecorded and a non-empty
         # stream, merges may have passed the window horizon unrecorded. The
         # gap becomes chained evidence — silence would let ``verify()`` pass
@@ -275,6 +296,42 @@ class ApprovalRecordReconciler:
         return raw.strip()
 
     # -- record building -----------------------------------------------------
+
+    def _filter_retention_expired(self, merged: list[dict[str, Any]]) -> set[int]:
+        """Scanned PR numbers eligible for recording under the retention floor.
+
+        When ``audit_retention_days_approval_records`` is configured, merges
+        older than the floor are excluded — RunsGC would prune (or already
+        pruned) their evidence, and re-recording would re-date sign-off
+        evidence the operator chose to expire. Fail-safe: a merge whose age
+        cannot be established is kept, never silently expired.
+        """
+        numbers = {
+            number
+            for number in (entry.get("number") for entry in merged)
+            if isinstance(number, int)
+        }
+        retention_days = self._config.audit_retention_days_approval_records
+        if retention_days is None:
+            return numbers
+        cutoff = datetime.now(UTC) - timedelta(days=retention_days)
+        expired: set[int] = set()
+        for entry in merged:
+            number = entry.get("number")
+            if not isinstance(number, int):
+                continue
+            merged_at = _parse_merged_at(entry.get("mergedAt"))
+            if merged_at is not None and merged_at < cutoff:
+                expired.add(number)
+        if expired:
+            logger.info(
+                "Approval records: %d scanned merge(s) older than the %d-day "
+                "retention floor skipped (evidence expired, not re-minted): %s",
+                len(expired),
+                retention_days,
+                sorted(expired)[:10],
+            )
+        return numbers - expired
 
     def _recorded_pr_numbers(self) -> set[int]:
         """Read back every approval ``pr_number`` already in the stream.

--- a/src/approval_records.py
+++ b/src/approval_records.py
@@ -63,6 +63,8 @@ from typing import TYPE_CHECKING, Any
 
 import subprocess_util
 from audit_chain import AuditChain
+from exception_classify import exc_detail
+from subprocess_util import AuthenticationError, CreditExhaustedError
 
 if TYPE_CHECKING:
     from config import HydraFlowConfig
@@ -173,19 +175,51 @@ class ApprovalRecordReconciler:
                 "merged_seen": len(merged),
                 "recorded": 0,
                 "capture_gap_risk": False,
+                "record_failures": 0,
             }
 
         factory_login = await self._fetch_factory_login()
         count = 0
+        failures = 0
+        last_error: Exception | None = None
         for number in todo:
-            detail = await self._fetch_pr_detail(number)
-            self._chain.append(self._build_record(detail, factory_login))
-            count += 1
-        logger.info("Approval records: recorded %d merged PR(s): %s", count, todo[:10])
+            # Per-PR isolation: one poisoned PR (deleted head repo 404,
+            # malformed payload) sits first in the sorted todo forever and
+            # would otherwise fail the whole cycle every tick — starving
+            # every PR behind it of its evidence record (a silent gap the
+            # zero-overlap heuristic cannot see, since overlap still exists).
+            try:
+                detail = await self._fetch_pr_detail(number)
+                self._chain.append(self._build_record(detail, factory_login))
+                count += 1
+            except (AuthenticationError, CreditExhaustedError):
+                # Fatal infrastructure signals (RuntimeError subclasses) must
+                # never be burned as per-PR failures — propagate immediately
+                # so the hosting loop's cycle handler sees them.
+                raise
+            except (RuntimeError, ValueError) as exc:
+                failures += 1
+                last_error = exc
+                logger.warning(
+                    "Approval records: recording PR #%d failed (%s) — "
+                    "continuing with the remaining %d PR(s).",
+                    number,
+                    exc_detail(exc),
+                    len(todo) - count - failures,
+                )
+        if failures and count == 0 and last_error is not None:
+            # Every todo PR failed: this is a gh outage, not per-PR poison.
+            # Propagate so the cycle handler applies its outage semantics.
+            raise last_error
+        if count:
+            logger.info(
+                "Approval records: recorded %d merged PR(s): %s", count, todo[:10]
+            )
         return {
             "merged_seen": len(merged),
             "recorded": count,
             "capture_gap_risk": gap_risk,
+            "record_failures": failures,
         }
 
     # -- gh boundary (raw gh via the shared subprocess helper; no new PRPort

--- a/src/audit_chain.py
+++ b/src/audit_chain.py
@@ -85,6 +85,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import math
 import os
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -211,6 +212,26 @@ def audit_streams(config: HydraFlowConfig) -> tuple[AuditStreamSpec, ...]:
             retention_days=config.audit_retention_days_evidence_packs,
         ),
     )
+
+
+def _coerce_non_finite(value: Any) -> Any:
+    """Recursively replace non-finite floats with string sentinels.
+
+    ``canonical_json`` rejects NaN/Infinity (``allow_nan=False`` is part of
+    the byte-stability pin), but evidence-grade streams must record the
+    event WITH the odd value rather than drop it — so the append path
+    coerces ``nan``/``inf``/``-inf`` to ``"NaN"``/``"Infinity"``/
+    ``"-Infinity"`` before hashing.
+    """
+    if isinstance(value, float) and not math.isfinite(value):
+        if math.isnan(value):
+            return "NaN"
+        return "Infinity" if value > 0 else "-Infinity"
+    if isinstance(value, dict):
+        return {k: _coerce_non_finite(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_coerce_non_finite(v) for v in value]
+    return value
 
 
 def _scrub_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
@@ -560,7 +581,7 @@ class AuditChain:
                 raise ValueError(
                     f"payload must not contain reserved chain field {field_name!r}"
                 )
-        payload = _scrub_payload(record)
+        payload = _scrub_payload(_coerce_non_finite(dict(record)))
         with file_lock(self._lock_path):
             truncated = self._heal_torn_tail()
             prev_hash = self._reconciled_head(truncated_bytes=truncated)
@@ -583,7 +604,12 @@ class AuditChain:
             prev_hash: str | None = None
             for record in records:
                 if prev_hash is None and not _is_chained(record):
-                    lines.append(json.dumps(_scrub_payload(record), sort_keys=True))
+                    lines.append(
+                        json.dumps(
+                            _scrub_payload(_coerce_non_finite(dict(record))),
+                            sort_keys=True,
+                        )
+                    )
                     continue
                 if prev_hash is None:
                     baseline = record.get("prev_hash")
@@ -591,7 +617,9 @@ class AuditChain:
                         baseline if isinstance(baseline, str) else GENESIS_PREV_HASH
                     )
                 payload = _scrub_payload(
-                    {k: v for k, v in record.items() if k not in _HASH_FIELDS}
+                    _coerce_non_finite(
+                        {k: v for k, v in record.items() if k not in _HASH_FIELDS}
+                    )
                 )
                 record_hash = compute_record_hash(payload, prev_hash)
                 lines.append(

--- a/src/audit_chain.py
+++ b/src/audit_chain.py
@@ -63,6 +63,21 @@ Named limitations
   the sidecar, an HMAC key held elsewhere, or periodic head escrow) —
   follow-up hardening, not claimed here. Truncating a stream to zero
   chained records is additionally indistinguishable from a clean rotation.
+
+Crash-window self-healing
+-------------------------
+Two torn states are deterministic artifacts of the two-step append (file
+append, then sidecar store) and are healed rather than reported as breaks:
+an unterminated unparseable FINAL line (``torn_tail`` — interrupted flush;
+truncated on the next mutation) and a sidecar exactly one append behind the
+stream (``sidecar_lag`` — fast-forwarded on the next append). Both are
+``ChainVerifyResult.warnings``, never breaks. Named tolerance this adds: an
+out-of-band writer who appends ONE validly-chained record (correct
+``prev_hash``/``record_hash``) without touching the sidecar now looks like
+sidecar lag instead of a break — such a writer already had everything needed
+to update the sidecar too, so no detection power is lost in practice.
+Mid-file damage, newline-terminated garbage (the #9474 shape), and clean
+tail-record deletion all remain hard breaks.
 """
 
 from __future__ import annotations
@@ -70,7 +85,8 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from dataclasses import dataclass
+import os
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -127,13 +143,19 @@ class ChainBreak:
 
 @dataclass(frozen=True)
 class ChainVerifyResult:
-    """Outcome of walking one stream file's hash chain."""
+    """Outcome of walking one stream file's hash chain.
+
+    ``warnings`` carries non-tamper anomalies (the two deterministic crash
+    windows: ``torn_tail`` and ``sidecar_lag``) that self-heal on the next
+    append; they do not affect ``ok``.
+    """
 
     path: Path
     total_records: int
     chained_records: int
     breaks: tuple[ChainBreak, ...]
     head: str | None
+    warnings: tuple[str, ...] = field(default=())
 
     @property
     def ok(self) -> bool:
@@ -225,10 +247,15 @@ def _parse_timestamp(value: object) -> datetime | None:
 
 
 def _iter_records(path: Path) -> list[tuple[int, str, dict[str, Any] | None]]:
-    """Return ``(record_no, raw_line, parsed-or-None)`` for each non-blank line."""
+    """Return ``(record_no, raw_line, parsed-or-None)`` for each non-blank line.
+
+    Undecodable bytes (a torn multibyte character from an interrupted append,
+    or external corruption) are replaced rather than raising — the affected
+    line simply fails to parse and is classified by the caller.
+    """
     out: list[tuple[int, str, dict[str, Any] | None]] = []
     record_no = 0
-    with path.open("r", encoding="utf-8") as fh:
+    with path.open("r", encoding="utf-8", errors="replace") as fh:
         for raw in fh:
             stripped = raw.strip()
             if not stripped:
@@ -244,6 +271,37 @@ def _iter_records(path: Path) -> list[tuple[int, str, dict[str, Any] | None]]:
     return out
 
 
+def _unterminated_tail_bytes(path: Path) -> bytes:
+    """Return the bytes after the final newline (``b""`` when the file is
+    absent, empty, or newline-terminated)."""
+    try:
+        with path.open("rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            pos = fh.tell()
+            buf = b""
+            chunk = 65536
+            while pos > 0:
+                step = min(chunk, pos)
+                pos -= step
+                fh.seek(pos)
+                buf = fh.read(step) + buf
+                newline = buf.rfind(b"\n")
+                if newline != -1:
+                    return buf[newline + 1 :]
+            return buf
+    except FileNotFoundError:
+        return b""
+
+
+def _parse_tail(tail: bytes) -> dict[str, Any] | None:
+    """Parse an unterminated tail; ``None`` when it is torn (unparseable)."""
+    try:
+        parsed = json.loads(tail.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
 def verify_file(path: Path, expected_head: str | None = None) -> ChainVerifyResult:
     """Walk one stream file and validate its hash chain.
 
@@ -254,18 +312,41 @@ def verify_file(path: Path, expected_head: str | None = None) -> ChainVerifyResu
     as-is (genesis or rotation carry-forward). When *expected_head* is given
     and the file contains chained records, the final ``record_hash`` must
     match it (tail-truncation detection).
+
+    Two deterministic crash windows are classified as ``warnings`` (healthy,
+    self-healing on the next append) instead of breaks:
+
+    * ``torn_tail`` — an unterminated, unparseable FINAL line. The chain
+      writer is the sole writer and appends ``line + "\\n"`` in one call, so
+      an interrupted flush leaves a strict prefix with no terminator; a
+      newline-terminated garbage line (the #9474 shape) stays a break.
+    * ``sidecar_lag`` — *expected_head* matches the final chained record's
+      ``prev_hash`` (crash between the file append and the sidecar store).
     """
     if not path.exists():
         return ChainVerifyResult(
             path=path, total_records=0, chained_records=0, breaks=(), head=None
         )
 
+    warnings: list[str] = []
+    entries = _iter_records(path)
+    tail = _unterminated_tail_bytes(path)
+    if tail and _parse_tail(tail) is None:
+        # Torn tail: a crash artifact, not a record. Exclude it from the walk.
+        if entries and entries[-1][2] is None:
+            entries = entries[:-1]
+        warnings.append(
+            f"torn_tail: unterminated unparseable final line ({len(tail)} "
+            "byte(s)) from an interrupted append — self-heals on next append"
+        )
+
     breaks: list[ChainBreak] = []
     total = 0
     chained = 0
     head: str | None = None
+    last_prev: str | None = None
 
-    for record_no, _raw, record in _iter_records(path):
+    for record_no, _raw, record in entries:
         total = record_no
         if record is None:
             breaks.append(ChainBreak(record_no, "invalid JSON line"))
@@ -300,6 +381,7 @@ def verify_file(path: Path, expected_head: str | None = None) -> ChainVerifyResu
                 )
             )
             head = record_hash
+            last_prev = prev_hash
             chained += 1
             continue
         if recomputed != record_hash:
@@ -307,16 +389,24 @@ def verify_file(path: Path, expected_head: str | None = None) -> ChainVerifyResu
                 ChainBreak(record_no, "record_hash mismatch (record content altered)")
             )
         head = record_hash
+        last_prev = prev_hash
         chained += 1
 
     if expected_head is not None and chained and head != expected_head:
-        breaks.append(
-            ChainBreak(
-                total,
-                "chain head mismatch against sidecar (tail truncated or "
-                "appended out-of-band)",
+        if expected_head == last_prev:
+            warnings.append(
+                "sidecar_lag: chain-head sidecar is exactly one append behind "
+                "the stream (crash between append and head store) — "
+                "self-heals on next append"
             )
-        )
+        else:
+            breaks.append(
+                ChainBreak(
+                    total,
+                    "chain head mismatch against sidecar (tail truncated or "
+                    "appended out-of-band)",
+                )
+            )
 
     return ChainVerifyResult(
         path=path,
@@ -324,6 +414,7 @@ def verify_file(path: Path, expected_head: str | None = None) -> ChainVerifyResu
         chained_records=chained,
         breaks=tuple(breaks),
         head=head,
+        warnings=tuple(warnings),
     )
 
 
@@ -346,23 +437,64 @@ class AuditChain:
 
     # -- head state ---------------------------------------------------------
 
-    def _load_head(self) -> str:
-        """Return the current chain head: sidecar, else last chained record,
-        else genesis (adoption / empty stream)."""
-        head = self._load_sidecar_head()
-        if head is not None:
-            return head
-        if self._path.exists():
-            # One-time self-heal (first post-adoption append, or a sidecar
-            # lost to data migration): recover the head from the last record.
-            entries = _iter_records(self._path)
-            if entries:
-                _no, _raw, record = entries[-1]
-                if record is not None and _is_chained(record):
-                    record_hash = record.get("record_hash")
-                    if isinstance(record_hash, str):
-                        return record_hash
-        return GENESIS_PREV_HASH
+    def _last_chained_record(self) -> tuple[str, str] | None:
+        """Return ``(record_hash, prev_hash)`` of the last parseable chained
+        record in the stream file, or ``None``."""
+        if not self._path.exists():
+            return None
+        for _no, _raw, record in reversed(_iter_records(self._path)):
+            if record is None:
+                continue
+            if not _is_chained(record):
+                return None  # adoption boundary: unchained tail
+            record_hash = record.get("record_hash")
+            prev_hash = record.get("prev_hash")
+            if isinstance(record_hash, str) and isinstance(prev_hash, str):
+                return record_hash, prev_hash
+            return None
+        return None
+
+    def _reconciled_head(self, *, truncated_bytes: int) -> str:
+        """Return the ``prev_hash`` for the next append, healing the
+        deterministic crash windows between the sidecar and the stream.
+
+        * sidecar exactly one behind the last record (crash between file
+          append and sidecar store) → fast-forward the sidecar (INFO);
+        * sidecar ahead of the last parseable record because this append
+          just truncated a torn tail → reset it (WARNING);
+        * any other mismatch is left in place — ``verify()`` reports it as
+          a hard break.
+        """
+        sidecar = self._load_sidecar_head()
+        last = self._last_chained_record()
+        if sidecar is None:
+            # First post-adoption append, or a sidecar lost to migration:
+            # recover the head from the last chained record.
+            return last[0] if last is not None else GENESIS_PREV_HASH
+        if last is None:
+            # Empty / rotated-away / unchained-prefix-only stream: the
+            # sidecar carries the head forward (rotation safety).
+            return sidecar
+        record_hash, prev_hash = last
+        if sidecar == record_hash:
+            return sidecar
+        if sidecar == prev_hash:
+            logger.info(
+                "Chain-head sidecar for %s is one append behind the stream "
+                "(crash between append and head store) — fast-forwarding.",
+                self._path,
+            )
+            self._store_head(record_hash)
+            return record_hash
+        if truncated_bytes:
+            logger.warning(
+                "Chain-head sidecar for %s pointed past the truncated torn "
+                "tail — resetting to the last parseable record.",
+                self._path,
+            )
+            self._store_head(record_hash)
+            return record_hash
+        return sidecar
 
     def _load_sidecar_head(self) -> str | None:
         if not self._head_path.exists():
@@ -384,18 +516,54 @@ class AuditChain:
             ),
         )
 
+    # -- crash-window healing -------------------------------------------------
+
+    def _heal_torn_tail(self) -> int:
+        """Repair an unterminated final line before mutating the stream.
+
+        Must be called under the stream lock. A torn (unparseable) tail is
+        truncated — it can only be the flush prefix of an interrupted append,
+        never a record. An unterminated but *complete* record (crash after
+        the content flushed, before its newline) is terminated in place so no
+        evidence is lost. Returns the number of bytes truncated.
+        """
+        tail = _unterminated_tail_bytes(self._path)
+        if not tail:
+            return 0
+        if _parse_tail(tail) is not None:
+            with self._path.open("ab") as fh:
+                fh.write(b"\n")
+                fh.flush()
+                os.fsync(fh.fileno())
+            logger.info(
+                "Terminated unterminated-but-complete final record in %s "
+                "(interrupted append).",
+                self._path,
+            )
+            return 0
+        size = self._path.stat().st_size
+        os.truncate(self._path, size - len(tail))
+        logger.warning(
+            "Truncated torn tail of %s: %d unparseable trailing byte(s) from "
+            "an interrupted append (crash artifact, not tampering).",
+            self._path,
+            len(tail),
+        )
+        return len(tail)
+
     # -- mutations ----------------------------------------------------------
 
     def append(self, record: Mapping[str, Any]) -> dict[str, Any]:
         """Append *record* to the stream with chain hashes; return the full row."""
-        for field in _HASH_FIELDS:
-            if field in record:
+        for field_name in _HASH_FIELDS:
+            if field_name in record:
                 raise ValueError(
-                    f"payload must not contain reserved chain field {field!r}"
+                    f"payload must not contain reserved chain field {field_name!r}"
                 )
         payload = _scrub_payload(record)
         with file_lock(self._lock_path):
-            prev_hash = self._load_head()
+            truncated = self._heal_torn_tail()
+            prev_hash = self._reconciled_head(truncated_bytes=truncated)
             record_hash = compute_record_hash(payload, prev_hash)
             full = {**payload, "prev_hash": prev_hash, "record_hash": record_hash}
             append_jsonl(self._path, json.dumps(full, sort_keys=True))
@@ -454,6 +622,9 @@ class AuditChain:
         if not self._path.exists():
             return 0
         with file_lock(self._lock_path):
+            # A torn tail (interrupted append) must not block retention
+            # forever; heal it exactly as append() would.
+            self._heal_torn_tail()
             entries = _iter_records(self._path)
             cut = 0
             for _no, _raw, record in entries:

--- a/src/health_monitor_loop.py
+++ b/src/health_monitor_loop.py
@@ -139,9 +139,11 @@ def _write_decision(decisions_dir: Path, record: dict[str, Any]) -> None:
         # Hash-chained append (CH-1, #9729): stamps prev_hash/record_hash so
         # out-of-band edits to the decision trail are detectable.
         AuditChain(decisions_dir / "decisions.jsonl").append(record)
-    except OSError:
-        # Disk full, permission, or other I/O error — the health monitor loop
-        # must not abort over a single failed decision write.
+    except (OSError, ValueError):
+        # Disk full, permission, or other I/O error — plus ValueError from
+        # the chain's serialization paths (incl. json.JSONDecodeError from
+        # secret scrubbing). The health monitor loop must not abort its tick
+        # over a single failed decision write.
         logger.warning(
             "Failed to persist health decision to %s", decisions_dir, exc_info=True
         )

--- a/src/prompt_telemetry.py
+++ b/src/prompt_telemetry.py
@@ -249,7 +249,11 @@ class PromptTelemetry:
             with file_lock(self._lock_file):
                 self._chain.append(record)
                 self._update_pr_stats(record)
-        except OSError:
+        except (OSError, ValueError):
+            # ValueError covers AuditChain serialization failures (incl.
+            # json.JSONDecodeError from scrub paths). record() runs unguarded
+            # in BaseRunner._execute's ``finally`` — telemetry must never
+            # convert a successful agent run into a hard failure.
             logger.warning(
                 "Could not write prompt telemetry to %s",
                 self._inferences_file,

--- a/src/runs_gc_loop.py
+++ b/src/runs_gc_loop.py
@@ -132,7 +132,15 @@ class RunsGCLoop(BaseBackgroundLoop):
                     )
                 )
                 continue
-            status[spec.name] = "ok" if result.chained_records else "empty"
+            # Crash-window warnings (torn_tail / sidecar_lag) are healthy:
+            # they self-heal on the stream's next append and MUST NOT raise
+            # the tamper alert or block retention pruning below.
+            if any(w.startswith("torn_tail") for w in result.warnings):
+                status[spec.name] = "torn_tail"
+            elif any(w.startswith("sidecar_lag") for w in result.warnings):
+                status[spec.name] = "sidecar_lag"
+            else:
+                status[spec.name] = "ok" if result.chained_records else "empty"
             recovered_key = f"audit_chain_break:{spec.name}"
             keys = self._chain_alert_dedup.get()
             if recovered_key in keys:

--- a/tests/scenarios/test_merge_state_watcher_scenario.py
+++ b/tests/scenarios/test_merge_state_watcher_scenario.py
@@ -180,6 +180,7 @@ class TestApprovalRecordScenario:
             "merged_seen": 1,
             "recorded": 1,
             "capture_gap_risk": False,
+            "record_failures": 0,
         }
 
         records = [
@@ -200,5 +201,6 @@ class TestApprovalRecordScenario:
             "merged_seen": 1,
             "recorded": 0,
             "capture_gap_risk": False,
+            "record_failures": 0,
         }
         assert len(config.approval_records_path.read_text().splitlines()) == 1

--- a/tests/test_approval_records.py
+++ b/tests/test_approval_records.py
@@ -537,6 +537,128 @@ class TestCaptureGapDetection:
         ] == []
 
 
+class TestRetentionWindow:
+    """CH-1 retention pruning deletes old approval records, but old PRs
+    re-enter the sort:updated-desc scan window whenever labeled/commented.
+    Evidence the operator chose to expire must not be re-minted with a fresh
+    timestamp — and its absence is not a capture gap."""
+
+    @staticmethod
+    def _iso_days_ago(days: int) -> str:
+        from datetime import UTC, datetime, timedelta
+
+        return (datetime.now(UTC) - timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    @staticmethod
+    def _seed_recorded(config, pr_number: int, *, days_ago: int) -> None:
+        AuditChain(config.approval_records_path).append(
+            {
+                "record_type": "approval",
+                "pr_number": pr_number,
+                "timestamp": TestRetentionWindow._iso_days_ago(days_ago),
+            }
+        )
+
+    async def test_retention_expired_pr_is_not_re_recorded_nor_a_gap(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """A pruned PR re-entering the window: no re-minted record, no
+        capture_gap marker for its absence, no detail fetch at all."""
+        config = ConfigFactory.create(
+            repo_root=tmp_path / "repo",
+            audit_retention_days_approval_records=30,
+        )
+        self._seed_recorded(config, 500, days_ago=1)
+        fake = FakeGh(
+            merged=[{"number": 42, "mergedAt": self._iso_days_ago(60)}],
+            details={},
+        )
+        _install(monkeypatch, fake)
+
+        result = await ApprovalRecordReconciler(config).reconcile()
+
+        assert result == {
+            "merged_seen": 1,
+            "recorded": 0,
+            "capture_gap_risk": False,
+            "record_failures": 0,
+        }
+        records = _read_records(config)
+        assert [r.get("pr_number") for r in records] == [500]
+        assert [r for r in records if r.get("record_type") == "capture_gap"] == []
+        assert fake.calls_starting("gh", "pr", "view") == []
+
+    async def test_expired_but_still_recorded_pr_anchors_continuity(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The zero-overlap detector must keep seeing an expired-but-not-yet-
+        pruned recorded PR as the continuity anchor: fresh merges alongside
+        it are recorded without a spurious gap marker."""
+        config = ConfigFactory.create(
+            repo_root=tmp_path / "repo",
+            audit_retention_days_approval_records=30,
+        )
+        self._seed_recorded(config, 42, days_ago=60)
+        fake = FakeGh(
+            merged=[
+                {"number": 42, "mergedAt": self._iso_days_ago(60)},
+                {"number": 43, "mergedAt": self._iso_days_ago(1)},
+            ],
+            details={43: _detail(43, merged_at=self._iso_days_ago(1))},
+        )
+        _install(monkeypatch, fake)
+
+        result = await ApprovalRecordReconciler(config).reconcile()
+
+        assert result == {
+            "merged_seen": 2,
+            "recorded": 1,
+            "capture_gap_risk": False,
+            "record_failures": 0,
+        }
+        approvals = [
+            r for r in _read_records(config) if r.get("record_type") == "approval"
+        ]
+        assert [r["pr_number"] for r in approvals] == [42, 43]
+
+    async def test_no_retention_configured_records_old_merges(
+        self, config, monkeypatch
+    ) -> None:
+        """retention=None (keep forever, the default) leaves the window
+        unfiltered — old merges are still backfilled."""
+        old = self._iso_days_ago(60)
+        fake = FakeGh(
+            merged=[{"number": 42, "mergedAt": old}],
+            details={42: _detail(42, merged_at=old)},
+        )
+        _install(monkeypatch, fake)
+
+        result = await ApprovalRecordReconciler(config).reconcile()
+
+        assert result["recorded"] == 1
+        assert [r["pr_number"] for r in _read_records(config)] == [42]
+
+    async def test_unparseable_merged_at_is_not_filtered(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """Fail-safe: a PR whose age cannot be established is recorded, never
+        silently expired."""
+        config = ConfigFactory.create(
+            repo_root=tmp_path / "repo",
+            audit_retention_days_approval_records=30,
+        )
+        fake = FakeGh(
+            merged=[{"number": 42, "mergedAt": "not-a-date"}],
+            details={42: _detail(42)},
+        )
+        _install(monkeypatch, fake)
+
+        result = await ApprovalRecordReconciler(config).reconcile()
+
+        assert result["recorded"] == 1
+        assert [r["pr_number"] for r in _read_records(config)] == [42]
+
+
 class TestPerPRErrorIsolation:
     """One poisoned PR (deleted head repo 404, malformed payload) sits first
     in the sorted todo list forever — without isolation it fails the whole

--- a/tests/test_approval_records.py
+++ b/tests/test_approval_records.py
@@ -24,6 +24,7 @@ from approval_records import (
     ApprovalRecordReconciler,
 )
 from audit_chain import AuditChain
+from subprocess_util import AuthenticationError, CreditExhaustedError
 from tests.helpers import ConfigFactory
 
 FACTORY_LOGIN = "hydra-ops-bot"
@@ -154,7 +155,12 @@ class TestRecordShape:
 
         result = await ApprovalRecordReconciler(config).reconcile()
 
-        assert result == {"merged_seen": 1, "recorded": 1, "capture_gap_risk": False}
+        assert result == {
+            "merged_seen": 1,
+            "recorded": 1,
+            "capture_gap_risk": False,
+            "record_failures": 0,
+        }
         records = _read_records(config)
         assert len(records) == 1
         rec = records[0]
@@ -354,7 +360,12 @@ class TestDedupAndIdempotency:
 
         result = await ApprovalRecordReconciler(config).reconcile()
 
-        assert result == {"merged_seen": 1, "recorded": 0, "capture_gap_risk": False}
+        assert result == {
+            "merged_seen": 1,
+            "recorded": 0,
+            "capture_gap_risk": False,
+            "record_failures": 0,
+        }
         assert fake.calls_starting("gh", "pr", "view") == []
         assert fake.calls_starting("gh", "api", "user") == []
 
@@ -426,7 +437,12 @@ class TestDedupAndIdempotency:
 
         result = await ApprovalRecordReconciler(config).reconcile()
 
-        assert result == {"merged_seen": 0, "recorded": 0, "capture_gap_risk": False}
+        assert result == {
+            "merged_seen": 0,
+            "recorded": 0,
+            "capture_gap_risk": False,
+            "record_failures": 0,
+        }
         assert len(fake.calls) == 1
         assert fake.calls[0][:3] == ("gh", "pr", "list")
 
@@ -454,7 +470,12 @@ class TestCaptureGapDetection:
         fake.details = {70: _detail(70)}
         result = await reconciler.reconcile()
 
-        assert result == {"merged_seen": 1, "recorded": 1, "capture_gap_risk": True}
+        assert result == {
+            "merged_seen": 1,
+            "recorded": 1,
+            "capture_gap_risk": True,
+            "record_failures": 0,
+        }
         markers = [
             r for r in _read_records(config) if r.get("record_type") == "capture_gap"
         ]
@@ -482,7 +503,12 @@ class TestCaptureGapDetection:
         fake.details = {10: _detail(10), 11: _detail(11)}
         result = await reconciler.reconcile()
 
-        assert result == {"merged_seen": 2, "recorded": 1, "capture_gap_risk": False}
+        assert result == {
+            "merged_seen": 2,
+            "recorded": 1,
+            "capture_gap_risk": False,
+            "record_failures": 0,
+        }
         assert [
             r for r in _read_records(config) if r.get("record_type") == "capture_gap"
         ] == []
@@ -500,10 +526,115 @@ class TestCaptureGapDetection:
 
         result = await ApprovalRecordReconciler(config).reconcile()
 
-        assert result == {"merged_seen": 1, "recorded": 1, "capture_gap_risk": False}
+        assert result == {
+            "merged_seen": 1,
+            "recorded": 1,
+            "capture_gap_risk": False,
+            "record_failures": 0,
+        }
         assert [
             r for r in _read_records(config) if r.get("record_type") == "capture_gap"
         ] == []
+
+
+class TestPerPRErrorIsolation:
+    """One poisoned PR (deleted head repo 404, malformed payload) sits first
+    in the sorted todo list forever — without isolation it fails the whole
+    cycle every tick and every PR behind it silently loses its evidence
+    record (a gap the zero-overlap heuristic cannot see)."""
+
+    _MERGED = [
+        {"number": 1, "mergedAt": "2026-07-08T10:00:00Z"},
+        {"number": 2, "mergedAt": "2026-07-08T11:00:00Z"},
+        {"number": 3, "mergedAt": "2026-07-08T12:00:00Z"},
+    ]
+
+    async def test_poisoned_first_pr_does_not_starve_later_prs(
+        self, config, monkeypatch
+    ) -> None:
+        fake = FakeGh(
+            merged=self._MERGED,
+            details={
+                1: RuntimeError("gh: HTTP 404 head repository was deleted"),
+                2: _detail(2),
+                3: _detail(3),
+            },
+        )
+        _install(monkeypatch, fake)
+
+        result = await ApprovalRecordReconciler(config).reconcile()
+
+        assert result == {
+            "merged_seen": 3,
+            "recorded": 2,
+            "capture_gap_risk": False,
+            "record_failures": 1,
+        }
+        assert [r["pr_number"] for r in _read_records(config)] == [2, 3]
+        assert AuditChain(config.approval_records_path).verify().ok
+
+    async def test_malformed_payload_value_error_is_isolated(
+        self, config, monkeypatch
+    ) -> None:
+        """A non-dict gh payload raises ValueError — same isolation."""
+        fake = FakeGh(
+            merged=self._MERGED,
+            details={1: ["not", "a", "dict"], 2: _detail(2), 3: _detail(3)},
+        )
+        _install(monkeypatch, fake)
+
+        result = await ApprovalRecordReconciler(config).reconcile()
+
+        assert result["recorded"] == 2
+        assert result["record_failures"] == 1
+        assert [r["pr_number"] for r in _read_records(config)] == [2, 3]
+
+    async def test_every_todo_pr_failing_raises_the_last_error(
+        self, config, monkeypatch
+    ) -> None:
+        """A true gh outage (everything failing) must still propagate to the
+        hosting loop's cycle handler."""
+        fake = FakeGh(
+            merged=self._MERGED,
+            details={
+                1: RuntimeError("gh: HTTP 502 (a)"),
+                2: RuntimeError("gh: HTTP 502 (b)"),
+                3: RuntimeError("gh: HTTP 502 (c)"),
+            },
+        )
+        _install(monkeypatch, fake)
+
+        with pytest.raises(RuntimeError, match=r"502 \(c\)"):
+            await ApprovalRecordReconciler(config).reconcile()
+        assert _read_records(config) == []
+
+    async def test_credit_exhaustion_propagates_immediately(
+        self, config, monkeypatch
+    ) -> None:
+        """CreditExhaustedError is a RuntimeError subclass but must NOT be
+        swallowed as a per-PR failure — burning the rest of the todo list
+        against an exhausted billing signal is the #9432 shape."""
+        fake = FakeGh(
+            merged=self._MERGED,
+            details={1: CreditExhaustedError("credits exhausted"), 2: _detail(2)},
+        )
+        _install(monkeypatch, fake)
+
+        with pytest.raises(CreditExhaustedError):
+            await ApprovalRecordReconciler(config).reconcile()
+        # Stopped immediately: nothing after the fatal signal was fetched.
+        assert _read_records(config) == []
+
+    async def test_auth_error_propagates_immediately(self, config, monkeypatch) -> None:
+        fake = FakeGh(
+            merged=self._MERGED,
+            details={1: AuthenticationError("gh: HTTP 401"), 2: _detail(2)},
+        )
+        _install(monkeypatch, fake)
+
+        with pytest.raises(AuthenticationError):
+            await ApprovalRecordReconciler(config).reconcile()
+        assert _read_records(config) == []
 
 
 class TestOutagesAndGates:
@@ -524,8 +655,8 @@ class TestOutagesAndGates:
     async def test_partial_failure_preserves_progress_and_self_heals(
         self, config, monkeypatch
     ) -> None:
-        """PR 1 records, PR 2's fetch fails → error propagates, PR 1 kept;
-        the next tick records PR 2 without duplicating PR 1."""
+        """PR 1 records, PR 2's fetch fails → cycle completes with the
+        failure counted; the next tick records PR 2 without duplicating PR 1."""
         merged = [
             {"number": 1, "mergedAt": "2026-07-08T10:00:00Z"},
             {"number": 2, "mergedAt": "2026-07-08T11:00:00Z"},
@@ -537,15 +668,26 @@ class TestOutagesAndGates:
         _install(monkeypatch, failing)
         reconciler = ApprovalRecordReconciler(config)
 
-        with pytest.raises(RuntimeError, match="503"):
-            await reconciler.reconcile()
+        first = await reconciler.reconcile()
+
+        assert first == {
+            "merged_seen": 2,
+            "recorded": 1,
+            "capture_gap_risk": False,
+            "record_failures": 1,
+        }
         assert [r["pr_number"] for r in _read_records(config)] == [1]
 
         recovered = FakeGh(merged=merged, details={1: _detail(1), 2: _detail(2)})
         _install(monkeypatch, recovered)
         result = await reconciler.reconcile()
 
-        assert result == {"merged_seen": 2, "recorded": 1, "capture_gap_risk": False}
+        assert result == {
+            "merged_seen": 2,
+            "recorded": 1,
+            "capture_gap_risk": False,
+            "record_failures": 0,
+        }
         assert [r["pr_number"] for r in _read_records(config)] == [1, 2]
         assert AuditChain(config.approval_records_path).verify().ok
 

--- a/tests/test_audit_chain.py
+++ b/tests/test_audit_chain.py
@@ -251,6 +251,55 @@ class TestVerify:
 
 
 # ---------------------------------------------------------------------------
+# Non-finite float coercion (evidence-grade streams must not drop records)
+# ---------------------------------------------------------------------------
+
+
+class TestNonFiniteSanitization:
+    """``canonical_json`` rejects NaN/Infinity (byte-stability pin), so the
+    append path must coerce non-finite floats to string sentinels — the
+    record lands WITH the odd value instead of being dropped."""
+
+    def test_append_coerces_non_finite_floats_to_sentinels(
+        self, tmp_path: Path
+    ) -> None:
+        chain = _stream(tmp_path)
+        chain.append(
+            {
+                "nan": float("nan"),
+                "pos": float("inf"),
+                "neg": float("-inf"),
+                "fine": 1.5,
+            }
+        )
+        (row,) = _read_lines(chain.path)
+        assert row["nan"] == "NaN"
+        assert row["pos"] == "Infinity"
+        assert row["neg"] == "-Infinity"
+        assert row["fine"] == 1.5
+        assert chain.verify().ok
+
+    def test_append_coerces_nested_non_finite_floats(self, tmp_path: Path) -> None:
+        chain = _stream(tmp_path)
+        chain.append({"usage": [{"payload": {"tokens": float("nan")}}]})
+        (row,) = _read_lines(chain.path)
+        assert row["usage"][0]["payload"]["tokens"] == "NaN"
+        assert chain.verify().ok
+
+    def test_rewrite_coerces_non_finite_floats(self, tmp_path: Path) -> None:
+        """Legacy lines may carry bare NaN literals (old json.dumps default
+        allowed them); the sanctioned amendment path must not crash on them."""
+        chain = _stream(tmp_path)
+        chain.append({"n": 1, "outcome": None})
+        records = _read_lines(chain.path)
+        records[0]["outcome"] = float("nan")
+        chain.rewrite(records)
+        (row,) = _read_lines(chain.path)
+        assert row["outcome"] == "NaN"
+        assert chain.verify().ok
+
+
+# ---------------------------------------------------------------------------
 # Crash-window self-healing (torn tail + sidecar lag)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_audit_chain.py
+++ b/tests/test_audit_chain.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -40,6 +41,27 @@ def _write_lines(path: Path, rows: list[dict[str, object]]) -> None:
         "".join(json.dumps(r, sort_keys=True) + "\n" for r in rows),
         encoding="utf-8",
     )
+
+
+def _sidecar(path: Path) -> Path:
+    return path.with_name(path.name + ".chainhead.json")
+
+
+def _set_sidecar_head(path: Path, head: str) -> None:
+    _sidecar(path).write_text(json.dumps({"head": head}), encoding="utf-8")
+
+
+def _tear_tail(path: Path, torn_bytes: bytes) -> None:
+    """Simulate a crash mid-append: unterminated garbage after the last record."""
+    with path.open("ab") as fh:
+        fh.write(torn_bytes)
+
+
+def _strip_final_newline(path: Path) -> None:
+    """Simulate a crash that flushed a full record but not its terminator."""
+    data = path.read_bytes()
+    assert data.endswith(b"\n")
+    path.write_bytes(data[:-1])
 
 
 # ---------------------------------------------------------------------------
@@ -226,6 +248,233 @@ class TestVerify:
         assert result.ok
         assert result.total_records == 2
         assert result.chained_records == 1
+
+
+# ---------------------------------------------------------------------------
+# Crash-window self-healing (torn tail + sidecar lag)
+# ---------------------------------------------------------------------------
+
+
+class TestTornTailVerify:
+    """verify() classifies the deterministic crash windows as non-tamper.
+
+    A torn FINAL line (unterminated, unparseable) can only be a crash
+    artifact — the chain writer is the sole writer and ``append_jsonl``
+    writes ``line + "\\n"`` in one call, so an interrupted flush leaves a
+    strict prefix with no terminator. Mid-file breaks between fully
+    parseable records remain tamper verdicts.
+    """
+
+    def test_unterminated_unparseable_final_line_is_torn_tail_not_break(
+        self, tmp_path: Path
+    ) -> None:
+        chain = _stream(tmp_path)
+        chain.append({"n": 1})
+        _tear_tail(chain.path, b'{"n": 2, "prev_hash": "ab')
+
+        result = chain.verify()
+        assert result.ok
+        assert any(w.startswith("torn_tail") for w in result.warnings)
+        assert result.chained_records == 1
+
+    def test_torn_tail_with_invalid_utf8_is_torn_tail_not_crash(
+        self, tmp_path: Path
+    ) -> None:
+        """A flush interrupted mid-multibyte-char must not crash the verifier."""
+        chain = _stream(tmp_path)
+        chain.append({"n": 1})
+        _tear_tail(chain.path, b'{"msg": "caf\xc3')  # é cut mid-sequence
+
+        result = chain.verify()
+        assert result.ok
+        assert any(w.startswith("torn_tail") for w in result.warnings)
+
+    def test_sidecar_one_behind_is_lag_warning_not_break(self, tmp_path: Path) -> None:
+        """Crash between file append and sidecar store: the last record is
+        intact but the sidecar still holds its prev_hash."""
+        chain = _stream(tmp_path)
+        first = chain.append({"n": 1})
+        chain.append({"n": 2})
+        _set_sidecar_head(chain.path, first["record_hash"])
+
+        result = chain.verify()
+        assert result.ok
+        assert any(w.startswith("sidecar_lag") for w in result.warnings)
+
+    def test_terminated_garbage_final_line_remains_a_break(
+        self, tmp_path: Path
+    ) -> None:
+        """A newline-terminated garbage line cannot be a torn append (a torn
+        flush never includes the terminator) — the #9474 shape stays tamper."""
+        chain = _stream(tmp_path)
+        chain.append({"n": 1})
+        with chain.path.open("a", encoding="utf-8") as fh:
+            fh.write("<<<<<<< Updated upstream\n")
+        result = chain.verify()
+        assert not result.ok
+        assert not result.warnings
+
+    def test_midfile_garbage_before_parseable_record_remains_a_break(
+        self, tmp_path: Path
+    ) -> None:
+        chain = _stream(tmp_path)
+        chain.append({"n": 1})
+        with chain.path.open("a", encoding="utf-8") as fh:
+            fh.write("NOT JSON\n")
+        chain.append({"n": 2})
+        result = chain.verify()
+        assert not result.ok
+
+    def test_tail_deletion_of_parseable_record_remains_a_break(
+        self, tmp_path: Path
+    ) -> None:
+        """Cleanly truncating a whole record (sidecar untouched) is tamper —
+        the sidecar points past the tail, not one behind it."""
+        chain = _stream(tmp_path)
+        for n in range(3):
+            chain.append({"n": n})
+        rows = _read_lines(chain.path)
+        _write_lines(chain.path, rows[:-1])
+        result = chain.verify()
+        assert not result.ok
+        assert not result.warnings
+
+    def test_clean_stream_has_no_warnings(self, tmp_path: Path) -> None:
+        chain = _stream(tmp_path)
+        chain.append({"n": 1})
+        result = chain.verify()
+        assert result.ok
+        assert result.warnings == ()
+
+
+class TestCrashWindowSelfHealingAppend:
+    """append() repairs both deterministic crash windows before writing."""
+
+    def test_append_truncates_torn_tail_and_chains_off_last_parseable(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        chain = _stream(tmp_path)
+        first = chain.append({"n": 1})
+        torn = b'{"n": 2, "prev_hash": "ab'
+        _tear_tail(chain.path, torn)
+
+        with caplog.at_level(logging.WARNING, logger="hydraflow.audit_chain"):
+            written = chain.append({"n": 3})
+
+        assert written["prev_hash"] == first["record_hash"]
+        rows = _read_lines(chain.path)
+        assert [r["n"] for r in rows] == [1, 3]
+        result = chain.verify()
+        assert result.ok
+        assert result.warnings == ()
+        truncation_logs = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert truncation_logs
+        assert str(len(torn)) in truncation_logs[0].getMessage()
+
+    def test_append_terminates_missing_newline_and_fast_forwards_sidecar(
+        self, tmp_path: Path
+    ) -> None:
+        """Crash after the record's content flushed but before its newline and
+        sidecar store: the record survives, nothing is lost."""
+        chain = _stream(tmp_path)
+        first = chain.append({"n": 1})
+        second = chain.append({"n": 2})
+        _strip_final_newline(chain.path)
+        _set_sidecar_head(chain.path, first["record_hash"])
+
+        written = chain.append({"n": 3})
+
+        assert written["prev_hash"] == second["record_hash"]
+        rows = _read_lines(chain.path)
+        assert [r["n"] for r in rows] == [1, 2, 3]
+        result = chain.verify()
+        assert result.ok
+        assert result.warnings == ()
+
+    def test_append_fast_forwards_sidecar_exactly_one_behind(
+        self, tmp_path: Path
+    ) -> None:
+        chain = _stream(tmp_path)
+        first = chain.append({"n": 1})
+        second = chain.append({"n": 2})
+        _set_sidecar_head(chain.path, first["record_hash"])
+
+        written = chain.append({"n": 3})
+
+        assert written["prev_hash"] == second["record_hash"]
+        result = chain.verify()
+        assert result.ok
+        assert result.warnings == ()
+        assert result.chained_records == 3
+
+    def test_append_resets_sidecar_ahead_of_truncated_torn_tail(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The torn line took the record the sidecar pinned: reset to the
+        last parseable record and continue."""
+        chain = _stream(tmp_path)
+        chain.append({"n": 1})
+        second = chain.append({"n": 2})
+        third = chain.append({"n": 3})
+        # Tear record 3's line mid-write; sidecar still pins its hash.
+        data = chain.path.read_bytes()
+        cut = data.rstrip(b"\n").rfind(b"\n") + 1
+        chain.path.write_bytes(data[: cut + 10])
+        _set_sidecar_head(chain.path, third["record_hash"])
+
+        with caplog.at_level(logging.WARNING, logger="hydraflow.audit_chain"):
+            written = chain.append({"n": 4})
+
+        assert written["prev_hash"] == second["record_hash"]
+        rows = _read_lines(chain.path)
+        assert [r["n"] for r in rows] == [1, 2, 4]
+        result = chain.verify()
+        assert result.ok
+        assert result.warnings == ()
+
+    def test_append_leaves_other_sidecar_mismatch_as_hard_break(
+        self, tmp_path: Path
+    ) -> None:
+        """A sidecar that matches neither the last record nor its prev is not
+        a known crash shape — the break must stay detectable."""
+        chain = _stream(tmp_path)
+        chain.append({"n": 1})
+        chain.append({"n": 2})
+        _set_sidecar_head(chain.path, "f" * 64)
+
+        chain.append({"n": 3})
+
+        assert not chain.verify().ok
+
+    def test_append_on_torn_only_file_starts_from_genesis(self, tmp_path: Path) -> None:
+        """A crash during the very first append leaves only torn bytes."""
+        path = tmp_path / "stream.jsonl"
+        path.write_bytes(b'{"n": 1, "prev')
+        chain = AuditChain(path)
+
+        written = chain.append({"n": 2})
+
+        assert written["prev_hash"] == GENESIS_PREV_HASH
+        assert [r["n"] for r in _read_lines(path)] == [2]
+        assert chain.verify().ok
+
+
+class TestTornTailPrune:
+    def test_prune_heals_torn_tail_and_prunes_prefix(self, tmp_path: Path) -> None:
+        """Retention must not be blocked forever by a crash artifact."""
+        chain = _stream(tmp_path)
+        chain.append({"ts": "2026-01-01T00:00:00Z"})
+        chain.append({"ts": "2026-07-01T00:00:00Z"})
+        _tear_tail(chain.path, b'{"ts": "2026-07-0')
+
+        removed = chain.prune_before(datetime(2026, 5, 1, tzinfo=UTC), "ts")
+
+        assert removed == 1
+        rows = _read_lines(chain.path)
+        assert [r["ts"] for r in rows] == ["2026-07-01T00:00:00Z"]
+        result = chain.verify()
+        assert result.ok
+        assert result.warnings == ()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_base_runner.py
+++ b/tests/test_base_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import sys
 from pathlib import Path
@@ -248,6 +249,42 @@ class TestExecute:
         assert result == "transcript output"
         assert mock.await_count == 2
         assert sleep_mock.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_non_finite_usage_payload_does_not_fail_the_run(
+        self, config, event_bus: EventBus, tmp_path: Path
+    ) -> None:
+        """Telemetry runs unguarded in _execute's ``finally``: a NaN in a
+        backend raw_usage payload must not convert a SUCCESSFUL agent run
+        into a hard failure (it would burn attempt budget), and the
+        telemetry record must still land."""
+        runner = _TestRunner(config, event_bus)
+
+        with patch("base_runner.stream_claude_process", new_callable=AsyncMock) as mock:
+            mock.return_value = "transcript output"
+            result = await runner._execute(
+                ["claude", "-p"],
+                "prompt",
+                tmp_path,
+                {"issue": 42},
+                telemetry_stats={
+                    "raw_usage": [
+                        {
+                            "backend": "claude",
+                            "event_type": "result",
+                            "payload": {"tokens_per_second": float("nan")},
+                        }
+                    ]
+                },
+            )
+
+        assert result == "transcript output"
+        inf_file = config.cost_inferences_path
+        rows = [
+            json.loads(ln) for ln in inf_file.read_text().splitlines() if ln.strip()
+        ]
+        assert len(rows) == 1
+        assert rows[0]["raw_usage"][0]["payload"]["tokens_per_second"] == "NaN"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_health_monitor_decisions_chain.py
+++ b/tests/test_health_monitor_decisions_chain.py
@@ -120,3 +120,36 @@ def test_update_decision_aborts_on_broken_chain(tmp_path: Path) -> None:
     assert decisions.read_text() == before
     # ...and the verifier still sees the break.
     assert not AuditChain(decisions).verify().ok
+
+
+def test_write_decision_with_non_finite_metric_still_lands(tmp_path: Path) -> None:
+    """A NaN trend metric must not crash the tick NOR drop the decision —
+    the record lands with the odd value coerced to a string sentinel."""
+    from health_monitor_loop import _write_decision
+
+    record = _record("adj-nan")
+    record["evidence_summary"] = {"first_pass_rate": float("nan")}
+    _write_decision(tmp_path, record)
+
+    (row,) = _read_rows(tmp_path)
+    assert row["evidence_summary"]["first_pass_rate"] == "NaN"
+    assert AuditChain(tmp_path / "decisions.jsonl").verify().ok
+
+
+def test_write_decision_swallows_value_error_from_chain(
+    tmp_path: Path, monkeypatch, caplog
+) -> None:
+    """Decision recording must never take down the health-monitor tick:
+    ValueError (incl. scrub-path JSONDecodeError) is logged, not raised."""
+    import health_monitor_loop
+    from health_monitor_loop import _write_decision
+
+    def _boom(self, _record):
+        raise ValueError("uncanonicalizable payload")
+
+    monkeypatch.setattr(health_monitor_loop.AuditChain, "append", _boom)
+
+    with caplog.at_level("WARNING", logger="hydraflow.health_monitor_loop"):
+        _write_decision(tmp_path, _record("adj-boom"))  # must not raise
+
+    assert any("decision" in r.getMessage().lower() for r in caplog.records)

--- a/tests/test_prompt_telemetry.py
+++ b/tests/test_prompt_telemetry.py
@@ -698,3 +698,70 @@ class TestHashChaining:
         self._record(telemetry)
         totals = telemetry.get_lifetime_totals()
         assert totals["inference_calls"] == 1
+
+
+class TestRecordNeverRaises:
+    """Telemetry must never take down the operation it documents.
+
+    ``record`` runs unguarded in BaseRunner._execute's ``finally`` — a raise
+    here converts a SUCCESSFUL agent run into a hard failure and burns
+    attempt budget.
+    """
+
+    def _record_with_stats(self, telemetry, stats: dict[str, object]) -> None:
+        telemetry.record(
+            source="implementer",
+            tool="claude",
+            model="sonnet",
+            issue_number=7,
+            pr_number=None,
+            session_id="sess-nan",
+            prompt_chars=100,
+            transcript_chars=200,
+            duration_seconds=1.0,
+            success=True,
+            stats=stats,
+        )
+
+    def test_non_finite_raw_usage_round_trips_and_lands(self, telemetry):
+        """A NaN in a backend raw_usage payload must not raise AND the record
+        must still land in the stream (evidence-grade: keep the odd value)."""
+        self._record_with_stats(
+            telemetry,
+            {
+                "raw_usage": [
+                    {
+                        "backend": "claude",
+                        "event_type": "result",
+                        "payload": {"tokens_per_second": float("nan")},
+                    }
+                ]
+            },
+        )
+
+        inf_file = telemetry._config.cost_inferences_path
+        rows = [
+            json.loads(ln) for ln in inf_file.read_text().splitlines() if ln.strip()
+        ]
+        assert len(rows) == 1
+        assert rows[0]["raw_usage"][0]["payload"]["tokens_per_second"] == "NaN"
+
+        from audit_chain import AuditChain
+
+        assert AuditChain(inf_file).verify().ok
+
+    def test_value_error_from_chain_append_is_swallowed(
+        self, telemetry, monkeypatch, caplog
+    ):
+        """Belt-and-braces: even an unforeseen ValueError from the append
+        path (e.g. a scrub-path JSONDecodeError) must not propagate."""
+
+        def _boom(_record):
+            raise ValueError("uncanonicalizable payload")
+
+        monkeypatch.setattr(telemetry._chain, "append", _boom)
+
+        with caplog.at_level("WARNING", logger="hydraflow.prompt_telemetry"):
+            self._record_with_stats(telemetry, {})
+
+        assert any("prompt telemetry" in r.getMessage().lower() for r in caplog.records)

--- a/tests/test_runs_gc_loop.py
+++ b/tests/test_runs_gc_loop.py
@@ -413,6 +413,69 @@ class TestAuditChainCaretaker:
         assert alerts[0].data["stream"] == "preflight"
 
     @pytest.mark.asyncio
+    async def test_torn_tail_is_not_tampering_and_retention_still_prunes(
+        self, tmp_path: Path
+    ) -> None:
+        """A crash artifact (unterminated final line) must not raise the
+        tamper SYSTEM_ALERT, must not poison the stream forever, and must
+        not block retention pruning (unbounded growth)."""
+        from datetime import UTC, datetime, timedelta
+
+        from events import EventType
+
+        loop, deps = _make_audit_loop(tmp_path, audit_retention_days_preflight=30)
+        fresh = datetime.now(UTC).isoformat()
+        stale = (datetime.now(UTC) - timedelta(days=90)).isoformat()
+        spec, chain = _seed_stream(deps.config, "preflight", [stale, fresh])
+        with spec.path.open("ab") as fh:
+            fh.write(b'{"ts": "2026-07-0')  # interrupted append, no newline
+
+        result = await loop._do_work()
+
+        assert result is not None
+        assert result["audit_chain_status"]["preflight"] == "torn_tail"
+        assert result["audit_pruned"]["preflight"] == 1
+        rows = [json.loads(line) for line in spec.path.read_text().splitlines()]
+        assert [r["ts"] for r in rows] == [fresh]
+        verify = chain.verify()
+        assert verify.ok
+        assert verify.warnings == ()
+        alerts = [
+            e
+            for e in deps.bus.get_history()
+            if e.type == EventType.SYSTEM_ALERT
+            and e.data.get("kind") == "audit_chain_break"
+        ]
+        assert alerts == []
+
+    @pytest.mark.asyncio
+    async def test_sidecar_lag_is_not_tampering(self, tmp_path: Path) -> None:
+        """Crash between append and sidecar store: no tamper alert."""
+        from events import EventType
+
+        loop, deps = _make_audit_loop(tmp_path)
+        spec, _chain = _seed_stream(
+            deps.config,
+            "preflight",
+            ["2026-07-01T00:00:00Z", "2026-07-02T00:00:00Z"],
+        )
+        rows = [json.loads(line) for line in spec.path.read_text().splitlines()]
+        sidecar = spec.path.with_name(spec.path.name + ".chainhead.json")
+        sidecar.write_text(json.dumps({"head": rows[0]["record_hash"]}))
+
+        result = await loop._do_work()
+
+        assert result is not None
+        assert result["audit_chain_status"]["preflight"] == "sidecar_lag"
+        alerts = [
+            e
+            for e in deps.bus.get_history()
+            if e.type == EventType.SYSTEM_ALERT
+            and e.data.get("kind") == "audit_chain_break"
+        ]
+        assert alerts == []
+
+    @pytest.mark.asyncio
     async def test_retention_floor_prunes_only_older_records(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary

Fixes the 4 CONFIRMED audit-chain/approval-records findings from the post-campaign convergence review — the top two severities of the pass.

1. **Routine crashes no longer read as tampering.** `AuditChain.append` heals the two deterministic crash windows under the stream lock: a torn (unterminated) final line is truncated with a byte-count warning, and a sidecar exactly one append behind is fast-forwarded. `verify()` classifies these as `torn_tail`/`sidecar_lag` **warnings** (`ok=True`), RunsGC reports them without the tamper SYSTEM_ALERT, and retention pruning proceeds. Deliberately preserved as tamper breaks (pinned by tests): mid-file edits, deleted records, and **newline-terminated garbage** — the exact #9474 stash-marker shape that motivated the module — since a single-write tear can only leave an *unterminated* prefix.
2. **Non-finite floats can't kill the writer.** NaN/±Infinity are coerced to string sentinels in the append/rewrite path (the record lands *with* the odd value; `canonical_json`'s byte-stability golden pin is untouched), and the two pre-CH-1 `except OSError` guards (`prompt_telemetry.record`, health-monitor `_write_decision`) widened to `(OSError, ValueError)` — a successful agent run can no longer be reported as failed by its own telemetry write in `BaseRunner._execute`'s `finally`.
3. **One poisoned PR no longer blocks the approval-evidence stream.** The CH-2 reconciler isolates per-PR fetch/append failures (warn, count, continue; `record_failures` surfaced in stats), re-raises credit/auth immediately, and still propagates a true outage (all-failed) to the cycle handler.
4. **Retention-expired evidence is never re-minted.** Scanned merges older than the configured retention floor are excluded from recording; the zero-overlap continuity check still sees the full scanned set, so expired PRs neither re-record nor false-trigger capture-gap markers.

## Testing

Strict TDD; 28 new tests across `test_audit_chain.py` (crash-window heal ×14, non-finite ×3), `test_runs_gc_loop.py` (no-false-tamper-alert ×2), `test_prompt_telemetry.py`, `test_base_runner.py` (real telemetry through `_execute`'s finally), `test_health_monitor_decisions_chain.py`, `test_approval_records.py` (isolation ×5, retention ×4).

- `make quality` — EXIT=0 (17,563 passed) · `make audit` — PASS 91 · `make scenario` 209 + `make scenario-loops` 156

Part of the convergence pass on #9729–#9735; siblings: #9743 (promotion evidence) + the gate-seams PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)