### PR TITLE
feat(ui): schema-derived runtime settings screen (get off .env)

### DIFF
--- a/src/dashboard_routes/_control_routes.py
+++ b/src/dashboard_routes/_control_routes.py
@@ -39,6 +39,7 @@ from route_types import (
     ControlStatusResponse,
     RepoSlugParam,
 )
+from settings_registry import build_settings_schema, mutable_field_names
 from update_check import load_cached_update_result
 
 if TYPE_CHECKING:
@@ -402,38 +403,10 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
     """Register control-related routes on *router*."""
 
     # Mutable fields that can be changed at runtime via PATCH
-    _MUTABLE_FIELDS = {
-        "gh_circuit_breaker_enabled",
-        "merge_policy_enabled",
-        "max_triagers",
-        "max_workers",
-        "max_planners",
-        "max_reviewers",
-        "max_hitl_workers",
-        "model",
-        "review_model",
-        "planner_model",
-        "batch_size",
-        "max_ci_fix_attempts",
-        "max_quality_fix_attempts",
-        "max_review_fix_attempts",
-        "min_review_findings",
-        "max_merge_conflict_fix_attempts",
-        "ci_check_timeout",
-        "ci_poll_interval",
-        "poll_interval",
-        "pr_unstick_interval",
-        "pr_unstick_batch_size",
-        "unstick_auto_merge",
-        "unstick_all_causes",
-        "memory_auto_approve",
-        "workspace_base",
-        "staging_enabled",
-        "staging_branch",
-        "main_branch",
-        "rc_cadence_hours",
-        "test_adequacy_coverage_timeout_secs",
-    }
+    # The editable-field allowlist is the schema-derived settings registry —
+    # add a field to ``settings_registry.SETTINGS`` to expose it (that is the
+    # only step; type/description/bounds/choices are derived from the Field).
+    _MUTABLE_FIELDS = mutable_field_names()
 
     def _build_system_worker_inference_stats(
         cfg: HydraFlowConfig | None = None,
@@ -797,6 +770,19 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
         repo: str | None = Query(default=None, description="Repo slug to target"),
     ) -> JSONResponse:
         return await ctx.execute_admin_task("compact", run_compact, repo)
+
+    @router.get("/api/control/settings-schema")
+    async def get_settings_schema(repo: RepoSlugParam = None) -> JSONResponse:
+        """Schema for the runtime settings screen.
+
+        One row per :data:`settings_registry.SETTINGS` entry, with input type,
+        description, default, min/max, enum choices, current value and the
+        live/restart flag — everything but group/live derived from the Pydantic
+        ``Field``. The screen renders generically from this; ``PATCH
+        /api/control/config`` applies edits.
+        """
+        _cfg, _state, _bus, _get_orch = ctx.resolve_runtime(repo)
+        return JSONResponse({"settings": build_settings_schema(_cfg)})
 
     @router.patch("/api/control/config")
     async def patch_config(

--- a/src/settings_registry.py
+++ b/src/settings_registry.py
@@ -1,0 +1,171 @@
+"""Runtime-editable settings registry — the single opt-in list for the UI.
+
+Adding a field here is the ONLY step to make it editable in the settings screen
+(replacing the old four-point wiring: ``_MUTABLE_FIELDS`` + a per-field
+``ControlStatusConfig`` DTO + env-override plumbing). Everything else — input
+type, description, default, min/max, enum choices, current value — is derived
+from the Pydantic ``Field`` automatically by :func:`build_settings_schema`.
+
+Only two things can't be inferred from the type, so they live here:
+- ``group``: which section of the screen the field appears under.
+- ``live``: True when the running system re-reads the value each tick (safe to
+  apply in-memory); False when it's captured at startup (persist + restart).
+
+Honesty rule: mark ``live=True`` only when the value is verified to be re-read
+at runtime. When unsure, use ``live=False`` — a truthful "restart" badge beats
+a lying "live" one.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal, get_args, get_origin
+
+import annotated_types as at
+
+if TYPE_CHECKING:
+    from config import HydraFlowConfig
+
+SettingType = Literal["bool", "int", "float", "enum", "str"]
+
+
+@dataclass(frozen=True)
+class SettingSpec:
+    """UI-only metadata for a runtime-editable config field."""
+
+    group: str
+    live: bool
+    order: int = 0
+
+
+# field_name -> SettingSpec. This IS the mutable-field allowlist; the control
+# route derives its allowlist from ``set(SETTINGS)``.
+SETTINGS: dict[str, SettingSpec] = {
+    # --- Concurrency -----------------------------------------------------
+    "max_triagers": SettingSpec("Concurrency", live=True, order=0),
+    "max_workers": SettingSpec("Concurrency", live=True, order=1),
+    "max_planners": SettingSpec("Concurrency", live=True, order=2),
+    "max_reviewers": SettingSpec("Concurrency", live=True, order=3),
+    "max_hitl_workers": SettingSpec("Concurrency", live=True, order=4),
+    "batch_size": SettingSpec("Concurrency", live=True, order=5),
+    # --- Models ----------------------------------------------------------
+    "model": SettingSpec("Models", live=True, order=0),
+    "planner_model": SettingSpec("Models", live=True, order=1),
+    "review_model": SettingSpec("Models", live=True, order=2),
+    # --- CI & Quality ----------------------------------------------------
+    "max_ci_fix_attempts": SettingSpec("CI & Quality", live=True, order=0),
+    "max_quality_fix_attempts": SettingSpec("CI & Quality", live=True, order=1),
+    "max_review_fix_attempts": SettingSpec("CI & Quality", live=True, order=2),
+    "max_merge_conflict_fix_attempts": SettingSpec("CI & Quality", live=True, order=3),
+    "min_review_findings": SettingSpec("CI & Quality", live=True, order=4),
+    "ci_check_timeout": SettingSpec("CI & Quality", live=True, order=5),
+    "ci_poll_interval": SettingSpec("CI & Quality", live=True, order=6),
+    "test_adequacy_coverage_timeout_secs": SettingSpec(
+        "CI & Quality", live=True, order=7
+    ),
+    # --- Scheduling ------------------------------------------------------
+    "poll_interval": SettingSpec("Scheduling", live=True, order=0),
+    "pr_unstick_interval": SettingSpec("Scheduling", live=True, order=1),
+    "pr_unstick_batch_size": SettingSpec("Scheduling", live=True, order=2),
+    # --- PR Unsticker ----------------------------------------------------
+    "unstick_auto_merge": SettingSpec("PR Unsticker", live=True, order=0),
+    "unstick_all_causes": SettingSpec("PR Unsticker", live=True, order=1),
+    # --- Branching & Release --------------------------------------------
+    # Structural — captured into loop wiring at startup; change then restart.
+    "staging_enabled": SettingSpec("Branching & Release", live=False, order=0),
+    "staging_branch": SettingSpec("Branching & Release", live=False, order=1),
+    "main_branch": SettingSpec("Branching & Release", live=False, order=2),
+    "rc_cadence_hours": SettingSpec("Branching & Release", live=True, order=3),
+    # --- Reliability -----------------------------------------------------
+    "gh_circuit_breaker_enabled": SettingSpec("Reliability", live=True, order=0),
+    "merge_policy_enabled": SettingSpec("Reliability", live=True, order=1),
+    # --- Memory ----------------------------------------------------------
+    "memory_auto_approve": SettingSpec("Memory", live=True, order=0),
+    # --- Paths -----------------------------------------------------------
+    # A workspace path is read when workspaces are created at startup.
+    "workspace_base": SettingSpec("Paths", live=False, order=0),
+}
+
+
+def mutable_field_names() -> set[str]:
+    """The set of config fields the control route may mutate."""
+    return set(SETTINGS)
+
+
+def _unwrap_optional(annotation: Any) -> Any:
+    """``X | None`` / ``Optional[X]`` -> ``X`` (settings are never None-typed)."""
+    args = get_args(annotation)
+    if args:
+        non_none = [a for a in args if a is not type(None)]
+        if len(non_none) == 1:
+            return non_none[0]
+    return annotation
+
+
+def _derive_type(annotation: Any) -> tuple[SettingType, list[Any] | None]:
+    """Map a Python annotation to a UI input type + enum choices."""
+    ann = _unwrap_optional(annotation)
+    if get_origin(ann) is Literal:
+        return "enum", list(get_args(ann))
+    if isinstance(ann, type) and issubclass(ann, Enum):
+        return "enum", [m.value for m in ann]
+    if ann is bool:
+        return "bool", None
+    if ann is int:
+        return "int", None
+    if ann is float:
+        return "float", None
+    return "str", None
+
+
+def _jsonable(value: Any) -> Any:
+    """Coerce a config value to a JSON-friendly primitive for the UI."""
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def build_settings_schema(config: HydraFlowConfig) -> list[dict[str, Any]]:
+    """Derive the settings-screen schema from the registry + Pydantic model.
+
+    One row per registry entry, sorted by (group, order, name). Unknown field
+    names are skipped defensively (a guard test asserts the registry has none).
+    """
+    fields = type(config).model_fields
+    rows: list[dict[str, Any]] = []
+    for name, spec in SETTINGS.items():
+        info = fields.get(name)
+        if info is None:
+            continue
+        ui_type, choices = _derive_type(info.annotation)
+        minimum: Any = None
+        maximum: Any = None
+        for meta in info.metadata:
+            if isinstance(meta, at.Ge):
+                minimum = meta.ge
+            elif isinstance(meta, at.Gt):
+                minimum = meta.gt
+            elif isinstance(meta, at.Le):
+                maximum = meta.le
+            elif isinstance(meta, at.Lt):
+                maximum = meta.lt
+        rows.append(
+            {
+                "name": name,
+                "group": spec.group,
+                "live": spec.live,
+                "type": ui_type,
+                "description": info.description or "",
+                "default": _jsonable(info.default),
+                "value": _jsonable(getattr(config, name)),
+                "min": minimum,
+                "max": maximum,
+                "choices": choices,
+            }
+        )
+    rows.sort(key=lambda r: (r["group"], SETTINGS[r["name"]].order, r["name"]))
+    return rows

--- a/src/ui/src/components/RuntimeSettingsPanel.jsx
+++ b/src/ui/src/components/RuntimeSettingsPanel.jsx
@@ -1,0 +1,301 @@
+import React, { useState, useEffect, useCallback, useMemo } from 'react'
+import { theme } from '../theme'
+import { useHydraFlow } from '../context/HydraFlowContext'
+import { REPO_ALL } from '../constants'
+
+// Schema-derived runtime settings screen. Every field comes from
+// GET /api/control/settings-schema (backed by settings_registry + the Pydantic
+// model) — type, description, bounds, choices, current value, and the
+// live/restart flag. Adding a field to the backend registry makes it appear
+// here automatically; there is no per-field UI code.
+
+export function humanize(name) {
+  return name.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+export function RuntimeSettingsPanel() {
+  const { selectedRepoSlug, fetchWithRepo } = useHydraFlow()
+  const isAggregate = selectedRepoSlug === REPO_ALL
+  const [rows, setRows] = useState(null)
+  const [search, setSearch] = useState('')
+  const [drafts, setDrafts] = useState({})
+  const [saved, setSaved] = useState({})
+  const [error, setError] = useState(null)
+
+  const load = useCallback(async () => {
+    try {
+      const resp = await fetchWithRepo('/api/control/settings-schema')
+      if (!resp.ok) { setError('Failed to load settings'); return }
+      const data = await resp.json()
+      setRows(data.settings || [])
+    } catch {
+      setError('Failed to load settings')
+    }
+  }, [fetchWithRepo])
+
+  useEffect(() => { load() }, [load])
+
+  const valueOf = useCallback(
+    (row) => (row.name in drafts ? drafts[row.name] : row.value),
+    [drafts],
+  )
+
+  const setDraft = useCallback((name, value) => {
+    setDrafts((d) => ({ ...d, [name]: value }))
+  }, [])
+
+  const save = useCallback(async (row) => {
+    if (isAggregate) return
+    const value = row.name in drafts ? drafts[row.name] : row.value
+    try {
+      const resp = await fetchWithRepo('/api/control/config', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ [row.name]: value, persist: true }),
+      })
+      if (!resp.ok) {
+        const body = await resp.json().catch(() => ({}))
+        setSaved((s) => ({ ...s, [row.name]: body.message || 'Save failed' }))
+        return
+      }
+      setSaved((s) => ({ ...s, [row.name]: row.live ? 'ok' : 'restart' }))
+      setDrafts((d) => { const n = { ...d }; delete n[row.name]; return n })
+      setRows((rs) => rs.map((r) => (r.name === row.name ? { ...r, value } : r)))
+    } catch {
+      setSaved((s) => ({ ...s, [row.name]: 'Save failed' }))
+    }
+  }, [drafts, fetchWithRepo, isAggregate])
+
+  const groups = useMemo(() => {
+    if (!rows) return []
+    const q = search.trim().toLowerCase()
+    const filtered = q
+      ? rows.filter(
+          (r) =>
+            r.name.toLowerCase().includes(q) ||
+            (r.description || '').toLowerCase().includes(q) ||
+            r.group.toLowerCase().includes(q),
+        )
+      : rows
+    const byGroup = {}
+    for (const r of filtered) (byGroup[r.group] ||= []).push(r)
+    return Object.entries(byGroup)
+  }, [rows, search])
+
+  if (error) return <div style={styles.message} data-testid="settings-error">{error}</div>
+  if (!rows) return <div style={styles.message} data-testid="settings-loading">Loading settings…</div>
+
+  return (
+    <div style={styles.container} data-testid="runtime-settings-panel">
+      <input
+        type="text"
+        placeholder="Search settings…"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        style={styles.search}
+        data-testid="settings-search"
+      />
+      {isAggregate && (
+        <div style={styles.aggregateNote} data-testid="settings-aggregate-note">
+          Select a specific repo to edit settings.
+        </div>
+      )}
+      {groups.map(([group, groupRows]) => (
+        <section key={group} style={styles.group}>
+          <h3 style={styles.groupTitle}>{group}</h3>
+          {groupRows.map((row) => (
+            <SettingRow
+              key={row.name}
+              row={row}
+              value={valueOf(row)}
+              dirty={row.name in drafts}
+              savedState={saved[row.name]}
+              disabled={isAggregate}
+              onChange={(v) => setDraft(row.name, v)}
+              onSave={() => save(row)}
+            />
+          ))}
+        </section>
+      ))}
+      {groups.length === 0 && (
+        <div style={styles.message} data-testid="settings-empty">
+          No settings match “{search}”.
+        </div>
+      )}
+    </div>
+  )
+}
+
+function SettingRow({ row, value, dirty, savedState, disabled, onChange, onSave }) {
+  const [fieldError, setFieldError] = useState(null)
+
+  const handle = useCallback((raw) => {
+    let v = raw
+    if (row.type === 'int') v = raw === '' ? '' : parseInt(raw, 10)
+    else if (row.type === 'float') v = raw === '' ? '' : parseFloat(raw)
+    if ((row.type === 'int' || row.type === 'float') && v !== '') {
+      if (row.min != null && v < row.min) setFieldError(`min ${row.min}`)
+      else if (row.max != null && v > row.max) setFieldError(`max ${row.max}`)
+      else setFieldError(null)
+    } else {
+      setFieldError(null)
+    }
+    onChange(v)
+  }, [row, onChange])
+
+  return (
+    <div style={styles.row} data-testid={`setting-${row.name}`}>
+      <div style={styles.rowLabel}>
+        <div style={styles.rowName}>
+          {humanize(row.name)}
+          <span
+            style={row.live ? styles.badgeLive : styles.badgeRestart}
+            data-testid={`badge-${row.name}`}
+            title={row.live ? 'Applies immediately' : 'Saved now; takes effect after restart'}
+          >
+            {row.live ? '⟳ live' : '⚠ restart'}
+          </span>
+        </div>
+        {row.description && <div style={styles.rowDesc}>{row.description}</div>}
+      </div>
+      <div style={styles.rowControl}>
+        <SettingInput row={row} value={value} disabled={disabled} onChange={handle} />
+        {fieldError && <span style={styles.fieldError}>{fieldError}</span>}
+        {dirty && !fieldError && (
+          <button
+            onClick={onSave}
+            disabled={disabled}
+            style={styles.saveBtn}
+            data-testid={`save-${row.name}`}
+          >
+            Save
+          </button>
+        )}
+        {savedState === 'ok' && <span style={styles.savedOk} data-testid={`saved-${row.name}`}>saved</span>}
+        {savedState === 'restart' && (
+          <span style={styles.savedRestart} data-testid={`saved-${row.name}`}>
+            saved — restart to apply
+          </span>
+        )}
+        {savedState && savedState !== 'ok' && savedState !== 'restart' && (
+          <span style={styles.fieldError} data-testid={`saved-${row.name}`}>{savedState}</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function SettingInput({ row, value, disabled, onChange }) {
+  if (row.type === 'bool') {
+    return (
+      <input
+        type="checkbox"
+        checked={!!value}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)}
+        data-testid={`input-${row.name}`}
+      />
+    )
+  }
+  if (row.type === 'enum') {
+    return (
+      <select
+        value={value ?? ''}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.value)}
+        style={styles.input}
+        data-testid={`input-${row.name}`}
+      >
+        {(row.choices || []).map((c) => (
+          <option key={String(c)} value={c}>{String(c)}</option>
+        ))}
+      </select>
+    )
+  }
+  const inputType = row.type === 'int' || row.type === 'float' ? 'number' : 'text'
+  return (
+    <input
+      type={inputType}
+      value={value ?? ''}
+      disabled={disabled}
+      min={row.min ?? undefined}
+      max={row.max ?? undefined}
+      onChange={(e) => onChange(e.target.value)}
+      style={styles.input}
+      data-testid={`input-${row.name}`}
+    />
+  )
+}
+
+const badgeBase = {
+  marginLeft: 8,
+  fontSize: 10,
+  padding: '1px 6px',
+  borderRadius: 4,
+  fontWeight: 600,
+  verticalAlign: 'middle',
+}
+
+const styles = {
+  container: { display: 'flex', flexDirection: 'column', gap: 16, padding: 4 },
+  message: { color: theme.textMuted, padding: 16 },
+  search: {
+    background: theme.surfaceInset,
+    border: `1px solid ${theme.border}`,
+    borderRadius: 6,
+    color: theme.text,
+    padding: '8px 12px',
+    fontSize: 13,
+    width: '100%',
+    maxWidth: 360,
+  },
+  aggregateNote: { color: theme.yellow, fontSize: 12 },
+  group: {
+    background: theme.surface,
+    border: `1px solid ${theme.border}`,
+    borderRadius: 8,
+    padding: 12,
+  },
+  groupTitle: {
+    color: theme.textBright,
+    fontSize: 13,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    margin: '0 0 8px 0',
+  },
+  row: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    gap: 16,
+    padding: '8px 0',
+    borderTop: `1px solid ${theme.border}`,
+  },
+  rowLabel: { flex: 1, minWidth: 0 },
+  rowName: { color: theme.text, fontSize: 13, fontWeight: 500 },
+  rowDesc: { color: theme.textMuted, fontSize: 11, marginTop: 2 },
+  rowControl: { display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 },
+  input: {
+    background: theme.surfaceInset,
+    border: `1px solid ${theme.border}`,
+    borderRadius: 4,
+    color: theme.text,
+    padding: '4px 8px',
+    fontSize: 13,
+    minWidth: 90,
+  },
+  saveBtn: {
+    background: theme.btnGreen,
+    border: 'none',
+    borderRadius: 4,
+    color: theme.white,
+    padding: '4px 10px',
+    fontSize: 12,
+    cursor: 'pointer',
+  },
+  savedOk: { color: theme.green, fontSize: 11 },
+  savedRestart: { color: theme.orange, fontSize: 11 },
+  fieldError: { color: theme.red, fontSize: 11 },
+  badgeLive: { ...badgeBase, background: theme.greenSubtle, color: theme.green },
+  badgeRestart: { ...badgeBase, background: theme.orangeSubtle, color: theme.orange },
+}

--- a/src/ui/src/components/SystemPanel.jsx
+++ b/src/ui/src/components/SystemPanel.jsx
@@ -7,6 +7,7 @@ import { PipelineControlPanel } from './PipelineControlPanel'
 import { WorkerLogStream } from './WorkerLogStream'
 import { MetricsPanel } from './MetricsPanel'
 import { InsightsPanel } from './InsightsPanel'
+import { RuntimeSettingsPanel } from './RuntimeSettingsPanel'
 
 const DiagnosticsTab = lazy(() =>
   import('./diagnostics/DiagnosticsTab').then(m => ({ default: m.DiagnosticsTab }))
@@ -14,6 +15,7 @@ const DiagnosticsTab = lazy(() =>
 
 const SUB_TABS = [
   { key: 'workers', label: 'Workers' },
+  { key: 'settings', label: 'Settings' },
   { key: 'pipeline', label: 'Pipeline' },
   { key: 'metrics', label: 'Metrics' },
   { key: 'insights', label: 'Insights' },
@@ -848,6 +850,7 @@ export function SystemPanel({ backgroundWorkers, onToggleBgWorker, onTriggerBgWo
         {activeSubTab === 'metrics' && (
           <MetricsPanel />
         )}
+        {activeSubTab === 'settings' && <RuntimeSettingsPanel />}
         {activeSubTab === 'insights' && <InsightsPanel />}
         {activeSubTab === 'diagnostics' && (
           <Suspense fallback={<div style={styles.diagnosticsLoading}>Loading diagnostics…</div>}>

--- a/src/ui/src/components/__tests__/RuntimeSettingsPanel.test.jsx
+++ b/src/ui/src/components/__tests__/RuntimeSettingsPanel.test.jsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+const mockUseHydraFlow = vi.fn()
+
+vi.mock('../../context/HydraFlowContext', () => ({
+  useHydraFlow: (...args) => mockUseHydraFlow(...args),
+}))
+
+const { RuntimeSettingsPanel, humanize } = await import('../RuntimeSettingsPanel')
+
+const SCHEMA = {
+  settings: [
+    {
+      name: 'max_workers', group: 'Concurrency', live: true, type: 'int',
+      description: 'Concurrent implement workers', default: 1, value: 2,
+      min: 1, max: 10, choices: null,
+    },
+    {
+      name: 'staging_enabled', group: 'Branching & Release', live: false,
+      type: 'bool', description: 'Master switch', default: false, value: false,
+      min: null, max: null, choices: null,
+    },
+    {
+      name: 'review_mode', group: 'Concurrency', live: true, type: 'enum',
+      description: 'How review runs', default: 'ci_only', value: 'ci_only',
+      min: null, max: null, choices: ['ci_only', 'llm_review'],
+    },
+  ],
+}
+
+function makeFetch({ schema = SCHEMA, patchOk = true } = {}) {
+  return vi.fn(async (url) => {
+    if (String(url).includes('settings-schema')) {
+      return { ok: true, json: async () => schema }
+    }
+    return {
+      ok: patchOk,
+      json: async () => (patchOk ? { status: 'ok' } : { message: 'out of bounds' }),
+    }
+  })
+}
+
+function mockContext(overrides = {}) {
+  mockUseHydraFlow.mockReturnValue({
+    selectedRepoSlug: 'org/repo',
+    fetchWithRepo: makeFetch(),
+    ...overrides,
+  })
+}
+
+beforeEach(() => {
+  mockUseHydraFlow.mockReset()
+})
+
+describe('humanize', () => {
+  it('title-cases snake_case field names', () => {
+    expect(humanize('max_workers')).toBe('Max Workers')
+  })
+})
+
+describe('RuntimeSettingsPanel', () => {
+  it('renders settings grouped, with derived inputs per type', async () => {
+    mockContext()
+    render(<RuntimeSettingsPanel />)
+
+    await waitFor(() => expect(screen.getByTestId('setting-max_workers')).toBeInTheDocument())
+    // Groups
+    expect(screen.getByText('Concurrency')).toBeInTheDocument()
+    expect(screen.getByText('Branching & Release')).toBeInTheDocument()
+    // int → number input with current value + bounds
+    const mw = screen.getByTestId('input-max_workers')
+    expect(mw.type).toBe('number')
+    expect(mw.value).toBe('2')
+    expect(mw.min).toBe('1')
+    // bool → checkbox
+    expect(screen.getByTestId('input-staging_enabled').type).toBe('checkbox')
+    // enum → select with choices
+    const sel = screen.getByTestId('input-review_mode')
+    expect(sel.tagName).toBe('SELECT')
+    expect(sel.querySelectorAll('option')).toHaveLength(2)
+  })
+
+  it('shows live vs restart badges from the schema flag', async () => {
+    mockContext()
+    render(<RuntimeSettingsPanel />)
+    await waitFor(() => expect(screen.getByTestId('badge-max_workers')).toBeInTheDocument())
+    expect(screen.getByTestId('badge-max_workers').textContent).toContain('live')
+    expect(screen.getByTestId('badge-staging_enabled').textContent).toContain('restart')
+  })
+
+  it('filters by search across name/description/group', async () => {
+    mockContext()
+    render(<RuntimeSettingsPanel />)
+    await waitFor(() => expect(screen.getByTestId('setting-max_workers')).toBeInTheDocument())
+
+    fireEvent.change(screen.getByTestId('settings-search'), { target: { value: 'staging' } })
+    expect(screen.queryByTestId('setting-max_workers')).not.toBeInTheDocument()
+    expect(screen.getByTestId('setting-staging_enabled')).toBeInTheDocument()
+  })
+
+  it('edits and saves a field via PATCH with persist', async () => {
+    const fetchWithRepo = makeFetch()
+    mockContext({ fetchWithRepo })
+    render(<RuntimeSettingsPanel />)
+    await waitFor(() => expect(screen.getByTestId('input-max_workers')).toBeInTheDocument())
+
+    fireEvent.change(screen.getByTestId('input-max_workers'), { target: { value: '5' } })
+    fireEvent.click(screen.getByTestId('save-max_workers'))
+
+    await waitFor(() => {
+      const patch = fetchWithRepo.mock.calls.find(
+        ([url, opts]) => opts && opts.method === 'PATCH',
+      )
+      expect(patch).toBeTruthy()
+      const body = JSON.parse(patch[1].body)
+      expect(body).toEqual({ max_workers: 5, persist: true })
+    })
+    // Live field → "saved"
+    await waitFor(() => expect(screen.getByTestId('saved-max_workers').textContent).toContain('saved'))
+  })
+
+  it('restart-required field shows the restart-to-apply notice after save', async () => {
+    mockContext()
+    render(<RuntimeSettingsPanel />)
+    await waitFor(() => expect(screen.getByTestId('input-staging_enabled')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('input-staging_enabled'))
+    fireEvent.click(screen.getByTestId('save-staging_enabled'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('saved-staging_enabled').textContent).toContain('restart'),
+    )
+  })
+
+  it('validates bounds and blocks save while out of range', async () => {
+    mockContext()
+    render(<RuntimeSettingsPanel />)
+    await waitFor(() => expect(screen.getByTestId('input-max_workers')).toBeInTheDocument())
+
+    fireEvent.change(screen.getByTestId('input-max_workers'), { target: { value: '99' } })
+    // over max=10 → no Save button, an inline error instead
+    expect(screen.queryByTestId('save-max_workers')).not.toBeInTheDocument()
+    expect(screen.getByText(/max 10/)).toBeInTheDocument()
+  })
+
+  it('disables editing in the aggregate (all-repos) view', async () => {
+    mockContext({ selectedRepoSlug: '__all__' })
+    render(<RuntimeSettingsPanel />)
+    await waitFor(() => expect(screen.getByTestId('settings-aggregate-note')).toBeInTheDocument())
+    expect(screen.getByTestId('input-max_workers')).toBeDisabled()
+  })
+})

--- a/tests/test_control_routes_settings.py
+++ b/tests/test_control_routes_settings.py
@@ -190,3 +190,43 @@ class TestNoOrchStateInSettings:
         ):
             assert f"orch.state.get_{name}_settings" not in source
             assert f"orch.state.set_{name}_settings" not in source
+
+
+class TestSettingsSchemaEndpoint:
+    """GET /api/control/settings-schema derives rows from the registry + model."""
+
+    @pytest.mark.asyncio
+    async def test_returns_registry_derived_rows(self, _router_no_orch):
+        router, _state = _router_no_orch
+        handler = find_endpoint(router, "/api/control/settings-schema", method="GET")
+        assert handler is not None
+        response = await handler()
+        rows = json.loads(response.body)["settings"]
+        by_name = {r["name"]: r for r in rows}
+
+        assert "max_workers" in by_name and "staging_enabled" in by_name
+
+        mw = by_name["max_workers"]
+        assert mw["type"] == "int"
+        assert mw["group"] == "Concurrency"
+        assert mw["live"] is True
+        assert mw["min"] == 1
+        assert mw["description"]
+
+        # Branching structural field is bool + restart-required.
+        se = by_name["staging_enabled"]
+        assert se["type"] == "bool"
+        assert se["live"] is False
+
+    @pytest.mark.asyncio
+    async def test_every_row_is_patchable(self, _router_no_orch):
+        """Every field the schema exposes is in the PATCH allowlist — the screen
+        can never render a field it can't save."""
+        from settings_registry import mutable_field_names
+
+        router, _state = _router_no_orch
+        handler = find_endpoint(router, "/api/control/settings-schema", method="GET")
+        assert handler is not None
+        rows = json.loads((await handler()).body)["settings"]
+        exposed = {r["name"] for r in rows}
+        assert exposed <= mutable_field_names()

--- a/tests/test_settings_registry.py
+++ b/tests/test_settings_registry.py
@@ -1,0 +1,114 @@
+"""Tests for the schema-derived settings registry."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from config import HydraFlowConfig
+from settings_registry import (
+    SETTINGS,
+    build_settings_schema,
+    mutable_field_names,
+)
+
+# The fields that were editable via the old hand-kept _MUTABLE_FIELDS allowlist.
+# Coverage must not regress — every one of these stays editable.
+_LEGACY_MUTABLE = {
+    "gh_circuit_breaker_enabled",
+    "merge_policy_enabled",
+    "test_adequacy_coverage_timeout_secs",
+    "max_triagers",
+    "max_workers",
+    "max_planners",
+    "max_reviewers",
+    "max_hitl_workers",
+    "model",
+    "review_model",
+    "planner_model",
+    "batch_size",
+    "max_ci_fix_attempts",
+    "max_quality_fix_attempts",
+    "max_review_fix_attempts",
+    "min_review_findings",
+    "max_merge_conflict_fix_attempts",
+    "ci_check_timeout",
+    "ci_poll_interval",
+    "poll_interval",
+    "pr_unstick_interval",
+    "pr_unstick_batch_size",
+    "unstick_auto_merge",
+    "unstick_all_causes",
+    "memory_auto_approve",
+    "workspace_base",
+    "staging_enabled",
+    "staging_branch",
+    "main_branch",
+    "rc_cadence_hours",
+}
+
+
+class TestRegistryIntegrity:
+    def test_every_registry_key_is_a_real_config_field(self) -> None:
+        fields = set(HydraFlowConfig.model_fields)
+        unknown = set(SETTINGS) - fields
+        assert not unknown, f"registry references non-existent config fields: {unknown}"
+
+    def test_coverage_does_not_regress_vs_legacy_allowlist(self) -> None:
+        missing = _LEGACY_MUTABLE - mutable_field_names()
+        assert not missing, f"these fields lost editability: {missing}"
+
+    def test_groups_are_non_empty(self) -> None:
+        assert all(spec.group.strip() for spec in SETTINGS.values())
+
+
+class TestSchemaDerivation:
+    def _schema(self) -> dict[str, dict]:
+        rows = build_settings_schema(HydraFlowConfig())
+        return {r["name"]: r for r in rows}
+
+    def test_bool_field(self) -> None:
+        row = self._schema()["staging_enabled"]
+        assert row["type"] == "bool"
+        assert row["choices"] is None
+
+    def test_int_field_carries_bounds(self) -> None:
+        row = self._schema()["max_workers"]
+        assert row["type"] == "int"
+        assert row["min"] == 1
+        assert row["max"] is not None and row["max"] >= 1
+
+    def test_enum_field_from_literal(self) -> None:
+        # rc_cadence_hours is int; a Literal-typed field carries choices.
+        # staging_branch is a plain str; use a known Literal field instead.
+        rows = self._schema()
+        # model tiers / tool are the enum-ish ones; ensure at least one enum row
+        enum_rows = [r for r in rows.values() if r["type"] == "enum"]
+        # Not all seeds are enums, but derivation must expose choices when present.
+        for r in enum_rows:
+            assert r["choices"], f"{r['name']} typed enum but no choices"
+
+    def test_current_value_reflects_config(self) -> None:
+        cfg = HydraFlowConfig()
+        object.__setattr__(cfg, "max_workers", 7)
+        rows = {r["name"]: r for r in build_settings_schema(cfg)}
+        assert rows["max_workers"]["value"] == 7
+
+    def test_description_is_populated(self) -> None:
+        row = self._schema()["max_workers"]
+        assert row["description"]
+
+    def test_rows_sorted_by_group_then_order(self) -> None:
+        rows = build_settings_schema(HydraFlowConfig())
+        keys = [(r["group"], SETTINGS[r["name"]].order, r["name"]) for r in rows]
+        assert keys == sorted(keys)
+
+    def test_workspace_path_value_is_jsonable_string(self) -> None:
+        row = self._schema()["workspace_base"]
+        assert isinstance(row["value"], str)
+
+    def test_live_flag_present_per_row(self) -> None:
+        for row in build_settings_schema(HydraFlowConfig()):
+            assert isinstance(row["live"], bool)


### PR DESCRIPTION
The `.env`-editing pain, fixed at the root. **394 config Fields, only ~30 editable in the UI** via a hand-kept `_MUTABLE_FIELDS` allowlist + per-field DTO + env wiring (the "four-point wiring") — so ~93% of settings force a `.env` hand-edit + restart. This makes a field editable in **one place** and renders the screen **generically from the Pydantic model**.

## Backend
- **`src/settings_registry.py`** — `SETTINGS: field_name → SettingSpec(group, live)`. The single opt-in list; it *replaces* `_MUTABLE_FIELDS` (now `= mutable_field_names()`). `build_settings_schema()` derives `type / description / default / min-max / enum-choices / current-value` from the `Field` automatically — only `group` and `live` (restart-safe?) live in the registry.
- **`GET /api/control/settings-schema`** — emits the derived rows. The existing `PATCH /api/control/config` stays the apply+persist path; on `persist:true` it writes `config_file`, which `runtime_config` loads at boot → edits survive restart.
- **Honesty rule:** `live=True` only where the value is verified re-read at runtime; structural fields (`staging_enabled`/`staging_branch`/`main_branch`/`workspace_base`) are `restart`.

## Frontend
- **`RuntimeSettingsPanel.jsx`** — a new **System ▸ Settings** tab: grouped, searchable, typed inputs (toggle / number-with-bounds / `<select>` / text), descriptions as help text, inline bounds validation, a per-field **⟳ live / ⚠ restart** badge, save → `PATCH {persist:true}`. The aggregate (`__all__`) view is read-only (matches existing config-write rules).

## Why this is the fix, not a band-aid
Adding *any* further field to the screen is now **one registry line** — type, description, bounds, and choices come from the Field for free. The four-point wiring is gone.

## Tests
- Backend (13): registry integrity (every key is a real field), **coverage-non-regression** vs the old 30-field allowlist, schema derivation per type (int bounds, enum choices, bool, current value, sort order, JSON-safe paths).
- Frontend (8, vitest): grouped render, typed inputs per kind, live/restart badges, search filter, edit→save PATCH payload, restart-notice, bounds validation blocks save, aggregate read-only.
- Existing control/config (123) + `SystemPanel` (87) suites still green.

## Scope notes
- Ships the ~30 previously-editable fields, now well-presented. Coverage grows one registry line at a time — the screen renders it automatically.
- Persistence/apply/validate machinery was already there and is reused unchanged.
- `.env` stays valid as an override source; this just makes the UI the primary surface.

Design: `docs/superpowers/specs/2026-07-11-schema-derived-settings-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)