### PR TITLE
feat(llm): pluggable one-shot LLM provider — OpenRouter dials per loop

### DIFF
--- a/disturbance/baselines/suppressions.yaml
+++ b/disturbance/baselines/suppressions.yaml
@@ -3,7 +3,10 @@ comment: "suppressions disturbance baseline. MUST NOT grow (gate fails on increa
   \ handler (intentional, sanctioned broad-except pattern for per-issue tick resilience).\
   \ re-snapshot 2026-07: +triage injection honeypot (triage_honeypot.py PLC0415 lazy\
   \ run_lightweight_agent import + BLE001 fail-open; triage.py BLE001 fail-open +\
-  \ alert-never-crash) \u2014 sanctioned per honeypot fail-open/defence-in-depth design."
+  \ alert-never-crash) \u2014 sanctioned per honeypot fail-open/defence-in-depth design.\
+  \ re-snapshot 2026-07-11: +runner_utils PLC0415 lazy imports for the inlined one-shot\
+  \ LLM provider backends (agent_cli/httpx/execution/subprocess \u2014 circular-safe\
+  \ + import-cost pattern, matches the file's existing lazy-import convention)."
 entries:
   src/acceptance_criteria.py::noqa:PLC0415: 2
   src/admin_tasks.py::noqa:PLC0415: 7
@@ -245,7 +248,7 @@ entries:
   src/review_phase/_phase.py::type-ignore[arg-type]: 2
   src/reviewer.py::noqa:PLC0415: 3
   src/route_back.py::noqa:BLE001: 6
-  src/runner_utils.py::noqa:PLC0415: 4
+  src/runner_utils.py::noqa:PLC0415: 7
   src/runners/base_subprocess_runner.py::noqa:PLC0415: 1
   src/runners/base_subprocess_runner.py::type-ignore[arg-type]: 1
   src/runtime_config.py::noqa:BLE001: 1

--- a/src/adr_reviewer.py
+++ b/src/adr_reviewer.py
@@ -536,6 +536,7 @@ minority_note: <dissenting opinion if not unanimous, or "none">"""
                 config=self._config,
                 tool=self._config.adr_review_tool,
                 model=self._config.adr_review_model,
+                provider=self._config.adr_review_provider,
                 prompt=prompt,
                 source="adr_reviewer",
                 timeout=self._config.agent_timeout,

--- a/src/config.py
+++ b/src/config.py
@@ -1388,6 +1388,32 @@ class HydraFlowConfig(BaseModel):
         default="sonnet",
         description="Model for triage evaluation (fast/cheap)",
     )
+    openrouter_base_url: str = Field(
+        default="https://openrouter.ai/api/v1",
+        description=(
+            "OpenAI-compatible base URL for the 'openrouter' one-shot LLM "
+            "provider. The API key is read from the OPENROUTER_API_KEY env var "
+            "(a secret — never stored on config or shown in the UI)."
+        ),
+    )
+    # Per-role backend dials for the one-shot (no-tools) loops. "claude" keeps
+    # the CLI harness; "openrouter" calls a cheap direct model. Pair each with
+    # the role's *_model (e.g. a DeepSeek/Flash id when set to openrouter).
+    wiki_compilation_provider: Literal["claude", "openrouter"] = Field(
+        default="claude", description="Backend for wiki topic compilation."
+    )
+    adr_review_provider: Literal["claude", "openrouter"] = Field(
+        default="claude", description="Backend for the ADR reviewer."
+    )
+    transcript_summary_provider: Literal["claude", "openrouter"] = Field(
+        default="claude", description="Backend for transcript summarization."
+    )
+    triage_honeypot_provider: Literal["claude", "openrouter"] = Field(
+        default="claude", description="Backend for the triage injection honeypot."
+    )
+    pr_unstick_provider: Literal["claude", "openrouter"] = Field(
+        default="claude", description="Backend for the PR-unsticker cause analysis."
+    )
     triage_max_turns: int = Field(
         default=3,
         ge=1,

--- a/src/pr_unsticker.py
+++ b/src/pr_unsticker.py
@@ -874,6 +874,7 @@ If nothing novel, output exactly: NO_NEW_PATTERN"""
                 config=self._config,
                 tool=tool,
                 model=model,
+                provider=self._config.pr_unstick_provider,
                 prompt=prompt,
                 source="pr_unsticker",
                 timeout=60.0,

--- a/src/runner_utils.py
+++ b/src/runner_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 import logging
 import os
 import signal
@@ -11,7 +12,7 @@ import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from activity_parser import ActivityParser, get_activity_parser
 from events import EventBus, EventType, HydraFlowEvent
@@ -567,6 +568,133 @@ async def stream_claude_with_telemetry(
         )
 
 
+# --- Pluggable one-shot LLM backends -----------------------------------------
+# These live in THIS module (the gate + telemetry seam) on purpose: the raw
+# spawns (CLI ``build_lightweight_command`` / OpenRouter ``httpx``) must sit
+# inside the seam so ``run_lightweight_agent`` always gates the prompt first and
+# records telemetry after. The agentic path (tools/multi-turn) stays on the
+# Claude harness — Anthropic doesn't support routing it to non-Claude models.
+
+_OPENROUTER = "openrouter"
+
+
+def _telemetry_cmd(provider: str, tool: str, model: str) -> list[str]:
+    """The ``cmd``-shaped descriptor ``_record_inference`` parses into
+    ``(tool, model)``. For OpenRouter the 'tool' is the provider name so the
+    cost dashboard attributes it distinctly from the CLI tools."""
+    head = _OPENROUTER if provider == _OPENROUTER else tool
+    return [head, "--model", model]
+
+
+def _openrouter_api_key() -> str:
+    """The OpenRouter key, read straight from the environment. It is a secret,
+    so it never lives on ``HydraFlowConfig`` (which can persist to config_file)
+    and never appears in the settings UI — it stays in ``.env`` only."""
+    return os.environ.get("OPENROUTER_API_KEY", "") or os.environ.get(
+        "HYDRAFLOW_OPENROUTER_API_KEY", ""
+    )
+
+
+async def _claude_cli_complete(
+    *,
+    runner: SubprocessRunner,
+    tool: str,
+    model: str,
+    prompt: str,
+    timeout: float,
+    gh_token: str,
+    isolate_user_settings: bool,
+) -> SimpleResult:
+    """The Claude CLI backend (today's behaviour). Credit-out surfaces as
+    ``rc != 0`` output text, so it is detected and raised here."""
+
+    from agent_cli import AgentTool, build_lightweight_command  # noqa: PLC0415
+
+    cmd, cmd_input = build_lightweight_command(
+        tool=cast(AgentTool, tool),
+        model=model,
+        prompt=prompt,
+        isolate_user_settings=isolate_user_settings,
+    )
+    env = make_clean_env(gh_token)
+    result = await runner.run_simple(cmd, env=env, input=cmd_input, timeout=timeout)
+    raise_if_credit_exhausted(result.stdout, result.stderr, tool)
+    return result
+
+
+async def _openrouter_complete(
+    *,
+    base_url: str,
+    api_key: str,
+    model: str,
+    prompt: str,
+    timeout: float,
+    response_schema: dict[str, object] | None = None,
+) -> SimpleResult:
+    """Direct OpenAI-compatible completion (OpenRouter et al.). One HTTP POST;
+    no tools, no agent loop. ``response_schema`` switches on native strict-JSON
+    output (more reliable than parsing JSON out of prose). HTTP 429/402 and
+    quota/credit error bodies raise :class:`CreditExhaustedError` so the
+    orchestrator's pause/refund fires."""
+
+    import httpx  # noqa: PLC0415
+
+    from execution import SimpleResult  # noqa: PLC0415
+    from subprocess_util import (  # noqa: PLC0415
+        CreditExhaustedError,
+        is_credit_exhaustion,
+    )
+
+    if not api_key:
+        return SimpleResult(stderr="OPENROUTER_API_KEY is not set", returncode=-1)
+
+    payload: dict[str, object] = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    if response_schema is not None:
+        payload["response_format"] = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "response",
+                "strict": True,
+                "schema": response_schema,
+            },
+        }
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(
+                f"{base_url.rstrip('/')}/chat/completions",
+                json=payload,
+                headers=headers,
+            )
+    except httpx.TimeoutException as exc:
+        raise TimeoutError(str(exc)) from exc
+
+    if resp.status_code in (402, 429):
+        raise CreditExhaustedError(f"openrouter {resp.status_code}: {resp.text[:200]}")
+    if resp.status_code >= 400:
+        body = resp.text or ""
+        if is_credit_exhaustion(body):
+            raise CreditExhaustedError(f"openrouter: {body[:200]}")
+        return SimpleResult(
+            stderr=f"openrouter http {resp.status_code}: {body[:300]}",
+            returncode=resp.status_code,
+        )
+    try:
+        data = resp.json()
+        content = data["choices"][0]["message"]["content"] or ""
+    except (json.JSONDecodeError, KeyError, IndexError, TypeError) as exc:
+        return SimpleResult(
+            stderr=f"openrouter: malformed response ({exc})", returncode=-1
+        )
+    return SimpleResult(stdout=content, returncode=0)
+
+
 async def run_lightweight_agent(
     *,
     runner: SubprocessRunner,
@@ -582,8 +710,18 @@ async def run_lightweight_agent(
     session_id: str | None = None,
     isolate_user_settings: bool = True,
     issue_labels: Sequence[str] = (),
+    provider: str = "claude",
+    response_schema: dict[str, object] | None = None,
 ) -> SimpleResult:
-    """One-shot lightweight LLM CLI call with credit detection + telemetry.
+    """One-shot lightweight LLM call with credit detection + telemetry.
+
+    *provider* selects the backend: ``"claude"`` (the CLI harness, default) or
+    ``"openrouter"`` (a direct OpenAI-compatible HTTP call — for the one-shot,
+    no-tools loops that don't need the harness). Both return the same
+    ``SimpleResult`` and own their own credit-exhaustion detection, so the
+    credit + telemetry contract below holds regardless of backend.
+    *response_schema*, when given, drives native strict-JSON output on the
+    OpenRouter path (the CLI path uses prompt-based JSON).
 
     Centralizes the credit + telemetry contract for the non-streaming
     ``run_simple`` spawn path so callers don't reinvent it:
@@ -617,7 +755,6 @@ async def run_lightweight_agent(
     ``issue.tags``); without them only the repo-declared class is enforced
     (``tests/test_prompt_gate_completeness.py`` pins every call site).
     """
-    from agent_cli import build_lightweight_command  # noqa: PLC0415
     from exception_classify import (  # noqa: PLC0415
         exc_detail,
         reraise_on_credit_or_bug,
@@ -641,22 +778,37 @@ async def run_lightweight_agent(
         return SimpleResult(stderr=str(exc), returncode=-1)
     prompt = gated.prompt
 
-    cmd, cmd_input = build_lightweight_command(
-        tool=tool,
-        model=model,
-        prompt=prompt,
-        isolate_user_settings=isolate_user_settings,
-    )
-    env = make_clean_env(gh_token)
+    # Backend selection (pluggable one-shot provider). The chosen backend owns
+    # its own credit-exhaustion detection (CLI: output text; OpenRouter: HTTP
+    # 429/402). Both spawns live in THIS seam module so the CH-6 gate (above)
+    # and the telemetry record (below) always wrap them. ``cmd`` is only a
+    # telemetry descriptor parsed into (tool, model).
+    cmd = _telemetry_cmd(provider, tool, model)
     start = time.monotonic()
     success = False
     record_row = False
     result = SimpleResult(returncode=-1)
     try:
         try:
-            result = await runner.run_simple(
-                cmd, env=env, input=cmd_input, timeout=timeout
-            )
+            if provider == _OPENROUTER:
+                result = await _openrouter_complete(
+                    base_url=config.openrouter_base_url,
+                    api_key=_openrouter_api_key(),
+                    model=model,
+                    prompt=prompt,
+                    timeout=timeout,
+                    response_schema=response_schema,
+                )
+            else:
+                result = await _claude_cli_complete(
+                    runner=runner,
+                    tool=tool,
+                    model=model,
+                    prompt=prompt,
+                    timeout=timeout,
+                    gh_token=gh_token,
+                    isolate_user_settings=isolate_user_settings,
+                )
         except TimeoutError:
             # ``asyncio.wait_for`` raises a *bare* TimeoutError whose ``str()``
             # is "", which would collapse to an undiagnosable "rc=-1: " at the
@@ -681,8 +833,6 @@ async def run_lightweight_agent(
             result = SimpleResult(stderr=exc_detail(exc), returncode=-1)
             record_row = True
             return result
-        # Credit-out via output text propagates without recording, same as above.
-        raise_if_credit_exhausted(result.stdout, result.stderr, tool)
         success = result.returncode == 0
         record_row = True
         return result

--- a/src/runner_utils.py
+++ b/src/runner_utils.py
@@ -630,6 +630,7 @@ async def _openrouter_complete(
     prompt: str,
     timeout: float,
     response_schema: dict[str, object] | None = None,
+    usage_out: dict[str, object] | None = None,
 ) -> SimpleResult:
     """Direct OpenAI-compatible completion (OpenRouter et al.). One HTTP POST;
     no tools, no agent loop. ``response_schema`` switches on native strict-JSON
@@ -692,6 +693,14 @@ async def _openrouter_complete(
         return SimpleResult(
             stderr=f"openrouter: malformed response ({exc})", returncode=-1
         )
+    # Surface the API's real token usage so telemetry records actual cost
+    # (token_source="actual") instead of the CLI path's char estimate.
+    if usage_out is not None:
+        u = data.get("usage") or {}
+        usage_out["input_tokens"] = int(u.get("prompt_tokens", 0) or 0)
+        usage_out["output_tokens"] = int(u.get("completion_tokens", 0) or 0)
+        usage_out["total_tokens"] = int(u.get("total_tokens", 0) or 0)
+        usage_out["usage_available"] = bool(u.get("total_tokens"))
     return SimpleResult(stdout=content, returncode=0)
 
 
@@ -788,9 +797,13 @@ async def run_lightweight_agent(
     success = False
     record_row = False
     result = SimpleResult(returncode=-1)
+    # Real token usage from the OpenRouter API (None on the CLI path, which has
+    # no usage stats and falls back to a char estimate).
+    usage_stats: dict[str, object] | None = None
     try:
         try:
             if provider == _OPENROUTER:
+                usage_stats = {}
                 result = await _openrouter_complete(
                     base_url=config.openrouter_base_url,
                     api_key=_openrouter_api_key(),
@@ -798,6 +811,7 @@ async def run_lightweight_agent(
                     prompt=prompt,
                     timeout=timeout,
                     response_schema=response_schema,
+                    usage_out=usage_stats,
                 )
             else:
                 result = await _claude_cli_complete(
@@ -849,5 +863,5 @@ async def run_lightweight_agent(
                 issue_number=issue_number,
                 pr_number=pr_number,
                 session_id=session_id,
-                stats=None,
+                stats=usage_stats,
             )

--- a/src/settings_registry.py
+++ b/src/settings_registry.py
@@ -87,15 +87,23 @@ SETTINGS: dict[str, SettingSpec] = {
     # A workspace path is read when workspaces are created at startup.
     "workspace_base": SettingSpec("Paths", live=False, order=0),
     # --- Model Routing (one-shot loop backends) --------------------------
-    # Each dial picks claude (harness) vs openrouter (cheap direct model) for a
-    # one-shot loop. Live: the next spawn re-reads the value. The OpenRouter API
-    # key is a secret and is intentionally NOT here — it stays in .env.
+    # Each one-shot loop gets a provider dial (claude harness vs openrouter cheap
+    # direct model) paired with its model id — both editable here, no config file.
+    # Live: the next spawn re-reads them. The OpenRouter API key is a secret and
+    # is intentionally NOT here — it stays in .env.
     "openrouter_base_url": SettingSpec("Model Routing", live=True, order=0),
-    "wiki_compilation_provider": SettingSpec("Model Routing", live=True, order=1),
-    "adr_review_provider": SettingSpec("Model Routing", live=True, order=2),
-    "transcript_summary_provider": SettingSpec("Model Routing", live=True, order=3),
-    "triage_honeypot_provider": SettingSpec("Model Routing", live=True, order=4),
-    "pr_unstick_provider": SettingSpec("Model Routing", live=True, order=5),
+    "wiki_compilation_provider": SettingSpec("Model Routing", live=True, order=10),
+    "wiki_compilation_model": SettingSpec("Model Routing", live=True, order=11),
+    "adr_review_provider": SettingSpec("Model Routing", live=True, order=20),
+    "adr_review_model": SettingSpec("Model Routing", live=True, order=21),
+    "transcript_summary_provider": SettingSpec("Model Routing", live=True, order=30),
+    "transcript_summary_model": SettingSpec("Model Routing", live=True, order=31),
+    "triage_honeypot_provider": SettingSpec("Model Routing", live=True, order=40),
+    "triage_honeypot_model": SettingSpec("Model Routing", live=True, order=41),
+    # pr-unsticker shares the general background_model (below), so only its
+    # provider dial lives here.
+    "pr_unstick_provider": SettingSpec("Model Routing", live=True, order=50),
+    "background_model": SettingSpec("Models", live=True, order=3),
 }
 
 

--- a/src/settings_registry.py
+++ b/src/settings_registry.py
@@ -86,6 +86,16 @@ SETTINGS: dict[str, SettingSpec] = {
     # --- Paths -----------------------------------------------------------
     # A workspace path is read when workspaces are created at startup.
     "workspace_base": SettingSpec("Paths", live=False, order=0),
+    # --- Model Routing (one-shot loop backends) --------------------------
+    # Each dial picks claude (harness) vs openrouter (cheap direct model) for a
+    # one-shot loop. Live: the next spawn re-reads the value. The OpenRouter API
+    # key is a secret and is intentionally NOT here — it stays in .env.
+    "openrouter_base_url": SettingSpec("Model Routing", live=True, order=0),
+    "wiki_compilation_provider": SettingSpec("Model Routing", live=True, order=1),
+    "adr_review_provider": SettingSpec("Model Routing", live=True, order=2),
+    "transcript_summary_provider": SettingSpec("Model Routing", live=True, order=3),
+    "triage_honeypot_provider": SettingSpec("Model Routing", live=True, order=4),
+    "pr_unstick_provider": SettingSpec("Model Routing", live=True, order=5),
 }
 
 

--- a/src/transcript_summarizer.py
+++ b/src/transcript_summarizer.py
@@ -297,6 +297,7 @@ class TranscriptSummarizer:
                 config=self._config,
                 tool=self._config.transcript_summary_tool,
                 model=self._config.transcript_summary_model,
+                provider=self._config.transcript_summary_provider,
                 prompt=prompt,
                 source="transcript_summary",
                 timeout=self._config.transcript_summary_timeout,

--- a/src/triage_honeypot.py
+++ b/src/triage_honeypot.py
@@ -163,6 +163,7 @@ async def screen_issue(
             config=config,
             tool=config.triage_tool,
             model=config.triage_honeypot_model,
+            provider=config.triage_honeypot_provider,
             prompt=prompt,
             source=source,
             timeout=config.triage_honeypot_timeout,

--- a/src/wiki_compiler.py
+++ b/src/wiki_compiler.py
@@ -907,6 +907,7 @@ class WikiCompiler:
                 config=self._config,
                 tool=self._config.wiki_compilation_tool,
                 model=self._config.wiki_compilation_model,
+                provider=self._config.wiki_compilation_provider,
                 prompt=prompt,
                 source="wiki_compilation",
                 timeout=self._config.wiki_compilation_timeout,

--- a/tests/test_openrouter_provider.py
+++ b/tests/test_openrouter_provider.py
@@ -1,0 +1,254 @@
+"""Tests for the pluggable one-shot LLM provider seam in runner_utils.
+
+Covers the OpenRouter HTTP backend (request/response mapping, credit detection,
+JSON-schema parity) and the provider dispatch inside run_lightweight_agent.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import httpx
+
+from runner_utils import (
+    _openrouter_api_key,
+    _openrouter_complete,
+    _telemetry_cmd,
+)
+from subprocess_util import CreditExhaustedError
+
+
+class _FakeResp:
+    def __init__(self, *, status_code=200, json_data=None, text=""):
+        self.status_code = status_code
+        self._json = json_data
+        self.text = text
+
+    def json(self):
+        if self._json is None:
+            raise json.JSONDecodeError("no json", "", 0)
+        return self._json
+
+
+class _FakeClient:
+    """Records the request and returns a canned response."""
+
+    calls: list[dict] = []
+
+    def __init__(self, resp, **_kw):
+        self._resp = resp
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+    async def post(self, url, *, json=None, headers=None):
+        _FakeClient.calls.append({"url": url, "json": json, "headers": headers})
+        if isinstance(self._resp, Exception):
+            raise self._resp
+        return self._resp
+
+
+def _patch_httpx(monkeypatch, resp):
+    _FakeClient.calls = []
+
+    def _factory(**kw):
+        return _FakeClient(resp, **kw)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _factory)
+
+
+def _ok(content="hello", usage=None):
+    return _FakeResp(
+        json_data={"choices": [{"message": {"content": content}}], "usage": usage or {}}
+    )
+
+
+class TestTelemetryCmd:
+    def test_openrouter_head_is_provider_name(self):
+        assert _telemetry_cmd("openrouter", "claude", "deepseek/x") == [
+            "openrouter",
+            "--model",
+            "deepseek/x",
+        ]
+
+    def test_claude_head_is_tool(self):
+        assert _telemetry_cmd("claude", "claude", "haiku") == [
+            "claude",
+            "--model",
+            "haiku",
+        ]
+
+
+class TestApiKeyFromEnv:
+    def test_reads_openrouter_env(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-123")
+        assert _openrouter_api_key() == "sk-or-123"
+
+    def test_falls_back_to_hydraflow_prefixed(self, monkeypatch):
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.setenv("HYDRAFLOW_OPENROUTER_API_KEY", "sk-hf")
+        assert _openrouter_api_key() == "sk-hf"
+
+    def test_empty_when_unset(self, monkeypatch):
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("HYDRAFLOW_OPENROUTER_API_KEY", raising=False)
+        assert _openrouter_api_key() == ""
+
+
+@pytest.mark.asyncio
+class TestOpenRouterComplete:
+    async def _run(self, monkeypatch, resp, **kw):
+        _patch_httpx(monkeypatch, resp)
+        return await _openrouter_complete(
+            base_url="https://openrouter.ai/api/v1",
+            api_key="sk-or-test",
+            model="deepseek/deepseek-chat",
+            prompt="classify this",
+            timeout=30.0,
+            **kw,
+        )
+
+    async def test_happy_path_returns_content(self, monkeypatch):
+        result = await self._run(monkeypatch, _ok("VERDICT: ok"))
+        assert result.returncode == 0
+        assert result.stdout == "VERDICT: ok"
+        # Request went to the chat/completions endpoint with the model + prompt.
+        req = _FakeClient.calls[0]
+        assert req["url"].endswith("/chat/completions")
+        assert req["json"]["model"] == "deepseek/deepseek-chat"
+        assert req["json"]["messages"][0]["content"] == "classify this"
+        assert req["headers"]["Authorization"] == "Bearer sk-or-test"
+
+    async def test_response_schema_sets_json_mode(self, monkeypatch):
+        schema = {"type": "object", "properties": {"ready": {"type": "boolean"}}}
+        await self._run(monkeypatch, _ok("{}"), response_schema=schema)
+        rf = _FakeClient.calls[0]["json"]["response_format"]
+        assert rf["type"] == "json_schema"
+        assert rf["json_schema"]["schema"] == schema
+        assert rf["json_schema"]["strict"] is True
+
+    async def test_no_schema_omits_response_format(self, monkeypatch):
+        await self._run(monkeypatch, _ok())
+        assert "response_format" not in _FakeClient.calls[0]["json"]
+
+    async def test_missing_api_key_soft_fails(self, monkeypatch):
+        _patch_httpx(monkeypatch, _ok())
+        result = await _openrouter_complete(
+            base_url="https://x", api_key="", model="m", prompt="p", timeout=5.0
+        )
+        assert result.returncode == -1
+        assert "OPENROUTER_API_KEY" in result.stderr
+        assert not _FakeClient.calls  # never made the request
+
+    async def test_429_raises_credit_exhausted(self, monkeypatch):
+        with pytest.raises(CreditExhaustedError):
+            await self._run(monkeypatch, _FakeResp(status_code=429, text="rate limit"))
+
+    async def test_402_raises_credit_exhausted(self, monkeypatch):
+        with pytest.raises(CreditExhaustedError):
+            await self._run(
+                monkeypatch, _FakeResp(status_code=402, text="insufficient credits")
+            )
+
+    async def test_400_with_credit_body_raises(self, monkeypatch):
+        # A non-402/429 error whose body signals exhaustion still pauses.
+        with pytest.raises(CreditExhaustedError):
+            await self._run(
+                monkeypatch,
+                _FakeResp(status_code=400, text="You've hit your usage limit"),
+            )
+
+    async def test_other_http_error_soft_fails(self, monkeypatch):
+        result = await self._run(
+            monkeypatch, _FakeResp(status_code=500, text="server boom")
+        )
+        assert result.returncode == 500
+        assert "openrouter http 500" in result.stderr
+
+    async def test_malformed_response_soft_fails(self, monkeypatch):
+        result = await self._run(monkeypatch, _FakeResp(json_data={"nope": 1}))
+        assert result.returncode == -1
+        assert "malformed" in result.stderr
+
+    async def test_timeout_becomes_timeouterror(self, monkeypatch):
+        with pytest.raises(TimeoutError):
+            await self._run(monkeypatch, httpx.TimeoutException("slow"))
+
+
+@pytest.mark.asyncio
+class TestRunLightweightAgentDispatch:
+    """The seam picks the backend from ``provider`` and still records telemetry
+    with the right (tool, model) descriptor."""
+
+    async def test_openrouter_provider_routes_to_http(self, monkeypatch):
+        from unittest.mock import AsyncMock
+
+        from execution import SimpleResult
+        from runner_utils import run_lightweight_agent
+        from tests.helpers import ConfigFactory
+
+        calls = {"n": 0}
+
+        async def _fake_or(**kwargs):
+            calls["n"] += 1
+            calls["kwargs"] = kwargs
+            return SimpleResult(stdout="OR-RESULT", returncode=0)
+
+        monkeypatch.setattr("runner_utils._openrouter_complete", _fake_or)
+
+        result = await run_lightweight_agent(
+            runner=AsyncMock(),
+            config=ConfigFactory.create(),
+            tool="claude",
+            model="deepseek/deepseek-chat",
+            prompt="p",
+            source="unit_test",
+            timeout=10.0,
+            provider="openrouter",
+        )
+        assert result.stdout == "OR-RESULT"
+        assert calls["n"] == 1
+        assert calls["kwargs"]["model"] == "deepseek/deepseek-chat"
+
+    async def test_default_provider_stays_claude_cli(self, monkeypatch):
+        from unittest.mock import AsyncMock
+
+        from execution import SimpleResult
+        from runner_utils import run_lightweight_agent
+        from tests.helpers import ConfigFactory
+
+        or_called = {"n": 0}
+        cli_called = {"n": 0}
+
+        async def _fake_or(**_kw):
+            or_called["n"] += 1
+            return SimpleResult(returncode=0)
+
+        async def _fake_cli(**_kw):
+            cli_called["n"] += 1
+            return SimpleResult(stdout="CLI", returncode=0)
+
+        monkeypatch.setattr("runner_utils._openrouter_complete", _fake_or)
+        monkeypatch.setattr("runner_utils._claude_cli_complete", _fake_cli)
+
+        result = await run_lightweight_agent(
+            runner=AsyncMock(),
+            config=ConfigFactory.create(),
+            tool="claude",
+            model="haiku",
+            prompt="p",
+            source="unit_test",
+            timeout=10.0,
+        )
+        assert result.stdout == "CLI"
+        assert cli_called["n"] == 1
+        assert or_called["n"] == 0

--- a/tests/test_openrouter_provider.py
+++ b/tests/test_openrouter_provider.py
@@ -174,6 +174,48 @@ class TestOpenRouterComplete:
         assert result.returncode == 500
         assert "openrouter http 500" in result.stderr
 
+    async def test_captures_real_token_usage(self, monkeypatch):
+        usage: dict = {}
+        _patch_httpx(
+            monkeypatch,
+            _ok(
+                "hi",
+                usage={
+                    "prompt_tokens": 120,
+                    "completion_tokens": 30,
+                    "total_tokens": 150,
+                },
+            ),
+        )
+        await _openrouter_complete(
+            base_url="https://x",
+            api_key="k",
+            model="m",
+            prompt="p",
+            timeout=5.0,
+            usage_out=usage,
+        )
+        assert usage == {
+            "input_tokens": 120,
+            "output_tokens": 30,
+            "total_tokens": 150,
+            "usage_available": True,
+        }
+
+    async def test_usage_available_false_when_api_omits_usage(self, monkeypatch):
+        usage: dict = {}
+        _patch_httpx(monkeypatch, _ok("hi", usage={}))
+        await _openrouter_complete(
+            base_url="https://x",
+            api_key="k",
+            model="m",
+            prompt="p",
+            timeout=5.0,
+            usage_out=usage,
+        )
+        assert usage["usage_available"] is False
+        assert usage["total_tokens"] == 0
+
     async def test_malformed_response_soft_fails(self, monkeypatch):
         result = await self._run(monkeypatch, _FakeResp(json_data={"nope": 1}))
         assert result.returncode == -1
@@ -218,6 +260,47 @@ class TestRunLightweightAgentDispatch:
         assert result.stdout == "OR-RESULT"
         assert calls["n"] == 1
         assert calls["kwargs"]["model"] == "deepseek/deepseek-chat"
+
+    async def test_openrouter_real_usage_flows_to_telemetry(self, monkeypatch):
+        from unittest.mock import AsyncMock
+
+        from execution import SimpleResult
+        from runner_utils import run_lightweight_agent
+        from tests.helpers import ConfigFactory
+
+        async def _fake_or(*, usage_out=None, **_kw):
+            if usage_out is not None:
+                usage_out.update(
+                    {
+                        "input_tokens": 100,
+                        "output_tokens": 20,
+                        "total_tokens": 120,
+                        "usage_available": True,
+                    }
+                )
+            return SimpleResult(stdout="ok", returncode=0)
+
+        recorded: dict = {}
+
+        def _fake_record(_config, **kw):
+            recorded.update(kw)
+
+        monkeypatch.setattr("runner_utils._openrouter_complete", _fake_or)
+        monkeypatch.setattr("runner_utils._record_inference", _fake_record)
+
+        await run_lightweight_agent(
+            runner=AsyncMock(),
+            config=ConfigFactory.create(),
+            tool="claude",
+            model="deepseek/deepseek-chat",
+            prompt="p",
+            source="unit_test",
+            timeout=10.0,
+            provider="openrouter",
+        )
+        # Real API usage reached the telemetry record → token_source="actual".
+        assert recorded["stats"]["total_tokens"] == 120
+        assert recorded["stats"]["usage_available"] is True
 
     async def test_default_provider_stays_claude_cli(self, monkeypatch):
         from unittest.mock import AsyncMock


### PR DESCRIPTION
Break the **one-shot maintenance loops** off the Claude CLI harness so each can run on a cheap direct model (OpenRouter), while the agentic work stays on the harness. From the harness/signals chat — "narrow each maintenance loop to a small model."

## Why this shape (verified, not assumed)
Per the Claude Code docs, Anthropic **does not support** routing Claude Code to non-Claude models — tool-use, the agent loop, and JSON all degrade. So we do **not** proxy Claude to OpenRouter. Instead, the loops that need none of that (a prompt in, JSON/text out, no tools — everything through `run_lightweight_agent`) call OpenRouter **directly**. Agentic loops (implement/plan/review/triage-with-tools) are untouched.

## What's here
- **The seam** — `run_lightweight_agent(provider=...)` dispatches to `_claude_cli_complete` (today's CLI path) or `_openrouter_complete` (direct OpenAI-compatible HTTP). Both spawns live **inside** the seam module, so the CH-6 prompt gate (before) and telemetry record (after) always wrap them — no new spawner bypasses the completeness guards. `response_schema` drives **native strict-JSON** on the OpenRouter path (more reliable than parsing JSON from prose). HTTP 429/402 + quota bodies raise `CreditExhaustedError` so the pause/refund machinery fires.
- **The dials** — `openrouter_base_url` (tunable) + per-role `*_provider` (`Literal["claude","openrouter"]`, default `claude`) for wiki-compile, adr-review, transcript-summary, honeypot, pr-unsticker. Threaded into all 5 callers. Registered in `settings_registry` under a **Model Routing** group, so they render as dropdowns in the settings screen (#9748). The **API key** is read from `OPENROUTER_API_KEY` env — a secret, never on config, never in the UI.
- **Cost obs** — telemetry tags OpenRouter calls as `("openrouter", model)`, so the cost dashboard splits a loop's spend by provider+model the moment a dial flips.

## Safety
Default is `claude` everywhere — **zero behaviour change** until a dial is set. Agentic path never touched.

## Tests
17 provider/dispatch tests (mocked `httpx`: request/response mapping, 429/402/400-body credit detection, json-schema parity, missing-key soft-fail, timeout, claude-stays-default-and-openrouter-routes). Both governance guards (gate + telemetry completeness) + the credit/telemetry regression pass. `make quality`: 17666 passed (lone failure is the "mkdocs not installed in the local runner" env artifact — green on CI). Disturbance baseline re-snapshot for the seam's lazy imports.

## Honest follow-ups (not blockers, called out in the design doc)
1. **Consolidate** the bespoke one-shot wrappers (term `ClaudeCLIClient`, semantic-drift `ask_llm`, corpus synth) onto the seam so they get dials too.
2. **Cost-obs completeness** — capture OpenRouter's real `usage` (vs the CLI's char-estimate) + add OpenRouter model pricing, so the dashboard shows real dollars.
3. **Evals before flipping** — per-role eval so a dial → openrouter can't trade cost for silent quality loss (only ~3 of ~15 roles have evals today).

Design: `docs/superpowers/specs/2026-07-11-pluggable-llm-provider-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)