### PR TITLE
feat(llm): make the term-proposer / entry-evidence drafters dial-able

### DIFF
--- a/disturbance/baselines/suppressions.yaml
+++ b/disturbance/baselines/suppressions.yaml
@@ -9,7 +9,10 @@ comment: "suppressions disturbance baseline. MUST NOT grow (gate fails on increa
   \ + import-cost pattern, matches the file's existing lazy-import convention). re-snapshot\
   \ 2026-07-11: +_control_routes PLC0415 lazy import of provider_key_presence for\
   \ the settings-schema key-status badge (matches the route module's existing deferred-import\
-  \ convention)."
+  \ convention). re-snapshot 2026-07-11: -1 term_proposer_runtime PLC0415 \u2014 ClaudeCLIClient\
+  \ now routes the drafter through run_lightweight_agent (one seam import replaces\
+  \ build_lightweight_command+raise_if_credit_exhausted), making it dial-able + gated\
+  \ + telemetried (dropped from both CH-6 grandfather lists)."
 entries:
   src/acceptance_criteria.py::noqa:PLC0415: 2
   src/admin_tasks.py::noqa:PLC0415: 7
@@ -299,7 +302,7 @@ entries:
   src/telemetry/otel.py::noqa:PLW0603: 3
   src/telemetry/spans.py::type-ignore[return-value]: 3
   src/term_proposer_loop.py::noqa:PLC0415: 1
-  src/term_proposer_runtime.py::noqa:PLC0415: 4
+  src/term_proposer_runtime.py::noqa:PLC0415: 3
   src/test_scaffold.py::noqa:BLE001: 1
   src/trace_collector.py::noqa:E402: 2
   "src/trace_collector.py::noqa:E402\u2014intentionallynearhelperstosurviveruffunused-importsweeps": 1

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,51 +1,51 @@
 {
-  "regenerated_at": "2026-07-11T19:46:48.669380+00:00",
-  "commit_sha": "be0b5d5cc9249c01ba3b66de5d99c7f7656a0996",
+  "regenerated_at": "2026-07-12T03:30:55.450477+00:00",
+  "commit_sha": "d3c244e1b9d0bb7dd3ba62a819b8a40e8bfc64f5",
   "artifacts": {
     "loops.md": {
-      "source_sha": "be0b5d5cc9249c01ba3b66de5d99c7f7656a0996"
+      "source_sha": "d3c244e1b9d0bb7dd3ba62a819b8a40e8bfc64f5"
     },
     "ports.md": {
-      "source_sha": "be0b5d5cc9249c01ba3b66de5d99c7f7656a0996"
+      "source_sha": "d3c244e1b9d0bb7dd3ba62a819b8a40e8bfc64f5"
     },
     "labels.md": {
-      "source_sha": "be0b5d5cc9249c01ba3b66de5d99c7f7656a0996"
+      "source_sha": "d3c244e1b9d0bb7dd3ba62a819b8a40e8bfc64f5"
     },
     "modules.md": {
-      "source_sha": "be0b5d5cc9249c01ba3b66de5d99c7f7656a0996"
+      "source_sha": "d3c244e1b9d0bb7dd3ba62a819b8a40e8bfc64f5"
     },
     "events.md": {
-      "source_sha": "be0b5d5cc9249c01ba3b66de5d99c7f7656a0996"
+      "source_sha": "d3c244e1b9d0bb7dd3ba62a819b8a40e8bfc64f5"
     },
     "adr_xref.md": {
-      "source_sha": "be0b5d5cc9249c01ba3b66de5d99c7f7656a0996"
+      "source_sha": "d3c244e1b9d0bb7dd3ba62a819b8a40e8bfc64f5"
     },
     "mockworld.md": {
-      "source_sha": "be0b5d5cc9249c01ba3b66de5d99c7f7656a0996"
+      "source_sha": "d3c244e1b9d0bb7dd3ba62a819b8a40e8bfc64f5"
     },
     "changelog.md": {
-      "source_sha": "be0b5d5cc9249c01ba3b66de5d99c7f7656a0996"
+      "source_sha": "d3c244e1b9d0bb7dd3ba62a819b8a40e8bfc64f5"
     },
     "coverage_matrix.md": {
-      "source_sha": "be0b5d5cc9249c01ba3b66de5d99c7f7656a0996"
+      "source_sha": "d3c244e1b9d0bb7dd3ba62a819b8a40e8bfc64f5"
     },
     "adr-conformance.md": {
-      "source_sha": "be0b5d5cc9249c01ba3b66de5d99c7f7656a0996"
+      "source_sha": "d3c244e1b9d0bb7dd3ba62a819b8a40e8bfc64f5"
     },
     "ai_system_inventory.md": {
-      "source_sha": "be0b5d5cc9249c01ba3b66de5d99c7f7656a0996"
+      "source_sha": "d3c244e1b9d0bb7dd3ba62a819b8a40e8bfc64f5"
     },
     "traceability_matrix.md": {
-      "source_sha": "be0b5d5cc9249c01ba3b66de5d99c7f7656a0996"
+      "source_sha": "d3c244e1b9d0bb7dd3ba62a819b8a40e8bfc64f5"
     },
     "functional_areas.md": {
-      "source_sha": "be0b5d5cc9249c01ba3b66de5d99c7f7656a0996"
+      "source_sha": "d3c244e1b9d0bb7dd3ba62a819b8a40e8bfc64f5"
     },
     "ubiquitous-language.md": {
-      "source_sha": "be0b5d5cc9249c01ba3b66de5d99c7f7656a0996"
+      "source_sha": "d3c244e1b9d0bb7dd3ba62a819b8a40e8bfc64f5"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "be0b5d5cc9249c01ba3b66de5d99c7f7656a0996"
+      "source_sha": "d3c244e1b9d0bb7dd3ba62a819b8a40e8bfc64f5"
     }
   }
 }

--- a/docs/arch/generated/ai_system_inventory.md
+++ b/docs/arch/generated/ai_system_inventory.md
@@ -52,6 +52,7 @@ Role registry from `config._ENV_COMBO_OVERRIDES` — each combo env var resolves
 | `HYDRAFLOW_SENTRY` | `sentry_tool` | `sentry_model` |
 | `HYDRAFLOW_ADR_REVIEW` | `adr_review_tool` | `adr_review_model` |
 | `HYDRAFLOW_REPORT_ISSUE` | `report_issue_tool` | `report_issue_model` |
+| `HYDRAFLOW_TERM_PROPOSER` | `term_proposer_tool` | `term_proposer_model` |
 
 ## Background loops (54)
 

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W28
 
+- `c34e61a` — feat(triage): prompt-injection honeypot — validate the request before handling (#9747) (#9747) *(2026-07-11)*
 - `be0b5d5` — feat(prompt-gate): lightweight-seam label enforcement + traceability marker verification (convergence findings 5,9,10) (#9745) (#9745) *(2026-07-09)*
 - `753658f` — feat(staging-promotion): close promotion-evidence gaps from convergence review (#9743) (#9743) *(2026-07-09)*
 - `b732f28` — feat(evidence-pack): per-RC release evidence-pack compiler — the binder (CH-4, #9732) (#9742) (#9742) *(2026-07-09)*

--- a/scripts/migrate_entries_to_term_evidence.py
+++ b/scripts/migrate_entries_to_term_evidence.py
@@ -185,8 +185,12 @@ async def main() -> int:
 
     logging.basicConfig(level=logging.INFO, format="%(name)s: %(message)s")
 
+    from config import HydraFlowConfig
+
     runner = get_default_runner()
-    llm: LLMClient = ClaudeCLIClient(runner=runner, model=args.model)
+    llm: LLMClient = ClaudeCLIClient(
+        runner=runner, config=HydraFlowConfig(), model=args.model
+    )
 
     stats = await run_migration(repo_root=REPO_ROOT, llm=llm, dry_run=args.dry_run)
     print("\n=== summary ===")

--- a/scripts/run_term_proposer_once.py
+++ b/scripts/run_term_proposer_once.py
@@ -45,7 +45,15 @@ async def main() -> int:
     credentials = build_credentials(config)
     runner = get_default_runner()
 
-    llm = TermProposerLLM(client=ClaudeCLIClient(runner=runner))
+    llm = TermProposerLLM(
+        client=ClaudeCLIClient(
+            runner=runner,
+            config=config,
+            tool=config.term_proposer_tool,
+            model=config.term_proposer_model,
+            provider=config.term_proposer_provider,
+        )
+    )
 
     pr_port: BotPRPort
     if args.dry_run:

--- a/src/config.py
+++ b/src/config.py
@@ -291,6 +291,7 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
     ),
     ("term_proposer_interval", "HYDRAFLOW_TERM_PROPOSER_INTERVAL", 14400),
     ("term_proposer_max_per_tick", "HYDRAFLOW_TERM_PROPOSER_MAX_PER_TICK", 10),
+    ("term_proposer_timeout", "HYDRAFLOW_TERM_PROPOSER_TIMEOUT", 180),
     (
         "term_proposer_cooldown_seconds",
         "HYDRAFLOW_TERM_PROPOSER_COOLDOWN_SECONDS",
@@ -695,6 +696,7 @@ _ENV_COMBO_OVERRIDES: list[tuple[str, str, str]] = [
     ("HYDRAFLOW_SENTRY", "sentry_tool", "sentry_model"),
     ("HYDRAFLOW_ADR_REVIEW", "adr_review_tool", "adr_review_model"),
     ("HYDRAFLOW_REPORT_ISSUE", "report_issue_tool", "report_issue_model"),
+    ("HYDRAFLOW_TERM_PROPOSER", "term_proposer_tool", "term_proposer_model"),
 ]
 
 
@@ -1422,6 +1424,10 @@ class HydraFlowConfig(BaseModel):
     )
     pr_unstick_provider: Literal["claude", "openrouter", "zai"] = Field(
         default="claude", description="Backend for the PR-unsticker cause analysis."
+    )
+    term_proposer_provider: Literal["claude", "openrouter", "zai"] = Field(
+        default="claude",
+        description="Backend for the term-proposer / entry-evidence drafters.",
     )
     triage_max_turns: int = Field(
         default=3,
@@ -2792,6 +2798,20 @@ class HydraFlowConfig(BaseModel):
         le=604800,
         description="Cooldown before retrying a candidate that previously failed validation or LLM draft.",
     )
+    term_proposer_model: str = Field(
+        default="claude-sonnet-4-6",
+        description="Model for the term-proposer / entry-evidence drafters.",
+    )
+    term_proposer_tool: Literal["claude", "codex", "gemini", "pi"] = Field(
+        default="claude",
+        description="CLI backend for the term-proposer drafters (claude path only).",
+    )
+    term_proposer_timeout: int = Field(
+        default=180,
+        ge=30,
+        le=1800,
+        description="Per-call timeout (seconds) for the term-proposer drafters.",
+    )
 
     # Trust fleet — TermPrunerLoop (ADR-0057)
     term_pruner_enabled: bool = Field(
@@ -3918,6 +3938,7 @@ def _harmonize_tool_model_defaults(config: HydraFlowConfig) -> None:
         ("report_issue", config.report_issue_tool, config.report_issue_model),
         ("sentry", config.sentry_tool, config.sentry_model),
         ("adr_review", config.adr_review_tool, config.adr_review_model),
+        ("term_proposer", config.term_proposer_tool, config.term_proposer_model),
     ]
 
     for stage, tool, model in stage_pairs:

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -1735,7 +1735,14 @@ def build_services(
         deps=loop_deps,
     )
 
-    term_proposer_claude_client = ClaudeCLIClient(runner=subprocess_runner)
+    term_proposer_claude_client = ClaudeCLIClient(
+        runner=subprocess_runner,
+        config=config,
+        tool=config.term_proposer_tool,
+        model=config.term_proposer_model,
+        timeout=config.term_proposer_timeout,
+        provider=config.term_proposer_provider,
+    )
     term_proposer_llm = TermProposerLLM(client=term_proposer_claude_client)
     term_proposer_pr_port = OpenAutoPRBotPRPort(
         repo_root=config.repo_root,

--- a/src/settings_registry.py
+++ b/src/settings_registry.py
@@ -105,6 +105,8 @@ SETTINGS: dict[str, SettingSpec] = {
     # pr-unsticker shares the general background_model (below), so only its
     # provider dial lives here.
     "pr_unstick_provider": SettingSpec("Model Routing", live=True, order=50),
+    "term_proposer_provider": SettingSpec("Model Routing", live=True, order=60),
+    "term_proposer_model": SettingSpec("Model Routing", live=True, order=61),
     "background_model": SettingSpec("Models", live=True, order=3),
 }
 

--- a/src/term_proposer_runtime.py
+++ b/src/term_proposer_runtime.py
@@ -25,61 +25,73 @@ from typing import TYPE_CHECKING, Any
 from agent_cli import AgentTool
 
 if TYPE_CHECKING:
+    from config import HydraFlowConfig
     from execution import SubprocessRunner
 
 logger = logging.getLogger("hydraflow.term_proposer_runtime")
 
 
 class ClaudeCLIClient:
-    """Subprocess-CLI adapter for the LLMClient Protocol.
+    """Subprocess adapter for the LLMClient Protocol.
 
-    Invokes `claude -p` (or another agent tool) one-shot via SubprocessRunner;
-    parses JSON out of stdout. Tolerant of markdown fences around the JSON
-    payload (model output sometimes wraps in ```json ... ```).
+    Routes one-shot draft calls through ``runner_utils.run_lightweight_agent``
+    (the shared no-tools seam) so the spawn is gated (CH-6), telemetried (spend
+    hits the cost cap), and credit-exhaustion aware — and so the backend follows
+    the ``term_proposer_provider`` dial (``claude`` CLI, or ``openrouter``/``zai``
+    over an OpenAI-compatible endpoint). Parses JSON out of the reply, tolerant
+    of markdown fences (``` ```json ... ``` ```).
     """
 
     def __init__(
         self,
         runner: SubprocessRunner,
+        config: HydraFlowConfig,
         *,
         tool: AgentTool = "claude",
         model: str = "claude-sonnet-4-6",
         timeout: int = 180,
+        provider: str = "claude",
+        source: str = "term_proposer",
     ) -> None:
         self._runner = runner
+        self._config = config
         self._tool: AgentTool = tool
         self._model = model
         self._timeout = timeout
+        self._provider = provider
+        self._source = source
 
     async def complete_structured(
         self, *, prompt: str, schema: dict[str, Any]
     ) -> dict[str, Any]:
-        """Send prompt to the CLI tool and return the parsed JSON object.
+        """Send prompt through the one-shot seam and return the parsed JSON.
 
-        `schema` is unused by the CLI path (the prompt itself instructs the
-        model on output shape); kept in the signature to satisfy the Protocol.
+        ``schema`` drives native strict-JSON output on the OpenAI-compatible
+        providers (openrouter/zai); the ``claude`` CLI path relies on the prompt
+        instructing output shape, so ``_extract_json`` handles both.
         """
-        del schema
-        from agent_cli import build_lightweight_command  # noqa: PLC0415
-        from runner_utils import raise_if_credit_exhausted  # noqa: PLC0415
+        from runner_utils import run_lightweight_agent  # noqa: PLC0415
 
-        cmd, cmd_input = build_lightweight_command(
+        # A term/entry-evidence drafter reads wiki-term + source files; no
+        # GitHub issue is in scope, so issue_labels=() and the CH-6 gate applies
+        # only the repo-declared data class. Credit-exhaustion is raised inside
+        # the seam (CreditExhaustedError), so no manual scan is needed here.
+        result = await run_lightweight_agent(
+            runner=self._runner,
+            config=self._config,
             tool=self._tool,
             model=self._model,
             prompt=prompt,
-            isolate_user_settings=True,
+            source=self._source,
+            timeout=self._timeout,
+            provider=self._provider,
+            response_schema=schema,
+            issue_labels=(),
         )
-        result = await self._runner.run_simple(
-            cmd, input=cmd_input, timeout=self._timeout
-        )
-        # run_simple surfaces credit-out as rc!=0 text (it never raises), so
-        # scan and convert to CreditExhaustedError — otherwise the billing
-        # signal is misclassified as a generic CLI failure and burns budget.
-        raise_if_credit_exhausted(result.stdout, result.stderr, self._tool)
         if result.returncode != 0:
             raise RuntimeError(
-                f"{self._tool} CLI failed (rc={result.returncode}): "
-                f"{result.stderr[:200]}"
+                f"{self._provider}/{self._tool} draft failed "
+                f"(rc={result.returncode}): {result.stderr[:200]}"
             )
         return self._extract_json(result.stdout)
 

--- a/tests/regressions/test_lightweight_spawn_credit_telemetry.py
+++ b/tests/regressions/test_lightweight_spawn_credit_telemetry.py
@@ -197,11 +197,15 @@ class TestRaiseIfCreditExhausted:
 
 class TestTermProposerCreditDetection:
     @pytest.mark.asyncio
-    async def test_complete_structured_raises_credit_exhausted(self) -> None:
-        # Regression: term_proposer's config-less CLI path previously raised a
-        # generic RuntimeError on credit-out; it must now raise CreditExhaustedError.
+    async def test_complete_structured_raises_credit_exhausted(self, tmp_path) -> None:
+        # Regression: term_proposer must surface credit-out as
+        # CreditExhaustedError, not a generic RuntimeError. Now that the drafter
+        # routes through run_lightweight_agent, the seam's _claude_cli_complete
+        # does the raise_if_credit_exhausted scan — this pins that it still fires.
         runner = _FakeRunner(stdout=_CREDIT_TEXT, returncode=1)
-        client = ClaudeCLIClient(runner=runner)
+        client = ClaudeCLIClient(
+            runner=runner, config=ConfigFactory.create(repo_root=tmp_path / "repo")
+        )
 
         with pytest.raises(CreditExhaustedError):
             await client.complete_structured(prompt="propose terms", schema={})

--- a/tests/test_prompt_gate_completeness.py
+++ b/tests/test_prompt_gate_completeness.py
@@ -53,7 +53,8 @@ _ASSEMBLY_SEAMS = frozenset(
 # grandfathering). Ratchet: MUST shrink toward empty, MUST NOT grow.
 _NAMED_GAPS = frozenset(
     {
-        "term_proposer_runtime.py",  # ClaudeCLIClient has no config field
+        # term_proposer_runtime.py graduated: ClaudeCLIClient now takes a
+        # HydraFlowConfig and routes through run_lightweight_agent (gated).
         "adversarial_agent_runner.py",  # SubprocessAgentRunner @dataclass, no config
     }
 )

--- a/tests/test_telemetry_source_completeness.py
+++ b/tests/test_telemetry_source_completeness.py
@@ -45,7 +45,8 @@ _APPROVED = frozenset(
 # follow-up. MUST shrink toward empty and MUST NOT grow.
 _GRANDFATHERED = frozenset(
     {
-        "term_proposer_runtime.py",  # ClaudeCLIClient has no config field
+        # term_proposer_runtime.py graduated: ClaudeCLIClient now takes a
+        # HydraFlowConfig and routes through run_lightweight_agent (telemetried).
         "adversarial_agent_runner.py",  # SubprocessAgentRunner @dataclass, no config
     }
 )

--- a/tests/test_term_proposer_evals.py
+++ b/tests/test_term_proposer_evals.py
@@ -239,10 +239,21 @@ ALL_CASES = HAPPY_CASES + SAD_CASES + EDGE_CASES
 
 @pytest.fixture(scope="module")
 def llm() -> TermProposerLLM:
+    from config import HydraFlowConfig
     from execution import get_default_runner
 
+    # Real config so the eval honors the term_proposer_provider/model dials.
+    config = HydraFlowConfig()
     runner = get_default_runner()
-    return TermProposerLLM(client=ClaudeCLIClient(runner=runner))
+    return TermProposerLLM(
+        client=ClaudeCLIClient(
+            runner=runner,
+            config=config,
+            tool=config.term_proposer_tool,
+            model=config.term_proposer_model,
+            provider=config.term_proposer_provider,
+        )
+    )
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_term_proposer_runtime.py
+++ b/tests/test_term_proposer_runtime.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import subprocess
 from pathlib import Path
 
 import pytest
@@ -31,51 +30,78 @@ def _term_file_str(name: str) -> str:
     return _render_term_file_str(term)
 
 
-class FakeRunner:
-    def __init__(self, *, returncode: int, stdout: str, stderr: str = "") -> None:
-        self._result = subprocess.CompletedProcess(
-            args=["fake"], returncode=returncode, stdout=stdout, stderr=stderr
-        )
-        self.calls: list[dict] = []
-
-    async def run_simple(
-        self, cmd, *, input=None, timeout=None, **_
-    ) -> subprocess.CompletedProcess[str]:
-        self.calls.append({"cmd": cmd, "input": input, "timeout": timeout})
-        return self._result
-
-
 class TestClaudeCLIClient:
+    """ClaudeCLIClient is a thin adapter over ``run_lightweight_agent`` (the
+    gated + telemetried seam). It threads the term-proposer dials and parses
+    JSON out of the reply; the seam's credit/gate/telemetry behavior is covered
+    by test_llm_provider.py, so here we mock the seam and assert the wiring."""
+
+    def _client(self, monkeypatch, *, stdout="", returncode=0, provider="claude"):
+        """Construct a client whose seam call returns a canned SimpleResult and
+        records the kwargs it was invoked with."""
+        from unittest.mock import AsyncMock
+
+        from execution import SimpleResult
+        from tests.helpers import ConfigFactory
+
+        captured: dict = {}
+
+        async def _fake_seam(**kwargs):
+            captured.update(kwargs)
+            return SimpleResult(stdout=stdout, stderr="boom", returncode=returncode)
+
+        monkeypatch.setattr("runner_utils.run_lightweight_agent", _fake_seam)
+        client = ClaudeCLIClient(
+            runner=AsyncMock(),
+            config=ConfigFactory.create(),
+            tool="claude",
+            model="glm-4.6" if provider != "claude" else "claude-sonnet-4-6",
+            provider=provider,
+            timeout=90,
+        )
+        return client, captured
+
     @pytest.mark.asyncio
-    async def test_returns_parsed_json(self) -> None:
-        runner = FakeRunner(returncode=0, stdout='{"foo": "bar", "n": 1}')
-        client = ClaudeCLIClient(runner=runner)
+    async def test_returns_parsed_json(self, monkeypatch) -> None:
+        client, _ = self._client(monkeypatch, stdout='{"foo": "bar", "n": 1}')
         out = await client.complete_structured(prompt="hi", schema={})
         assert out == {"foo": "bar", "n": 1}
 
     @pytest.mark.asyncio
-    async def test_extracts_json_from_markdown_fence(self) -> None:
-        runner = FakeRunner(
-            returncode=0,
+    async def test_extracts_json_from_markdown_fence(self, monkeypatch) -> None:
+        client, _ = self._client(
+            monkeypatch,
             stdout='Here is the result:\n```json\n{"k": "v"}\n```\nDone.',
         )
-        client = ClaudeCLIClient(runner=runner)
         out = await client.complete_structured(prompt="hi", schema={})
         assert out == {"k": "v"}
 
     @pytest.mark.asyncio
-    async def test_raises_on_nonzero_returncode(self) -> None:
-        runner = FakeRunner(returncode=1, stdout="", stderr="boom")
-        client = ClaudeCLIClient(runner=runner)
-        with pytest.raises(RuntimeError, match="claude CLI failed"):
+    async def test_raises_on_nonzero_returncode(self, monkeypatch) -> None:
+        client, _ = self._client(monkeypatch, returncode=1)
+        with pytest.raises(RuntimeError, match="draft failed"):
             await client.complete_structured(prompt="hi", schema={})
 
     @pytest.mark.asyncio
-    async def test_raises_when_no_json_in_output(self) -> None:
-        runner = FakeRunner(returncode=0, stdout="just prose, no json here")
-        client = ClaudeCLIClient(runner=runner)
+    async def test_raises_when_no_json_in_output(self, monkeypatch) -> None:
+        client, _ = self._client(monkeypatch, stdout="just prose, no json here")
         with pytest.raises(RuntimeError, match="no JSON object"):
             await client.complete_structured(prompt="hi", schema={})
+
+    @pytest.mark.asyncio
+    async def test_threads_dial_and_schema_to_the_seam(self, monkeypatch) -> None:
+        # The provider/model/tool dials + the JSON schema reach the seam, so
+        # flipping term_proposer_provider to zai actually routes the draft there.
+        client, captured = self._client(
+            monkeypatch, stdout='{"ok": true}', provider="zai"
+        )
+        schema = {"type": "object", "properties": {"ok": {"type": "boolean"}}}
+        await client.complete_structured(prompt="draft this", schema=schema)
+        assert captured["provider"] == "zai"
+        assert captured["model"] == "glm-4.6"
+        assert captured["tool"] == "claude"
+        assert captured["response_schema"] == schema
+        assert captured["source"] == "term_proposer"
 
 
 class TestOpenAutoPRBotPRPort:


### PR DESCRIPTION
## Why
Follow-up to #9751. The term-proposer drafter (shared by term-proposer + entry-evidence loops) was the one one-shot LLM role still on a bespoke `build_lightweight_command` + `run_simple` path — so it couldn't be routed to a cheap backend, its spend was invisible to the cost cap, and it sat on **two CH-6 governance allowlists** as an un-gated/un-telemetried spawner ("ClaudeCLIClient has no config field").

## What
Threading a `HydraFlowConfig` through `ClaudeCLIClient` and routing `complete_structured` through `run_lightweight_agent` fixes all of it at once:

- **Dial-able**: `term_proposer_provider` / `_model` (Settings ▸ Model Routing, claude/openrouter/**zai**) + `_tool` / `_timeout` knobs, wired through the combo-env override and `_harmonize_tool_model_defaults`. The dropdown gains "zai" automatically (Literal-derived). Key stays env-only.
- **Telemetried + gated**: records `PromptTelemetry(source="term_proposer")` (spend hits the cost cap) and passes the CH-6 gate. `issue_labels=()` — a maintenance drafter has no issue in scope.
- **Native strict-JSON** on openrouter/zai: `complete_structured`'s `schema` is now `response_schema` (the old CLI path ignored it).
- **Governance tightening**: removed `term_proposer_runtime.py` from `_GRANDFATHERED` (telemetry) **and** `_NAMED_GAPS` (prompt-gate) — both ratchets "shrink toward empty".

`entry-evidence` shares the same client → dial-able for free.

## Tests
- Runtime tests mock the seam and assert the dial is threaded; credit regression pins `CreditExhaustedError` still fires via the seam.
- Both CH-6 completeness guards now **enforce** (not exempt) seam-routing.
- `make quality` green (17,684 passed); suppressions baseline −1; arch-regen refreshed. Two utility scripts updated to pass config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)