### PR TITLE
test(sandbox): s53 e2e — Model-Routing settings UI (zai dropdowns + key badge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,9 +376,9 @@ jobs:
           python-version: "3.11"
       - run: pip install uv && uv pip install --system -e ".[dev]"
       - run: docker compose -f docker-compose.sandbox.yml build hydraflow ui playwright
-      - name: Run fast subset (s01, s06)
+      - name: Run fast subset (s01, s06, s53)
         run: |
-          for s in s01_happy_single_issue s06_kill_switch_via_ui; do
+          for s in s01_happy_single_issue s06_kill_switch_via_ui s53_model_routing_settings_ui; do
             python scripts/sandbox_scenario.py run $s || exit 1
           done
       - if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,9 +378,19 @@ jobs:
       - run: docker compose -f docker-compose.sandbox.yml build hydraflow ui playwright
       - name: Run fast subset (s01, s06, s53)
         run: |
+          # Run every scenario and aggregate failures — do NOT early-exit on the
+          # first red, or a broken leading scenario (e.g. s01, #9754) silently
+          # hides the status of the ones after it. Report which failed.
+          rc=0
           for s in s01_happy_single_issue s06_kill_switch_via_ui s53_model_routing_settings_ui; do
-            python scripts/sandbox_scenario.py run $s || exit 1
+            if python scripts/sandbox_scenario.py run "$s"; then
+              echo "::notice::sandbox $s PASSED"
+            else
+              echo "::error::sandbox $s FAILED"
+              rc=1
+            fi
           done
+          exit $rc
       - if: failure()
         uses: actions/upload-artifact@v4
         with:

--- a/tests/sandbox_scenarios/scenarios/s53_model_routing_settings_ui.py
+++ b/tests/sandbox_scenarios/scenarios/s53_model_routing_settings_ui.py
@@ -1,0 +1,63 @@
+"""s53 — Model-Routing settings UI renders the provider dials + key-status badge.
+
+Guards the schema-driven Settings ▸ Model Routing screen end-to-end: every
+one-shot role's provider dropdown must offer the ``zai`` backend (Literal-derived
+enum choices), and each ``<provider>_base_url`` row must carry the key-status
+badge (booleans-only; no key in the sandbox → "not set"). This is the sandbox
+e2e layer for the pluggable-provider UI (unit coverage: RuntimeSettingsPanel
+vitest; API coverage: test_control_routes_settings). Without it the dropdown +
+badge wiring is validated only below the browser layer.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s53_model_routing_settings_ui"
+DESCRIPTION = (
+    "System ▸ Settings ▸ Model Routing exposes the zai provider option in every "
+    "one-shot role dropdown and a key-status badge (no key → 'not set')."
+)
+
+
+def seed() -> MockWorldSeed:
+    # No pipeline activity needed — this exercises the settings screen only.
+    return MockWorldSeed(cycles_to_run=1)
+
+
+async def assert_outcome(api, page) -> None:
+    await page.goto("/")
+    await page.click("text=System")
+    # Open the Settings sub-tab (schema-driven RuntimeSettingsPanel).
+    await page.get_by_text("Settings", exact=True).first.click()
+
+    panel = page.locator("[data-testid='runtime-settings-panel']")
+    await panel.wait_for(timeout=15_000)
+    # The Model Routing group renders its base-URL row (schema-derived).
+    await page.locator("[data-testid='setting-zai_base_url']").wait_for(timeout=15_000)
+
+    # Every one-shot role's provider dropdown offers the "zai" backend — the
+    # choices derive from the config Literal, so a missing option means the
+    # dial can't be pointed at z.ai from the UI.
+    for field in (
+        "wiki_compilation_provider",
+        "adr_review_provider",
+        "transcript_summary_provider",
+        "triage_honeypot_provider",
+        "pr_unstick_provider",
+        "term_proposer_provider",
+    ):
+        options = page.locator(f"[data-testid='input-{field}'] option", has_text="zai")
+        assert await options.count() > 0, (
+            f"{field} dropdown is missing the 'zai' option"
+        )
+
+    # The key-status badge renders. No provider key is set in the sandbox, so it
+    # must read "not set" (booleans only — the secret value never reaches the UI).
+    badge = page.locator("[data-testid='keystatus-zai_base_url']")
+    await badge.wait_for(timeout=10_000)
+    badge_text = await badge.inner_text()
+    assert "not set" in badge_text.lower(), (
+        f"expected the zai key-status badge to read 'not set' (no key in sandbox), "
+        f"got {badge_text!r}"
+    )

--- a/tests/sandbox_scenarios/seeds/s53_model_routing_settings_ui.json
+++ b/tests/sandbox_scenarios/seeds/s53_model_routing_settings_ui.json
@@ -1,0 +1,16 @@
+{
+  "repos": [],
+  "issues": [],
+  "comments": {},
+  "prs": [],
+  "scripts": {},
+  "advisor_scripts": {},
+  "phase_scripts": {},
+  "cycles_to_run": 1,
+  "loops_enabled": null,
+  "main_branch_ci_status": [
+    "success",
+    ""
+  ],
+  "plan_hold_seconds": 0.0
+}


### PR DESCRIPTION
## Why
The pluggable-provider UI (provider dropdowns + 🔑 key-status badge, #9751/#9752) had unit coverage (RuntimeSettingsPanel vitest) and API coverage (test_control_routes_settings) but **no sandbox e2e** — the browser layer your three-layer rule asks for. This adds it.

## What
`s53_model_routing_settings_ui` drives the live sandbox stack:
1. Opens System ▸ Settings (schema-driven `RuntimeSettingsPanel`).
2. Asserts **every** one-shot role's provider dropdown offers the `zai` backend (choices derive from the config `Literal` — a missing option means the dial can't reach z.ai from the UI). Covers all six: wiki_compilation, adr_review, transcript_summary, triage_honeypot, pr_unstick, term_proposer.
3. Asserts the `zai_base_url` row carries a **key-status badge reading "not set"** (no key in the sandbox; booleans-only — the secret never reaches the UI).

Auto-discovered by the scenario loader; added to the PR→staging fast subset (`s01, s06, s53`).

## Verification
Ran the real harness locally against a rebuilt image:
```
$ uv run python scripts/sandbox_scenario.py run s53_model_routing_settings_ui
[5/5] Running playwright assertions...
PASSED s53_model_routing_settings_ui
```
`make audit` clean (touches `ci.yml`); ruff clean; scenario imports + parametrizes via the loader.

## Note
The fast-subset job also runs `s01`, which is **pre-existing broken on staging** (tracked in #9754, unrelated to this change) — so the aggregate job stays red until #9754 is fixed. s53 itself passes independently (proven above); once #9754 lands, the fast subset goes fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)