### PR TITLE
fix(sandbox): disable CH-3 merge policy in the air-gapped sandbox (#9754)

### DIFF
--- a/disturbance/baselines/suppressions.yaml
+++ b/disturbance/baselines/suppressions.yaml
@@ -12,7 +12,10 @@ comment: "suppressions disturbance baseline. MUST NOT grow (gate fails on increa
   \ convention). re-snapshot 2026-07-11: -1 term_proposer_runtime PLC0415 \u2014 ClaudeCLIClient\
   \ now routes the drafter through run_lightweight_agent (one seam import replaces\
   \ build_lightweight_command+raise_if_credit_exhausted), making it dial-able + gated\
-  \ + telemetried (dropped from both CH-6 grandfather lists)."
+  \ + telemetried (dropped from both CH-6 grandfather lists). re-snapshot 2026-07-13:\
+  \ +1 sandbox_main type-ignore[misc] (3->4) — _apply_sandbox_config_overrides sets\
+  \ config.merge_policy_enabled=False for the air-gap (#9754), same frozen-field\
+  \ assignment idiom as the 3 sibling overrides it now sits beside."
 entries:
   src/acceptance_criteria.py::noqa:PLC0415: 2
   src/admin_tasks.py::noqa:PLC0415: 7
@@ -176,7 +179,7 @@ entries:
   src/mockworld/fakes/fake_wiki_compiler.py::noqa:PLC0415: 1
   src/mockworld/sandbox_main.py::noqa:PLC0415: 1
   src/mockworld/sandbox_main.py::type-ignore[attr-defined]: 6
-  src/mockworld/sandbox_main.py::type-ignore[misc]: 3
+  src/mockworld/sandbox_main.py::type-ignore[misc]: 4
   "src/models.py::noqa:F401\u2014usedinField(validation_alias=...)": 1
   "src/models.py::noqa:UP035\u2014neededatruntimeforPydantictoexcludefromfields": 1
   src/models.py::type-ignore[assignment]: 2

--- a/src/mockworld/sandbox_main.py
+++ b/src/mockworld/sandbox_main.py
@@ -16,7 +16,7 @@ import signal
 import sys
 from collections.abc import Callable
 from pathlib import Path
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from dashboard import HydraFlowDashboard
 from events import EventBus
@@ -38,6 +38,38 @@ from service_registry import (
     build_services,
     build_state_tracker,
 )
+
+if TYPE_CHECKING:
+    from config import HydraFlowConfig
+
+
+def _apply_sandbox_config_overrides(config: HydraFlowConfig) -> None:
+    """Turn off production code paths that reach services unreachable on the
+    air-gapped sandbox network (``internal: true`` in docker-compose.sandbox.yml).
+
+    The four primary LLM-backed runners (triage/plan/agent/review) are already
+    replaced with FakeLLM; these flags turn off the remaining external reachers,
+    which otherwise either hang for the full subprocess timeout or hard-fail:
+
+    - ``transcript_summarization``/``research``: secondary ``claude`` callers
+      (TranscriptSummarizer after each agent phase; ResearchRunner before each
+      plan phase) that hang ~30s on api_retry backoff before failing.
+    - ``contract_refresh_external``: ContractRefreshLoop's github/claude/docker
+      recorders reach the contracts-sandbox repo / api.anthropic.com / alpine
+      pull, each blocking up to the 120s subprocess timeout (s30).
+    - ``merge_policy`` (#9754): CH-3 ``enforce_merge_policy`` fetches PR labels
+      via a RAW ``gh pr view --json labels`` subprocess
+      (``merge_policy._fetch_pr_labels`` — deliberately not routed through
+      PRPort, so FakeGitHub never sees it). On the air-gapped network that gh
+      call runs against an empty ``config.repo``, falls back to git, and fails
+      with "not a git repository", so EVERY approved PR's merge raises and no
+      issue reaches the "merged" outcome (s01's happy path). The compliance
+      gate has its own unit tests; the sandbox exercises the pipeline.
+    """
+    config.transcript_summarization_enabled = False  # type: ignore[misc]
+    config.research_enabled = False  # type: ignore[misc]
+    config.contract_refresh_external_enabled = False  # type: ignore[misc]
+    config.merge_policy_enabled = False  # type: ignore[misc]
 
 
 def _load_seed() -> MockWorldSeed:
@@ -141,31 +173,9 @@ def _build_caretaker_enabled_cb(
 
 async def main() -> None:
     config = load_runtime_config()
-    # Sandbox-specific config overrides — disable downstream code paths
-    # that spawn real `claude` subprocesses. The sandbox is `internal: true`
-    # per docker-compose.sandbox.yml, so these subprocesses hang for ~30s
-    # of api_retry exponential backoff before failing with "unknown"
-    # network errors. With multiple parallel issues (s02_batch_three_issues)
-    # the cumulative hang exceeds the per-scenario 60s test timeout.
-    #
-    # The four primary LLM-backed runners (triage/plan/agent/review) are
-    # already overridden via `runners=fake_llm` below; these flags turn
-    # off the remaining secondary `claude` callers:
-    #
-    # - TranscriptSummarizer: spawns `claude` via subprocess_util.run_simple
-    #   after each agent phase to summarize the transcript.
-    # - ResearchRunner: spawns `claude` via _execute before each plan phase
-    #   to gather codebase context. PlanPhase._should_research() honors
-    #   this flag (see src/plan_phase.py).
-    config.transcript_summarization_enabled = False  # type: ignore[misc]
-    config.research_enabled = False  # type: ignore[misc]
-    # ContractRefreshLoop's github/claude/docker recorders reach external
-    # services (contracts-sandbox repo, api.anthropic.com, alpine pull) that
-    # are unreachable on the internal sandbox network; each blocks up to the
-    # 120s subprocess timeout, so the loop never emits its worker-status event
-    # within a scenario's window (s30). Skip them — only the local git
-    # recorder runs.
-    config.contract_refresh_external_enabled = False  # type: ignore[misc]
+    # Disable production code paths that reach services unreachable on the
+    # air-gapped sandbox network (see the helper for the per-flag rationale).
+    _apply_sandbox_config_overrides(config)
     seed = _load_seed()
     event_bus = EventBus()
     state = build_state_tracker(config)

--- a/tests/regressions/test_sandbox_merge_policy_airgap_9754.py
+++ b/tests/regressions/test_sandbox_merge_policy_airgap_9754.py
@@ -1,0 +1,40 @@
+"""Regression (#9754): the sandbox must disable CH-3 merge policy.
+
+`enforce_merge_policy` fetches PR labels via a RAW `gh pr view --json labels`
+subprocess (`merge_policy._fetch_pr_labels`, deliberately not routed through
+PRPort). On the air-gapped sandbox network that runs against an empty
+`config.repo`, falls back to git, and fails with "not a git repository" — so
+EVERY approved PR's merge raised and no issue reached the "merged" outcome
+(s01_happy_single_issue timed out with 0 merged issues).
+
+`sandbox_main._apply_sandbox_config_overrides` must turn merge_policy off,
+alongside the other external-reaching features it already disables. The e2e
+guard is the s01 sandbox scenario, but that job is path-filtered and often
+skipped; this fast unit guard runs in every `make quality`.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from mockworld.sandbox_main import _apply_sandbox_config_overrides
+from tests.helpers import ConfigFactory
+
+
+def test_sandbox_disables_merge_policy_and_other_external_reachers() -> None:
+    config = ConfigFactory.create()
+    # Sanity: these default ON in production, so the overrides are meaningful.
+    assert config.merge_policy_enabled is True
+    assert config.research_enabled is True
+
+    _apply_sandbox_config_overrides(config)
+
+    # The #9754 fix: merge policy off so the raw gh label read never fires.
+    assert config.merge_policy_enabled is False
+    # The siblings it sits beside — all external reachers, all off.
+    assert config.transcript_summarization_enabled is False
+    assert config.research_enabled is False
+    assert config.contract_refresh_external_enabled is False


### PR DESCRIPTION
## Summary
Fixes **#9754** — `s01_happy_single_issue` (and thus the `Sandbox (PR→staging fast subset)` check) failed deterministically on clean `staging`, blocking the rc/* → main promotion gate.

## Root cause (confirmed in docker)
The seeded issue is fully triaged → planned → implemented → reviewed and **APPROVED** — then the merge fails. `enforce_merge_policy` (CH-3) fetches PR labels via a **raw `gh pr view --json labels`** subprocess (`merge_policy._fetch_pr_labels`, deliberately not routed through `PRPort`, so `FakeGitHub` never sees it). On the sandbox's internal air-gapped network that `gh` call runs against an **empty `config.repo`**, falls back to git, and fails with `not a git repository`. The `RuntimeError` propagates `post_merge_handler.handle_approved → review_phase`, failing the merge for **every** approved PR — so no issue ever reaches the `merged` outcome and the happy-path assertion times out.

The reported "0 inferences" was a red herring; the pipeline runs fine up to the merge.

## Fix
`sandbox_main` disables `merge_policy_enabled`, exactly as it already disables `transcript_summarization` / `research` / `contract_refresh_external` for the same air-gap reason. The compliance gate has its own unit tests; the sandbox exercises the pipeline. The four inline overrides are extracted into a testable `_apply_sandbox_config_overrides` helper.

## Verification
- **Docker: `s01_happy_single_issue` PASS, `s06_kill_switch_via_ui` PASS** (no regression).
- Regression guard in `tests/regressions/test_sandbox_merge_policy_airgap_9754.py` — the sandbox e2e check is path-filtered and often skipped, so a fast unit guard runs in every `make quality`.
- `make quality` green (17709 passed); disturbance ratchet re-snapshot for the one new frozen-field `type: ignore[misc]`.

## Not in scope
The other air-gap log noise (`approval_records` `gh pr list --repo ''`, caretaker `not a git repository`) is benign — s01 passes with just this fix. Those are separate raw-gh reads that don't block the pipeline.

Closes #9754

🤖 Generated with [Claude Code](https://claude.com/claude-code)