### PR TITLE
test(fitness): de-time-bomb scorecard scenario tests (hardcoded date aged out)

### DIFF
--- a/tests/scenarios/test_fitness_scorecard_e2e.py
+++ b/tests/scenarios/test_fitness_scorecard_e2e.py
@@ -12,7 +12,7 @@ at tmp_path), and a fake issue_fetcher.  No docker / live services required.
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock
 
 import pytest
@@ -76,7 +76,11 @@ async def test_fitness_scorecard_e2e(tmp_path) -> None:
                 labels=["x-proposal"],
                 is_pr=True,
                 merged=(n % 2 == 0),
-                created_at=datetime(2026, 6, 15, tzinfo=UTC),
+                # Relative to now so the record always lands inside the window
+                # (window_start = now - fitness_window_days); a hardcoded date
+                # silently ages out and makes the score None (time-bombed on
+                # 2026-07-15 when a prior fixed 2026-06-15 aged out of 30 days).
+                created_at=datetime.now(UTC) - timedelta(days=1),
             )
             for n in range(4)
         ]

--- a/tests/scenarios/test_fitness_scorecard_scenario.py
+++ b/tests/scenarios/test_fitness_scorecard_scenario.py
@@ -8,7 +8,7 @@ history.  Asserts it emits ``LOOP_FITNESS_UPDATE`` and writes
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock
 
 import pytest
@@ -55,7 +55,12 @@ async def test_scorecard_scenario(tmp_path) -> None:
                 labels=["x-proposal"],
                 is_pr=True,
                 merged=(n % 2 == 0),
-                created_at=datetime(2026, 6, 15, tzinfo=UTC),
+                # Relative to now so the record always lands inside the
+                # window (window_start = now - fitness_window_days). A hardcoded
+                # date silently falls out of the window once the calendar passes
+                # it, making the score None — the whole suite time-bombed on
+                # 2026-07-15 when a prior fixed 2026-06-15 aged out of 30 days.
+                created_at=datetime.now(UTC) - timedelta(days=1),
             )
             for n in range(4)
         ]


### PR DESCRIPTION
## Summary
Two fitness-scorecard scenario tests hardcoded `created_at=datetime(2026, 6, 15)` and score merged-ratio against a `now() − fitness_window_days` (30-day) window. On **2026-07-15** that fixed date fell out of the window (`window_start = now − 30d ≈ 2026-06-15 02:55Z > record's 00:00Z`), so `filed` went empty, `proposal_acceptance_fitness` returned `INSUFFICIENT_DATA` (`score=None`), and `assert score == 0.5` failed.

**This is a repo-wide calendar time-bomb** — it fails `make quality`/CI on *every* branch as of today, with no code change. Confirmed failing on clean `staging`.

## Fix
Place the test records at `now − 1 day` so they always land inside the window regardless of when the suite runs. Comment added so a fixed date isn't reintroduced.

- `tests/scenarios/test_fitness_scorecard_scenario.py`
- `tests/scenarios/test_fitness_scorecard_e2e.py`

Test-only; no production code. Both tests pass; pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)