### PR TITLE
chore(pricing): refresh from LiteLLM — 2026-07-18

### DIFF
--- a/src/assets/model_pricing.json
+++ b/src/assets/model_pricing.json
@@ -1,56 +1,222 @@
 {
   "schema_version": 1,
   "currency": "USD",
-  "updated_at": "2026-04-26",
+  "updated_at": "2026-07-18",
   "source": "https://docs.anthropic.com/en/docs/about-claude/models",
   "models": {
     "claude-haiku-4-5-20251001": {
       "provider": "anthropic",
-      "aliases": ["haiku", "claude-haiku-4-5", "claude-4-5-haiku"],
-      "input_cost_per_million": 1.00,
-      "output_cost_per_million": 5.00,
+      "aliases": [
+        "haiku",
+        "claude-haiku-4-5",
+        "claude-4-5-haiku"
+      ],
+      "input_cost_per_million": 1.0,
+      "output_cost_per_million": 5.0,
       "cache_write_cost_per_million": 1.25,
-      "cache_read_cost_per_million": 0.10
+      "cache_read_cost_per_million": 0.1
     },
     "claude-sonnet-4-6": {
       "provider": "anthropic",
-      "aliases": ["sonnet", "claude-sonnet-4-6", "claude-4-6-sonnet"],
-      "input_cost_per_million": 3.00,
-      "output_cost_per_million": 15.00,
+      "aliases": [
+        "sonnet",
+        "claude-sonnet-4-6",
+        "claude-4-6-sonnet"
+      ],
+      "input_cost_per_million": 3.0,
+      "output_cost_per_million": 15.0,
       "cache_write_cost_per_million": 3.75,
-      "cache_read_cost_per_million": 0.30
+      "cache_read_cost_per_million": 0.3
     },
     "claude-opus-4-7": {
       "provider": "anthropic",
-      "aliases": ["opus", "claude-opus-4-7", "claude-4-7-opus", "claude-opus-4-7[1m]"],
-      "input_cost_per_million": 5.00,
-      "output_cost_per_million": 25.00,
+      "aliases": [
+        "opus",
+        "claude-opus-4-7",
+        "claude-4-7-opus",
+        "claude-opus-4-7[1m]"
+      ],
+      "input_cost_per_million": 5.0,
+      "output_cost_per_million": 25.0,
       "cache_write_cost_per_million": 6.25,
-      "cache_read_cost_per_million": 0.50
+      "cache_read_cost_per_million": 0.5
     },
     "claude-3-5-haiku-20241022": {
       "provider": "anthropic",
-      "aliases": ["claude-3-5-haiku", "claude-3.5-haiku"],
-      "input_cost_per_million": 0.80,
-      "output_cost_per_million": 4.00,
-      "cache_write_cost_per_million": 1.00,
+      "aliases": [
+        "claude-3-5-haiku",
+        "claude-3.5-haiku"
+      ],
+      "input_cost_per_million": 0.8,
+      "output_cost_per_million": 4.0,
+      "cache_write_cost_per_million": 1.0,
       "cache_read_cost_per_million": 0.08
     },
     "claude-sonnet-4-20250514": {
       "provider": "anthropic",
-      "aliases": ["claude-4-sonnet", "claude-sonnet-4"],
-      "input_cost_per_million": 3.00,
-      "output_cost_per_million": 15.00,
+      "aliases": [
+        "claude-4-sonnet",
+        "claude-sonnet-4"
+      ],
+      "input_cost_per_million": 3.0,
+      "output_cost_per_million": 15.0,
       "cache_write_cost_per_million": 3.75,
-      "cache_read_cost_per_million": 0.30
+      "cache_read_cost_per_million": 0.3
     },
     "claude-opus-4-20250514": {
       "provider": "anthropic",
-      "aliases": ["claude-4-opus", "claude-opus-4"],
-      "input_cost_per_million": 15.00,
-      "output_cost_per_million": 75.00,
+      "aliases": [
+        "claude-4-opus",
+        "claude-opus-4"
+      ],
+      "input_cost_per_million": 15.0,
+      "output_cost_per_million": 75.0,
       "cache_write_cost_per_million": 18.75,
-      "cache_read_cost_per_million": 1.50
+      "cache_read_cost_per_million": 1.5
+    },
+    "claude-haiku-4-5": {
+      "provider": "anthropic",
+      "aliases": [],
+      "input_cost_per_million": 1.0,
+      "output_cost_per_million": 5.0,
+      "cache_write_cost_per_million": 1.25,
+      "cache_read_cost_per_million": 0.1
+    },
+    "claude-3-7-sonnet-20250219": {
+      "provider": "anthropic",
+      "aliases": [],
+      "input_cost_per_million": 3.0,
+      "output_cost_per_million": 15.0,
+      "cache_write_cost_per_million": 3.75,
+      "cache_read_cost_per_million": 0.3
+    },
+    "claude-3-haiku-20240307": {
+      "provider": "anthropic",
+      "aliases": [],
+      "input_cost_per_million": 0.25,
+      "output_cost_per_million": 1.25,
+      "cache_write_cost_per_million": 0.3,
+      "cache_read_cost_per_million": 0.03
+    },
+    "claude-3-opus-20240229": {
+      "provider": "anthropic",
+      "aliases": [],
+      "input_cost_per_million": 15.0,
+      "output_cost_per_million": 75.0,
+      "cache_write_cost_per_million": 18.75,
+      "cache_read_cost_per_million": 1.5
+    },
+    "claude-4-opus-20250514": {
+      "provider": "anthropic",
+      "aliases": [],
+      "input_cost_per_million": 15.0,
+      "output_cost_per_million": 75.0,
+      "cache_write_cost_per_million": 18.75,
+      "cache_read_cost_per_million": 1.5
+    },
+    "claude-4-sonnet-20250514": {
+      "provider": "anthropic",
+      "aliases": [],
+      "input_cost_per_million": 3.0,
+      "output_cost_per_million": 15.0,
+      "cache_write_cost_per_million": 3.75,
+      "cache_read_cost_per_million": 0.3
+    },
+    "claude-sonnet-4-5": {
+      "provider": "anthropic",
+      "aliases": [],
+      "input_cost_per_million": 3.0,
+      "output_cost_per_million": 15.0,
+      "cache_write_cost_per_million": 3.75,
+      "cache_read_cost_per_million": 0.3
+    },
+    "claude-sonnet-4-5-20250929": {
+      "provider": "anthropic",
+      "aliases": [],
+      "input_cost_per_million": 3.0,
+      "output_cost_per_million": 15.0,
+      "cache_write_cost_per_million": 3.75,
+      "cache_read_cost_per_million": 0.3
+    },
+    "claude-sonnet-5": {
+      "provider": "anthropic",
+      "aliases": [],
+      "input_cost_per_million": 2.0,
+      "output_cost_per_million": 10.0,
+      "cache_write_cost_per_million": 2.5,
+      "cache_read_cost_per_million": 0.2
+    },
+    "claude-opus-4-1": {
+      "provider": "anthropic",
+      "aliases": [],
+      "input_cost_per_million": 15.0,
+      "output_cost_per_million": 75.0,
+      "cache_write_cost_per_million": 18.75,
+      "cache_read_cost_per_million": 1.5
+    },
+    "claude-opus-4-1-20250805": {
+      "provider": "anthropic",
+      "aliases": [],
+      "input_cost_per_million": 15.0,
+      "output_cost_per_million": 75.0,
+      "cache_write_cost_per_million": 18.75,
+      "cache_read_cost_per_million": 1.5
+    },
+    "claude-opus-4-5-20251101": {
+      "provider": "anthropic",
+      "aliases": [],
+      "input_cost_per_million": 5.0,
+      "output_cost_per_million": 25.0,
+      "cache_write_cost_per_million": 6.25,
+      "cache_read_cost_per_million": 0.5
+    },
+    "claude-opus-4-5": {
+      "provider": "anthropic",
+      "aliases": [],
+      "input_cost_per_million": 5.0,
+      "output_cost_per_million": 25.0,
+      "cache_write_cost_per_million": 6.25,
+      "cache_read_cost_per_million": 0.5
+    },
+    "claude-opus-4-6": {
+      "provider": "anthropic",
+      "aliases": [],
+      "input_cost_per_million": 5.0,
+      "output_cost_per_million": 25.0,
+      "cache_write_cost_per_million": 6.25,
+      "cache_read_cost_per_million": 0.5
+    },
+    "claude-opus-4-6-20260205": {
+      "provider": "anthropic",
+      "aliases": [],
+      "input_cost_per_million": 5.0,
+      "output_cost_per_million": 25.0,
+      "cache_write_cost_per_million": 6.25,
+      "cache_read_cost_per_million": 0.5
+    },
+    "claude-opus-4-7-20260416": {
+      "provider": "anthropic",
+      "aliases": [],
+      "input_cost_per_million": 5.0,
+      "output_cost_per_million": 25.0,
+      "cache_write_cost_per_million": 6.25,
+      "cache_read_cost_per_million": 0.5
+    },
+    "claude-fable-5": {
+      "provider": "anthropic",
+      "aliases": [],
+      "input_cost_per_million": 10.0,
+      "output_cost_per_million": 50.0,
+      "cache_write_cost_per_million": 12.5,
+      "cache_read_cost_per_million": 1.0
+    },
+    "claude-opus-4-8": {
+      "provider": "anthropic",
+      "aliases": [],
+      "input_cost_per_million": 5.0,
+      "output_cost_per_million": 25.0,
+      "cache_write_cost_per_million": 6.25,
+      "cache_read_cost_per_million": 0.5
     }
   }
 }


### PR DESCRIPTION
Auto-generated by `PricingRefreshLoop`. The pricing data in
`src/assets/model_pricing.json` was refreshed from LiteLLM's
structured upstream JSON.

**Added** (18 model(s)):

- `claude-3-7-sonnet-20250219`
- `claude-3-haiku-20240307`
- `claude-3-opus-20240229`
- `claude-4-opus-20250514`
- `claude-4-sonnet-20250514`
- `claude-fable-5`
- `claude-haiku-4-5`
- `claude-opus-4-1`
- `claude-opus-4-1-20250805`
- `claude-opus-4-5`
- `claude-opus-4-5-20251101`
- `claude-opus-4-6`
- `claude-opus-4-6-20260205`
- `claude-opus-4-7-20260416`
- `claude-opus-4-8`
- `claude-sonnet-4-5`
- `claude-sonnet-4-5-20250929`
- `claude-sonnet-5`

Source: <https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json>

Per ADR-0029 caretaker pattern. **Human review required**;
loop never auto-merges pricing changes.