### PR TITLE
chore: align ui package-lock version to 0.9.7

### DIFF
--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydraflow-ui",
-  "version": "0.9.1",
+  "version": "0.9.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydraflow-ui",
-      "version": "0.9.1",
+      "version": "0.9.7",
       "dependencies": {
         "@xyflow/react": "^12.10.2",
         "d3-force": "^3.0.0",


### PR DESCRIPTION
Companion to #9763. `src/ui/package.json` was bumped to 0.9.7 but `package-lock.json` still read 0.9.1 — this aligns it. **Version field only, no dependency changes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)