### PR TITLE
chore: point stale model defaults at latest Sonnet

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -2844,7 +2844,7 @@ class HydraFlowConfig(BaseModel):
         description="Cooldown before retrying a candidate that previously failed validation or LLM draft.",
     )
     term_proposer_model: str = Field(
-        default="claude-sonnet-4-6",
+        default="sonnet",
         description="Model for the term-proposer / entry-evidence drafters.",
     )
     term_proposer_tool: Literal["claude", "codex", "gemini", "pi"] = Field(

--- a/src/onboarding/design_ai.py
+++ b/src/onboarding/design_ai.py
@@ -20,7 +20,7 @@ METHODOLOGY_PROMPT = (
 )
 ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
 ANTHROPIC_VERSION = "2023-06-01"
-DEFAULT_CLAUDE_MODEL = "claude-sonnet-4-6"
+DEFAULT_CLAUDE_MODEL = "claude-sonnet-5"
 
 _NAME_RE = re.compile(r"\b[a-z][a-z0-9]+(?:-[a-z0-9]+)+\b")
 _OWNER_RE = re.compile(

--- a/src/term_proposer_runtime.py
+++ b/src/term_proposer_runtime.py
@@ -48,7 +48,7 @@ class ClaudeCLIClient:
         config: HydraFlowConfig,
         *,
         tool: AgentTool = "claude",
-        model: str = "claude-sonnet-4-6",
+        model: str = "sonnet",
         timeout: int = 180,
         provider: str = "claude",
         source: str = "term_proposer",


### PR DESCRIPTION
Three model defaults were pinned to the retired `claude-sonnet-4-6`; this points them at the latest Sonnet so every role uses current models.

- `config.term_proposer_model` → `sonnet` (alias — CLI resolves to latest)
- `TermProposerRuntime` default `model` → `sonnet` (alias)
- `onboarding/design_ai.DEFAULT_CLAUDE_MODEL` → `claude-sonnet-5` (explicit id — this path calls the Anthropic Messages API directly, which doesn't resolve tier aliases)

Everything else already tracks latest: claude roles use `opus`/`sonnet`/`haiku` aliases, background one-shot roles run z.ai `glm-5.2`, and `kimi` is available on `kimi-k3`. Cost-rollup test fixtures keep their arbitrary model strings (they assert cost math, not model selection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)