### PR TITLE
fix: min-sample floor for tick_error_ratio detector (#9772)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -319,6 +319,11 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
         "HYDRAFLOW_LOOP_ANOMALY_REPAIR_MIN_SAMPLE",
         3,
     ),
+    (
+        "loop_anomaly_tick_error_min_sample",
+        "HYDRAFLOW_LOOP_ANOMALY_TICK_ERROR_MIN_SAMPLE",
+        3,
+    ),
     ("corpus_learning_interval", "HYDRAFLOW_CORPUS_LEARNING_INTERVAL", 3600),
     ("contract_refresh_interval", "HYDRAFLOW_CONTRACT_REFRESH_INTERVAL", 604800),
     ("max_fake_repair_attempts", "HYDRAFLOW_MAX_FAKE_REPAIR_ATTEMPTS", 3),
@@ -3106,6 +3111,18 @@ class HydraFlowConfig(BaseModel):
         description=(
             "TrustFleetSanityLoop: `ticks_errored / ticks_total` over 24h "
             "breach threshold (spec §12.1)."
+        ),
+    )
+    loop_anomaly_tick_error_min_sample: int = Field(
+        default=3,
+        ge=1,
+        le=1000,
+        description=(
+            "TrustFleetSanityLoop: minimum 24h `ticks_total` before the "
+            "tick_error_ratio detector can breach. Below this floor the "
+            "signal is too small to escalate and the detector returns "
+            "`insufficient_data` (false-positive guard, mirrors "
+            "loop_anomaly_repair_min_sample, issue #9458 / #9772)."
         ),
     )
     loop_anomaly_staleness_multiplier: float = Field(

--- a/src/trust_fleet_anomaly_detectors.py
+++ b/src/trust_fleet_anomaly_detectors.py
@@ -141,8 +141,18 @@ def detect_tick_error_ratio(
     metrics: dict[str, Any],
     *,
     threshold: float,
+    min_sample: int = 1,
 ) -> tuple[bool, dict[str, Any]]:
-    """`ticks_errored / ticks_total >= threshold` over 24h (spec §12.1 bullet 3)."""
+    """`ticks_errored / ticks_total >= threshold` over 24h (spec §12.1 bullet 3).
+
+    ``min_sample`` is the floor on 24h ``ticks_total`` required before the
+    ratio can breach. A loop that has only ticked once or twice in the
+    window (just started, or a long interval) can show a 50-100% error
+    ratio from a single transient failure — below the floor the detector
+    returns no breach with ``status="insufficient_data"``, mirroring the
+    ``detect_repair_ratio`` min-sample guard (false-positive guard, issue
+    #9458 / #9772).
+    """
     total = int(metrics.get("ticks_total", 0))
     errored = int(metrics.get("ticks_errored", 0))
     if total == 0:
@@ -150,6 +160,14 @@ def detect_tick_error_ratio(
             "worker": worker,
             "status": "insufficient_data",
             "ticks_total": 0,
+        }
+    if total < min_sample:
+        return False, {
+            "worker": worker,
+            "status": "insufficient_data",
+            "ticks_total": total,
+            "ticks_errored": errored,
+            "min_sample": min_sample,
         }
     ratio = errored / total
     breached = ratio >= threshold

--- a/src/trust_fleet_sanity_loop.py
+++ b/src/trust_fleet_sanity_loop.py
@@ -267,6 +267,7 @@ class TrustFleetSanityLoop(BaseBackgroundLoop):
                     worker,
                     metrics,
                     threshold=cfg.loop_anomaly_tick_error_ratio,
+                    min_sample=cfg.loop_anomaly_tick_error_min_sample,
                 )
                 if breached:
                     per_worker_breaches.append(("tick_error_ratio", details))

--- a/tests/scenarios/test_trust_fleet_sanity_scenario.py
+++ b/tests/scenarios/test_trust_fleet_sanity_scenario.py
@@ -251,6 +251,58 @@ class TestTrustFleetSanityBreachScenario:
         titles = [issue.title for issue in world.github._issues.values()]
         assert any("tick_error_ratio" in t and "corpus_learning" in t for t in titles)
 
+    async def test_tick_error_ratio_below_min_sample_does_not_breach(
+        self, tmp_path
+    ) -> None:
+        """rc_budget with 1 errored / 2 total ticks -> no escalation.
+
+        Regression for issue #9772: a 50% error ratio from only 2 ticks in
+        the 24h window (e.g. a loop that just started, or one transient
+        failure) is too small a sample to page a human. Mirrors the
+        min-sample guard added to repair_ratio for #9458.
+        """
+        world = MockWorld(tmp_path)
+
+        now = _dt.datetime.now(_dt.UTC)
+        seeded_bus = EventBus()
+
+        def _make_ev(status: str, ago_s: int) -> HydraFlowEvent:
+            ts = (now - _dt.timedelta(seconds=ago_s)).isoformat()
+            return HydraFlowEvent(
+                type=EventType.BACKGROUND_WORKER_STATUS,
+                timestamp=ts,
+                data={"worker": "rc_budget", "status": status, "details": {}},
+            )
+
+        all_events = [
+            _make_ev("ok", 3601),
+            _make_ev("error", 3602),
+        ]
+
+        async def _preloaded_load(since: _dt.datetime) -> list[HydraFlowEvent]:
+            return [e for e in all_events if e.timestamp >= since.isoformat()]
+
+        seeded_bus.load_events_since = _preloaded_load  # type: ignore[method-assign]
+
+        state = MagicMock()
+        state.get_worker_heartbeats.return_value = {}
+        state.get_trust_fleet_sanity_attempts.return_value = 0
+        state.inc_trust_fleet_sanity_attempts.return_value = 1
+        state.get_trust_fleet_sanity_last_seen_counts.return_value = {}
+
+        _seed_ports(
+            world,
+            trust_fleet_sanity_state=state,
+            event_bus=seeded_bus,
+        )
+
+        stats = await world.run_with_loops(["trust_fleet_sanity"], cycles=1)
+
+        assert stats["trust_fleet_sanity"]["status"] == "ok", stats
+        assert stats["trust_fleet_sanity"].get("filed", 0) == 0, stats
+        titles = [issue.title for issue in world.github._issues.values()]
+        assert not any("tick_error_ratio" in t for t in titles)
+
     async def test_repair_ratio_breach_files_escalation(self, tmp_path) -> None:
         """rc_budget with failed repairs dominating successes -> escalation."""
         world = MockWorld(tmp_path)

--- a/tests/test_config_trust_fleet_sanity.py
+++ b/tests/test_config_trust_fleet_sanity.py
@@ -13,6 +13,7 @@ def test_default_values() -> None:
     assert cfg.loop_anomaly_issues_per_hour == 10
     assert cfg.loop_anomaly_repair_ratio == 2.0
     assert cfg.loop_anomaly_tick_error_ratio == 0.2
+    assert cfg.loop_anomaly_tick_error_min_sample == 3
     assert cfg.loop_anomaly_staleness_multiplier == 2.0
     assert cfg.loop_anomaly_cost_spike_ratio == 5.0
 
@@ -22,6 +23,7 @@ def test_env_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("HYDRAFLOW_LOOP_ANOMALY_ISSUES_PER_HOUR", "25")
     monkeypatch.setenv("HYDRAFLOW_LOOP_ANOMALY_REPAIR_RATIO", "3.5")
     monkeypatch.setenv("HYDRAFLOW_LOOP_ANOMALY_TICK_ERROR_RATIO", "0.5")
+    monkeypatch.setenv("HYDRAFLOW_LOOP_ANOMALY_TICK_ERROR_MIN_SAMPLE", "5")
     monkeypatch.setenv("HYDRAFLOW_LOOP_ANOMALY_STALENESS_MULTIPLIER", "4.0")
     monkeypatch.setenv("HYDRAFLOW_LOOP_ANOMALY_COST_SPIKE_RATIO", "10.0")
     cfg = HydraFlowConfig()
@@ -29,6 +31,7 @@ def test_env_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
     assert cfg.loop_anomaly_issues_per_hour == 25
     assert cfg.loop_anomaly_repair_ratio == 3.5
     assert cfg.loop_anomaly_tick_error_ratio == 0.5
+    assert cfg.loop_anomaly_tick_error_min_sample == 5
     assert cfg.loop_anomaly_staleness_multiplier == 4.0
     assert cfg.loop_anomaly_cost_spike_ratio == 10.0
 

--- a/tests/test_trust_fleet_anomaly_detectors.py
+++ b/tests/test_trust_fleet_anomaly_detectors.py
@@ -110,6 +110,30 @@ def test_tick_error_ratio_at_threshold_breaches() -> None:
     assert breached is True
 
 
+def test_tick_error_ratio_below_min_sample_does_not_breach() -> None:
+    """A single error out of 2 ticks is a 50% ratio but too small a sample
+    to escalate — regression for issue #9772 (rc_budget false positive)."""
+    metrics = {"ticks_total": 2, "ticks_errored": 1}
+    breached, details = detect_tick_error_ratio(
+        "rc_budget", metrics, threshold=0.2, min_sample=3
+    )
+    assert breached is False
+    assert details["status"] == "insufficient_data"
+
+
+def test_tick_error_ratio_min_sample_floor_is_inclusive_lower_bound() -> None:
+    below = detect_tick_error_ratio(
+        "x", {"ticks_total": 2, "ticks_errored": 2}, threshold=0.2, min_sample=3
+    )
+    assert below[0] is False
+    assert below[1]["status"] == "insufficient_data"
+
+    at_floor = detect_tick_error_ratio(
+        "x", {"ticks_total": 3, "ticks_errored": 1}, threshold=0.2, min_sample=3
+    )
+    assert at_floor[0] is True
+
+
 # --- 4. staleness ---
 
 


### PR DESCRIPTION
## Summary

- Fixes issue #9772: `TrustFleetSanityLoop`'s `tick_error_ratio` detector filed a false-positive HITL escalation against `rc_budget` (`ticks_errored=1`, `ticks_total=2` → 50% ratio vs. the 20% default threshold).
- Root cause: this is the same false-positive class fixed for the sibling `repair_ratio` detector in #9458 — a tiny sample size lets a single transient error read as a catastrophic error rate. #9458 added a `min_sample` floor to `detect_repair_ratio` but never extended the same guard to `detect_tick_error_ratio`, which has the identical small-denominator failure mode.
- Adds `loop_anomaly_tick_error_min_sample` config field (default `3`, mirrors `loop_anomaly_repair_min_sample`) and threads it into `detect_tick_error_ratio`: when `ticks_total` is below the floor, the detector returns `insufficient_data` instead of breaching, regardless of ratio.

## Test plan
- [x] New unit tests for `detect_tick_error_ratio` min-sample floor (below floor / at floor) in `tests/test_trust_fleet_anomaly_detectors.py`
- [x] New config default/env-override assertions in `tests/test_config_trust_fleet_sanity.py`
- [x] New MockWorld scenario test reproducing the exact #9772 shape (`rc_budget`, 1 errored / 2 total ticks) asserting no escalation is filed, alongside the existing breach-path scenario (5 ticks, 4 errors) confirming real breaches still fire
- [x] `make quality` — full suite green (17833 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)