### PR TITLE
fix: add min-sample floor to tick_error_ratio anomaly detector

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -319,6 +319,11 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
         "HYDRAFLOW_LOOP_ANOMALY_REPAIR_MIN_SAMPLE",
         3,
     ),
+    (
+        "loop_anomaly_tick_error_min_sample",
+        "HYDRAFLOW_LOOP_ANOMALY_TICK_ERROR_MIN_SAMPLE",
+        3,
+    ),
     ("corpus_learning_interval", "HYDRAFLOW_CORPUS_LEARNING_INTERVAL", 3600),
     ("contract_refresh_interval", "HYDRAFLOW_CONTRACT_REFRESH_INTERVAL", 604800),
     ("max_fake_repair_attempts", "HYDRAFLOW_MAX_FAKE_REPAIR_ATTEMPTS", 3),
@@ -3106,6 +3111,17 @@ class HydraFlowConfig(BaseModel):
         description=(
             "TrustFleetSanityLoop: `ticks_errored / ticks_total` over 24h "
             "breach threshold (spec §12.1)."
+        ),
+    )
+    loop_anomaly_tick_error_min_sample: int = Field(
+        default=3,
+        ge=1,
+        le=1000,
+        description=(
+            "TrustFleetSanityLoop: minimum 24h `ticks_total` count before the "
+            "tick_error_ratio detector escalates. Below this floor the signal "
+            "is too small to escalate and the detector returns "
+            "`insufficient_data` (false-positive guard, issue #9811)."
         ),
     )
     loop_anomaly_staleness_multiplier: float = Field(

--- a/src/trust_fleet_anomaly_detectors.py
+++ b/src/trust_fleet_anomaly_detectors.py
@@ -141,8 +141,17 @@ def detect_tick_error_ratio(
     metrics: dict[str, Any],
     *,
     threshold: float,
+    min_sample: int = 1,
 ) -> tuple[bool, dict[str, Any]]:
-    """`ticks_errored / ticks_total >= threshold` over 24h (spec §12.1 bullet 3)."""
+    """`ticks_errored / ticks_total >= threshold` over 24h (spec §12.1 bullet 3).
+
+    ``min_sample`` is the floor on the 24h ``ticks_total`` count required
+    before the ratio can breach. Low-cadence loops (e.g. weekly ticks) can hit
+    a high error *ratio* off a single transient failure; below the floor the
+    detector returns no breach with ``status="insufficient_data"``, mirroring
+    ``detect_repair_ratio``'s min-sample guard (false-positive guard, issue
+    #9811).
+    """
     total = int(metrics.get("ticks_total", 0))
     errored = int(metrics.get("ticks_errored", 0))
     if total == 0:
@@ -150,6 +159,14 @@ def detect_tick_error_ratio(
             "worker": worker,
             "status": "insufficient_data",
             "ticks_total": 0,
+        }
+    if total < min_sample:
+        return False, {
+            "worker": worker,
+            "status": "insufficient_data",
+            "ticks_total": total,
+            "ticks_errored": errored,
+            "min_sample": min_sample,
         }
     ratio = errored / total
     breached = ratio >= threshold

--- a/src/trust_fleet_sanity_loop.py
+++ b/src/trust_fleet_sanity_loop.py
@@ -267,6 +267,7 @@ class TrustFleetSanityLoop(BaseBackgroundLoop):
                     worker,
                     metrics,
                     threshold=cfg.loop_anomaly_tick_error_ratio,
+                    min_sample=cfg.loop_anomaly_tick_error_min_sample,
                 )
                 if breached:
                     per_worker_breaches.append(("tick_error_ratio", details))

--- a/tests/regressions/test_issue_9811.py
+++ b/tests/regressions/test_issue_9811.py
@@ -1,0 +1,74 @@
+"""Regression for issue #9811 — false-positive tick_error_ratio HITL escalation.
+
+HITL #9811 was auto-filed by `TrustFleetSanityLoop`'s `tick_error_ratio`
+detector against the `fake_coverage_auditor` loop with `ticks_total=2,
+ticks_errored=1, ratio=0.5` against `threshold=0.2`. It was a false positive:
+`fake_coverage_auditor` is a weekly-cadence loop with 0-2 ticks/24h, so a
+single transient tick error produces a high *ratio* off a sample too small to
+mean anything.
+
+`detect_tick_error_ratio` now requires `ticks_total >=
+loop_anomaly_tick_error_min_sample` (default 3) before it can breach; below
+the floor it returns no breach with `status="insufficient_data"`, mirroring
+the `detect_repair_ratio` min-sample guard added for issue #9458.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from config import HydraFlowConfig
+from trust_fleet_anomaly_detectors import detect_tick_error_ratio
+
+
+def test_issue_repro_below_min_sample_does_not_breach() -> None:
+    """Exact repro from #9811: ticks_total=2, ticks_errored=1, threshold=0.2."""
+    metrics = {"ticks_total": 2, "ticks_errored": 1}
+    breached, details = detect_tick_error_ratio(
+        "fake_coverage_auditor",
+        metrics,
+        threshold=0.2,
+        min_sample=3,
+    )
+    assert breached is False
+    assert details["status"] == "insufficient_data"
+
+
+def test_min_sample_floor_is_inclusive_lower_bound() -> None:
+    below = detect_tick_error_ratio(
+        "x", {"ticks_total": 2, "ticks_errored": 1}, threshold=0.2, min_sample=3
+    )
+    assert below[0] is False
+    assert below[1]["status"] == "insufficient_data"
+
+    at_floor = detect_tick_error_ratio(
+        "x", {"ticks_total": 3, "ticks_errored": 1}, threshold=0.2, min_sample=3
+    )
+    assert at_floor[0] is True
+    assert "ratio" in at_floor[1]
+
+
+def test_real_anomaly_at_or_above_floor_still_breaches() -> None:
+    """A genuine anomaly with enough samples must still escalate."""
+    breached, details = detect_tick_error_ratio(
+        "x",
+        {"ticks_total": 10, "ticks_errored": 5},
+        threshold=0.2,
+        min_sample=3,
+    )
+    assert breached is True
+    assert details["ratio"] == 0.5
+
+
+def test_default_min_sample_is_one_when_unspecified() -> None:
+    """Callers that don't pass min_sample keep today's behavior (no regression)."""
+    breached, details = detect_tick_error_ratio(
+        "x", {"ticks_total": 2, "ticks_errored": 1}, threshold=0.2
+    )
+    assert breached is True
+    assert details["ratio"] == 0.5
+
+
+def test_default_config_carries_min_sample_floor() -> None:
+    cfg = HydraFlowConfig(data_root=Path("/tmp"), repo="hydra/hydraflow")
+    assert cfg.loop_anomaly_tick_error_min_sample == 3


### PR DESCRIPTION
## Summary
- `detect_tick_error_ratio` in `src/trust_fleet_anomaly_detectors.py` had no minimum-sample floor, unlike its sibling `detect_repair_ratio` (fixed for #9458).
- `fake_coverage_auditor` is a weekly-cadence loop with 0-2 ticks/24h, so a single transient tick error yields `ratio=0.5` against `threshold=0.2` — a false-positive escalation, not a real anomaly.
- Adds `loop_anomaly_tick_error_min_sample` (default 3, env `HYDRAFLOW_LOOP_ANOMALY_TICK_ERROR_MIN_SAMPLE`) mirroring the existing `loop_anomaly_repair_min_sample` pattern. Below the floor, the detector returns no breach with `status="insufficient_data"` instead of escalating.

Closes #9811.

## Test plan
- [x] New regression tests in `tests/regressions/test_issue_9811.py`: exact issue repro (no breach, `insufficient_data`), floor boundary (at/below), real anomaly at/above floor still breaches, unspecified `min_sample` preserves prior behavior, default config value is 3.
- [x] Existing `tests/test_trust_fleet_anomaly_detectors.py` and `tests/test_trust_fleet_sanity_loop.py` pass unchanged (911 tests).
- [x] `make quality` run in full — one unrelated pre-existing failure found (`tests/regressions/test_term_proposer_model_id.py`, stale hard-coded model ID unrelated to trust-loop anomaly detection); confirmed pre-existing on unmodified `staging` HEAD via `git stash` and filed as #9819, not fixed here to keep this diff scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)