### PR TITLE
chore(wiki): maintenance 2026-07-18

### DIFF
--- a/repo_wiki/T-rav/hydraflow/gotchas/0012-issue-9442-error-tolerance-tests-must-cover-creditexhausteder.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0012-issue-9442-error-tolerance-tests-must-cover-creditexhausteder.md
@@ -4,8 +4,9 @@ topic: gotchas
 source_issue: 9442
 source_phase: review
 created_at: 2026-06-13T07:10:55.323944+00:00
-status: active
+status: superseded
 corroborations: 1
+superseded_by: 0044
 ---
 
 # Error-tolerance tests must cover CreditExhaustedError re-raise, not just swallow

--- a/repo_wiki/T-rav/hydraflow/gotchas/0012-issue-synthesis-use-type-checking-guards-for-forward-reference-ann.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0012-issue-synthesis-use-type-checking-guards-for-forward-reference-ann.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.692826+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Use TYPE_CHECKING guards for forward-reference annotations

--- a/repo_wiki/T-rav/hydraflow/gotchas/0013-issue-9442-update-emit-trace-command-strings-when-migrating-f.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0013-issue-9442-update-emit-trace-command-strings-when-migrating-f.md
@@ -4,8 +4,9 @@ topic: gotchas
 source_issue: 9442
 source_phase: review
 created_at: 2026-06-13T07:10:55.323956+00:00
-status: active
+status: superseded
 corroborations: 1
+superseded_by: 0044
 ---
 
 # Update _emit_trace command strings when migrating from subprocess to Port calls

--- a/repo_wiki/T-rav/hydraflow/gotchas/0013-issue-synthesis-grep-for-runtime-references-before-removing-an-imp.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0013-issue-synthesis-grep-for-runtime-references-before-removing-an-imp.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.693090+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Grep for runtime references before removing an import

--- a/repo_wiki/T-rav/hydraflow/gotchas/0014-issue-synthesis-use-is-none-is-not-none-for-optional-sentinels.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0014-issue-synthesis-use-is-none-is-not-none-for-optional-sentinels.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.693302+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Use `is None` / `is not None` for optional sentinels

--- a/repo_wiki/T-rav/hydraflow/gotchas/0015-issue-synthesis-sync-all-protocol-implementations-in-one-pr-when-a.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0015-issue-synthesis-sync-all-protocol-implementations-in-one-pr-when-a.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.693526+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Sync all protocol implementations in one PR when a port signature changes

--- a/repo_wiki/T-rav/hydraflow/gotchas/0016-issue-synthesis-delete-code-blocks-bottom-to-top-to-avoid-line-num.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0016-issue-synthesis-delete-code-blocks-bottom-to-top-to-avoid-line-num.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.693726+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Delete code blocks bottom-to-top to avoid line-number shifting

--- a/repo_wiki/T-rav/hydraflow/gotchas/0017-issue-synthesis-patch-functions-at-their-definition-site-not-the-i.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0017-issue-synthesis-patch-functions-at-their-definition-site-not-the-i.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.693915+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Patch functions at their definition site, not the import site

--- a/repo_wiki/T-rav/hydraflow/gotchas/0018-issue-synthesis-verify-a-file-exists-before-writing-a-plan-task-th.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0018-issue-synthesis-verify-a-file-exists-before-writing-a-plan-task-th.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.694110+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Verify a file exists before writing a plan task that modifies it

--- a/repo_wiki/T-rav/hydraflow/gotchas/0019-issue-synthesis-test-pydantic-serialization-with-both-round-trip-a.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0019-issue-synthesis-test-pydantic-serialization-with-both-round-trip-a.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.694293+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Test Pydantic serialization with both round-trip and save/load tests

--- a/repo_wiki/T-rav/hydraflow/gotchas/0020-issue-synthesis-run-full-make-quality-before-declaring-implementat.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0020-issue-synthesis-run-full-make-quality-before-declaring-implementat.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.694480+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Run full `make quality` before declaring implementation complete

--- a/repo_wiki/T-rav/hydraflow/gotchas/0021-issue-synthesis-use-log-exception-with-bug-classification-to-separ.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0021-issue-synthesis-use-log-exception-with-bug-classification-to-separ.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.694669+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Use `log_exception_with_bug_classification()` to separate bugs from transient errors

--- a/repo_wiki/T-rav/hydraflow/gotchas/0022-issue-synthesis-use-logger-warning-exc-info-true-for-transient-err.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0022-issue-synthesis-use-logger-warning-exc-info-true-for-transient-err.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.694860+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Use `logger.warning(..., exc_info=True)` for transient errors, not `logger.exception()`

--- a/repo_wiki/T-rav/hydraflow/gotchas/0023-issue-synthesis-timeoutexpired-and-calledprocesserror-are-siblings.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0023-issue-synthesis-timeoutexpired-and-calledprocesserror-are-siblings.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.695033+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # `TimeoutExpired` and `CalledProcessError` are siblings — catch both

--- a/repo_wiki/T-rav/hydraflow/gotchas/0024-issue-synthesis-omitting-await-on-an-async-call-silently-returns-a.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0024-issue-synthesis-omitting-await-on-an-async-call-silently-returns-a.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.695205+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Omitting `await` on an async call silently returns a coroutine object

--- a/repo_wiki/T-rav/hydraflow/gotchas/0025-issue-synthesis-store-asyncio-create-task-results-unreferenced-tas.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0025-issue-synthesis-store-asyncio-create-task-results-unreferenced-tas.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.695381+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Store `asyncio.create_task()` results — unreferenced tasks are GC'd silently

--- a/repo_wiki/T-rav/hydraflow/gotchas/0026-issue-synthesis-new-pydantic-fields-must-have-defaults-so-existing.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0026-issue-synthesis-new-pydantic-fields-must-have-defaults-so-existing.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.695559+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # New Pydantic fields must have defaults so existing state files still load

--- a/repo_wiki/T-rav/hydraflow/gotchas/0027-issue-synthesis-use-atomic-write-instead-of-path-write-text-for-js.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0027-issue-synthesis-use-atomic-write-instead-of-path-write-text-for-js.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.695739+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Use `atomic_write()` instead of `Path.write_text()` for JSON state files

--- a/repo_wiki/T-rav/hydraflow/gotchas/0028-issue-synthesis-use-typeddict-total-false-for-backward-compatible-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0028-issue-synthesis-use-typeddict-total-false-for-backward-compatible-.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.695927+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Use `TypedDict(total=False)` for backward-compatible event payloads

--- a/repo_wiki/T-rav/hydraflow/gotchas/0029-issue-synthesis-new-hydraflowconfig-label-fields-must-be-optional-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0029-issue-synthesis-new-hydraflowconfig-label-fields-must-be-optional-.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.696116+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # New HydraFlowConfig label fields must be optional params in ConfigFactory

--- a/repo_wiki/T-rav/hydraflow/gotchas/0030-issue-synthesis-reverse-state-transitions-on-non-fatal-exceptions-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0030-issue-synthesis-reverse-state-transitions-on-non-fatal-exceptions-.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.696297+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Reverse state transitions on non-fatal exceptions to avoid stuck issues

--- a/repo_wiki/T-rav/hydraflow/gotchas/0031-issue-synthesis-use-the-same-id-extraction-logic-everywhere-files-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0031-issue-synthesis-use-the-same-id-extraction-logic-everywhere-files-.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.696488+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Use the same ID extraction logic everywhere files are keyed by issue

--- a/repo_wiki/T-rav/hydraflow/gotchas/0032-issue-synthesis-join-factory-pipeline-metrics-by-issue-number-not-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0032-issue-synthesis-join-factory-pipeline-metrics-by-issue-number-not-.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.696672+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Join factory pipeline metrics by `issue_number`, not `pr_number`

--- a/repo_wiki/T-rav/hydraflow/gotchas/0033-issue-synthesis-test-pipeline-stage-ordering-not-just-status-value.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0033-issue-synthesis-test-pipeline-stage-ordering-not-just-status-value.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.696858+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Test pipeline stage ordering, not just status values, after inserting a stage

--- a/repo_wiki/T-rav/hydraflow/gotchas/0034-issue-synthesis-filter-evicted-memories-on-both-content-prefix-and.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0034-issue-synthesis-filter-evicted-memories-on-both-content-prefix-and.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.697057+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Filter evicted memories on both content prefix AND metadata status

--- a/repo_wiki/T-rav/hydraflow/gotchas/0035-issue-synthesis-new-automated-skills-must-start-with-blocking-fals.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0035-issue-synthesis-new-automated-skills-must-start-with-blocking-fals.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.697259+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # New automated skills must start with `blocking=False` until proven stable

--- a/repo_wiki/T-rav/hydraflow/gotchas/0036-issue-synthesis-validate-parsers-against-realistic-multi-paragraph.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0036-issue-synthesis-validate-parsers-against-realistic-multi-paragraph.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.697465+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Validate parsers against realistic multi-paragraph agent output

--- a/repo_wiki/T-rav/hydraflow/gotchas/0037-issue-synthesis-log-a-warning-when-transcript-extraction-finds-zer.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0037-issue-synthesis-log-a-warning-when-transcript-extraction-finds-zer.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.697666+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Log a warning when transcript extraction finds zero matches on non-empty input

--- a/repo_wiki/T-rav/hydraflow/gotchas/0038-issue-synthesis-use-portable-shell-commands-in-alpine-containers-p.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0038-issue-synthesis-use-portable-shell-commands-in-alpine-containers-p.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.697862+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Use portable shell commands in Alpine containers — Python is absent

--- a/repo_wiki/T-rav/hydraflow/gotchas/0039-issue-synthesis-separate-silent-with-result-events-from-purely-sil.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0039-issue-synthesis-separate-silent-with-result-events-from-purely-sil.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.698054+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Separate silent-with-result events from purely silent events in dispatch dicts

--- a/repo_wiki/T-rav/hydraflow/gotchas/0040-issue-synthesis-create-a-specialized-method-rather-than-overloadin.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0040-issue-synthesis-create-a-specialized-method-rather-than-overloadin.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.698248+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Create a specialized method rather than overloading a general one

--- a/repo_wiki/T-rav/hydraflow/gotchas/0041-issue-synthesis-ruff-strips-unused-imports-mid-tdd-cycle.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0041-issue-synthesis-ruff-strips-unused-imports-mid-tdd-cycle.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.698454+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Ruff strips unused imports mid-TDD cycle

--- a/repo_wiki/T-rav/hydraflow/gotchas/0042-issue-synthesis-verify-implementation-files-are-in-the-diff-before.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0042-issue-synthesis-verify-implementation-files-are-in-the-diff-before.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:13:17.698658+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0008,0009,0010,0011
+superseded_by: 0044
 ---
 
 # Verify implementation files are in the diff before merging a feature PR

--- a/repo_wiki/T-rav/hydraflow/gotchas/0043-issue-9567-coverage-delta-gate-semantics-asymmetric-gaps-bloc.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0043-issue-9567-coverage-delta-gate-semantics-asymmetric-gaps-bloc.md
@@ -4,8 +4,9 @@ topic: gotchas
 source_issue: 9567
 source_phase: review
 created_at: 2026-06-20T09:15:00.395676+00:00
-status: active
+status: superseded
 corroborations: 1
+superseded_by: 0044
 ---
 
 # Coverage-delta gate semantics: asymmetric — gaps block, clean defers

--- a/repo_wiki/T-rav/hydraflow/gotchas/0044-issue-synthesis-error-tolerance-tests-must-cover-creditexhausteder.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0044-issue-synthesis-error-tolerance-tests-must-cover-creditexhausteder.md
@@ -1,0 +1,24 @@
+---
+id: 0044
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.446165+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Error-tolerance tests must cover CreditExhaustedError re-raise, not just swallow
+
+When testing that a loop tolerates port/runner failures, include a case asserting `CreditExhaustedError` is re-raised, not just swallowed.
+
+```python
+port.side_effect = CreditExhaustedError("exhausted")
+with pytest.raises(CreditExhaustedError):
+    await loop._reconcile(...)
+```
+
+See `test_review_phase_core.py:1919` for the full pattern.
+
+**Why:** `reraise_on_credit_or_bug` is a load-bearing call mandated by CLAUDE.md; testing only the swallow path leaves the re-raise contract unchecked.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0045-issue-synthesis-use-type-checking-guards-for-forward-reference-ann.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0045-issue-synthesis-use-type-checking-guards-for-forward-reference-ann.md
@@ -1,0 +1,18 @@
+---
+id: 0045
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.446430+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Use TYPE_CHECKING guards for forward-reference annotations
+
+Use `from __future__ import annotations` with `TYPE_CHECKING` guards for forward-reference type annotations.
+
+Example: `if TYPE_CHECKING: from mymodule import MyType` keeps the import from executing at runtime.
+
+**Why:** Without the guard the symbol is evaluated at import time, creating circular imports or `ImportError` in modules that aren't always available.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0046-issue-synthesis-update-emit-trace-command-strings-when-migrating-f.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0046-issue-synthesis-update-emit-trace-command-strings-when-migrating-f.md
@@ -1,0 +1,19 @@
+---
+id: 0046
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.446728+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Update _emit_trace command strings when migrating from subprocess to Port calls
+
+After replacing a `gh`/subprocess call with a Port method, update any `_emit_trace` or telemetry command strings to reflect the new surface.
+
+- Old: `command=["gh", "issue", "list", "--label", "wiki-rot-stuck"]`
+- New: `PRPort.list_closed_issues_by_label("wiki-rot-stuck", limit=50)`
+
+**Why:** Observability consumers rely on command strings to diagnose failures; stale strings misdirect operators toward subprocess debugging when the actual call path is a Port method.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0047-issue-synthesis-grep-for-runtime-references-before-removing-an-imp.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0047-issue-synthesis-grep-for-runtime-references-before-removing-an-imp.md
@@ -1,0 +1,18 @@
+---
+id: 0047
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.446944+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Grep for runtime references before removing an import
+
+Before deleting an import, grep the file for runtime uses: `isinstance()` calls, variable assignments, and decorator calls.
+
+Example: `grep -n 'MyClass' src/foo.py` — a hit in `isinstance(x, MyClass)` means the import is load-bearing even if type checkers flag it as unused.
+
+**Why:** Ruff's `F401` rule does not inspect `isinstance` call sites; removing an apparently-unused import that is used at runtime produces `NameError`.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0048-issue-synthesis-use-is-none-is-not-none-for-optional-sentinels.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0048-issue-synthesis-use-is-none-is-not-none-for-optional-sentinels.md
@@ -1,0 +1,18 @@
+---
+id: 0048
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.447156+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Use `is None` / `is not None` for optional sentinels
+
+Prefer identity checks (`is None`, `is not None`) over equality checks for optional objects, especially callables and stores.
+
+Example: `if callback is None: return` — not `if callback == None`.
+
+**Why:** Identity checks are O(1) and immune to overridden `__eq__`; equality checks against `None` can accidentally match falsy custom objects with a permissive `__eq__`.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0049-issue-synthesis-sync-all-protocol-implementations-in-one-pr-when-a.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0049-issue-synthesis-sync-all-protocol-implementations-in-one-pr-when-a.md
@@ -1,0 +1,18 @@
+---
+id: 0049
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.447380+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Sync all protocol implementations in one PR when a port signature changes
+
+When a port or protocol method signature changes, update every concrete implementation atomically in the same PR — never staggered across tasks.
+
+Example: adding `ctx: Context` to `def process(self, item)` requires changing every class implementing the protocol before merging.
+
+**Why:** Staggered updates leave implementations out of sync with the protocol, causing Pyright errors that block CI until every site is updated.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0050-issue-synthesis-delete-code-blocks-bottom-to-top-to-avoid-line-num.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0050-issue-synthesis-delete-code-blocks-bottom-to-top-to-avoid-line-num.md
@@ -1,0 +1,18 @@
+---
+id: 0050
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.447592+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Delete code blocks bottom-to-top to avoid line-number shifting
+
+When removing multiple code blocks from the same file in a single session, delete the lowest block first (highest line number) and work upward.
+
+Example: delete lines 120–130 before deleting lines 80–90; reversing the order shifts targets for the second deletion.
+
+**Why:** Deleting a higher block shifts all lower line numbers; later deletions then target wrong lines or miss content entirely.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0051-issue-synthesis-patch-functions-at-their-definition-site-not-the-i.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0051-issue-synthesis-patch-functions-at-their-definition-site-not-the-i.md
@@ -1,0 +1,18 @@
+---
+id: 0051
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.447816+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Patch functions at their definition site, not the import site
+
+Always patch functions at where they are defined, not where they are imported into the module under test.
+
+Example: `@patch('hindsight.retain_safe')` not `@patch('my_module.retain_safe')` when `my_module` imports from `hindsight`.
+
+**Why:** Patching the import site only replaces that module's local reference; all other callers continue using the real function, making the mock ineffective.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0052-issue-synthesis-verify-a-file-exists-before-writing-a-plan-task-th.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0052-issue-synthesis-verify-a-file-exists-before-writing-a-plan-task-th.md
@@ -1,0 +1,18 @@
+---
+id: 0052
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.448029+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Verify a file exists before writing a plan task that modifies it
+
+Before adding a plan task that edits a specific file, confirm the file exists via `git ls-files <path>` or grep.
+
+Example: `git ls-files src/shared_prompt_prefix.py` returns empty → file never existed; update the plan before implementation starts.
+
+**Why:** Planning tasks against nonexistent files wastes implementation work and causes confusing "file not found" failures mid-execution.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0053-issue-synthesis-test-pydantic-serialization-with-both-round-trip-a.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0053-issue-synthesis-test-pydantic-serialization-with-both-round-trip-a.md
@@ -1,0 +1,18 @@
+---
+id: 0053
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.448341+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Test Pydantic serialization with both round-trip and save/load tests
+
+Validate Pydantic models with both a `model_dump_json() → model_validate_json()` round-trip (serialization fidelity) and a full save/load cycle (persistence integration).
+
+Example: a JSON round-trip catches field-name mismatches; a save/load test catches type coercion surprises from JSONL storage that round-trips hide.
+
+**Why:** JSON round-trips can pass while save/load fails due to type coercion or missing `model_config` settings at the persistence layer.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0054-issue-synthesis-run-full-make-quality-before-declaring-implementat.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0054-issue-synthesis-run-full-make-quality-before-declaring-implementat.md
@@ -1,0 +1,18 @@
+---
+id: 0054
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.448545+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Run full `make quality` before declaring implementation complete
+
+Always run the full `make quality` gate — never a file-targeted test subset — before declaring a task done.
+
+Example: `pytest tests/test_foo.py` passes; `make quality` reveals 7 failures in `test_audit_prompts.py` caused by the same change (PR #8460 → hotfix #8463).
+
+**Why:** Targeted runs miss cross-module regressions; cleanup PRs have higher blast radius than their diffs suggest.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0055-issue-synthesis-use-log-exception-with-bug-classification-for-bug-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0055-issue-synthesis-use-log-exception-with-bug-classification-for-bug-.md
@@ -1,0 +1,18 @@
+---
+id: 0055
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.448741+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Use `log_exception_with_bug_classification()` for bug vs transient errors
+
+Use `log_exception_with_bug_classification()` or `is_likely_bug()` to distinguish bug exceptions (TypeError, AttributeError, KeyError) from transient errors (OSError, network errors).
+
+Example: in `finally` blocks use `log_exception_with_bug_classification(exc)` rather than `reraise`, to preserve finally semantics while still classifying.
+
+**Why:** Logging all exceptions as bugs floods Sentry with transient noise; wrong classification makes signal-to-noise ratio useless.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0056-issue-synthesis-use-logger-warning-not-logger-exception-for-transi.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0056-issue-synthesis-use-logger-warning-not-logger-exception-for-transi.md
@@ -1,0 +1,18 @@
+---
+id: 0056
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.448956+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Use `logger.warning` not `logger.exception()` for transient errors
+
+Log transient operational failures with `logger.warning(msg, exc_info=True)`. Reserve `logger.exception()` for genuine bugs.
+
+Example: `except (OSError, httpx.NetworkError) as exc: logger.warning('fetch failed', exc_info=True)`.
+
+**Why:** When migrating from `logger.exception()` to `logger.warning()`, forgetting `exc_info=True` silently drops the traceback, making failures undebuggable in production.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0057-issue-synthesis-timeoutexpired-and-calledprocesserror-are-siblings.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0057-issue-synthesis-timeoutexpired-and-calledprocesserror-are-siblings.md
@@ -1,0 +1,23 @@
+---
+id: 0057
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.449164+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# `TimeoutExpired` and `CalledProcessError` are siblings — catch both
+
+Catch `subprocess.TimeoutExpired` and `subprocess.CalledProcessError` in separate `except` clauses.
+
+```python
+except subprocess.TimeoutExpired:
+    handle_timeout()
+except subprocess.CalledProcessError:
+    handle_failure()
+```
+
+**Why:** `TimeoutExpired` is not a subclass of `CalledProcessError`; a single `except CalledProcessError` silently misses timeouts, letting them propagate as unhandled exceptions.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0058-issue-synthesis-omitting-await-on-an-async-call-silently-returns-a.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0058-issue-synthesis-omitting-await-on-an-async-call-silently-returns-a.md
@@ -1,0 +1,18 @@
+---
+id: 0058
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.449365+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Omitting `await` on an async call silently returns a coroutine object
+
+Always `await` async method calls; storing an unawaited coroutine silently never executes its body.
+
+Example: `result = fetch_data()` stores a `Coroutine` object; `result = await fetch_data()` executes it. Pyright flags the former if a type annotation is present.
+
+**Why:** Unawaited coroutines silently no-op; Pyright only catches them at `make typecheck` time when call sites have annotations.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0059-issue-synthesis-store-asyncio-create-task-results-unreferenced-tas.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0059-issue-synthesis-store-asyncio-create-task-results-unreferenced-tas.md
@@ -1,0 +1,18 @@
+---
+id: 0059
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.449566+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Store `asyncio.create_task()` results — unreferenced tasks are GC'd silently
+
+Assign every `asyncio.create_task()` result to a set and add a done callback for error logging.
+
+Example: `self._tasks.add(t := asyncio.create_task(work())); t.add_done_callback(self._tasks.discard)`.
+
+**Why:** Tasks without a live reference are garbage-collected mid-execution, silently dropping their work and exceptions with no observable signal.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0060-issue-synthesis-new-pydantic-fields-must-have-defaults-so-existing.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0060-issue-synthesis-new-pydantic-fields-must-have-defaults-so-existing.md
@@ -1,0 +1,18 @@
+---
+id: 0060
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.449795+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# New Pydantic fields must have defaults so existing state files still load
+
+Add new fields to Pydantic models as `field: Type = default_value` — never as required fields — so existing serialized state files continue to deserialize.
+
+Example: `retry_count: int = 0` allows old state JSONs that lack the key to load without error.
+
+**Why:** A required field with no default causes `ValidationError` on every existing persisted object, breaking recovery from saved state on the first restart after deploy.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0061-issue-synthesis-use-atomic-write-instead-of-path-write-text-for-js.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0061-issue-synthesis-use-atomic-write-instead-of-path-write-text-for-js.md
@@ -1,0 +1,18 @@
+---
+id: 0061
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.450004+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Use `atomic_write()` instead of `Path.write_text()` for JSON state files
+
+Write JSON state files via `file_util.atomic_write()`, not `Path.write_text()`.
+
+Example: `atomic_write(state_path, json_str)` writes to a `.tmp` sibling then renames atomically — a crash mid-write leaves the original intact.
+
+**Why:** `Path.write_text()` truncates before writing; a crash mid-operation produces a zero-byte or partial JSON that fails to parse on restart, corrupting persisted state.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0062-issue-synthesis-use-typeddict-total-false-for-backward-compatible-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0062-issue-synthesis-use-typeddict-total-false-for-backward-compatible-.md
@@ -1,0 +1,18 @@
+---
+id: 0062
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.450232+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Use `TypedDict(total=False)` for backward-compatible event payloads
+
+Define event payload TypedDicts with `total=False` so all fields are optional, allowing old producers and new consumers to interoperate.
+
+Example: `class MergePayload(TypedDict, total=False): pr_number: int; labels: list[str]`.
+
+**Why:** A `total=True` TypedDict requires all fields; adding a new field breaks any existing producer that doesn't include it, preventing rolling deployments.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0063-issue-synthesis-new-hydraflowconfig-label-fields-must-be-optional-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0063-issue-synthesis-new-hydraflowconfig-label-fields-must-be-optional-.md
@@ -1,0 +1,18 @@
+---
+id: 0063
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.450439+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# New HydraFlowConfig label fields must be optional params in ConfigFactory
+
+When adding a `list[str]` label field to `HydraFlowConfig`, add it as an optional `ConfigFactory.create()` parameter with a sensible default.
+
+Example: omitting the parameter causes `TypeError: create() got an unexpected keyword argument` in every test fixture that constructs a config.
+
+**Why:** `ConfigFactory.create()` is called across the entire test suite; missing parameters break all tests that construct a config without the new field.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0064-issue-synthesis-reverse-state-transitions-on-non-fatal-exceptions-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0064-issue-synthesis-reverse-state-transitions-on-non-fatal-exceptions-.md
@@ -1,0 +1,18 @@
+---
+id: 0064
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.450669+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Reverse state transitions on non-fatal exceptions to avoid stuck issues
+
+Wrap label-swap + operation + cleanup in a try/except that reverses the transition on non-fatal errors.
+
+Example: if a label is swapped `plan → implement` but the API call fails, swap it back to `plan` before re-raising.
+
+**Why:** An exception after a successful state transition but before cleanup leaves issues stuck in intermediate states with no automated recovery path.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0065-issue-synthesis-use-the-same-id-extraction-logic-everywhere-files-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0065-issue-synthesis-use-the-same-id-extraction-logic-everywhere-files-.md
@@ -1,0 +1,18 @@
+---
+id: 0065
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.450879+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Use the same ID extraction logic everywhere files are keyed by issue
+
+Define ID prefix lengths as named constants and centralize extraction so every site that keys files by issue uses identical logic.
+
+Example: define `DISCOVER_PREFIX_LEN = 9`; use it in both the writer and the reader rather than hardcoding `fname[9:]` in each.
+
+**Why:** Inconsistent ID logic causes silent lookup failures — a plan is written under key A but read back under key B, producing phantom missing plans.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0066-issue-synthesis-join-factory-pipeline-metrics-by-issue-number-not-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0066-issue-synthesis-join-factory-pipeline-metrics-by-issue-number-not-.md
@@ -1,0 +1,18 @@
+---
+id: 0066
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.451098+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Join factory pipeline metrics by `issue_number`, not `pr_number`
+
+When correlating factory metrics or reviews across pipeline tables, join on `issue_number` rather than `pr_number`.
+
+Example: a PR can be closed and recreated with a new number; `issue_number` is stable across the full lifecycle.
+
+**Why:** `pr_number` changes when PRs are recycled; joining on it silently drops or duplicates records for any issue where the PR was recreated.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0067-issue-synthesis-test-pipeline-stage-ordering-not-just-status-value.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0067-issue-synthesis-test-pipeline-stage-ordering-not-just-status-value.md
@@ -1,0 +1,18 @@
+---
+id: 0067
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.451347+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Test pipeline stage ordering, not just status values, after inserting a stage
+
+After inserting a new stage into `PIPELINE_STAGES`, assert both that the stage's status value is correct and that its array index is correct.
+
+Example: inserting a stage at index 2 shifts all downstream indices; a test checking only `status == 'active'` passes while skip-detection silently breaks.
+
+**Why:** Index-based progression logic produces incorrect skip decisions when stages are reordered, with no immediate test failure.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0068-issue-synthesis-filter-evicted-memories-on-both-content-prefix-and.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0068-issue-synthesis-filter-evicted-memories-on-both-content-prefix-and.md
@@ -1,0 +1,18 @@
+---
+id: 0068
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.451597+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Filter evicted memories on both content prefix AND metadata status
+
+Apply dual filters when loading recalled memories: check both the `[EVICTED]` content prefix and `status: evicted` in metadata before injecting into prompts.
+
+Example: `if mem.content.startswith('[EVICTED]') or mem.metadata.get('status') == 'evicted': skip`.
+
+**Why:** A single filter has a failure path; if one guard is missing or malformed, a tombstone leaks into agent prompts and produces confusing or incorrect agent behavior.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0069-issue-synthesis-new-automated-skills-must-start-with-blocking-fals.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0069-issue-synthesis-new-automated-skills-must-start-with-blocking-fals.md
@@ -1,0 +1,18 @@
+---
+id: 0069
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.451810+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# New automated skills must start with `blocking=False` until proven stable
+
+Register new dynamic skills with `blocking=False` and graduate to `blocking=True` only after ≥20 runs at ≥95% success rate.
+
+Example: a new lint-skill marked `blocking=True` on day one fails builds on edge cases the author didn't anticipate.
+
+**Why:** Unproven blocking skills immediately break CI on legitimate code; graduated promotion ensures checks are stable before they can gate merges.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0070-issue-synthesis-validate-parsers-against-realistic-multi-paragraph.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0070-issue-synthesis-validate-parsers-against-realistic-multi-paragraph.md
@@ -1,0 +1,18 @@
+---
+id: 0070
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.452031+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Validate parsers against realistic multi-paragraph agent output
+
+Write parser tests against realistic multi-paragraph transcripts — prose interspersed with structured markers — not bare marker strings.
+
+Example: test input should resemble real `claude` CLI output; assert on structured markers, not prose wording, so transcript rewords don't break tests.
+
+**Why:** Bare-marker tests pass even when the parser fails on the surrounding prose context present in real output, hiding real format regressions.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0071-issue-synthesis-log-a-warning-when-transcript-extraction-finds-zer.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0071-issue-synthesis-log-a-warning-when-transcript-extraction-finds-zer.md
@@ -1,0 +1,18 @@
+---
+id: 0071
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.452291+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Log a warning when transcript extraction finds zero matches on non-empty input
+
+When extracting structured data from CLI transcripts, wrap regex in try/except and log a warning on zero matches against non-empty input.
+
+Example: `matches = RE.findall(text); if not matches and text.strip(): logger.warning('parser found 0 matches on non-empty transcript')`.
+
+**Why:** Silent zero-match returns hide format drift between transcript versions; warnings surface parser breakage before it causes downstream data loss.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0072-issue-synthesis-use-portable-shell-commands-in-alpine-containers-p.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0072-issue-synthesis-use-portable-shell-commands-in-alpine-containers-p.md
@@ -1,0 +1,18 @@
+---
+id: 0072
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.452521+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Use portable shell commands in Alpine containers — Python is absent
+
+In Alpine-based Docker containers, avoid Python and non-standard utilities. Use portable POSIX commands for memory/CPU operations.
+
+Example: `dd if=/dev/zero bs=1M count=32 of=/dev/null` or `head -c 33554432 /dev/zero > /dev/null` instead of a Python `bytearray` allocation.
+
+**Why:** Alpine's minimal tooling excludes Python and many GNU utilities; scripts that rely on them fail with `command not found` in constrained CI environments.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0073-issue-synthesis-separate-silent-with-result-events-from-purely-sil.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0073-issue-synthesis-separate-silent-with-result-events-from-purely-sil.md
@@ -1,0 +1,18 @@
+---
+id: 0073
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.452742+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Separate silent-with-result events from purely silent events in dispatch dicts
+
+In event dispatch tables, distinguish events that produce no display output but set a result value (e.g., `agent_end`, `turn_end`) from events that are truly silent and set nothing.
+
+Example: check `_SILENT_WITH_RESULT` before `_SILENT_EVENTS` so result-setting events are routed correctly.
+
+**Why:** Treating silent-with-result events as purely silent discards their return values, causing downstream state to silently receive `None` instead of the real result.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0074-issue-synthesis-create-a-specialized-method-rather-than-overloadin.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0074-issue-synthesis-create-a-specialized-method-rather-than-overloadin.md
@@ -1,0 +1,18 @@
+---
+id: 0074
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.453019+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Create a specialized method rather than overloading a general one
+
+When a general method returns insufficient data for a specific use case, create a separate focused method rather than adding optional parameters.
+
+Example: `list_issues_by_label()` returns basic metadata; `get_issue_updated_at()` handles timestamps in a separate call — not an optional flag on the list method.
+
+**Why:** Overloading general methods couples unrelated concerns and complicates callers that need only one piece of data.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0075-issue-synthesis-ruff-strips-unused-imports-mid-tdd-cycle.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0075-issue-synthesis-ruff-strips-unused-imports-mid-tdd-cycle.md
@@ -1,0 +1,20 @@
+---
+id: 0075
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.453348+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Ruff strips unused imports mid-TDD cycle
+
+During TDD, write the test body (which uses the new symbol) before adding its import — or use a function-local import inside the test body.
+
+Example: `def test_score(): from scripts.audit import score_rule; assert score_rule(...)`.
+
+**Why:** Pre-commit `ruff --fix` removes imports not yet referenced on the first save, producing `NameError` on the second save and breaking the TDD red-phase.
+
+See also: Testing — feedback memory `feedback_ruff_strips_unused_imports_during_tdd.md`.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0076-issue-synthesis-verify-implementation-files-are-in-the-diff-before.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0076-issue-synthesis-verify-implementation-files-are-in-the-diff-before.md
@@ -1,0 +1,18 @@
+---
+id: 0076
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.453668+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Verify implementation files are in the diff before merging a feature PR
+
+Before merging, confirm the target source file appears in `git diff --name-only origin/main`.
+
+Example: PR closes #7644 but `git diff --name-only` shows only `docs/` and `tests/` — `src/makefile_scaffold.py` has 0 changes; the implementation was never committed.
+
+**Why:** Tests can pass against stubs or unchanged code; a green CI with no implementation changes ships dead-end work that silently does nothing.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0077-issue-synthesis-coverage-delta-gate-semantics-asymmetric-gaps-bloc.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0077-issue-synthesis-coverage-delta-gate-semantics-asymmetric-gaps-bloc.md
@@ -1,0 +1,21 @@
+---
+id: 0077
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:59:29.453961+00:00
+status: active
+corroborations: 1
+supersedes: 0012,0012,0013,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043
+---
+
+# Coverage-delta gate semantics: asymmetric — gaps block, clean defers
+
+The coverage-delta gate overrides LLM verdict only in one direction: uncovered changed lines force a FAIL regardless of LLM PASS; a clean coverage result does NOT override an LLM RETRY or FAIL.
+
+- Uncovered lines found → FAIL (override)
+- Clean coverage + LLM PASS → PASS
+- Clean coverage + LLM RETRY → RETRY (defer to LLM)
+- Gate unavailable → fall back to LLM verdict unchanged
+
+**Why:** Symmetric override would allow a coverage pass to rescue an LLM RETRY, defeating the purpose of the independent verification; the gate is a one-way ratchet against self-grading, not a replacement for the LLM verdict.

--- a/repo_wiki/T-rav/hydraflow/patterns/0008-issue-synthesis-use-optional-fields-with-defaults-for-backward-com.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0008-issue-synthesis-use-optional-fields-with-defaults-for-backward-com.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.312835+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Use optional fields with defaults for backward-compatible schema changes

--- a/repo_wiki/T-rav/hydraflow/patterns/0009-issue-synthesis-distinguish-bare-str-from-str-none-before-narrowin.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0009-issue-synthesis-distinguish-bare-str-from-str-none-before-narrowin.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.313084+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Distinguish bare `str` from `str | None` before narrowing a field type

--- a/repo_wiki/T-rav/hydraflow/patterns/0010-issue-synthesis-use-strenum-coercion-to-auto-convert-stored-string.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0010-issue-synthesis-use-strenum-coercion-to-auto-convert-stored-string.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.313296+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Use StrEnum coercion to auto-convert stored string values on load

--- a/repo_wiki/T-rav/hydraflow/patterns/0011-issue-synthesis-define-canonical-constants-as-single-source-of-tru.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0011-issue-synthesis-define-canonical-constants-as-single-source-of-tru.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.313486+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Define canonical constants as single source of truth for label lists

--- a/repo_wiki/T-rav/hydraflow/patterns/0012-issue-synthesis-use-metadata-tags-instead-of-enum-variants-for-sha.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0012-issue-synthesis-use-metadata-tags-instead-of-enum-variants-for-sha.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.313684+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Use metadata tags instead of enum variants for shared-bank categorization

--- a/repo_wiki/T-rav/hydraflow/patterns/0013-issue-synthesis-grep-all-call-sites-before-changing-a-function-sig.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0013-issue-synthesis-grep-all-call-sites-before-changing-a-function-sig.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.313872+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Grep all call sites before changing a function signature

--- a/repo_wiki/T-rav/hydraflow/patterns/0014-issue-synthesis-update-all-callers-atomically-when-a-return-type-c.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0014-issue-synthesis-update-all-callers-atomically-when-a-return-type-c.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.314046+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Update all callers atomically when a return type changes

--- a/repo_wiki/T-rav/hydraflow/patterns/0015-issue-synthesis-preserve-public-api-during-extraction-via-thin-del.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0015-issue-synthesis-preserve-public-api-during-extraction-via-thin-del.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.314227+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Preserve public API during extraction via thin delegation stubs

--- a/repo_wiki/T-rav/hydraflow/patterns/0016-issue-synthesis-extract-pure-transform-functions-before-moving-cod.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0016-issue-synthesis-extract-pure-transform-functions-before-moving-cod.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.314407+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Extract pure transform functions before moving code to new classes

--- a/repo_wiki/T-rav/hydraflow/patterns/0017-issue-synthesis-preserve-per-concern-try-except-blocks-during-refa.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0017-issue-synthesis-preserve-per-concern-try-except-blocks-during-refa.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.314606+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Preserve per-concern try/except blocks during refactoring

--- a/repo_wiki/T-rav/hydraflow/patterns/0018-issue-synthesis-extract-duplicated-jsonl-reading-logic-to-a-shared.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0018-issue-synthesis-extract-duplicated-jsonl-reading-logic-to-a-shared.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.314799+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Extract duplicated JSONL-reading logic to a shared `_load_jsonl()` helper

--- a/repo_wiki/T-rav/hydraflow/patterns/0019-issue-synthesis-mock-at-the-definition-site-not-the-import-site.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0019-issue-synthesis-mock-at-the-definition-site-not-the-import-site.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.315009+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Mock at the definition site, not the import site

--- a/repo_wiki/T-rav/hydraflow/patterns/0020-issue-synthesis-retarget-mock-patches-to-the-new-location-before-m.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0020-issue-synthesis-retarget-mock-patches-to-the-new-location-before-m.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.315212+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Retarget mock patches to the new location before moving a method

--- a/repo_wiki/T-rav/hydraflow/patterns/0021-issue-synthesis-generated-test-content-must-reference-function-nam.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0021-issue-synthesis-generated-test-content-must-reference-function-nam.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.315425+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Generated test content must reference function names, not line numbers

--- a/repo_wiki/T-rav/hydraflow/patterns/0022-issue-synthesis-use-meta-tests-to-enforce-anti-pattern-absence-acr.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0022-issue-synthesis-use-meta-tests-to-enforce-anti-pattern-absence-acr.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.315634+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Use meta-tests to enforce anti-pattern absence across the test suite

--- a/repo_wiki/T-rav/hydraflow/patterns/0023-issue-synthesis-use-threading-lock-for-thread-pool-code-asyncio-lo.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0023-issue-synthesis-use-threading-lock-for-thread-pool-code-asyncio-lo.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.315867+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Use `threading.Lock` for thread-pool code; `asyncio.Lock` only for pure coroutines

--- a/repo_wiki/T-rav/hydraflow/patterns/0024-issue-synthesis-extract-unlocked-helpers-to-prevent-re-entrant-loc.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0024-issue-synthesis-extract-unlocked-helpers-to-prevent-re-entrant-loc.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.316066+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Extract `_unlocked()` helpers to prevent re-entrant lock attempts

--- a/repo_wiki/T-rav/hydraflow/patterns/0025-issue-synthesis-use-file-util-append-jsonl-for-crash-safe-jsonl-ap.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0025-issue-synthesis-use-file-util-append-jsonl-for-crash-safe-jsonl-ap.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.316252+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Use `file_util.append_jsonl()` for crash-safe JSONL appends

--- a/repo_wiki/T-rav/hydraflow/patterns/0026-issue-synthesis-use-file-util-atomic-write-for-critical-state-file.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0026-issue-synthesis-use-file-util-atomic-write-for-critical-state-file.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.316464+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Use `file_util.atomic_write()` for critical state file updates

--- a/repo_wiki/T-rav/hydraflow/patterns/0027-issue-synthesis-use-claim-then-merge-for-async-queue-processing-to.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0027-issue-synthesis-use-claim-then-merge-for-async-queue-processing-to.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.316653+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Use claim-then-merge for async queue processing to prevent lost entries

--- a/repo_wiki/T-rav/hydraflow/patterns/0028-issue-synthesis-set-and-clear-trace-context-in-a-single-try-finall.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0028-issue-synthesis-set-and-clear-trace-context-in-a-single-try-finall.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.316844+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Set and clear trace context in a single try/finally block

--- a/repo_wiki/T-rav/hydraflow/patterns/0029-issue-synthesis-keep-event-publishing-coupled-with-the-condition-t.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0029-issue-synthesis-keep-event-publishing-coupled-with-the-condition-t.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.317043+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Keep event publishing coupled with the condition that gates it

--- a/repo_wiki/T-rav/hydraflow/patterns/0030-issue-synthesis-preserve-exact-retry-counter-state-during-dispatch.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0030-issue-synthesis-preserve-exact-retry-counter-state-during-dispatch.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.317258+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Preserve exact retry counter state during dispatcher refactoring

--- a/repo_wiki/T-rav/hydraflow/patterns/0031-issue-synthesis-dry-run-mode-must-not-emit-state-changing-events.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0031-issue-synthesis-dry-run-mode-must-not-emit-state-changing-events.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.317466+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Dry-run mode must not emit state-changing events

--- a/repo_wiki/T-rav/hydraflow/patterns/0032-issue-synthesis-maintain-immutable-return-contract-for-parse-tuple.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0032-issue-synthesis-maintain-immutable-return-contract-for-parse-tuple.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.317676+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Maintain immutable return contract for `parse()` — `tuple[str, str | None]`

--- a/repo_wiki/T-rav/hydraflow/patterns/0033-issue-synthesis-define-event-to-stage-and-source-to-stage-mappings.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0033-issue-synthesis-define-event-to-stage-and-source-to-stage-mappings.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.317893+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Define EVENT_TO_STAGE and SOURCE_TO_STAGE mappings before skip detection

--- a/repo_wiki/T-rav/hydraflow/patterns/0034-issue-synthesis-pre-allocate-memory-budget-upfront-before-prompt-a.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0034-issue-synthesis-pre-allocate-memory-budget-upfront-before-prompt-a.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.318127+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Pre-allocate memory budget upfront before prompt assembly

--- a/repo_wiki/T-rav/hydraflow/patterns/0035-issue-synthesis-use-a-two-round-allocator-section-minimums-first-t.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0035-issue-synthesis-use-a-two-round-allocator-section-minimums-first-t.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.318328+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Use a two-round allocator: section minimums first, then proportional surplus

--- a/repo_wiki/T-rav/hydraflow/patterns/0036-issue-synthesis-deduct-wiki-budget-from-memory-surplus-before-redi.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0036-issue-synthesis-deduct-wiki-budget-from-memory-surplus-before-redi.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.318537+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Deduct wiki budget from memory surplus before redistributing

--- a/repo_wiki/T-rav/hydraflow/patterns/0037-issue-synthesis-lazy-load-memory-context-on-explicit-user-action-n.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0037-issue-synthesis-lazy-load-memory-context-on-explicit-user-action-n.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.318752+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Lazy-load memory context on explicit user action, not on list render

--- a/repo_wiki/T-rav/hydraflow/patterns/0038-issue-synthesis-use-sha-256-truncated-to-16-chars-for-memory-dedup.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0038-issue-synthesis-use-sha-256-truncated-to-16-chars-for-memory-dedup.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.318976+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Use SHA-256 truncated to 16 chars for memory dedup keys

--- a/repo_wiki/T-rav/hydraflow/patterns/0039-issue-synthesis-use-asymmetric-word-set-overlap-for-memory-dedupli.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0039-issue-synthesis-use-asymmetric-word-set-overlap-for-memory-dedupli.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.319206+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Use asymmetric word-set overlap for memory deduplication

--- a/repo_wiki/T-rav/hydraflow/patterns/0040-issue-synthesis-batch-load-scoring-data-once-per-eviction-operatio.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0040-issue-synthesis-batch-load-scoring-data-once-per-eviction-operatio.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.319423+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Batch-load scoring data once per eviction operation, not per item

--- a/repo_wiki/T-rav/hydraflow/patterns/0041-issue-synthesis-hindsightclient-retain-coerces-metadata-to-str-use.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0041-issue-synthesis-hindsightclient-retain-coerces-metadata-to-str-use.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.319646+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # HindsightClient.retain() coerces metadata to `str` — use `== "true"`, not `is True`

--- a/repo_wiki/T-rav/hydraflow/patterns/0042-issue-synthesis-memory-contradiction-resolution-provenance-wins-ov.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0042-issue-synthesis-memory-contradiction-resolution-provenance-wins-ov.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.319935+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Memory contradiction resolution: provenance wins over recency

--- a/repo_wiki/T-rav/hydraflow/patterns/0043-issue-synthesis-memory-eviction-must-atomically-update-both-item-s.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0043-issue-synthesis-memory-eviction-must-atomically-update-both-item-s.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.320233+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Memory eviction must atomically update both `item_scores.json` and `items.jsonl`

--- a/repo_wiki/T-rav/hydraflow/patterns/0044-issue-synthesis-guard-close-with-a-closed-flag-to-make-it-idempote.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0044-issue-synthesis-guard-close-with-a-closed-flag-to-make-it-idempote.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.320497+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Guard `close()` with a `_closed` flag to make it idempotent

--- a/repo_wiki/T-rav/hydraflow/patterns/0045-issue-synthesis-memory-staleness-detection-should-emit-events-not-.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0045-issue-synthesis-memory-staleness-detection-should-emit-events-not-.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.320763+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Memory staleness detection should emit events, not silently mutate state

--- a/repo_wiki/T-rav/hydraflow/patterns/0046-issue-synthesis-adr-files-without-readme-entries-are-invisible-to-.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0046-issue-synthesis-adr-files-without-readme-entries-are-invisible-to-.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.320983+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # ADR files without README entries are invisible to tooling

--- a/repo_wiki/T-rav/hydraflow/patterns/0047-issue-synthesis-preserve-the-hf-namespace-prefix-when-renaming-ski.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0047-issue-synthesis-preserve-the-hf-namespace-prefix-when-renaming-ski.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.321204+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Preserve the `hf.` namespace prefix when renaming skill or command files

--- a/repo_wiki/T-rav/hydraflow/patterns/0048-issue-synthesis-keep-skill-prompts-in-sync-across-all-four-backend.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0048-issue-synthesis-keep-skill-prompts-in-sync-across-all-four-backend.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-14T05:09:18.321427+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007
+superseded_by: 0050
 ---
 
 # Keep skill prompts in sync across all four backend locations

--- a/repo_wiki/T-rav/hydraflow/patterns/0049-issue-9567-in-place-diff-truncation-silently-corrupts-downstr.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0049-issue-9567-in-place-diff-truncation-silently-corrupts-downstr.md
@@ -4,8 +4,9 @@ topic: patterns
 source_issue: 9567
 source_phase: review
 created_at: 2026-06-20T09:15:00.395666+00:00
-status: active
+status: superseded
 corroborations: 1
+superseded_by: 0050
 ---
 
 # In-place diff truncation silently corrupts downstream non-LLM consumers

--- a/repo_wiki/T-rav/hydraflow/patterns/0050-issue-synthesis-use-optional-fields-with-defaults-for-backward-com.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0050-issue-synthesis-use-optional-fields-with-defaults-for-backward-com.md
@@ -1,0 +1,18 @@
+---
+id: 0050
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.399148+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Use optional fields with defaults for backward-compatible schema changes
+
+New Pydantic fields must be optional with sensible defaults so existing state.json files load without migration.
+
+Example: `field: str = "default"` or `field: str | None = None`; read with `.get("scope", "repo")`.
+
+**Why:** Pydantic v2 auto-coerces raw dicts from state.json into typed models — no migration step exists, so non-optional new fields crash on load.

--- a/repo_wiki/T-rav/hydraflow/patterns/0051-issue-synthesis-distinguish-bare-str-from-str-none-before-narrowin.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0051-issue-synthesis-distinguish-bare-str-from-str-none-before-narrowin.md
@@ -1,0 +1,18 @@
+---
+id: 0051
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.399421+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Distinguish bare `str` from `str | None` before narrowing a field type
+
+Narrowing a bare `str` field to a StrEnum is safe when all stored values conform; narrowing a union like `str | None` requires union narrowing, not direct replacement.
+
+Example: grep all state.json consumers and call sites exhaustively before narrowing; treat union fields separately.
+
+**Why:** Narrowing a union type as if it were a bare type causes `ValidationError` on load for any stored `None` values.

--- a/repo_wiki/T-rav/hydraflow/patterns/0052-issue-synthesis-use-strenum-coercion-to-auto-convert-stored-string.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0052-issue-synthesis-use-strenum-coercion-to-auto-convert-stored-string.md
@@ -1,0 +1,18 @@
+---
+id: 0052
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.399663+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Use StrEnum coercion to auto-convert stored string values on load
+
+Declare Pydantic fields as StrEnum when values already conform, so Pydantic v2 auto-coerces stored strings at load time.
+
+Example: `class Phase(StrEnum): READY = "hydraflow-ready"` — field `phase: Phase` coerces `"hydraflow-ready"` from state.json automatically.
+
+**Why:** Manual `Phase(raw)` coercions at every read site diverge when new read paths are added; StrEnum coercion centralises conversion.

--- a/repo_wiki/T-rav/hydraflow/patterns/0053-issue-synthesis-define-canonical-constants-as-single-source-of-tru.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0053-issue-synthesis-define-canonical-constants-as-single-source-of-tru.md
@@ -1,0 +1,18 @@
+---
+id: 0053
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.415852+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Define canonical constants as single source of truth for label lists
+
+Establish a canonical constant (e.g., `ALL_LIFECYCLE_LABEL_FIELDS`) and derive every label list from it; never duplicate the list inline.
+
+Example: reset code, validators, and display logic all reference `ALL_LIFECYCLE_LABEL_FIELDS` — no magic strings.
+
+**Why:** Duplicated label lists diverge silently; a canonical constant makes omissions a grep-findable gap, not a runtime miss.

--- a/repo_wiki/T-rav/hydraflow/patterns/0054-issue-synthesis-use-metadata-tags-instead-of-enum-variants-for-sha.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0054-issue-synthesis-use-metadata-tags-instead-of-enum-variants-for-sha.md
@@ -1,0 +1,18 @@
+---
+id: 0054
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.416496+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Use metadata tags instead of enum variants for shared-bank categorization
+
+Tag items with metadata (e.g., `{"source": "adr_council"}`) rather than adding new enum variants for each category.
+
+Example: `retain(bank=Bank.LEARNINGS, metadata={"source": "adr_council"})` — no new enum variant needed.
+
+**Why:** Enum variants require syncing type checks, prompts, and display order across the codebase; a metadata tag adds a category with no schema change.

--- a/repo_wiki/T-rav/hydraflow/patterns/0055-issue-synthesis-grep-all-call-sites-before-changing-a-function-sig.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0055-issue-synthesis-grep-all-call-sites-before-changing-a-function-sig.md
@@ -1,0 +1,18 @@
+---
+id: 0055
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.417417+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Grep all call sites before changing a function signature
+
+Run `git grep <function_name>` before modifying any signature; for public functions, verify zero remaining unpatched matches after the change.
+
+Example: `git grep 'load_state'` before changing its return type — update every caller in the same commit.
+
+**Why:** Missing even one call site causes `TypeError` at runtime; exhaustive grep audit is the only way to confirm full coverage.

--- a/repo_wiki/T-rav/hydraflow/patterns/0056-issue-synthesis-update-all-callers-atomically-when-a-return-type-c.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0056-issue-synthesis-update-all-callers-atomically-when-a-return-type-c.md
@@ -1,0 +1,18 @@
+---
+id: 0056
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.418165+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Update all callers atomically when a return type changes
+
+When a function's return type changes (e.g., `str | None` → `dict | None`), update every caller in a single commit — never in separate PRs.
+
+Example: change `parse()` return type and grep + update all `result[0]` / `result[1]` unpack sites before committing. See also: patterns — Grep all call sites before changing a function signature.
+
+**Why:** A partially-migrated codebase compiles but crashes at runtime on unpatched callers.

--- a/repo_wiki/T-rav/hydraflow/patterns/0057-issue-synthesis-preserve-public-api-during-extraction-via-thin-del.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0057-issue-synthesis-preserve-public-api-during-extraction-via-thin-del.md
@@ -1,0 +1,18 @@
+---
+id: 0057
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.419133+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Preserve public API during extraction via thin delegation stubs
+
+When extracting code that tests or external callers depend on, keep the original method as a thin stub delegating to the new location.
+
+Example: leave `Client.old_method(self, x)` calling `new_module.old_method(x)` after extraction.
+
+**Why:** Removing public/semi-public methods during refactoring breaks callers that aren't visible in local grep (e.g., dynamically assembled call sites or test mocks).

--- a/repo_wiki/T-rav/hydraflow/patterns/0058-issue-synthesis-extract-pure-transform-functions-before-moving-cod.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0058-issue-synthesis-extract-pure-transform-functions-before-moving-cod.md
@@ -1,0 +1,18 @@
+---
+id: 0058
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.420482+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Extract pure transform functions before moving code to new classes
+
+Identify pure functions (no mutable closure state, no side effects) and extract them to module-level first; only then move to a class if ownership is clear.
+
+Example: extract `_format_label(name)` before creating `LabelFormatter` — the extracted form is independently testable.
+
+**Why:** Pure functions have the smallest blast radius and validate the extraction boundary before higher-risk class restructuring.

--- a/repo_wiki/T-rav/hydraflow/patterns/0059-issue-synthesis-preserve-per-concern-try-except-blocks-during-refa.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0059-issue-synthesis-preserve-per-concern-try-except-blocks-during-refa.md
@@ -1,0 +1,18 @@
+---
+id: 0059
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.423403+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Preserve per-concern try/except blocks during refactoring
+
+Do not merge or widen separate try/except blocks that each guard a specific concern — keep them as-is when extracting surrounding code.
+
+Example: if `fetch_labels()` and `post_comment()` each have their own try/except, extracted helpers must not share a single outer handler.
+
+**Why:** Merging exception scopes lets a failure in one concern silently suppress or skip a different concern.

--- a/repo_wiki/T-rav/hydraflow/patterns/0060-issue-synthesis-extract-duplicated-jsonl-reading-logic-to-a-shared.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0060-issue-synthesis-extract-duplicated-jsonl-reading-logic-to-a-shared.md
@@ -1,0 +1,18 @@
+---
+id: 0060
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.423699+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Extract duplicated JSONL-reading logic to a shared `_load_jsonl()` helper
+
+Shared JSONL-reading logic must be extracted to a `_load_jsonl(path, label)` helper rather than duplicated inline.
+
+Example: `records = _load_jsonl(path, "events")` — one implementation, multiple callers.
+
+**Why:** Inline duplication causes silent divergence when one copy gets a bug fix (e.g., empty-file guard) that the other copies miss.

--- a/repo_wiki/T-rav/hydraflow/patterns/0061-issue-synthesis-mock-at-the-definition-site-not-the-import-site.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0061-issue-synthesis-mock-at-the-definition-site-not-the-import-site.md
@@ -1,0 +1,18 @@
+---
+id: 0061
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.424451+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Mock at the definition site, not the import site
+
+Patch `hindsight.tombstone_safe`, not `module_under_test.tombstone_safe`; combine with deferred imports inside test methods.
+
+Example: `@patch('hindsight.tombstone_safe')` not `@patch('mymodule.tombstone_safe')`.
+
+**Why:** Import-site patches fail when the import is deferred or when optional dependencies are conditionally loaded — definition-site patches intercept regardless of import order.

--- a/repo_wiki/T-rav/hydraflow/patterns/0062-issue-synthesis-retarget-mock-patches-to-the-new-location-before-m.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0062-issue-synthesis-retarget-mock-patches-to-the-new-location-before-m.md
@@ -1,0 +1,18 @@
+---
+id: 0062
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.425480+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Retarget mock patches to the new location before moving a method
+
+Before moving a method to a new module, update all `@patch` decorators in tests to point to the destination path, then move the implementation.
+
+Example: change `@patch('old.module.Method')` → `@patch('new.module.Method')` before the move commit.
+
+**Why:** Moving a method without updating patches leaves tests patching a now-unused import, so the live code runs unpatched and the test silently stops covering the real path.

--- a/repo_wiki/T-rav/hydraflow/patterns/0063-issue-synthesis-generated-test-content-must-reference-function-nam.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0063-issue-synthesis-generated-test-content-must-reference-function-nam.md
@@ -1,0 +1,18 @@
+---
+id: 0063
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.427113+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Generated test content must reference function names, not line numbers
+
+Test skeletons, comments, and generated assertions must use exact function/class names for stability across refactors.
+
+Example: `# tests path through calculate_drift()` not `# tests line 42 in drift.py`.
+
+**Why:** Line numbers shift on every edit, making generated references immediately stale and misleading.

--- a/repo_wiki/T-rav/hydraflow/patterns/0064-issue-synthesis-use-meta-tests-to-enforce-anti-pattern-absence-acr.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0064-issue-synthesis-use-meta-tests-to-enforce-anti-pattern-absence-acr.md
@@ -1,0 +1,18 @@
+---
+id: 0064
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.427409+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Use meta-tests to enforce anti-pattern absence across the test suite
+
+Write meta-tests that scan `tests/test_*.py` for forbidden patterns (e.g., `sys.path.insert`, "Should..." docstrings, AAA comments) and fail CI if any are found.
+
+Example: `assert not any('sys.path.insert' in line for line in test_files)` as a standalone test.
+
+**Why:** Manual review misses anti-patterns introduced across hundreds of test files; a meta-test turns the check into a permanent CI gate.

--- a/repo_wiki/T-rav/hydraflow/patterns/0065-issue-synthesis-use-threading-lock-for-thread-pool-code-asyncio-lo.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0065-issue-synthesis-use-threading-lock-for-thread-pool-code-asyncio-lo.md
@@ -1,0 +1,18 @@
+---
+id: 0065
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.428356+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Use `threading.Lock` for thread-pool code; `asyncio.Lock` only for coroutines
+
+When code runs via `asyncio.to_thread()` or is called from both sync and async contexts, use `threading.Lock`. Use `asyncio.Lock` only for coordinating pure coroutines without thread-pool involvement.
+
+Example: `self._lock = threading.Lock()` for a cache shared between thread-pool workers.
+
+**Why:** `asyncio.Lock` is not thread-safe — acquiring it from a thread pool raises or silently corrupts state.

--- a/repo_wiki/T-rav/hydraflow/patterns/0066-issue-synthesis-extract-unlocked-helpers-to-prevent-re-entrant-loc.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0066-issue-synthesis-extract-unlocked-helpers-to-prevent-re-entrant-loc.md
@@ -1,0 +1,18 @@
+---
+id: 0066
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.428716+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Extract `_unlocked()` helpers to prevent re-entrant lock attempts
+
+When a lock-holding method needs to call another method that also acquires the same lock, extract an `_unlocked()` variant and call that from both.
+
+Example: `def update(self): with self._lock: self._update_unlocked()` — `batch_update` calls `_update_unlocked()` too. See also: patterns — Use `threading.Lock` for thread-pool code.
+
+**Why:** Re-entrant `threading.Lock` acquisition deadlocks; re-entrant `asyncio.Lock` raises — `_unlocked()` variants eliminate both failure modes.

--- a/repo_wiki/T-rav/hydraflow/patterns/0067-issue-synthesis-use-file-util-append-jsonl-for-crash-safe-jsonl-ap.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0067-issue-synthesis-use-file-util-append-jsonl-for-crash-safe-jsonl-ap.md
@@ -1,0 +1,18 @@
+---
+id: 0067
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.433583+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Use `file_util.append_jsonl()` for crash-safe JSONL appends
+
+Wrap JSONL appends in `file_util.append_jsonl()`, which calls `flush()` + `os.fsync()` inside a `file_lock()`.
+
+Example: `file_util.append_jsonl(path, record)` — not `with open(path, 'a') as f: f.write(...)`.
+
+**Why:** Bare `open(..., 'a')` without fsync loses the last record on crash; the lock prevents interleaved writes from concurrent processes.

--- a/repo_wiki/T-rav/hydraflow/patterns/0068-issue-synthesis-use-file-util-atomic-write-for-critical-state-file.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0068-issue-synthesis-use-file-util-atomic-write-for-critical-state-file.md
@@ -1,0 +1,18 @@
+---
+id: 0068
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.434984+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Use `file_util.atomic_write()` for critical state file updates
+
+Write critical state via `file_util.atomic_write()`, which writes to a temp file then calls `os.replace()` atomically.
+
+Example: `file_util.atomic_write(state_path, json.dumps(state))` — not `open(path, 'w').write(...)`.
+
+**Why:** A crash mid-write with `open(..., 'w')` truncates the file, producing an empty or partial state that cannot be loaded.

--- a/repo_wiki/T-rav/hydraflow/patterns/0069-issue-synthesis-use-claim-then-merge-for-async-queue-processing-to.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0069-issue-synthesis-use-claim-then-merge-for-async-queue-processing-to.md
@@ -1,0 +1,18 @@
+---
+id: 0069
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.436086+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Use claim-then-merge for async queue processing to prevent lost entries
+
+Atomically claim queue items (clear/load under lock), release lock, perform async work, re-acquire lock, reload new items, merge, then atomically write.
+
+Example: `with lock: batch = queue.copy(); queue.clear()` → async work → `with lock: queue.update(new); queue.update(results); write(queue)`.
+
+**Why:** Releasing the lock during async work avoids deadlock, but re-acquiring before write prevents entries appended during the async gap from being lost.

--- a/repo_wiki/T-rav/hydraflow/patterns/0070-issue-synthesis-set-and-clear-trace-context-in-a-single-try-finall.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0070-issue-synthesis-set-and-clear-trace-context-in-a-single-try-finall.md
@@ -1,0 +1,18 @@
+---
+id: 0070
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.436535+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Set and clear trace context in a single try/finally block
+
+Set/clear or begin/end pairs for tracing context MUST execute within a single try/finally — never split across separate methods.
+
+Example: `token = ctx.set(val); try: ... finally: ctx.reset(token)` — both in one scope.
+
+**Why:** Splitting the set/clear across call boundaries leaks trace state across issues or loop iterations, corrupting span attribution.

--- a/repo_wiki/T-rav/hydraflow/patterns/0071-issue-synthesis-keep-event-publishing-coupled-with-the-condition-t.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0071-issue-synthesis-keep-event-publishing-coupled-with-the-condition-t.md
@@ -1,0 +1,18 @@
+---
+id: 0071
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.436818+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Keep event publishing coupled with the condition that gates it
+
+The `if should_alert:` check and `event_bus.publish(ALERT)` must live in the same method body — never separated into different methods.
+
+Example: inline both in `_check_and_notify()` rather than calling `_check()` then `_publish()`.
+
+**Why:** Separating them creates code paths where the gate is checked but the event isn't fired (or vice versa), breaking observability silently.

--- a/repo_wiki/T-rav/hydraflow/patterns/0072-issue-synthesis-preserve-exact-retry-counter-state-during-dispatch.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0072-issue-synthesis-preserve-exact-retry-counter-state-during-dispatch.md
@@ -1,0 +1,18 @@
+---
+id: 0072
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.437063+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Preserve exact retry counter state during dispatcher refactoring
+
+When refactoring state machine dispatchers, carry over retry counters and escalation conditions (e.g., epic-child label swaps) exactly — do not reset or re-derive them.
+
+Example: copy `issue.attempt_count` and `issue.escalation_triggered` into the refactored handler without modification.
+
+**Why:** Dropping retry state silently resets attempt budgets, allowing previously-exhausted issues to cycle again or miss escalation thresholds.

--- a/repo_wiki/T-rav/hydraflow/patterns/0073-issue-synthesis-dry-run-mode-must-not-emit-state-changing-events.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0073-issue-synthesis-dry-run-mode-must-not-emit-state-changing-events.md
@@ -1,0 +1,18 @@
+---
+id: 0073
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.437878+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Dry-run mode must not emit state-changing events
+
+Gate every side-effecting event bus publish behind `if not self.dry_run:` to ensure dry-run has no observable side effects.
+
+Example: `if not self.dry_run: self.event_bus.publish(TRIAGE_ROUTING, ...)` — not emitted during dry-run. See also: patterns — Keep event publishing coupled with the condition that gates it.
+
+**Why:** An emitted event in dry-run triggers downstream label mutations and state transitions, making dry-run non-idempotent.

--- a/repo_wiki/T-rav/hydraflow/patterns/0074-issue-synthesis-maintain-immutable-return-contract-for-parse-tuple.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0074-issue-synthesis-maintain-immutable-return-contract-for-parse-tuple.md
@@ -1,0 +1,18 @@
+---
+id: 0074
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.438186+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Maintain immutable return contract for `parse()` — `tuple[str, str | None]`
+
+Phase result `parse()` must always return `tuple[str, str | None]`; refactors that widen or change this shape break all callers.
+
+Example: return `("approved", None)` or `("rejected", "reason")` — never a plain `str` or `dict`.
+
+**Why:** Callers destructure the tuple positionally; a shape change produces `TypeError` or silent data corruption at the unpack site.

--- a/repo_wiki/T-rav/hydraflow/patterns/0075-issue-synthesis-define-event-to-stage-and-source-to-stage-mappings.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0075-issue-synthesis-define-event-to-stage-and-source-to-stage-mappings.md
@@ -1,0 +1,18 @@
+---
+id: 0075
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.438457+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Define EVENT_TO_STAGE and SOURCE_TO_STAGE mappings before skip detection
+
+Implement event/worker-to-stage mappings together with skip detection logic — never add a mapping after skip detection is wired.
+
+Example: define `EVENT_TO_STAGE = {...}` and `SOURCE_TO_STAGE = {...}` before the `if event in skip_set: return` guard.
+
+**Why:** Mappings added after the early-return guard are never evaluated, making the new stage silently unreachable.

--- a/repo_wiki/T-rav/hydraflow/patterns/0076-issue-synthesis-pre-allocate-memory-budget-upfront-before-prompt-a.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0076-issue-synthesis-pre-allocate-memory-budget-upfront-before-prompt-a.md
@@ -1,0 +1,18 @@
+---
+id: 0076
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.438732+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Pre-allocate memory budget upfront before prompt assembly
+
+Call `get_allocation()` and consume all budget caps before starting `_inject_memory()` — post-hoc surplus reclamation is not possible.
+
+Example: allocate wiki budget first, deduct from surplus, then distribute remaining memory budget proportionally. See also: patterns — Use a two-round allocator for memory sections.
+
+**Why:** Prompt assembly is streaming; once a section is written, its token budget cannot be reclaimed for a different section.

--- a/repo_wiki/T-rav/hydraflow/patterns/0077-issue-synthesis-use-a-two-round-allocator-section-minimums-first-t.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0077-issue-synthesis-use-a-two-round-allocator-section-minimums-first-t.md
@@ -1,0 +1,18 @@
+---
+id: 0077
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.438998+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Use a two-round allocator: section minimums first, then proportional surplus
+
+Round one gives each memory section its minimum budget; round two distributes the remainder proportionally by `_DEFAULT_PRIORITIES` label.
+
+Example: `min_alloc = {k: MINIMUMS[k] for k in sections}; surplus = total - sum(min_alloc.values()); prop += surplus * weights`.
+
+**Why:** A single-round proportional allocator can starve low-priority sections below their functional minimum, breaking prompt structure.

--- a/repo_wiki/T-rav/hydraflow/patterns/0078-issue-synthesis-deduct-wiki-budget-from-memory-surplus-before-redi.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0078-issue-synthesis-deduct-wiki-budget-from-memory-surplus-before-redi.md
@@ -1,0 +1,18 @@
+---
+id: 0078
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.439255+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Deduct wiki budget from memory surplus before redistributing
+
+Compute the wiki budget (`max_repo_wiki_chars`) and subtract it from the memory surplus BEFORE distributing the remainder proportionally across memory sections.
+
+Example: `surplus -= wiki_budget; memory_alloc = distribute(surplus, weights)`. See also: patterns — Pre-allocate memory budget upfront before prompt assembly.
+
+**Why:** Not deducting first causes memory sections to over-allocate, then the wiki gets truncated when both compete for the same token pool.

--- a/repo_wiki/T-rav/hydraflow/patterns/0079-issue-synthesis-lazy-load-memory-context-on-explicit-user-action-n.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0079-issue-synthesis-lazy-load-memory-context-on-explicit-user-action-n.md
@@ -1,0 +1,18 @@
+---
+id: 0079
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.439691+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Lazy-load memory context on explicit user action, not on list render
+
+Fetch memory context only when the user expands a section — not when the HITL list view renders.
+
+Example: expand button triggers `fetchMemoryContext(issueId)` — the list view fires no memory API calls.
+
+**Why:** Pre-fetching on render causes N+1 API calls on every HITL list load, amplified by the number of open issues.

--- a/repo_wiki/T-rav/hydraflow/patterns/0080-issue-synthesis-use-sha-256-truncated-to-16-chars-for-memory-dedup.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0080-issue-synthesis-use-sha-256-truncated-to-16-chars-for-memory-dedup.md
@@ -1,0 +1,18 @@
+---
+id: 0080
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.439989+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Use SHA-256 truncated to 16 chars for memory dedup keys
+
+Compute dedup keys and recall-hit tracking via `SHA-256(content)[:16]`.
+
+Example: `key = hashlib.sha256(item['text'].encode()).hexdigest()[:16]`.
+
+**Why:** Consistent hashing ensures the same content maps to the same key across process restarts; truncation keeps keys human-scannable in logs.

--- a/repo_wiki/T-rav/hydraflow/patterns/0081-issue-synthesis-use-asymmetric-word-set-overlap-for-memory-dedupli.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0081-issue-synthesis-use-asymmetric-word-set-overlap-for-memory-dedupli.md
@@ -1,0 +1,18 @@
+---
+id: 0081
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.440248+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Use asymmetric word-set overlap for memory deduplication
+
+Compute dedup similarity as `len(words & existing) / max(len(words), 1)` with a configurable threshold (default 0.85).
+
+Example: new item with 10 words sharing 9 with an existing item → score 0.9 → suppress.
+
+**Why:** Symmetric Jaccard penalises short additions to long entries; asymmetric overlap correctly identifies content that's mostly a subset of existing memory.

--- a/repo_wiki/T-rav/hydraflow/patterns/0082-issue-synthesis-batch-load-scoring-data-once-per-eviction-operatio.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0082-issue-synthesis-batch-load-scoring-data-once-per-eviction-operatio.md
@@ -1,0 +1,18 @@
+---
+id: 0082
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.441253+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Batch-load scoring data once per eviction operation, not per item
+
+Call `MemoryScorer.load_item_scores()` once per eviction pass and reuse the result across all items.
+
+Example: `scores = scorer.load_item_scores(); for item in items: rank(item, scores)`.
+
+**Why:** Per-item score loading reads the same file N times; batch loading makes eviction O(1) in I/O regardless of corpus size.

--- a/repo_wiki/T-rav/hydraflow/patterns/0083-issue-synthesis-retain-coerces-metadata-to-str-compare-with-true-n.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0083-issue-synthesis-retain-coerces-metadata-to-str-compare-with-true-n.md
@@ -1,0 +1,18 @@
+---
+id: 0083
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.442047+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# retain() coerces metadata to `str` — compare with `== "true"`, not `is True`
+
+`retain()` calls `str(v)` on all metadata values; boolean `True` becomes string `"true"`.
+
+Example: `metadata={"warning": "true"}` not `{"warning": True}`; check with `metadata.get("warning") == "true"`.
+
+**Why:** `metadata.get("warning") is True` always returns `False` after coercion, silently disabling warning-based filtering.

--- a/repo_wiki/T-rav/hydraflow/patterns/0084-issue-synthesis-memory-contradiction-resolution-provenance-wins-ov.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0084-issue-synthesis-memory-contradiction-resolution-provenance-wins-ov.md
@@ -1,0 +1,18 @@
+---
+id: 0084
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.444154+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Memory contradiction resolution: provenance wins over recency
+
+When two memory items contradict, human-sourced wins over agent-sourced regardless of timestamp; among equal provenance, newer wins.
+
+Example: a human-written learning from 2024 beats an agent-written one from 2025.
+
+**Why:** Agent-sourced items can encode hallucinations; provenance-first resolution ensures human corrections are never overwritten by automated entries.

--- a/repo_wiki/T-rav/hydraflow/patterns/0085-issue-synthesis-memory-eviction-must-atomically-update-both-scores.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0085-issue-synthesis-memory-eviction-must-atomically-update-both-scores.md
@@ -1,0 +1,18 @@
+---
+id: 0085
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.444954+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Memory eviction must atomically update both scores and items files
+
+An eviction operation must write `item_scores.json` and `items.jsonl` together within the same lock scope — never update one without the other.
+
+Example: `atomic_write(scores_path, ...)` then `atomic_write(items_path, ...)` under a single lock acquire. See also: patterns — Use `file_util.atomic_write()` for critical state file updates.
+
+**Why:** A partial update leaves scores referencing evicted items (or items with stale scores), corrupting ranking on the next eviction pass.

--- a/repo_wiki/T-rav/hydraflow/patterns/0086-issue-synthesis-guard-close-with-a-closed-flag-to-make-it-idempote.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0086-issue-synthesis-guard-close-with-a-closed-flag-to-make-it-idempote.md
@@ -1,0 +1,18 @@
+---
+id: 0086
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.445727+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Guard `close()` with a `_closed` flag to make it idempotent
+
+All cleanup methods must check and set a `_closed` flag as their first step.
+
+Example: `def close(self): if self._closed: return; self._closed = True; await self._resource.aclose()`.
+
+**Why:** Double-close on an async resource (e.g., HTTP session) raises; idempotent close makes teardown order-independent in test fixtures.

--- a/repo_wiki/T-rav/hydraflow/patterns/0087-issue-synthesis-memory-staleness-detection-should-emit-events-not-.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0087-issue-synthesis-memory-staleness-detection-should-emit-events-not-.md
@@ -1,0 +1,18 @@
+---
+id: 0087
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.446460+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Memory staleness detection should emit events, not silently mutate state
+
+Staleness detection must emit events or log warnings rather than silently deleting or modifying stale entries.
+
+Example: `event_bus.publish(STALE_MEMORY, item_id=item.id, age_days=age)` instead of `self._items.pop(item.id)`.
+
+**Why:** Silent mutation removes the operator's ability to review or override staleness decisions; events keep the action reversible.

--- a/repo_wiki/T-rav/hydraflow/patterns/0088-issue-synthesis-adr-files-without-readme-entries-are-invisible-to-.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0088-issue-synthesis-adr-files-without-readme-entries-are-invisible-to-.md
@@ -1,0 +1,18 @@
+---
+id: 0088
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.447618+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# ADR files without README entries are invisible to tooling
+
+Every ADR file in `docs/adr/` must have a corresponding row in `docs/adr/README.md` to be canonically referenceable.
+
+Example: adding `docs/adr/0055-new-decision.md` requires a matching `| 0055 | New Decision | Accepted |` row in README.
+
+**Why:** `scan_adr_directory()` builds its index from README rows; a file without a row is silently skipped by drift detection and cross-reference tooling.

--- a/repo_wiki/T-rav/hydraflow/patterns/0089-issue-synthesis-preserve-the-hf-namespace-prefix-when-renaming-ski.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0089-issue-synthesis-preserve-the-hf-namespace-prefix-when-renaming-ski.md
@@ -1,0 +1,18 @@
+---
+id: 0089
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.447973+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Preserve the `hf.` namespace prefix when renaming skill or command files
+
+When renaming fixture or command files, keep the `hf.` or `hf-` prefix intact.
+
+Example: rename `hf.audit-code.md` → `hf.audit-contracts.md`, not `audit-contracts.md`.
+
+**Why:** Skill lookup strips the prefix at registration; dropping it makes the skill unreachable via `/hf.audit-contracts` and breaks namespace consistency.

--- a/repo_wiki/T-rav/hydraflow/patterns/0090-issue-synthesis-keep-skill-prompts-in-sync-across-all-four-backend.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0090-issue-synthesis-keep-skill-prompts-in-sync-across-all-four-backend.md
@@ -1,0 +1,18 @@
+---
+id: 0090
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.448326+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# Keep skill prompts in sync across all four backend locations
+
+Skill prompt text lives in `src/`, `.claude/commands/`, `.pi/skills/`, and `.codex/skills/` — update all four locations when changing a prompt.
+
+Example: editing `.claude/commands/hf.diff-sanity.md` requires mirroring the change to the other three locations.
+
+**Why:** Missed updates cause the same skill to behave differently depending on which backend routes the request, producing inconsistent LLM behavior.

--- a/repo_wiki/T-rav/hydraflow/patterns/0091-issue-synthesis-in-place-diff-truncation-silently-corrupts-downstr.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0091-issue-synthesis-in-place-diff-truncation-silently-corrupts-downstr.md
@@ -1,0 +1,18 @@
+---
+id: 0091
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T14:57:29.448642+00:00
+status: active
+corroborations: 1
+supersedes: 0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0037,0038,0039,0040,0041,0042,0043,0044,0045,0046,0047,0048,0049
+---
+
+# In-place diff truncation silently corrupts downstream non-LLM consumers
+
+When a diff is truncated for an LLM prompt, rebind to a separate name rather than mutating the original variable.
+
+Example: `prompt_diff = diff[:max_diff] + "[truncated]"` — keep `full_diff = diff` for the coverage engine. Never rebind `diff` in place.
+
+**Why:** In-place truncation causes coverage mapping to silently under-report changed lines in the tail of large diffs, making the gate fail-open on the diffs most likely to need it.

--- a/repo_wiki/T-rav/hydraflow/testing/0007-issue-synthesis-mock-at-definition-site-not-at-usage-site.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0007-issue-synthesis-mock-at-definition-site-not-at-usage-site.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.408197+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Mock at definition site, not at usage site

--- a/repo_wiki/T-rav/hydraflow/testing/0008-issue-synthesis-mark-pytest-mark-integration-only-for-real-externa.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0008-issue-synthesis-mark-pytest-mark-integration-only-for-real-externa.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.408369+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Mark @pytest.mark.integration only for real external dependencies

--- a/repo_wiki/T-rav/hydraflow/testing/0009-issue-synthesis-await-asyncio-sleep-0-after-create-task-before-ass.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0009-issue-synthesis-await-asyncio-sleep-0-after-create-task-before-ass.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.408500+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Await asyncio.sleep(0) after create_task() before asserting

--- a/repo_wiki/T-rav/hydraflow/testing/0010-issue-synthesis-reset-global-module-level-state-in-both-setup-and-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0010-issue-synthesis-reset-global-module-level-state-in-both-setup-and-.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.408625+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Reset global/module-level state in both setup and teardown

--- a/repo_wiki/T-rav/hydraflow/testing/0011-issue-synthesis-use-tmp-path-and-factory-for-all-file-based-test-i.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0011-issue-synthesis-use-tmp-path-and-factory-for-all-file-based-test-i.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.408759+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Use tmp_path and factory for all file-based test I/O

--- a/repo_wiki/T-rav/hydraflow/testing/0012-issue-synthesis-validate-sys-modules-cleanup-with-multiple-random-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0012-issue-synthesis-validate-sys-modules-cleanup-with-multiple-random-.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.408876+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Validate sys.modules cleanup with multiple random seeds

--- a/repo_wiki/T-rav/hydraflow/testing/0013-issue-synthesis-caplog-assertions-must-name-the-exact-logger.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0013-issue-synthesis-caplog-assertions-must-name-the-exact-logger.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.408997+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Caplog assertions must name the exact logger

--- a/repo_wiki/T-rav/hydraflow/testing/0014-issue-synthesis-test-protocol-satisfaction-with-both-isinstance-an.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0014-issue-synthesis-test-protocol-satisfaction-with-both-isinstance-an.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.409122+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Test protocol satisfaction with both isinstance and hasattr

--- a/repo_wiki/T-rav/hydraflow/testing/0015-issue-synthesis-fa-ade-tests-cover-routing-error-delegation-and-ba.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0015-issue-synthesis-fa-ade-tests-cover-routing-error-delegation-and-ba.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.409248+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Façade tests: cover routing, error, delegation, and backward compat

--- a/repo_wiki/T-rav/hydraflow/testing/0016-issue-synthesis-skip-broken-tests-with-an-issue-reference-remove-a.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0016-issue-synthesis-skip-broken-tests-with-an-issue-reference-remove-a.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.409375+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Skip broken tests with an issue reference; remove after fix

--- a/repo_wiki/T-rav/hydraflow/testing/0017-issue-synthesis-browser-rendered-attributes-require-playwright-not.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0017-issue-synthesis-browser-rendered-attributes-require-playwright-not.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.409494+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Browser-rendered attributes require Playwright, not TestClient

--- a/repo_wiki/T-rav/hydraflow/testing/0018-issue-synthesis-subprocess-cli-test-stubs-log-invocations-to-jsonl.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0018-issue-synthesis-subprocess-cli-test-stubs-log-invocations-to-jsonl.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.409621+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Subprocess CLI test stubs: log invocations to JSONL

--- a/repo_wiki/T-rav/hydraflow/testing/0019-issue-synthesis-integration-test-runners-mock-only-execute-wire-re.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0019-issue-synthesis-integration-test-runners-mock-only-execute-wire-re.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.409744+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Integration test runners: mock only _execute(), wire real logic

--- a/repo_wiki/T-rav/hydraflow/testing/0020-issue-synthesis-use-word-boundary-matching-in-coverage-checks-not-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0020-issue-synthesis-use-word-boundary-matching-in-coverage-checks-not-.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.409865+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Use word-boundary matching in coverage checks, not substring

--- a/repo_wiki/T-rav/hydraflow/testing/0021-issue-synthesis-use-is-to-verify-shared-runner-instance-across-com.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0021-issue-synthesis-use-is-to-verify-shared-runner-instance-across-com.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.409988+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Use is to verify shared runner instance across components

--- a/repo_wiki/T-rav/hydraflow/testing/0022-issue-synthesis-enforce-50-30-line-limits-on-handlers-and-registra.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0022-issue-synthesis-enforce-50-30-line-limits-on-handlers-and-registra.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.410113+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Enforce 50/30-line limits on handlers and registration wiring

--- a/repo_wiki/T-rav/hydraflow/testing/0023-issue-synthesis-assert-relative-event-ordering-not-absolute-id-val.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0023-issue-synthesis-assert-relative-event-ordering-not-absolute-id-val.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.410246+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Assert relative event ordering, not absolute ID values

--- a/repo_wiki/T-rav/hydraflow/testing/0024-issue-synthesis-add-structural-tests-for-transition-graphs-before-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0024-issue-synthesis-add-structural-tests-for-transition-graphs-before-.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.410376+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Add structural tests for transition graphs before property-based tests

--- a/repo_wiki/T-rav/hydraflow/testing/0025-issue-synthesis-sync-test-label-constants-with-production-pipeline.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0025-issue-synthesis-sync-test-label-constants-with-production-pipeline.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.410503+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Sync test label constants with production pipeline definitions

--- a/repo_wiki/T-rav/hydraflow/testing/0026-issue-synthesis-pydantic-typeddict-field-changes-require-updates-i.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0026-issue-synthesis-pydantic-typeddict-field-changes-require-updates-i.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.410673+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Pydantic/TypedDict field changes require updates in 4 places

--- a/repo_wiki/T-rav/hydraflow/testing/0027-issue-synthesis-feature-toggles-need-both-a-config-field-and-env-i.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0027-issue-synthesis-feature-toggles-need-both-a-config-field-and-env-i.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.410812+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Feature toggles need both a config field and _ENV_INT_OVERRIDES entry

--- a/repo_wiki/T-rav/hydraflow/testing/0028-issue-synthesis-dict-to-typeddict-migrations-require-no-new-tests.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0028-issue-synthesis-dict-to-typeddict-migrations-require-no-new-tests.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.410951+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # dict-to-TypedDict migrations require no new tests

--- a/repo_wiki/T-rav/hydraflow/testing/0029-issue-synthesis-concurrent-jsonl-appends-assert-exact-event-counts.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0029-issue-synthesis-concurrent-jsonl-appends-assert-exact-event-counts.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.411086+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Concurrent JSONL appends: assert exact event counts, not timing

--- a/repo_wiki/T-rav/hydraflow/testing/0030-issue-synthesis-memory-bank-keys-must-be-consistent-across-dedup-a.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0030-issue-synthesis-memory-bank-keys-must-be-consistent-across-dedup-a.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.411216+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Memory bank keys must be consistent across dedup and assembly

--- a/repo_wiki/T-rav/hydraflow/testing/0031-issue-synthesis-memory-dedup-higher-priority-bank-wins-on-collisio.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0031-issue-synthesis-memory-dedup-higher-priority-bank-wins-on-collisio.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.411360+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Memory dedup: higher-priority bank wins on collision

--- a/repo_wiki/T-rav/hydraflow/testing/0032-issue-synthesis-skill-markers-must-be-present-in-all-4-backend-cop.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0032-issue-synthesis-skill-markers-must-be-present-in-all-4-backend-cop.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.411504+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Skill markers must be present in all 4 backend copies

--- a/repo_wiki/T-rav/hydraflow/testing/0033-issue-synthesis-generate-adr-derived-tests-as-skipped-skeletons-by.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0033-issue-synthesis-generate-adr-derived-tests-as-skipped-skeletons-by.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.411637+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Generate ADR-derived tests as skipped skeletons by default

--- a/repo_wiki/T-rav/hydraflow/testing/0034-issue-synthesis-adr-pre-validator-enforce-required-sections-and-st.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0034-issue-synthesis-adr-pre-validator-enforce-required-sections-and-st.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.411772+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # ADR pre-validator: enforce required sections and status values

--- a/repo_wiki/T-rav/hydraflow/testing/0035-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0035-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.411909+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Never import private helpers at module level in test files

--- a/repo_wiki/T-rav/hydraflow/testing/0036-issue-synthesis-pin-function-signatures-before-writing-callers-or-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0036-issue-synthesis-pin-function-signatures-before-writing-callers-or-.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-13T05:43:53.412085+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006
+superseded_by: 0217
 ---
 
 # Pin function signatures before writing callers or tests

--- a/repo_wiki/T-rav/hydraflow/testing/0183-issue-9567-hoist-deterministic-gates-outside-llm-retry-loops.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0183-issue-9567-hoist-deterministic-gates-outside-llm-retry-loops.md
@@ -4,8 +4,9 @@ topic: testing
 source_issue: 9567
 source_phase: review
 created_at: 2026-06-20T09:15:00.395639+00:00
-status: active
+status: superseded
 corroborations: 1
+superseded_by: 0217
 ---
 
 # Hoist deterministic gates outside LLM retry loops

--- a/repo_wiki/T-rav/hydraflow/testing/0183-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0183-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.782918+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Never import private helpers at module level in test files

--- a/repo_wiki/T-rav/hydraflow/testing/0184-issue-synthesis-pin-function-signatures-in-the-source-file-before-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0184-issue-synthesis-pin-function-signatures-in-the-source-file-before-.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.783288+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Pin function signatures in the source file before writing tests or docs

--- a/repo_wiki/T-rav/hydraflow/testing/0185-issue-synthesis-use-public-fakegithub-api-in-scenario-tests-never-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0185-issue-synthesis-use-public-fakegithub-api-in-scenario-tests-never-.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.783632+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Use public FakeGitHub API in scenario tests — never mutate _issues directly

--- a/repo_wiki/T-rav/hydraflow/testing/0186-issue-synthesis-mock-at-definition-site-not-at-the-import-site.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0186-issue-synthesis-mock-at-definition-site-not-at-the-import-site.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.783966+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Mock at definition site, not at the import site

--- a/repo_wiki/T-rav/hydraflow/testing/0187-issue-synthesis-reserve-pytest-mark-integration-for-real-external-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0187-issue-synthesis-reserve-pytest-mark-integration-for-real-external-.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.784311+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Reserve @pytest.mark.integration for real external dependencies only

--- a/repo_wiki/T-rav/hydraflow/testing/0188-issue-synthesis-await-asyncio-sleep-0-before-asserting-on-create-t.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0188-issue-synthesis-await-asyncio-sleep-0-before-asserting-on-create-t.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.784644+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Await asyncio.sleep(0) before asserting on create_task() side effects

--- a/repo_wiki/T-rav/hydraflow/testing/0189-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0189-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.784968+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Test async context managers in three standard scenarios

--- a/repo_wiki/T-rav/hydraflow/testing/0190-issue-synthesis-use-python-script-stand-ins-to-test-subprocess-bou.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0190-issue-synthesis-use-python-script-stand-ins-to-test-subprocess-bou.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.785304+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Use Python script stand-ins to test subprocess boundaries

--- a/repo_wiki/T-rav/hydraflow/testing/0191-issue-synthesis-reset-module-level-global-state-in-both-setup-and-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0191-issue-synthesis-reset-module-level-global-state-in-both-setup-and-.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.785638+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Reset module-level global state in both setup and teardown

--- a/repo_wiki/T-rav/hydraflow/testing/0192-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0192-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.785994+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Use tmp_path with ConfigFactory for all file-based test I/O

--- a/repo_wiki/T-rav/hydraflow/testing/0193-issue-synthesis-wire-real-business-logic-in-phase-runner-integrati.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0193-issue-synthesis-wire-real-business-logic-in-phase-runner-integrati.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.786329+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Wire real business logic in phase-runner integration tests

--- a/repo_wiki/T-rav/hydraflow/testing/0194-issue-synthesis-test-protocol-compliance-with-structural-typing-an.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0194-issue-synthesis-test-protocol-compliance-with-structural-typing-an.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.786664+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Test protocol compliance with structural typing and duck-typing

--- a/repo_wiki/T-rav/hydraflow/testing/0195-issue-synthesis-test-fa-ade-getattr-routing-attributeerror-and-pro.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0195-issue-synthesis-test-fa-ade-getattr-routing-attributeerror-and-pro.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.787002+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Test façade __getattr__ routing, AttributeError, and protocol delegation

--- a/repo_wiki/T-rav/hydraflow/testing/0196-issue-synthesis-assert-relative-event-id-ordering-never-absolute-v.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0196-issue-synthesis-assert-relative-event-id-ordering-never-absolute-v.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.787334+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Assert relative event ID ordering, never absolute values

--- a/repo_wiki/T-rav/hydraflow/testing/0197-issue-synthesis-add-structural-tests-before-property-based-transit.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0197-issue-synthesis-add-structural-tests-before-property-based-transit.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.787682+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Add structural tests before property-based transition graph tests

--- a/repo_wiki/T-rav/hydraflow/testing/0198-issue-synthesis-grep-all-model-usages-before-committing-pydantic-o.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0198-issue-synthesis-grep-all-model-usages-before-committing-pydantic-o.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.788034+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Grep all model usages before committing Pydantic or TypedDict changes

--- a/repo_wiki/T-rav/hydraflow/testing/0199-issue-synthesis-feature-toggles-require-both-a-config-field-and-an.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0199-issue-synthesis-feature-toggles-require-both-a-config-field-and-an.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.788379+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Feature toggles require both a config field and an _ENV_INT_OVERRIDES entry

--- a/repo_wiki/T-rav/hydraflow/testing/0200-issue-synthesis-test-concurrent-jsonl-appends-with-exact-counts-no.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0200-issue-synthesis-test-concurrent-jsonl-appends-with-exact-counts-no.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.788716+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Test concurrent JSONL appends with exact counts, not timing

--- a/repo_wiki/T-rav/hydraflow/testing/0201-issue-synthesis-use-identical-string-keys-across-memory-bank-dedup.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0201-issue-synthesis-use-identical-string-keys-across-memory-bank-dedup.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.789055+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Use identical string keys across memory bank deduplication and assembly

--- a/repo_wiki/T-rav/hydraflow/testing/0202-issue-synthesis-skill-definition-changes-must-update-all-4-backend.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0202-issue-synthesis-skill-definition-changes-must-update-all-4-backend.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.789384+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Skill definition changes must update all 4 backend copies

--- a/repo_wiki/T-rav/hydraflow/testing/0203-issue-synthesis-auto-generated-adr-tests-must-use-pytest-mark-skip.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0203-issue-synthesis-auto-generated-adr-tests-must-use-pytest-mark-skip.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.789727+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Auto-generated ADR tests must use @pytest.mark.skip by default

--- a/repo_wiki/T-rav/hydraflow/testing/0204-issue-synthesis-every-adr-must-pass-structural-section-validation-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0204-issue-synthesis-every-adr-must-pass-structural-section-validation-.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.790066+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Every ADR must pass structural section validation before merge

--- a/repo_wiki/T-rav/hydraflow/testing/0205-issue-synthesis-specify-exact-logger-name-in-caplog-at-level-asser.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0205-issue-synthesis-specify-exact-logger-name-in-caplog-at-level-asser.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.790404+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Specify exact logger name in caplog.at_level() assertions

--- a/repo_wiki/T-rav/hydraflow/testing/0206-issue-synthesis-js-rendered-accessibility-attributes-require-playw.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0206-issue-synthesis-js-rendered-accessibility-attributes-require-playw.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.790762+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # JS-rendered accessibility attributes require Playwright, not TestClient

--- a/repo_wiki/T-rav/hydraflow/testing/0207-issue-synthesis-use-word-boundary-matching-in-name-coverage-checks.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0207-issue-synthesis-use-word-boundary-matching-in-name-coverage-checks.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.791102+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Use word-boundary matching in name-coverage checks to prevent collisions

--- a/repo_wiki/T-rav/hydraflow/testing/0208-issue-synthesis-keep-test-label-stage-constants-synchronized-with-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0208-issue-synthesis-keep-test-label-stage-constants-synchronized-with-.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.791449+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Keep test label/stage constants synchronized with production definitions

--- a/repo_wiki/T-rav/hydraflow/testing/0209-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels-n.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0209-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels-n.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.791797+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Test direct-swap labels via swap_pipeline_labels(), not transitions

--- a/repo_wiki/T-rav/hydraflow/testing/0210-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0210-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.792140+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Allow ±3 line drift in AST-based structure assertions

--- a/repo_wiki/T-rav/hydraflow/testing/0211-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0211-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.792497+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Existing tests cover private-method extractions; add only new-behavior tests

--- a/repo_wiki/T-rav/hydraflow/testing/0212-issue-synthesis-enforce-50-line-handler-and-30-line-wiring-limits-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0212-issue-synthesis-enforce-50-line-handler-and-30-line-wiring-limits-.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.792854+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Enforce 50-line handler and 30-line wiring limits for testability

--- a/repo_wiki/T-rav/hydraflow/testing/0213-issue-synthesis-type-only-annotation-changes-require-no-new-tests.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0213-issue-synthesis-type-only-annotation-changes-require-no-new-tests.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.793210+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Type-only annotation changes require no new tests

--- a/repo_wiki/T-rav/hydraflow/testing/0214-issue-synthesis-assert-numeric-values-in-sentry-breadcrumbs-not-ju.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0214-issue-synthesis-assert-numeric-values-in-sentry-breadcrumbs-not-ju.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.793574+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Assert numeric values in Sentry breadcrumbs, not just key presence

--- a/repo_wiki/T-rav/hydraflow/testing/0215-issue-synthesis-test-pydantic-literal-constraints-cover-both-valid.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0215-issue-synthesis-test-pydantic-literal-constraints-cover-both-valid.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.794015+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Test Pydantic Literal constraints: cover both valid and invalid values

--- a/repo_wiki/T-rav/hydraflow/testing/0216-issue-synthesis-verify-fatal-exception-propagation-through-multi-p.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0216-issue-synthesis-verify-fatal-exception-propagation-through-multi-p.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-06-20T05:43:45.794459+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0001,0002,0003,0004,0005,0006,0007,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179,0180,0181,0182
+superseded_by: 0217
 ---
 
 # Verify fatal exception propagation through multi-phase loops

--- a/repo_wiki/T-rav/hydraflow/testing/0217-issue-synthesis-mock-at-definition-site-not-at-usage-site.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0217-issue-synthesis-mock-at-definition-site-not-at-usage-site.md
@@ -1,0 +1,18 @@
+---
+id: 0217
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.856059+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Mock at definition site, not at usage site
+
+Patch symbols at the module where they are *defined*, not where they are imported.
+
+Good: `patch('src.foo._cache')` — Bad: `patch('src.consumer._cache')`. For optional deps like `sentry_sdk`, use `patch.dict('sys.modules', {'sentry_sdk': mock, 'sentry_sdk.integrations': mock})`; patch sub-modules explicitly to prevent import leaks.
+
+**Why:** Usage-site patches intercept only that one import; other callers and subsequent imports still see the real object, producing inconsistent test behavior.

--- a/repo_wiki/T-rav/hydraflow/testing/0218-issue-synthesis-reserve-pytest-mark-integration-for-real-external-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0218-issue-synthesis-reserve-pytest-mark-integration-for-real-external-.md
@@ -1,0 +1,18 @@
+---
+id: 0218
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.856683+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Reserve @pytest.mark.integration for real external dependencies only
+
+Apply `@pytest.mark.integration` only when a test exercises Docker, network, filesystem, worktrees, or live service instances — not when all deps are `AsyncMock` or `MagicMock`.
+
+Use `pytest.mark.skipif(shutil.which('tool') is None, ...)` for optional CLI tools.
+
+**Why:** Over-marking slows the fast suite and blurs the unit/integration boundary, making targeted test runs unreliable and hiding real coverage gaps.

--- a/repo_wiki/T-rav/hydraflow/testing/0219-issue-synthesis-await-asyncio-sleep-0-after-create-task-before-ass.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0219-issue-synthesis-await-asyncio-sleep-0-after-create-task-before-ass.md
@@ -1,0 +1,22 @@
+---
+id: 0219
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.857330+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Await asyncio.sleep(0) after create_task() before asserting
+
+After triggering a fire-and-forget task, yield one event loop tick before asserting.
+
+```python
+task = asyncio.create_task(fn())
+await asyncio.sleep(0)
+mock.assert_called_once()
+```
+
+**Why:** Without yielding, the scheduled task has not run yet; assertions fire on stale state and produce false negatives non-deterministically.

--- a/repo_wiki/T-rav/hydraflow/testing/0220-issue-synthesis-reset-global-module-level-state-in-both-setup-and-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0220-issue-synthesis-reset-global-module-level-state-in-both-setup-and-.md
@@ -1,0 +1,23 @@
+---
+id: 0220
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.857931+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Reset global/module-level state in both setup and teardown
+
+Fixtures that touch shared singletons (e.g., `_gh_semaphore`, `_rate_limit_until`) must reset them at fixture start *and* at teardown. Use an autouse conftest fixture so every test starts from a clean slate.
+
+```python
+def setup_method(self):
+    module._rate_limit_until = 0
+def teardown_method(self):
+    module._rate_limit_until = 0
+```
+
+**Why:** Stale state from a prior test leaks into later tests, causing order-dependent flakiness invisible when the test runs in isolation.

--- a/repo_wiki/T-rav/hydraflow/testing/0221-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0221-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md
@@ -1,0 +1,21 @@
+---
+id: 0221
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.858496+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Use tmp_path with ConfigFactory for all file-based test I/O
+
+All tests that read or write files must use pytest's `tmp_path` combined with `ConfigFactory.create(base_path=tmp_path)` — never write to real project paths.
+
+```python
+def test_something(tmp_path):
+    config = ConfigFactory.create(base_path=tmp_path)
+```
+
+**Why:** Tests writing to project paths corrupt the working directory and cause hard-to-reproduce cross-test pollution, especially under parallel execution.

--- a/repo_wiki/T-rav/hydraflow/testing/0222-issue-synthesis-validate-sys-modules-cleanup-with-multiple-random-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0222-issue-synthesis-validate-sys-modules-cleanup-with-multiple-random-.md
@@ -1,0 +1,16 @@
+---
+id: 0222
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.859236+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Validate sys.modules cleanup with multiple random seeds
+
+Run `pytest --randomly-seed=<N>` with at least two different seeds to confirm that module-level import side effects do not leak between tests.
+
+**Why:** Cleanup failures only surface under specific test orderings; a single seed may never trigger the problematic sequence.

--- a/repo_wiki/T-rav/hydraflow/testing/0223-issue-synthesis-specify-exact-logger-name-in-caplog-at-level-asser.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0223-issue-synthesis-specify-exact-logger-name-in-caplog-at-level-asser.md
@@ -1,0 +1,22 @@
+---
+id: 0223
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.859781+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Specify exact logger name in caplog.at_level() assertions
+
+Always pass the module's logger name to `caplog.at_level()` and clear caplog before the action under test.
+
+```python
+with caplog.at_level(logging.WARNING, logger='src.module.name'):
+    trigger_action()
+assert 'expected substring' in caplog.text
+```
+
+**Why:** Without the logger filter, caplog captures all loggers and assertions may match unrelated log lines, producing false positives.

--- a/repo_wiki/T-rav/hydraflow/testing/0224-issue-synthesis-test-protocol-compliance-with-isinstance-hasattr-a.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0224-issue-synthesis-test-protocol-compliance-with-isinstance-hasattr-a.md
@@ -1,0 +1,16 @@
+---
+id: 0224
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.860351+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Test protocol compliance with isinstance, hasattr, and signature comparison
+
+Verify protocol satisfaction with three complementary checks: (1) `isinstance(obj, Protocol)` with `@runtime_checkable`, (2) `hasattr(obj, 'method_name')` for each method, and (3) `inspect.signature()` comparison to catch parameter drift. Parametrize tests over all protocol methods.
+
+**Why:** `isinstance` alone misses methods added at runtime; `hasattr` alone skips type-contract enforcement; signature comparison catches arity and keyword drift.

--- a/repo_wiki/T-rav/hydraflow/testing/0225-issue-synthesis-fa-ade-tests-cover-routing-error-delegation-and-ba.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0225-issue-synthesis-fa-ade-tests-cover-routing-error-delegation-and-ba.md
@@ -1,0 +1,16 @@
+---
+id: 0225
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.860959+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Façade tests: cover routing, error, delegation, and backward compat
+
+When testing a façade's `__getattr__`, verify four cases: (1) correct method routes to the right sub-client; (2) nonexistent method raises `AttributeError`; (3) façade satisfies the protocol via delegation; (4) existing tests that mock the original class still pass. Assert sub-components receive mutable shared-state references, not copies.
+
+**Why:** Missing any case allows silent routing failures to ship undetected — pre-existing tests mock the original class directly, not the façade.

--- a/repo_wiki/T-rav/hydraflow/testing/0226-issue-synthesis-skip-broken-tests-with-an-issue-reference-remove-a.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0226-issue-synthesis-skip-broken-tests-with-an-issue-reference-remove-a.md
@@ -1,0 +1,22 @@
+---
+id: 0226
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.861562+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Skip broken tests with an issue reference; remove after fix
+
+Mark broken tests with a referenced issue, never a bare skip.
+
+```python
+@pytest.mark.skip(reason="documenting bug: #1234")
+```
+
+Remove the skip immediately after the issue is resolved.
+
+**Why:** Without an issue reference, skipped tests become permanent dead weight with no path to removal or triage.

--- a/repo_wiki/T-rav/hydraflow/testing/0227-issue-synthesis-js-rendered-attributes-require-playwright-not-test.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0227-issue-synthesis-js-rendered-attributes-require-playwright-not-test.md
@@ -1,0 +1,16 @@
+---
+id: 0227
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.862172+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# JS-rendered attributes require Playwright, not TestClient
+
+Server-side `TestClient` (Django/FastAPI) only sees the initial HTML shell; accessibility attributes like `aria-labelledby` set by JavaScript are absent. Delete dead server-side tests that assert JS-rendered HTML; replace with Playwright-based browser tests.
+
+**Why:** TestClient assertions on JS-rendered attributes always pass vacuously — the attribute is missing from the initial render, giving false confidence about real rendering behavior.

--- a/repo_wiki/T-rav/hydraflow/testing/0228-issue-synthesis-subprocess-cli-test-stubs-log-invocations-to-jsonl.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0228-issue-synthesis-subprocess-cli-test-stubs-log-invocations-to-jsonl.md
@@ -1,0 +1,21 @@
+---
+id: 0228
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.862850+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Subprocess CLI test stubs: log invocations to JSONL
+
+Replace real CLI dependencies in tests with small Python scripts that accept the same arguments, write each invocation to a JSONL file, and exit 0.
+
+```python
+subprocess_runner = ['python3', 'fake_gh.py']
+# then assert via json.loads(log_path.read_text())
+```
+
+**Why:** Real subprocess boundaries catch shell-quoting, PATH resolution, and argument-passing bugs that mock-based patches cannot detect.

--- a/repo_wiki/T-rav/hydraflow/testing/0229-issue-synthesis-integration-test-runners-mock-only-execute-wire-re.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0229-issue-synthesis-integration-test-runners-mock-only-execute-wire-re.md
@@ -1,0 +1,16 @@
+---
+id: 0229
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.863652+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Integration test runners: mock only _execute(), wire real logic
+
+In phase-runner integration tests, wire real `StateTracker`, `EventBus`, `VerificationJudge`, and `RetrospectiveCollector`. Mock only the `_execute()` subprocess boundary with configurable transcript strings. Validate via `StateTracker` APIs and `EventBus.get_history()`, not mock call assertions.
+
+**Why:** Fully-mocked runners hide parser mismatches between test transcripts and real output formats — exactly the bugs integration tests exist to catch.

--- a/repo_wiki/T-rav/hydraflow/testing/0230-issue-synthesis-use-word-boundary-matching-in-coverage-checks-not-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0230-issue-synthesis-use-word-boundary-matching-in-coverage-checks-not-.md
@@ -1,0 +1,19 @@
+---
+id: 0230
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.864239+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Use word-boundary matching in coverage checks, not substring
+
+When asserting that a name appears in coverage output, use full-name or word-boundary matching.
+
+- Bad: `'Foo' in text` — also matches `FooBar`, `PrefixFoo`
+- Good: `re.search(r'\bFoo\b', text)`
+
+**Why:** Substring collision with longer names produces false positives that silently mask missing coverage entries.

--- a/repo_wiki/T-rav/hydraflow/testing/0231-issue-synthesis-use-is-to-verify-shared-runner-instance-across-com.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0231-issue-synthesis-use-is-to-verify-shared-runner-instance-across-com.md
@@ -1,0 +1,20 @@
+---
+id: 0231
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.864819+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Use is to verify shared runner instance across components
+
+Assert that two components share the same subprocess runner with `is`, not `==`.
+
+```python
+assert component_a.runner is component_b.runner
+```
+
+**Why:** `==` may pass even when different instances are created; `is` verifies the exact object reference required by the single-runner design contract.

--- a/repo_wiki/T-rav/hydraflow/testing/0232-issue-synthesis-enforce-50-line-handler-and-30-line-wiring-limits-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0232-issue-synthesis-enforce-50-line-handler-and-30-line-wiring-limits-.md
@@ -1,0 +1,18 @@
+---
+id: 0232
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.865382+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Enforce 50-line handler and 30-line wiring limits for testability
+
+Keep handler functions to ≤ 50 lines and registration wiring to ≤ 30 lines. Extract nested closures into instance methods to hold nesting to ≤ 3 levels. Enforce via AST-based tests with ±3 line tolerance.
+
+See also: testing — Allow ±3 line drift in AST-based structure assertions.
+
+**Why:** Functions exceeding these limits are difficult to test in isolation; deeply nested closures cannot be mocked independently.

--- a/repo_wiki/T-rav/hydraflow/testing/0233-issue-synthesis-assert-relative-event-ordering-not-absolute-id-val.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0233-issue-synthesis-assert-relative-event-ordering-not-absolute-id-val.md
@@ -1,0 +1,19 @@
+---
+id: 0233
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.865984+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Assert relative event ordering, not absolute ID values
+
+Tests must never assert on absolute event counter values — only on relative ordering and uniqueness within a single test run.
+
+- Good: `assert event_a.id < event_b.id`
+- Bad: `assert event_a.id == 1`
+
+**Why:** Global counters are shared across all test instances; absolute ID assertions are order-dependent and flaky under parallel execution.

--- a/repo_wiki/T-rav/hydraflow/testing/0234-issue-synthesis-add-structural-tests-for-transition-graphs-before-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0234-issue-synthesis-add-structural-tests-for-transition-graphs-before-.md
@@ -1,0 +1,20 @@
+---
+id: 0234
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.866546+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Add structural tests for transition graphs before property-based tests
+
+Before running property-based tests on a transition graph, add structural tests: every target is a valid stage, every stage has a transition entry, no dangling references exist.
+
+```python
+assert set(VALID_TRANSITIONS.keys()) == VALID_STAGES
+```
+
+**Why:** Property-based tests discover transition paths but silently skip unreachable states caused by structural gaps in the graph definition.

--- a/repo_wiki/T-rav/hydraflow/testing/0235-issue-synthesis-sync-test-label-stage-constants-with-production-pi.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0235-issue-synthesis-sync-test-label-stage-constants-with-production-pi.md
@@ -1,0 +1,25 @@
+---
+id: 0235
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.867120+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Sync test label/stage constants with production pipeline definitions
+
+Keep test constants (`ALL_PIPELINE_LABELS`, `VALID_STAGES`, `VALID_TRANSITIONS`) synchronized with production definitions. Use dynamic length and set-equality checks:
+
+```python
+assert len(LABELS) == len(ALL_PIPELINE_LABELS)
+assert set(VALID_TRANSITIONS.keys()) == VALID_STAGES
+```
+
+Test both `EVENT_TYPE_TO_STAGE` and `SOURCE_TO_STAGE` paths independently.
+
+See also: testing — Test direct-swap labels via swap_pipeline_labels(), not transitions.
+
+**Why:** Stale test constants let new label additions pass CI without being exercised by the test suite.

--- a/repo_wiki/T-rav/hydraflow/testing/0236-issue-synthesis-grep-all-model-usages-before-committing-pydantic-o.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0236-issue-synthesis-grep-all-model-usages-before-committing-pydantic-o.md
@@ -1,0 +1,18 @@
+---
+id: 0236
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.867722+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Grep all model usages before committing Pydantic or TypedDict changes
+
+When adding or removing fields, update: (1) model definition, (2) test factory defaults, (3) field-presence assertions, (4) serialization round-trip tests. Before committing, `grep -r "ModelName" tests/`. For `NotRequired` fields, update exact-match assertions but not missing-key assertions.
+
+See also: testing — Type-only annotation changes require no new tests.
+
+**Why:** Missed exact-match assertions silently pass when a field is optional, masking coverage gaps until a stricter test runs.

--- a/repo_wiki/T-rav/hydraflow/testing/0237-issue-synthesis-feature-toggles-need-both-a-config-field-and-env-i.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0237-issue-synthesis-feature-toggles-need-both-a-config-field-and-env-i.md
@@ -1,0 +1,18 @@
+---
+id: 0237
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.868261+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Feature toggles need both a config field and _ENV_INT_OVERRIDES entry
+
+Every toggle requires both a field in `config.py` AND an entry in `_ENV_INT_OVERRIDES`. Test both the default value and the env-var override path. The `_ENV_INT_OVERRIDES` tuple default must equal the Field default or the override silently stops applying.
+
+See also: architecture-state-persistence — `_ENV_INT_OVERRIDES` default sync.
+
+**Why:** Without the overrides entry, the env-var has no effect; the toggle appears configurable at runtime but is not.

--- a/repo_wiki/T-rav/hydraflow/testing/0238-issue-synthesis-type-only-annotation-changes-require-no-new-tests.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0238-issue-synthesis-type-only-annotation-changes-require-no-new-tests.md
@@ -1,0 +1,18 @@
+---
+id: 0238
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.868847+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Type-only annotation changes require no new tests
+
+Migrating `dict[str, Any]` to TypedDicts or narrowing parameter types requires no additional tests; the change is purely static. TypedDicts are plain dicts at runtime, so existing assertions continue to work. Verify via `make quality-lite` and `make test`.
+
+See also: testing — Grep all model usages before committing Pydantic or TypedDict changes.
+
+**Why:** Adding tests for a purely static type change wastes effort and can introduce false precision assumptions about runtime structure.

--- a/repo_wiki/T-rav/hydraflow/testing/0239-issue-synthesis-concurrent-jsonl-appends-assert-exact-event-counts.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0239-issue-synthesis-concurrent-jsonl-appends-assert-exact-event-counts.md
@@ -1,0 +1,23 @@
+---
+id: 0239
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.869535+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Concurrent JSONL appends: assert exact event counts, not timing
+
+Test concurrent file operations with a fixed thread count and deterministic iteration count, then assert on exact line counts.
+
+```python
+# 10 threads × 20 events = 200 total
+assert len(lines) == 200
+```
+
+POSIX guarantees atomicity for writes under ~4 KB; validate empirically before relying on this.
+
+**Why:** Timing-based assertions are flaky; deterministic event counts make failures reproducible and expose real data loss.

--- a/repo_wiki/T-rav/hydraflow/testing/0240-issue-synthesis-use-identical-string-keys-across-memory-bank-dedup.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0240-issue-synthesis-use-identical-string-keys-across-memory-bank-dedup.md
@@ -1,0 +1,16 @@
+---
+id: 0240
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.870193+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Use identical string keys across memory bank dedup and assembly
+
+Use identical string keys (e.g., `'review_insights'`, not `'review-insights'`) in both deduplication priority maps and bank-assembly pipelines. Fallback recall functions must try multiple field names (`learning`, `text`, `content`, `display_text`) when extracting text payload from different bank record formats.
+
+**Why:** Key mismatches cause entire banks to be silently skipped during validation, producing gaps that look like passing coverage.

--- a/repo_wiki/T-rav/hydraflow/testing/0241-issue-synthesis-memory-dedup-higher-priority-bank-wins-on-collisio.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0241-issue-synthesis-memory-dedup-higher-priority-bank-wins-on-collisio.md
@@ -1,0 +1,16 @@
+---
+id: 0241
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.870816+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Memory dedup: higher-priority bank wins on collision
+
+When two near-duplicate items collide, the higher-priority bank's item survives. Priority order: LEARNINGS (5) > TROUBLESHOOTING (4) > RETROSPECTIVES (3) > REVIEW_INSIGHTS (2) > HARNESS_INSIGHTS (1). Test collision behavior explicitly, not just deduplication count.
+
+**Why:** Without priority enforcement, a lower-quality retrospective can silently overwrite a load-bearing learning entry.

--- a/repo_wiki/T-rav/hydraflow/testing/0242-issue-synthesis-skill-definition-changes-must-update-all-4-backend.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0242-issue-synthesis-skill-definition-changes-must-update-all-4-backend.md
@@ -1,0 +1,16 @@
+---
+id: 0242
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.871426+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Skill definition changes must update all 4 backend copies
+
+HydraFlow skills replicate across `.claude/commands/`, `.pi/skills/`, `.codex/skills/`, and `src/*.py`. Validate marker presence via substring search across all 4 locations using a manual `SKILL_MARKERS` mapping (not regex introspection). A single skill change may require updating 3+ test fixture files.
+
+**Why:** Updating fewer than 4 copies silently diverges behavior across execution environments with no test failure to signal the gap.

--- a/repo_wiki/T-rav/hydraflow/testing/0243-issue-synthesis-generate-adr-derived-tests-as-skipped-skeletons-by.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0243-issue-synthesis-generate-adr-derived-tests-as-skipped-skeletons-by.md
@@ -1,0 +1,16 @@
+---
+id: 0243
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.872044+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Generate ADR-derived tests as skipped skeletons by default
+
+When auto-generating tests from ADR Decision sections, emit all tests with `@pytest.mark.skip(reason='skeleton: requires human review')`. Extract only 4 high-confidence baseline patterns per ADR: uniqueness, usage, negative, coverage.
+
+**Why:** Automated pattern matching on ADR language is ambiguous; unskipped generated tests produce false-positive CI failures on legitimate wording updates.

--- a/repo_wiki/T-rav/hydraflow/testing/0244-issue-synthesis-every-adr-must-pass-structural-section-validation-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0244-issue-synthesis-every-adr-must-pass-structural-section-validation-.md
@@ -1,0 +1,18 @@
+---
+id: 0244
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.872672+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Every ADR must pass structural section validation before merge
+
+All ADRs must pass `tests/test_adr_pre_validator.py`, which enforces required sections (Status, Context, Decision, Consequences) and valid status values (Proposed, Accepted, Deprecated, Superseded).
+
+See also: architecture — ADR number collision and README guards.
+
+**Why:** Missing sections or invalid status values make ADRs non-machine-readable, breaking automated drift detection and the ADR README completeness guard.

--- a/repo_wiki/T-rav/hydraflow/testing/0245-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0245-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md
@@ -1,0 +1,22 @@
+---
+id: 0245
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.873266+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Never import private helpers at module level in test files
+
+Import private or internal functions (`_foo`) inside the test function or a `pytest.fixture`, never at module top level.
+
+```python
+# good — failure scoped to the test
+def test_check_prereq():
+    from src.makefile_scaffold import _check_prereq_deps
+```
+
+**Why:** A module-level `ImportError` prevents pytest from collecting the file, silently destroying all pre-existing passing tests in that module.

--- a/repo_wiki/T-rav/hydraflow/testing/0246-issue-synthesis-pin-function-signatures-in-source-before-writing-t.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0246-issue-synthesis-pin-function-signatures-in-source-before-writing-t.md
@@ -1,0 +1,20 @@
+---
+id: 0246
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.873871+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Pin function signatures in source before writing tests or docs
+
+Write the function stub first, copy its exact signature into the docstring, then write the test.
+
+1. Write the function stub
+2. Copy its exact signature into the docstring
+3. Write the test
+
+**Why:** When docs and tests are authored before implementation, signature drift goes undetected until runtime — both artifacts can be wrong simultaneously.

--- a/repo_wiki/T-rav/hydraflow/testing/0247-issue-synthesis-hoist-deterministic-gates-outside-llm-retry-loops.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0247-issue-synthesis-hoist-deterministic-gates-outside-llm-retry-loops.md
@@ -1,0 +1,19 @@
+---
+id: 0247
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.874488+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Hoist deterministic gates outside LLM retry loops
+
+Run subprocess-based validation (coverage, linting) once after the loop exits, not inside each retry iteration.
+
+Bad: `for attempt in range(...): ... _run_coverage_delta_check(diff)`
+Good: `result = run_llm_loop(...); if result == PASS: _run_coverage_delta_check(diff)`
+
+**Why:** Placing an expensive deterministic check inside the retry loop multiplies wall-clock cost by `max_attempts` without any additional signal.

--- a/repo_wiki/T-rav/hydraflow/testing/0248-issue-synthesis-use-public-fakegithub-api-in-scenario-tests-never-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0248-issue-synthesis-use-public-fakegithub-api-in-scenario-tests-never-.md
@@ -1,0 +1,19 @@
+---
+id: 0248
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.875077+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Use public FakeGitHub API in scenario tests — never mutate _issues directly
+
+Always use the public API to mutate `FakeGitHub` state in scenario tests; never write to private attributes directly.
+
+- Bad: `world.github._issues[901].state = "closed"`
+- Good: `await world.github.close_issue(901)`
+
+**Why:** If `FakeIssue` internals change, direct attribute writes silently remain valid Python while the fake's behavior drifts — the public API is the compatibility boundary that signals breakage.

--- a/repo_wiki/T-rav/hydraflow/testing/0249-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0249-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
@@ -1,0 +1,21 @@
+---
+id: 0249
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.875654+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Test async context managers in three standard scenarios
+
+Cover async context managers with three scenarios: (1) idempotent close — calling `close()` twice is safe; (2) `__aexit__` triggers `close()` exactly once; (3) `__aenter__` returns `self`.
+
+```python
+async with resource as r:
+    assert r is resource
+```
+
+**Why:** Missing any scenario leaves an incomplete behavioral contract, hiding bugs in external-connection or file-handle management.

--- a/repo_wiki/T-rav/hydraflow/testing/0250-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels-n.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0250-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels-n.md
@@ -1,0 +1,18 @@
+---
+id: 0250
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.876275+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Test direct-swap labels via swap_pipeline_labels(), not transitions
+
+Labels set via atomic swap (`hitl-active`, `fixed`) bypass the transition graph and are applied by `swap_pipeline_labels()` — test them on that call path, not through `VALID_TRANSITIONS`.
+
+See also: testing — Sync test label/stage constants with production pipeline definitions.
+
+**Why:** Testing swap labels through the transition graph masks missing coverage; they have no transition entry by design.

--- a/repo_wiki/T-rav/hydraflow/testing/0251-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0251-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
@@ -1,0 +1,20 @@
+---
+id: 0251
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.876940+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Allow ±3 line drift in AST-based structure assertions
+
+For tests that verify code structure by parsing source ASTs (e.g., checking function length), allow ±3 line tolerance.
+
+Example: Assert `len(func.body) <= 53` rather than `<= 50` to account for blank lines and decorator variations.
+
+See also: testing — Enforce 50-line handler and 30-line wiring limits for testability.
+
+**Why:** Exact line-count assertions redden CI on whitespace-only diffs, creating maintenance noise without improving correctness.

--- a/repo_wiki/T-rav/hydraflow/testing/0252-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0252-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md
@@ -1,0 +1,16 @@
+---
+id: 0252
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.877563+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Existing tests cover private-method extractions; add only new-behavior tests
+
+When extracting a private method from a public one with an unchanged public API, the existing test suite provides full coverage — no new tests are needed for the extraction itself. Run prompt-assertion tests in isolation immediately after extraction to verify parity.
+
+**Why:** Adding duplicate tests for unchanged behavior inflates the suite; the real regression risk is behavioral, which existing tests already guard.

--- a/repo_wiki/T-rav/hydraflow/testing/0253-issue-synthesis-assert-numeric-values-in-sentry-breadcrumbs-not-ju.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0253-issue-synthesis-assert-numeric-values-in-sentry-breadcrumbs-not-ju.md
@@ -1,0 +1,23 @@
+---
+id: 0253
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.878171+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Assert numeric values in Sentry breadcrumbs, not just key presence
+
+When testing Sentry integration, assert actual numeric values in breadcrumbs and metrics, not just that a key exists.
+
+```python
+# good
+assert breadcrumb['data']['latency_ms'] == 42
+# bad
+assert 'latency_ms' in breadcrumb['data']
+```
+
+**Why:** Key-presence assertions pass even when values are wrong or zero; numeric value assertions catch metric miscalculation bugs that presence checks miss entirely.

--- a/repo_wiki/T-rav/hydraflow/testing/0254-issue-synthesis-test-pydantic-literal-constraints-cover-both-valid.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0254-issue-synthesis-test-pydantic-literal-constraints-cover-both-valid.md
@@ -1,0 +1,18 @@
+---
+id: 0254
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.878725+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Test Pydantic Literal constraints: cover both valid and invalid values
+
+When adding `Literal` constraints to Pydantic fields, test both valid and invalid values — verify valid values are accepted and invalid values raise `ValidationError`.
+
+Example: For `status: Literal['open', 'closed']`, test `status='open'` passes and `status='unknown'` raises.
+
+**Why:** Literal constraints are invisible at runtime if only valid values are tested; invalid-value tests confirm the constraint is actually enforced.

--- a/repo_wiki/T-rav/hydraflow/testing/0255-issue-synthesis-verify-fatal-exception-propagation-through-multi-p.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0255-issue-synthesis-verify-fatal-exception-propagation-through-multi-p.md
@@ -1,0 +1,22 @@
+---
+id: 0255
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-18T15:01:50.879338+00:00
+status: active
+corroborations: 1
+supersedes: 0007,0008,0009,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,0030,0031,0032,0033,0034,0035,0036,0183,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216
+---
+
+# Verify fatal exception propagation through multi-phase loops
+
+Test that fatal exceptions propagate through multi-phase loops by mocking internal methods to raise specific exception types, then asserting the exception reaches the caller without being swallowed.
+
+```python
+mock._execute.side_effect = FatalError()
+with pytest.raises(FatalError):
+    await loop.run_once()
+```
+
+**Why:** Broad `except Exception` blocks in loop runners silently swallow fatal exceptions, making multi-phase loops appear to succeed when they have failed.


### PR DESCRIPTION
Automated wiki maintenance PR opened by `RepoWikiLoop`.

## Actions

- 0 entries marked stale
- 0 entries pruned
- 116 entries compiled / synthesized
- 0 console-triggered tasks drained

## Files changed

- `repo_wiki/T-rav/hydraflow/gotchas/0012-issue-9442-error-tolerance-tests-must-cover-creditexhausteder.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0012-issue-synthesis-use-type-checking-guards-for-forward-reference-ann.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0013-issue-9442-update-emit-trace-command-strings-when-migrating-f.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0013-issue-synthesis-grep-for-runtime-references-before-removing-an-imp.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0014-issue-synthesis-use-is-none-is-not-none-for-optional-sentinels.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0015-issue-synthesis-sync-all-protocol-implementations-in-one-pr-when-a.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0016-issue-synthesis-delete-code-blocks-bottom-to-top-to-avoid-line-num.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0017-issue-synthesis-patch-functions-at-their-definition-site-not-the-i.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0018-issue-synthesis-verify-a-file-exists-before-writing-a-plan-task-th.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0019-issue-synthesis-test-pydantic-serialization-with-both-round-trip-a.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0020-issue-synthesis-run-full-make-quality-before-declaring-implementat.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0021-issue-synthesis-use-log-exception-with-bug-classification-to-separ.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0022-issue-synthesis-use-logger-warning-exc-info-true-for-transient-err.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0023-issue-synthesis-timeoutexpired-and-calledprocesserror-are-siblings.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0024-issue-synthesis-omitting-await-on-an-async-call-silently-returns-a.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0025-issue-synthesis-store-asyncio-create-task-results-unreferenced-tas.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0026-issue-synthesis-new-pydantic-fields-must-have-defaults-so-existing.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0027-issue-synthesis-use-atomic-write-instead-of-path-write-text-for-js.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0028-issue-synthesis-use-typeddict-total-false-for-backward-compatible-.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0029-issue-synthesis-new-hydraflowconfig-label-fields-must-be-optional-.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0030-issue-synthesis-reverse-state-transitions-on-non-fatal-exceptions-.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0031-issue-synthesis-use-the-same-id-extraction-logic-everywhere-files-.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0032-issue-synthesis-join-factory-pipeline-metrics-by-issue-number-not-.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0033-issue-synthesis-test-pipeline-stage-ordering-not-just-status-value.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0034-issue-synthesis-filter-evicted-memories-on-both-content-prefix-and.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0035-issue-synthesis-new-automated-skills-must-start-with-blocking-fals.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0036-issue-synthesis-validate-parsers-against-realistic-multi-paragraph.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0037-issue-synthesis-log-a-warning-when-transcript-extraction-finds-zer.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0038-issue-synthesis-use-portable-shell-commands-in-alpine-containers-p.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0039-issue-synthesis-separate-silent-with-result-events-from-purely-sil.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0040-issue-synthesis-create-a-specialized-method-rather-than-overloadin.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0041-issue-synthesis-ruff-strips-unused-imports-mid-tdd-cycle.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0042-issue-synthesis-verify-implementation-files-are-in-the-diff-before.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0043-issue-9567-coverage-delta-gate-semantics-asymmetric-gaps-bloc.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0044-issue-synthesis-error-tolerance-tests-must-cover-creditexhausteder.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0045-issue-synthesis-use-type-checking-guards-for-forward-reference-ann.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0046-issue-synthesis-update-emit-trace-command-strings-when-migrating-f.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0047-issue-synthesis-grep-for-runtime-references-before-removing-an-imp.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0048-issue-synthesis-use-is-none-is-not-none-for-optional-sentinels.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0049-issue-synthesis-sync-all-protocol-implementations-in-one-pr-when-a.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0050-issue-synthesis-delete-code-blocks-bottom-to-top-to-avoid-line-num.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0051-issue-synthesis-patch-functions-at-their-definition-site-not-the-i.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0052-issue-synthesis-verify-a-file-exists-before-writing-a-plan-task-th.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0053-issue-synthesis-test-pydantic-serialization-with-both-round-trip-a.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0054-issue-synthesis-run-full-make-quality-before-declaring-implementat.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0055-issue-synthesis-use-log-exception-with-bug-classification-for-bug-.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0056-issue-synthesis-use-logger-warning-not-logger-exception-for-transi.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0057-issue-synthesis-timeoutexpired-and-calledprocesserror-are-siblings.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0058-issue-synthesis-omitting-await-on-an-async-call-silently-returns-a.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0059-issue-synthesis-store-asyncio-create-task-results-unreferenced-tas.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0060-issue-synthesis-new-pydantic-fields-must-have-defaults-so-existing.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0061-issue-synthesis-use-atomic-write-instead-of-path-write-text-for-js.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0062-issue-synthesis-use-typeddict-total-false-for-backward-compatible-.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0063-issue-synthesis-new-hydraflowconfig-label-fields-must-be-optional-.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0064-issue-synthesis-reverse-state-transitions-on-non-fatal-exceptions-.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0065-issue-synthesis-use-the-same-id-extraction-logic-everywhere-files-.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0066-issue-synthesis-join-factory-pipeline-metrics-by-issue-number-not-.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0067-issue-synthesis-test-pipeline-stage-ordering-not-just-status-value.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0068-issue-synthesis-filter-evicted-memories-on-both-content-prefix-and.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0069-issue-synthesis-new-automated-skills-must-start-with-blocking-fals.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0070-issue-synthesis-validate-parsers-against-realistic-multi-paragraph.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0071-issue-synthesis-log-a-warning-when-transcript-extraction-finds-zer.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0072-issue-synthesis-use-portable-shell-commands-in-alpine-containers-p.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0073-issue-synthesis-separate-silent-with-result-events-from-purely-sil.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0074-issue-synthesis-create-a-specialized-method-rather-than-overloadin.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0075-issue-synthesis-ruff-strips-unused-imports-mid-tdd-cycle.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0076-issue-synthesis-verify-implementation-files-are-in-the-diff-before.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0077-issue-synthesis-coverage-delta-gate-semantics-asymmetric-gaps-bloc.md`
- `repo_wiki/T-rav/hydraflow/patterns/0008-issue-synthesis-use-optional-fields-with-defaults-for-backward-com.md`
- `repo_wiki/T-rav/hydraflow/patterns/0009-issue-synthesis-distinguish-bare-str-from-str-none-before-narrowin.md`
- `repo_wiki/T-rav/hydraflow/patterns/0010-issue-synthesis-use-strenum-coercion-to-auto-convert-stored-string.md`
- `repo_wiki/T-rav/hydraflow/patterns/0011-issue-synthesis-define-canonical-constants-as-single-source-of-tru.md`
- `repo_wiki/T-rav/hydraflow/patterns/0012-issue-synthesis-use-metadata-tags-instead-of-enum-variants-for-sha.md`
- `repo_wiki/T-rav/hydraflow/patterns/0013-issue-synthesis-grep-all-call-sites-before-changing-a-function-sig.md`
- `repo_wiki/T-rav/hydraflow/patterns/0014-issue-synthesis-update-all-callers-atomically-when-a-return-type-c.md`
- `repo_wiki/T-rav/hydraflow/patterns/0015-issue-synthesis-preserve-public-api-during-extraction-via-thin-del.md`
- `repo_wiki/T-rav/hydraflow/patterns/0016-issue-synthesis-extract-pure-transform-functions-before-moving-cod.md`
- `repo_wiki/T-rav/hydraflow/patterns/0017-issue-synthesis-preserve-per-concern-try-except-blocks-during-refa.md`
- `repo_wiki/T-rav/hydraflow/patterns/0018-issue-synthesis-extract-duplicated-jsonl-reading-logic-to-a-shared.md`
- `repo_wiki/T-rav/hydraflow/patterns/0019-issue-synthesis-mock-at-the-definition-site-not-the-import-site.md`
- `repo_wiki/T-rav/hydraflow/patterns/0020-issue-synthesis-retarget-mock-patches-to-the-new-location-before-m.md`
- `repo_wiki/T-rav/hydraflow/patterns/0021-issue-synthesis-generated-test-content-must-reference-function-nam.md`
- `repo_wiki/T-rav/hydraflow/patterns/0022-issue-synthesis-use-meta-tests-to-enforce-anti-pattern-absence-acr.md`
- `repo_wiki/T-rav/hydraflow/patterns/0023-issue-synthesis-use-threading-lock-for-thread-pool-code-asyncio-lo.md`
- `repo_wiki/T-rav/hydraflow/patterns/0024-issue-synthesis-extract-unlocked-helpers-to-prevent-re-entrant-loc.md`
- `repo_wiki/T-rav/hydraflow/patterns/0025-issue-synthesis-use-file-util-append-jsonl-for-crash-safe-jsonl-ap.md`
- `repo_wiki/T-rav/hydraflow/patterns/0026-issue-synthesis-use-file-util-atomic-write-for-critical-state-file.md`
- `repo_wiki/T-rav/hydraflow/patterns/0027-issue-synthesis-use-claim-then-merge-for-async-queue-processing-to.md`
- `repo_wiki/T-rav/hydraflow/patterns/0028-issue-synthesis-set-and-clear-trace-context-in-a-single-try-finall.md`
- `repo_wiki/T-rav/hydraflow/patterns/0029-issue-synthesis-keep-event-publishing-coupled-with-the-condition-t.md`
- `repo_wiki/T-rav/hydraflow/patterns/0030-issue-synthesis-preserve-exact-retry-counter-state-during-dispatch.md`
- `repo_wiki/T-rav/hydraflow/patterns/0031-issue-synthesis-dry-run-mode-must-not-emit-state-changing-events.md`
- `repo_wiki/T-rav/hydraflow/patterns/0032-issue-synthesis-maintain-immutable-return-contract-for-parse-tuple.md`
- `repo_wiki/T-rav/hydraflow/patterns/0033-issue-synthesis-define-event-to-stage-and-source-to-stage-mappings.md`
- `repo_wiki/T-rav/hydraflow/patterns/0034-issue-synthesis-pre-allocate-memory-budget-upfront-before-prompt-a.md`
- `repo_wiki/T-rav/hydraflow/patterns/0035-issue-synthesis-use-a-two-round-allocator-section-minimums-first-t.md`
- `repo_wiki/T-rav/hydraflow/patterns/0036-issue-synthesis-deduct-wiki-budget-from-memory-surplus-before-redi.md`
- `repo_wiki/T-rav/hydraflow/patterns/0037-issue-synthesis-lazy-load-memory-context-on-explicit-user-action-n.md`
- `repo_wiki/T-rav/hydraflow/patterns/0038-issue-synthesis-use-sha-256-truncated-to-16-chars-for-memory-dedup.md`
- `repo_wiki/T-rav/hydraflow/patterns/0039-issue-synthesis-use-asymmetric-word-set-overlap-for-memory-dedupli.md`
- `repo_wiki/T-rav/hydraflow/patterns/0040-issue-synthesis-batch-load-scoring-data-once-per-eviction-operatio.md`
- `repo_wiki/T-rav/hydraflow/patterns/0041-issue-synthesis-hindsightclient-retain-coerces-metadata-to-str-use.md`
- `repo_wiki/T-rav/hydraflow/patterns/0042-issue-synthesis-memory-contradiction-resolution-provenance-wins-ov.md`
- `repo_wiki/T-rav/hydraflow/patterns/0043-issue-synthesis-memory-eviction-must-atomically-update-both-item-s.md`
- `repo_wiki/T-rav/hydraflow/patterns/0044-issue-synthesis-guard-close-with-a-closed-flag-to-make-it-idempote.md`
- `repo_wiki/T-rav/hydraflow/patterns/0045-issue-synthesis-memory-staleness-detection-should-emit-events-not-.md`
- `repo_wiki/T-rav/hydraflow/patterns/0046-issue-synthesis-adr-files-without-readme-entries-are-invisible-to-.md`
- `repo_wiki/T-rav/hydraflow/patterns/0047-issue-synthesis-preserve-the-hf-namespace-prefix-when-renaming-ski.md`
- `repo_wiki/T-rav/hydraflow/patterns/0048-issue-synthesis-keep-skill-prompts-in-sync-across-all-four-backend.md`
- `repo_wiki/T-rav/hydraflow/patterns/0049-issue-9567-in-place-diff-truncation-silently-corrupts-downstr.md`
- `repo_wiki/T-rav/hydraflow/patterns/0050-issue-synthesis-use-optional-fields-with-defaults-for-backward-com.md`
- `repo_wiki/T-rav/hydraflow/patterns/0051-issue-synthesis-distinguish-bare-str-from-str-none-before-narrowin.md`
- `repo_wiki/T-rav/hydraflow/patterns/0052-issue-synthesis-use-strenum-coercion-to-auto-convert-stored-string.md`
- `repo_wiki/T-rav/hydraflow/patterns/0053-issue-synthesis-define-canonical-constants-as-single-source-of-tru.md`
- `repo_wiki/T-rav/hydraflow/patterns/0054-issue-synthesis-use-metadata-tags-instead-of-enum-variants-for-sha.md`
- `repo_wiki/T-rav/hydraflow/patterns/0055-issue-synthesis-grep-all-call-sites-before-changing-a-function-sig.md`
- `repo_wiki/T-rav/hydraflow/patterns/0056-issue-synthesis-update-all-callers-atomically-when-a-return-type-c.md`
- `repo_wiki/T-rav/hydraflow/patterns/0057-issue-synthesis-preserve-public-api-during-extraction-via-thin-del.md`
- `repo_wiki/T-rav/hydraflow/patterns/0058-issue-synthesis-extract-pure-transform-functions-before-moving-cod.md`
- `repo_wiki/T-rav/hydraflow/patterns/0059-issue-synthesis-preserve-per-concern-try-except-blocks-during-refa.md`
- `repo_wiki/T-rav/hydraflow/patterns/0060-issue-synthesis-extract-duplicated-jsonl-reading-logic-to-a-shared.md`
- `repo_wiki/T-rav/hydraflow/patterns/0061-issue-synthesis-mock-at-the-definition-site-not-the-import-site.md`
- `repo_wiki/T-rav/hydraflow/patterns/0062-issue-synthesis-retarget-mock-patches-to-the-new-location-before-m.md`
- `repo_wiki/T-rav/hydraflow/patterns/0063-issue-synthesis-generated-test-content-must-reference-function-nam.md`
- `repo_wiki/T-rav/hydraflow/patterns/0064-issue-synthesis-use-meta-tests-to-enforce-anti-pattern-absence-acr.md`
- `repo_wiki/T-rav/hydraflow/patterns/0065-issue-synthesis-use-threading-lock-for-thread-pool-code-asyncio-lo.md`
- `repo_wiki/T-rav/hydraflow/patterns/0066-issue-synthesis-extract-unlocked-helpers-to-prevent-re-entrant-loc.md`
- `repo_wiki/T-rav/hydraflow/patterns/0067-issue-synthesis-use-file-util-append-jsonl-for-crash-safe-jsonl-ap.md`
- `repo_wiki/T-rav/hydraflow/patterns/0068-issue-synthesis-use-file-util-atomic-write-for-critical-state-file.md`
- `repo_wiki/T-rav/hydraflow/patterns/0069-issue-synthesis-use-claim-then-merge-for-async-queue-processing-to.md`
- `repo_wiki/T-rav/hydraflow/patterns/0070-issue-synthesis-set-and-clear-trace-context-in-a-single-try-finall.md`
- `repo_wiki/T-rav/hydraflow/patterns/0071-issue-synthesis-keep-event-publishing-coupled-with-the-condition-t.md`
- `repo_wiki/T-rav/hydraflow/patterns/0072-issue-synthesis-preserve-exact-retry-counter-state-during-dispatch.md`
- `repo_wiki/T-rav/hydraflow/patterns/0073-issue-synthesis-dry-run-mode-must-not-emit-state-changing-events.md`
- `repo_wiki/T-rav/hydraflow/patterns/0074-issue-synthesis-maintain-immutable-return-contract-for-parse-tuple.md`
- `repo_wiki/T-rav/hydraflow/patterns/0075-issue-synthesis-define-event-to-stage-and-source-to-stage-mappings.md`
- `repo_wiki/T-rav/hydraflow/patterns/0076-issue-synthesis-pre-allocate-memory-budget-upfront-before-prompt-a.md`
- `repo_wiki/T-rav/hydraflow/patterns/0077-issue-synthesis-use-a-two-round-allocator-section-minimums-first-t.md`
- `repo_wiki/T-rav/hydraflow/patterns/0078-issue-synthesis-deduct-wiki-budget-from-memory-surplus-before-redi.md`
- `repo_wiki/T-rav/hydraflow/patterns/0079-issue-synthesis-lazy-load-memory-context-on-explicit-user-action-n.md`
- `repo_wiki/T-rav/hydraflow/patterns/0080-issue-synthesis-use-sha-256-truncated-to-16-chars-for-memory-dedup.md`
- `repo_wiki/T-rav/hydraflow/patterns/0081-issue-synthesis-use-asymmetric-word-set-overlap-for-memory-dedupli.md`
- `repo_wiki/T-rav/hydraflow/patterns/0082-issue-synthesis-batch-load-scoring-data-once-per-eviction-operatio.md`
- `repo_wiki/T-rav/hydraflow/patterns/0083-issue-synthesis-retain-coerces-metadata-to-str-compare-with-true-n.md`
- `repo_wiki/T-rav/hydraflow/patterns/0084-issue-synthesis-memory-contradiction-resolution-provenance-wins-ov.md`
- `repo_wiki/T-rav/hydraflow/patterns/0085-issue-synthesis-memory-eviction-must-atomically-update-both-scores.md`
- `repo_wiki/T-rav/hydraflow/patterns/0086-issue-synthesis-guard-close-with-a-closed-flag-to-make-it-idempote.md`
- `repo_wiki/T-rav/hydraflow/patterns/0087-issue-synthesis-memory-staleness-detection-should-emit-events-not-.md`
- `repo_wiki/T-rav/hydraflow/patterns/0088-issue-synthesis-adr-files-without-readme-entries-are-invisible-to-.md`
- `repo_wiki/T-rav/hydraflow/patterns/0089-issue-synthesis-preserve-the-hf-namespace-prefix-when-renaming-ski.md`
- `repo_wiki/T-rav/hydraflow/patterns/0090-issue-synthesis-keep-skill-prompts-in-sync-across-all-four-backend.md`
- `repo_wiki/T-rav/hydraflow/patterns/0091-issue-synthesis-in-place-diff-truncation-silently-corrupts-downstr.md`
- `repo_wiki/T-rav/hydraflow/testing/0007-issue-synthesis-mock-at-definition-site-not-at-usage-site.md`
- `repo_wiki/T-rav/hydraflow/testing/0008-issue-synthesis-mark-pytest-mark-integration-only-for-real-externa.md`
- `repo_wiki/T-rav/hydraflow/testing/0009-issue-synthesis-await-asyncio-sleep-0-after-create-task-before-ass.md`
- `repo_wiki/T-rav/hydraflow/testing/0010-issue-synthesis-reset-global-module-level-state-in-both-setup-and-.md`
- `repo_wiki/T-rav/hydraflow/testing/0011-issue-synthesis-use-tmp-path-and-factory-for-all-file-based-test-i.md`
- `repo_wiki/T-rav/hydraflow/testing/0012-issue-synthesis-validate-sys-modules-cleanup-with-multiple-random-.md`
- `repo_wiki/T-rav/hydraflow/testing/0013-issue-synthesis-caplog-assertions-must-name-the-exact-logger.md`
- `repo_wiki/T-rav/hydraflow/testing/0014-issue-synthesis-test-protocol-satisfaction-with-both-isinstance-an.md`
- `repo_wiki/T-rav/hydraflow/testing/0015-issue-synthesis-fa-ade-tests-cover-routing-error-delegation-and-ba.md`
- `repo_wiki/T-rav/hydraflow/testing/0016-issue-synthesis-skip-broken-tests-with-an-issue-reference-remove-a.md`
- `repo_wiki/T-rav/hydraflow/testing/0017-issue-synthesis-browser-rendered-attributes-require-playwright-not.md`
- `repo_wiki/T-rav/hydraflow/testing/0018-issue-synthesis-subprocess-cli-test-stubs-log-invocations-to-jsonl.md`
- `repo_wiki/T-rav/hydraflow/testing/0019-issue-synthesis-integration-test-runners-mock-only-execute-wire-re.md`
- `repo_wiki/T-rav/hydraflow/testing/0020-issue-synthesis-use-word-boundary-matching-in-coverage-checks-not-.md`
- `repo_wiki/T-rav/hydraflow/testing/0021-issue-synthesis-use-is-to-verify-shared-runner-instance-across-com.md`
- `repo_wiki/T-rav/hydraflow/testing/0022-issue-synthesis-enforce-50-30-line-limits-on-handlers-and-registra.md`
- `repo_wiki/T-rav/hydraflow/testing/0023-issue-synthesis-assert-relative-event-ordering-not-absolute-id-val.md`
- `repo_wiki/T-rav/hydraflow/testing/0024-issue-synthesis-add-structural-tests-for-transition-graphs-before-.md`
- `repo_wiki/T-rav/hydraflow/testing/0025-issue-synthesis-sync-test-label-constants-with-production-pipeline.md`
- `repo_wiki/T-rav/hydraflow/testing/0026-issue-synthesis-pydantic-typeddict-field-changes-require-updates-i.md`
- `repo_wiki/T-rav/hydraflow/testing/0027-issue-synthesis-feature-toggles-need-both-a-config-field-and-env-i.md`
- `repo_wiki/T-rav/hydraflow/testing/0028-issue-synthesis-dict-to-typeddict-migrations-require-no-new-tests.md`
- `repo_wiki/T-rav/hydraflow/testing/0029-issue-synthesis-concurrent-jsonl-appends-assert-exact-event-counts.md`
- `repo_wiki/T-rav/hydraflow/testing/0030-issue-synthesis-memory-bank-keys-must-be-consistent-across-dedup-a.md`
- `repo_wiki/T-rav/hydraflow/testing/0031-issue-synthesis-memory-dedup-higher-priority-bank-wins-on-collisio.md`
- `repo_wiki/T-rav/hydraflow/testing/0032-issue-synthesis-skill-markers-must-be-present-in-all-4-backend-cop.md`
- `repo_wiki/T-rav/hydraflow/testing/0033-issue-synthesis-generate-adr-derived-tests-as-skipped-skeletons-by.md`
- `repo_wiki/T-rav/hydraflow/testing/0034-issue-synthesis-adr-pre-validator-enforce-required-sections-and-st.md`
- `repo_wiki/T-rav/hydraflow/testing/0035-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md`
- `repo_wiki/T-rav/hydraflow/testing/0036-issue-synthesis-pin-function-signatures-before-writing-callers-or-.md`
- `repo_wiki/T-rav/hydraflow/testing/0183-issue-9567-hoist-deterministic-gates-outside-llm-retry-loops.md`
- `repo_wiki/T-rav/hydraflow/testing/0183-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md`
- `repo_wiki/T-rav/hydraflow/testing/0184-issue-synthesis-pin-function-signatures-in-the-source-file-before-.md`
- `repo_wiki/T-rav/hydraflow/testing/0185-issue-synthesis-use-public-fakegithub-api-in-scenario-tests-never-.md`
- `repo_wiki/T-rav/hydraflow/testing/0186-issue-synthesis-mock-at-definition-site-not-at-the-import-site.md`
- `repo_wiki/T-rav/hydraflow/testing/0187-issue-synthesis-reserve-pytest-mark-integration-for-real-external-.md`
- `repo_wiki/T-rav/hydraflow/testing/0188-issue-synthesis-await-asyncio-sleep-0-before-asserting-on-create-t.md`
- `repo_wiki/T-rav/hydraflow/testing/0189-issue-synthesis-test-async-context-managers-in-three-standard-scen.md`
- `repo_wiki/T-rav/hydraflow/testing/0190-issue-synthesis-use-python-script-stand-ins-to-test-subprocess-bou.md`
- `repo_wiki/T-rav/hydraflow/testing/0191-issue-synthesis-reset-module-level-global-state-in-both-setup-and-.md`
- `repo_wiki/T-rav/hydraflow/testing/0192-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md`
- `repo_wiki/T-rav/hydraflow/testing/0193-issue-synthesis-wire-real-business-logic-in-phase-runner-integrati.md`
- `repo_wiki/T-rav/hydraflow/testing/0194-issue-synthesis-test-protocol-compliance-with-structural-typing-an.md`
- `repo_wiki/T-rav/hydraflow/testing/0195-issue-synthesis-test-fa-ade-getattr-routing-attributeerror-and-pro.md`
- `repo_wiki/T-rav/hydraflow/testing/0196-issue-synthesis-assert-relative-event-id-ordering-never-absolute-v.md`
- `repo_wiki/T-rav/hydraflow/testing/0197-issue-synthesis-add-structural-tests-before-property-based-transit.md`
- `repo_wiki/T-rav/hydraflow/testing/0198-issue-synthesis-grep-all-model-usages-before-committing-pydantic-o.md`
- `repo_wiki/T-rav/hydraflow/testing/0199-issue-synthesis-feature-toggles-require-both-a-config-field-and-an.md`
- `repo_wiki/T-rav/hydraflow/testing/0200-issue-synthesis-test-concurrent-jsonl-appends-with-exact-counts-no.md`
- `repo_wiki/T-rav/hydraflow/testing/0201-issue-synthesis-use-identical-string-keys-across-memory-bank-dedup.md`
- `repo_wiki/T-rav/hydraflow/testing/0202-issue-synthesis-skill-definition-changes-must-update-all-4-backend.md`
- `repo_wiki/T-rav/hydraflow/testing/0203-issue-synthesis-auto-generated-adr-tests-must-use-pytest-mark-skip.md`
- `repo_wiki/T-rav/hydraflow/testing/0204-issue-synthesis-every-adr-must-pass-structural-section-validation-.md`
- `repo_wiki/T-rav/hydraflow/testing/0205-issue-synthesis-specify-exact-logger-name-in-caplog-at-level-asser.md`
- `repo_wiki/T-rav/hydraflow/testing/0206-issue-synthesis-js-rendered-accessibility-attributes-require-playw.md`
- `repo_wiki/T-rav/hydraflow/testing/0207-issue-synthesis-use-word-boundary-matching-in-name-coverage-checks.md`
- `repo_wiki/T-rav/hydraflow/testing/0208-issue-synthesis-keep-test-label-stage-constants-synchronized-with-.md`
- `repo_wiki/T-rav/hydraflow/testing/0209-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels-n.md`
- `repo_wiki/T-rav/hydraflow/testing/0210-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md`
- `repo_wiki/T-rav/hydraflow/testing/0211-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md`
- `repo_wiki/T-rav/hydraflow/testing/0212-issue-synthesis-enforce-50-line-handler-and-30-line-wiring-limits-.md`
- `repo_wiki/T-rav/hydraflow/testing/0213-issue-synthesis-type-only-annotation-changes-require-no-new-tests.md`
- `repo_wiki/T-rav/hydraflow/testing/0214-issue-synthesis-assert-numeric-values-in-sentry-breadcrumbs-not-ju.md`
- `repo_wiki/T-rav/hydraflow/testing/0215-issue-synthesis-test-pydantic-literal-constraints-cover-both-valid.md`
- `repo_wiki/T-rav/hydraflow/testing/0216-issue-synthesis-verify-fatal-exception-propagation-through-multi-p.md`
- `repo_wiki/T-rav/hydraflow/testing/0217-issue-synthesis-mock-at-definition-site-not-at-usage-site.md`
- `repo_wiki/T-rav/hydraflow/testing/0218-issue-synthesis-reserve-pytest-mark-integration-for-real-external-.md`
- `repo_wiki/T-rav/hydraflow/testing/0219-issue-synthesis-await-asyncio-sleep-0-after-create-task-before-ass.md`
- `repo_wiki/T-rav/hydraflow/testing/0220-issue-synthesis-reset-global-module-level-state-in-both-setup-and-.md`
- `repo_wiki/T-rav/hydraflow/testing/0221-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md`
- `repo_wiki/T-rav/hydraflow/testing/0222-issue-synthesis-validate-sys-modules-cleanup-with-multiple-random-.md`
- `repo_wiki/T-rav/hydraflow/testing/0223-issue-synthesis-specify-exact-logger-name-in-caplog-at-level-asser.md`
- `repo_wiki/T-rav/hydraflow/testing/0224-issue-synthesis-test-protocol-compliance-with-isinstance-hasattr-a.md`
- `repo_wiki/T-rav/hydraflow/testing/0225-issue-synthesis-fa-ade-tests-cover-routing-error-delegation-and-ba.md`
- `repo_wiki/T-rav/hydraflow/testing/0226-issue-synthesis-skip-broken-tests-with-an-issue-reference-remove-a.md`
- `repo_wiki/T-rav/hydraflow/testing/0227-issue-synthesis-js-rendered-attributes-require-playwright-not-test.md`
- `repo_wiki/T-rav/hydraflow/testing/0228-issue-synthesis-subprocess-cli-test-stubs-log-invocations-to-jsonl.md`
- `repo_wiki/T-rav/hydraflow/testing/0229-issue-synthesis-integration-test-runners-mock-only-execute-wire-re.md`
- `repo_wiki/T-rav/hydraflow/testing/0230-issue-synthesis-use-word-boundary-matching-in-coverage-checks-not-.md`
- `repo_wiki/T-rav/hydraflow/testing/0231-issue-synthesis-use-is-to-verify-shared-runner-instance-across-com.md`
- `repo_wiki/T-rav/hydraflow/testing/0232-issue-synthesis-enforce-50-line-handler-and-30-line-wiring-limits-.md`
- `repo_wiki/T-rav/hydraflow/testing/0233-issue-synthesis-assert-relative-event-ordering-not-absolute-id-val.md`
- `repo_wiki/T-rav/hydraflow/testing/0234-issue-synthesis-add-structural-tests-for-transition-graphs-before-.md`
- `repo_wiki/T-rav/hydraflow/testing/0235-issue-synthesis-sync-test-label-stage-constants-with-production-pi.md`
- `repo_wiki/T-rav/hydraflow/testing/0236-issue-synthesis-grep-all-model-usages-before-committing-pydantic-o.md`
- `repo_wiki/T-rav/hydraflow/testing/0237-issue-synthesis-feature-toggles-need-both-a-config-field-and-env-i.md`
- `repo_wiki/T-rav/hydraflow/testing/0238-issue-synthesis-type-only-annotation-changes-require-no-new-tests.md`
- `repo_wiki/T-rav/hydraflow/testing/0239-issue-synthesis-concurrent-jsonl-appends-assert-exact-event-counts.md`
- `repo_wiki/T-rav/hydraflow/testing/0240-issue-synthesis-use-identical-string-keys-across-memory-bank-dedup.md`
- `repo_wiki/T-rav/hydraflow/testing/0241-issue-synthesis-memory-dedup-higher-priority-bank-wins-on-collisio.md`
- `repo_wiki/T-rav/hydraflow/testing/0242-issue-synthesis-skill-definition-changes-must-update-all-4-backend.md`
- `repo_wiki/T-rav/hydraflow/testing/0243-issue-synthesis-generate-adr-derived-tests-as-skipped-skeletons-by.md`
- `repo_wiki/T-rav/hydraflow/testing/0244-issue-synthesis-every-adr-must-pass-structural-section-validation-.md`
- `repo_wiki/T-rav/hydraflow/testing/0245-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md`
- `repo_wiki/T-rav/hydraflow/testing/0246-issue-synthesis-pin-function-signatures-in-source-before-writing-t.md`
- `repo_wiki/T-rav/hydraflow/testing/0247-issue-synthesis-hoist-deterministic-gates-outside-llm-retry-loops.md`
- `repo_wiki/T-rav/hydraflow/testing/0248-issue-synthesis-use-public-fakegithub-api-in-scenario-tests-never-.md`
- `repo_wiki/T-rav/hydraflow/testing/0249-issue-synthesis-test-async-context-managers-in-three-standard-scen.md`
- `repo_wiki/T-rav/hydraflow/testing/0250-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels-n.md`
- `repo_wiki/T-rav/hydraflow/testing/0251-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md`
- `repo_wiki/T-rav/hydraflow/testing/0252-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md`
- `repo_wiki/T-rav/hydraflow/testing/0253-issue-synthesis-assert-numeric-values-in-sentry-breadcrumbs-not-ju.md`
- `repo_wiki/T-rav/hydraflow/testing/0254-issue-synthesis-test-pydantic-literal-constraints-cover-both-valid.md`
- `repo_wiki/T-rav/hydraflow/testing/0255-issue-synthesis-verify-fatal-exception-propagation-through-multi-p.md`

Auto-merge is enabled when CI is green; if CI fails, the PR stays open and subsequent ticks will append commits instead of opening a new PR.

## Reproducibility Manifest

```json
{
  "config_snapshot": {
    "agent_unrestricted_tools": false,
    "dry_run": false,
    "epic_gap_review_max_iterations": 2,
    "epic_group_planning": true,
    "implement_two_stage_review_enabled": true,
    "max_review_fix_attempts": 2,
    "research_enabled": true,
    "staging_enabled": true,
    "tdd_max_remediation_loops": 4,
    "use_quality_gate_in_review": true
  },
  "hydraflow_sha": "e88ad1c706899ae17abb1540b36795be6700da8c",
  "models": {
    "ac": {
      "model": "sonnet",
      "tool": "claude"
    },
    "adr_review": {
      "model": "sonnet",
      "tool": "claude"
    },
    "background": {
      "model": "sonnet",
      "tool": "claude"
    },
    "corpus_learning_synthesis": {
      "model": "opus",
      "tool": null
    },
    "debug": {
      "model": "opus",
      "tool": "claude"
    },
    "implementation": {
      "model": "sonnet",
      "tool": "claude"
    },
    "planner": {
      "model": "opus",
      "tool": "claude"
    },
    "report_issue": {
      "model": "opus",
      "tool": "claude"
    },
    "review": {
      "model": "sonnet",
      "tool": "claude"
    },
    "sentry": {
      "model": "sonnet",
      "tool": "claude"
    },
    "subskill": {
      "model": "haiku",
      "tool": "claude"
    },
    "system": {
      "model": "",
      "tool": "inherit"
    },
    "transcript_summary": {
      "model": "sonnet",
      "tool": "claude"
    },
    "triage": {
      "model": "sonnet",
      "tool": "claude"
    },
    "verification_judge": {
      "model": "sonnet",
      "tool": "claude"
    },
    "wiki_compilation": {
      "model": "sonnet",
      "tool": "claude"
    }
  },
  "prompt_hash_spec": "prompts/**/*.md + .codex/skills/*/SKILL.md",
  "prompt_hashes": {
    ".codex/skills/continuous-learning-v2/SKILL.md": "sha256:727bdebde88d3f921ee6cbd95eaacb76162292b0dce80360ff3ba4c955d04e54",
    ".codex/skills/eval-harness/SKILL.md": "sha256:0bc29828b0b20c57f1d0904fab2f046155aae9e6d9cf1d7587dd8776a8747f3d",
    ".codex/skills/hf.adr/SKILL.md": "sha256:1e4c17da929ffc6e39ca138e5c422310f15d0dc93e7bdadebe0e7187647fa96f",
    ".codex/skills/hf.audit-code/SKILL.md": "sha256:1415ca494b985cc1f8a070dca3e4043582fcb2231fc13456ad9183dbc25daff6",
    ".codex/skills/hf.audit-hooks/SKILL.md": "sha256:fdf420e9df31e3c7cc7271223ba7d3fa21e0fc50694efd2a701c9a00159a1882",
    ".codex/skills/hf.audit-integration-tests/SKILL.md": "sha256:4ed0c1e5c699c47c8fcf0bea8ca7ff6736fb4e64125bdd61f54d1cd2852a82db",
    ".codex/skills/hf.audit-tests/SKILL.md": "sha256:020e20353ead961eb8fa6b8f4585b22b39a1df46c6ff8b755167a599b6af32f2",
    ".codex/skills/hf.block-destructive-git/SKILL.md": "sha256:4fe0c54910c976cc5c52193895cb3a25742f1dc474c69d90a1800591c51a6a8b",
    ".codex/skills/hf.check-cross-service-impact/SKILL.md": "sha256:c19e25c7a23c4cc0f138880b0fae2dec11963c7e304b023fb5addfd349f5f7cf",
    ".codex/skills/hf.check-reindex-needed/SKILL.md": "sha256:e6f99d2d8686e77ae1ec515c868234b5308df8a89363cdc8c4f8b3dc2244b92b",
    ".codex/skills/hf.check-test-counterpart/SKILL.md": "sha256:68b3244b3651e0486a0c5fa90df30bdab4553c410b237656ef94b8e52891883d",
    ".codex/skills/hf.cleanup-code-change-marker/SKILL.md": "sha256:54da0160dbfcbaaff4756d091a15d66c4f777e76ec6ff4afd92d6c16f1d4f515",
    ".codex/skills/hf.code-quality-enforcer/SKILL.md": "sha256:683d35e6dab3b32fe0f2839d6a7bee8009f971785190e99ac7014d09e1ae6064",
    ".codex/skills/hf.diff-sanity/SKILL.md": "sha256:c9c51395767233759f512c70eb719e8f856ff42f231a8147bc3694ff07b368af",
    ".codex/skills/hf.enforce-migrations/SKILL.md": "sha256:d6e8ad5eb6ec37c55f6f2ce57b35574cdc63ae4ffea4ff4bdf39ae044e1429c4",
    ".codex/skills/hf.enforce-plan-and-explore/SKILL.md": "sha256:0fb13579a24f866a4b3a43530b8420e3051ea5488f84e5cd5c4f01ba322fd483",
    ".codex/skills/hf.gate-stop-agents/SKILL.md": "sha256:74290331c5e0fec2e73d91d0a4b9203ce3895f4ef37480e91ebe9729715556fc",
    ".codex/skills/hf.issue/SKILL.md": "sha256:6dbb9f5f452f7cc307f6820ee6a0adc3eca5040f2ae615a2a49e344014b05fae",
    ".codex/skills/hf.memory/SKILL.md": "sha256:10af7412e3d454e766f69ca17ebd54a469ccd3d8b2f53e09dfde40246f951af3",
    ".codex/skills/hf.scan-secrets-before-commit/SKILL.md": "sha256:df9ab39009bed4ad9107873bbf24be458fc142c7fb32154b4511ab87e360eeca",
    ".codex/skills/hf.test-adequacy/SKILL.md": "sha256:76fe7560b9156bb9adeb32f21c715a3e0c87fbe502c399fca8250bb7b7f4151c",
    ".codex/skills/hf.test-audit/SKILL.md": "sha256:1db8d645a5de1eea16db0130cfabdc24a18f0e2dc13bf2673868a881da1c432e",
    ".codex/skills/hf.track-code-changes/SKILL.md": "sha256:ff3e1ee6f7f24b805052280cc16c0a125d03ebbdc5fee39799e8500b9164e7bf",
    ".codex/skills/hf.track-exploration/SKILL.md": "sha256:1db09bb75e078275eb2c3acfd095f25c7c35a9eaff2f3d7d12a566f10bc09ca1",
    ".codex/skills/hf.track-indexed/SKILL.md": "sha256:5832d0c725f617d39cf00d2ce0d57295a1a66753754d0d357a13e4b9f358dcb4",
    ".codex/skills/hf.track-planning/SKILL.md": "sha256:295c903f1ed95350d64af5273e0456eb57ac1f8a7089158831a14a90941f6a4a",
    ".codex/skills/hf.track-reindex-needed/SKILL.md": "sha256:8a087b89c7cb263f8f022010e0c4d392c81976d923bce2297d12d04f9327d55a",
    ".codex/skills/hf.validate-tests-before-commit/SKILL.md": "sha256:a906ab14c80dc8b25a1cbbdf86eaff02f427bbf560bcb7eae9a88fb32b1380e7",
    ".codex/skills/hf.warn-new-file-creation/SKILL.md": "sha256:2c8ec336bec3643a919b0b44326d70c3dc75754f9ed67e05882e240c505c7648",
    ".codex/skills/skill-stocktake/SKILL.md": "sha256:2964e3b6a11b4d9d76b99a218a5d627c91da63ecc080feb686c895c2e52e37ab",
    ".codex/skills/strategic-compact/SKILL.md": "sha256:a8ac1ec9b56dca7735d54c90dee38860197e71f6eed7e9f12ed9cd720b1ba7ca",
    ".codex/skills/verification-loop/SKILL.md": "sha256:01a9ae310ad4426bb05660dda6cefdeaac9513417585c09c8bb1b94738649a78",
    "prompts/auto_agent/_default.md": "sha256:bd1a34e46bb5cca691ce042c95aea265284a4f2df3a9fddba98c3942b44f8c65",
    "prompts/auto_agent/_envelope.md": "sha256:04f971e041b6811c3566b932ebdef4cc22da577f9d2c62bde11a44ab6b5c3071",
    "prompts/auto_agent/discover-stuck.md": "sha256:79f8f2cbaeb1c44cce76959b8f466da3970296fd380a83fe2f080801920c0452",
    "prompts/auto_agent/fake-coverage-stuck.md": "sha256:8868aa6836bf2d7379ace6471b8516cb7c93edc39af2ff4152fce7ed2328c860",
    "prompts/auto_agent/fake-drift-stuck.md": "sha256:832537b8b3250c80d5e8abe818b1484066a9b91415189d11f675b9a9283b8c16",
    "prompts/auto_agent/flaky-test-stuck.md": "sha256:559afd514324a2148bbf38acb2c81b00d5407d24f43ead4189eed59f8d860523",
    "prompts/auto_agent/implement-stuck.md": "sha256:6ed3f0694b15b64ff79e501cfd9bb03f884c2f21219099e3227177b4a2a98dca",
    "prompts/auto_agent/plan-stuck.md": "sha256:67ceaae9ae4d066e3ae3392d6a13e660366fe8c5a5d41b1ef0108f8a5bc57f88",
    "prompts/auto_agent/rc-duration-stuck.md": "sha256:8812229041e11ca0ecf4a1982af47e5834c517a98c8893b329083e927f0726b0",
    "prompts/auto_agent/rc-red-bisect-exhausted.md": "sha256:35b6c34cdd68aaf3f194503b9dcf23ee1472fff6be10d7c00d8d0639df04cc3b",
    "prompts/auto_agent/revert-conflict.md": "sha256:a44013827625c3d52a5edfd8f0ef1f10e8ae872815b6d7c2a2fab02fc6e5abd5",
    "prompts/auto_agent/review-stuck.md": "sha256:11d658a092b1f37e4693ff47601747321c830d36dbb45fdc6acc08c7471cee6b",
    "prompts/auto_agent/sandbox_fix.md": "sha256:390ba65c0ca227075f43f5b545541d3ec3a1f3f4bfcead605a02d2eb7f6a6fe3",
    "prompts/auto_agent/skill-prompt-stuck.md": "sha256:89921ea3b39d044c1d592e6388aed3e92af1b774f36b120d08cd7683fe9e301e",
    "prompts/auto_agent/triage-stuck.md": "sha256:5e3ac9eb449a175de2ce5a9d8d032a9ca08f7b802e8e871654f804f766b9fe93",
    "prompts/auto_agent/trust-loop-anomaly.md": "sha256:ac2a78e24763a42cc9f200822b08877c7ba84e0a730339311c00dab7e3fd2638",
    "prompts/auto_agent/wiki-rot-stuck.md": "sha256:620cb12bdef2bf95caa09f93045caffea38969e4dec22d8a3493b8f2c37050a1"
  },
  "schema": "hydraflow.repro-manifest/v1"
}
```
