### PR TITLE
fix(dependabot-merge): detect bots via is_bot + factory branch prefixes

### DIFF
--- a/src/dependabot_merge_loop.py
+++ b/src/dependabot_merge_loop.py
@@ -31,6 +31,24 @@ logger = logging.getLogger("hydraflow.dependabot_merge_loop")
 # (``agent/issue-N``), so matching on it is safe.
 _AUTO_AGENT_BRANCH_PREFIX = "agent/auto-agent-"
 
+# Factory-owned branch prefixes for the UL + pricing maintenance loops. Like the
+# auto-agent PRs above, these are opened under the ambient factory token
+# (``HydraOps-T-rav`` for the UL loops, ``T-rav`` for pricing) — NOT a configured
+# bot author — and they carry workflow labels (``hydraflow-ul-*`` /
+# ``pricing-refresh``) rather than ``agent/issue-N``. So author-based selection
+# misses them AND the review→merge pipeline ignores them, and they pile up
+# unmerged (#9843). Matching on these exact factory-owned prefixes is safe: no
+# human or normal-pipeline branch uses them. Once selected, the CI-green merge
+# and the stale-arch self-heal path below handle the rest.
+_FACTORY_MAINTENANCE_BRANCH_PREFIXES = (
+    "ul-proposer/",  # term_proposer_loop
+    "ul-evidence/",  # entry_evidence_loop
+    "ul-edges/",  # edge_proposer_loop
+    "ul-pruner/",  # term_pruner_loop
+    "pricing-refresh-auto",  # pricing_refresh_loop (_REGEN_BRANCH)
+    "hydraflow/wiki-maint-",  # repo_wiki_loop
+)
+
 # Markers in ``wait_for_ci``'s ``summary`` that identify an arch-staleness CI
 # failure. ``wait_for_ci`` returns ``"Failed checks: <name>, ..."`` where each
 # ``<name>`` is the GitHub check (job) name (see ``PRManager._evaluate_ci_checks``
@@ -65,6 +83,23 @@ def _is_arch_staleness_failure(summary: str) -> bool:
     return any(marker in lowered for marker in _ARCH_STALENESS_MARKERS)
 
 
+def _normalize_author(login: str) -> str:
+    """Normalize a PR-author login for bot matching.
+
+    ``gh pr list --json author`` renders a GitHub App author as ``app/dependabot``
+    (the GraphQL form) while the configured / REST form is ``dependabot[bot]``.
+    Strip the ``app/`` prefix and the ``[bot]`` suffix so the two compare equal —
+    otherwise even real Dependabot PRs never match ``settings.authors`` and the
+    loop merges nothing. Pure + case-insensitive for unit-testing in isolation.
+    """
+    normalized = login.strip().lower()
+    if normalized.startswith("app/"):
+        normalized = normalized[len("app/") :]
+    if normalized.endswith("[bot]"):
+        normalized = normalized[: -len("[bot]")]
+    return normalized
+
+
 class DependabotMergeLoop(BaseBackgroundLoop):
     """Polls open PRs and auto-merges configured bot PRs + Auto-Agent PRs after CI passes."""
 
@@ -92,7 +127,7 @@ class DependabotMergeLoop(BaseBackgroundLoop):
             return {"status": "config_disabled"}
         settings = self._state.get_dependabot_merge_settings()
         processed = self._state.get_dependabot_merge_processed()
-        bot_authors = {a.lower() for a in settings.authors}
+        bot_authors = {_normalize_author(a) for a in settings.authors}
 
         # Read the label-agnostic snapshot: bot PRs carry only GitHub-native
         # labels (e.g. ``dependencies``) and are absent from the workflow-label
@@ -103,9 +138,19 @@ class DependabotMergeLoop(BaseBackgroundLoop):
             pr
             for pr in open_prs
             if pr.pr not in processed
+            and not pr.draft  # never auto-merge a draft, even a bot's
             and (
-                pr.author.lower() in bot_authors
+                # GitHub's own bot flag — catches Dependabot/Renovate/any App
+                # generically, the same way the UI tags them, without linking to
+                # specific account logins (#9843).
+                pr.is_bot
+                # Explicit author allowlist (normalized so ``app/dependabot`` and
+                # ``dependabot[bot]`` compare equal) — for configured non-App bots.
+                or _normalize_author(pr.author) in bot_authors
+                # Factory PRs opened under a *user* token (is_bot=False):
+                # auto-agent preflight + the UL/pricing/wiki maintenance loops.
                 or pr.branch.startswith(_AUTO_AGENT_BRANCH_PREFIX)
+                or pr.branch.startswith(_FACTORY_MAINTENANCE_BRANCH_PREFIXES)
             )
         ]
 

--- a/src/mockworld/fakes/fake_github.py
+++ b/src/mockworld/fakes/fake_github.py
@@ -98,6 +98,10 @@ class FakePR:
     # PR author login (e.g. "dependabot[bot]"). Drives DependabotMergeLoop's
     # bot-PR eligibility (it matches pr.author against the configured bots).
     author: str = "fake-author"
+    # GitHub's ``author.is_bot`` flag — true for GitHub Apps (Dependabot,
+    # Renovate). DependabotMergeLoop's primary bot-detection signal, mirroring
+    # the UI. Lets scenarios seed a bot PR without an author allowlist.
+    is_bot: bool = False
     # Commit count used by ``find_label_drift`` (ADR-0088) to distinguish
     # zero-commit PRs from real ones. Defaults to 1 so seeded PRs look
     # "real" without explicit setup.
@@ -171,6 +175,7 @@ class FakeGitHub:
                 ci_status=pr_dict.get("ci_status", "pass"),
                 merged=pr_dict.get("merged", False),
                 author=pr_dict.get("author", "fake-author"),
+                is_bot=pr_dict.get("is_bot", False),
             )
             for label in pr_dict.get("labels", []):
                 gh.add_pr_label(pr_dict["number"], label)
@@ -226,6 +231,7 @@ class FakeGitHub:
         ci_status: str = "pass",
         merged: bool = False,
         author: str = "fake-author",
+        is_bot: bool = False,
     ) -> None:
         """Directly insert a PR record (sync helper for test seeding).
 
@@ -240,6 +246,7 @@ class FakeGitHub:
             merged=merged,
             ci_status=ci_status,
             author=author,
+            is_bot=is_bot,
         )
 
     def add_pr_label(self, pr_number: int, label: str) -> None:
@@ -1044,6 +1051,7 @@ class FakeGitHub:
                     title="",
                     merged=pr.merged,
                     author=pr.author,
+                    is_bot=pr.is_bot,
                 )
             )
         return out
@@ -1070,6 +1078,7 @@ class FakeGitHub:
                 title="",
                 merged=pr.merged,
                 author=pr.author,
+                is_bot=pr.is_bot,
             )
             for pr in self._prs.values()
             if not pr.merged

--- a/src/models.py
+++ b/src/models.py
@@ -2544,6 +2544,12 @@ class PRListItem(BaseModel):
     title: str = ""
     merged: bool = False
     author: str = ""
+    # GitHub's own bot flag (``author.is_bot``) — true for GitHub Apps like
+    # Dependabot/Renovate. Lets consumers detect bot PRs the same way the UI
+    # does, without linking to specific account logins. Populated by
+    # ``PRManager.list_all_open_prs``; defaults False for label-filtered/legacy
+    # snapshots that don't project it.
+    is_bot: bool = False
 
 
 class HITLItem(BaseModel):

--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -3019,6 +3019,7 @@ class PRManager:
                     draft=bool(item.get("isDraft", False)),
                     title=str(item.get("title", "")),
                     author=str((item.get("author") or {}).get("login", "")),
+                    is_bot=bool((item.get("author") or {}).get("is_bot", False)),
                 )
             )
         return prs

--- a/tests/test_dashboard_lifecycle.py
+++ b/tests/test_dashboard_lifecycle.py
@@ -738,6 +738,7 @@ class TestPRsRoute:
             "title",
             "merged",
             "author",
+            "is_bot",
             "repo",  # repo-tagged so the aggregate view de-collides same-number PRs
         }
         assert set(body[0].keys()) == expected_keys

--- a/tests/test_dependabot_merge_loop.py
+++ b/tests/test_dependabot_merge_loop.py
@@ -22,6 +22,7 @@ def _make_pr(
     author: str = "dependabot[bot]",
     title: str = "Bump foo",
     branch: str = "",
+    is_bot: bool = False,
 ) -> PRListItem:
     """Build a minimal PRListItem for testing."""
     return PRListItem(
@@ -29,6 +30,7 @@ def _make_pr(
         author=author,
         title=title,
         branch=branch,
+        is_bot=is_bot,
         url=f"https://github.com/o/r/pull/{pr}",
     )
 
@@ -574,6 +576,193 @@ class TestDependabotArchSelfHeal:
         )
         state.bump_dependabot_arch_refresh_attempts.assert_called_once_with(9427)
         assert result["skipped"] == 1
+
+
+class TestDependabotMergeLoopFactoryMaintenanceBranches:
+    """UL proposer/evidence/edge + pricing-refresh PRs are opened under the
+    ambient factory token (``HydraOps-T-rav`` for UL, ``T-rav`` for pricing) —
+    NOT a configured bot author — and they carry workflow labels
+    (``hydraflow-ul-*`` / ``pricing-refresh``) rather than ``agent/issue-N``, so
+    both author-based selection and the review->merge pipeline miss them and
+    they pile up. The loop merges them by their factory-owned branch prefix
+    (#9843), mirroring the auto-agent prefix fix.
+    """
+
+    @pytest.mark.parametrize(
+        "branch",
+        [
+            "ul-proposer/4e3d7b2b",
+            "ul-evidence/5ebff585",
+            "ul-edges/0afc892d",
+            "ul-pruner/9f1c2d3e",
+            "pricing-refresh-auto",
+            "hydraflow/wiki-maint-20260718-1200",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_merges_factory_maintenance_pr_despite_non_bot_author(
+        self, tmp_path: Path, branch: str
+    ) -> None:
+        loop, _, _, prs, state = _make_loop(
+            tmp_path,
+            open_prs=[_make_pr(50, author="HydraOps-T-rav", branch=branch)],
+            ci_result=(True, "All checks passed"),
+        )
+
+        result = await loop._do_work()
+
+        assert result["merged"] == 1
+        prs.merge_pr.assert_awaited_once_with(50, auto_rebase=True)
+        state.add_dependabot_merge_processed.assert_called_once_with(50)
+
+    @pytest.mark.asyncio
+    async def test_stale_arch_factory_pr_selected_and_self_heals(
+        self, tmp_path: Path
+    ) -> None:
+        """A UL PR red purely on stale arch is now *selected* (by branch prefix)
+        and rides the existing arch self-heal path — the #9838 case that
+        previously never even entered the loop."""
+        loop, _, _, prs, state = _make_loop(
+            tmp_path,
+            open_prs=[
+                _make_pr(9838, author="HydraOps-T-rav", branch="ul-proposer/4e3d7b2b")
+            ],
+            ci_result=(False, "Failed checks: arch-check"),
+            failure_strategy="skip",
+        )
+
+        result = await loop._do_work()
+
+        prs.refresh_pr_branch_with_arch_regen.assert_awaited_once_with(
+            9838, "ul-proposer/4e3d7b2b"
+        )
+        state.bump_dependabot_arch_refresh_attempts.assert_called_once_with(9838)
+        assert result["skipped"] == 1
+
+    @pytest.mark.asyncio
+    async def test_ul_lookalike_branch_not_merged(self, tmp_path: Path) -> None:
+        """Prefixes are exact: a human branch that merely starts with ``ul-``
+        (e.g. ``ul-cleanup-notes``) must not auto-merge."""
+        loop, _, _, prs, _ = _make_loop(
+            tmp_path,
+            open_prs=[_make_pr(60, author="human-dev", branch="ul-cleanup-notes")],
+        )
+
+        result = await loop._do_work()
+
+        assert result == {"merged": 0, "skipped": 0, "failed": 0}
+        prs.wait_for_ci.assert_not_awaited()
+
+
+class TestIsBotDetection:
+    """GitHub's ``author.is_bot`` flag (the same signal the UI uses to tag a PR
+    as a bot) is the primary auto-merge selector, so Dependabot/Renovate/any App
+    is picked up generically — without linking to specific account logins (#9843).
+    """
+
+    @pytest.mark.asyncio
+    async def test_is_bot_pr_merges_without_author_allowlist(
+        self, tmp_path: Path
+    ) -> None:
+        """An is_bot PR merges even when ``settings.authors`` is empty — the bot
+        flag alone qualifies it (the operator's ask: don't tie detection to
+        account names)."""
+        loop, _, _, prs, _ = _make_loop(
+            tmp_path,
+            open_prs=[
+                _make_pr(
+                    1,
+                    author="app/dependabot",
+                    branch="dependabot/uv/foo",
+                    is_bot=True,
+                )
+            ],
+            authors=[],
+            ci_result=(True, "All checks passed"),
+        )
+
+        result = await loop._do_work()
+
+        assert result["merged"] == 1
+        prs.merge_pr.assert_awaited_once_with(1, auto_rebase=True)
+
+    @pytest.mark.asyncio
+    async def test_non_bot_human_pr_not_merged(self, tmp_path: Path) -> None:
+        """is_bot=False on an arbitrary branch stays ignored (no over-merge)."""
+        loop, _, _, prs, _ = _make_loop(
+            tmp_path,
+            open_prs=[
+                _make_pr(1, author="some-human", branch="feature/x", is_bot=False)
+            ],
+            authors=[],
+        )
+
+        result = await loop._do_work()
+
+        assert result == {"merged": 0, "skipped": 0, "failed": 0}
+        prs.wait_for_ci.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_draft_bot_pr_not_merged(self, tmp_path: Path) -> None:
+        """A draft is never auto-merged, even from a bot author."""
+        loop, _, _, prs, _ = _make_loop(
+            tmp_path,
+            open_prs=[
+                _make_pr(1, author="app/dependabot", branch="dependabot/x", is_bot=True)
+            ],
+        )
+        # Mark the seeded PR draft (the helper builds non-draft by default).
+        loop._cache.get_all_open_prs.return_value[0].draft = True
+
+        result = await loop._do_work()
+
+        assert result == {"merged": 0, "skipped": 0, "failed": 0}
+        prs.wait_for_ci.assert_not_awaited()
+
+
+class TestAuthorNormalization:
+    """gh's ``--json author`` renders a GitHub App as ``app/dependabot`` while
+    ``settings.authors`` holds the ``dependabot[bot]`` form. Without normalizing
+    both sides even real Dependabot PRs never match and the loop merges nothing
+    (#9843)."""
+
+    @pytest.mark.parametrize(
+        "pr_author",
+        ["app/dependabot", "dependabot[bot]", "Dependabot[bot]", "app/Dependabot"],
+    )
+    @pytest.mark.asyncio
+    async def test_dependabot_app_login_matches_config(
+        self, tmp_path: Path, pr_author: str
+    ) -> None:
+        loop, _, _, prs, _ = _make_loop(
+            tmp_path,
+            open_prs=[_make_pr(1, author=pr_author, branch="dependabot/uv/foo")],
+            authors=["dependabot[bot]"],
+            ci_result=(True, "All checks passed"),
+        )
+
+        result = await loop._do_work()
+
+        assert result["merged"] == 1
+        prs.merge_pr.assert_awaited_once_with(1, auto_rebase=True)
+
+    @pytest.mark.parametrize(
+        ("login", "expected"),
+        [
+            ("app/dependabot", "dependabot"),
+            ("dependabot[bot]", "dependabot"),
+            ("Dependabot[bot]", "dependabot"),
+            ("app/renovate", "renovate"),
+            ("renovate[bot]", "renovate"),
+            ("T-rav", "t-rav"),
+            ("HydraOps-T-rav", "hydraops-t-rav"),
+            ("", ""),
+        ],
+    )
+    def test_normalize_author(self, login: str, expected: str) -> None:
+        from dependabot_merge_loop import _normalize_author
+
+        assert _normalize_author(login) == expected
 
 
 class TestMergePolicyGate:

--- a/tests/test_models_core.py
+++ b/tests/test_models_core.py
@@ -874,6 +874,7 @@ class TestPRListItem:
             "title": "Add tests",
             "merged": False,
             "author": "",
+            "is_bot": False,
         }
 
     def test_merged_field_defaults_false(self) -> None:


### PR DESCRIPTION
## Problem
`DependabotMergeLoop` merged **nothing** but Claude/agent PRs. Selection matched only an author-login allowlist or the `agent/auto-agent-` branch prefix, so:
- **Even real Dependabot PRs were dropped** — `gh --json author` renders GitHub Apps as `app/dependabot`, which never equals the configured `dependabot[bot]`.
- **UL / pricing / wiki maintenance PRs** (opened under a user token: `HydraOps-T-rav` / `T-rav`, `is_bot=false`, on `ul-*`/`pricing-refresh-auto`/`hydraflow/wiki-maint-` branches) matched neither → piled up (this is what #9843 tracked).

## Fix
- **Primary signal is now GitHub's own `author.is_bot`** (same as the UI) — Dependabot/Renovate/any App is picked up generically, no account-name allowlist needed. Threaded `PRListItem.is_bot` ← `PRManager.list_all_open_prs` ← `gh --json author`, mirrored in `FakeGitHub`/`FakePR`.
- **Factory branch prefixes** for the user-token maintenance loops: `ul-proposer/`, `ul-evidence/`, `ul-edges/`, `ul-pruner/`, `pricing-refresh-auto`, `hydraflow/wiki-maint-`.
- **Author normalization** (`app/dependabot` ≡ `dependabot[bot]`) for explicit allowlisting.
- **Draft guard** — the broadened net never auto-merges a draft.

Once selected, the existing arch self-heal (cap=2) clears stale-arch bot PRs automatically.

## Tests
- `is_bot` merges without any author allowlist; all 6 factory branch prefixes; `app/dependabot`≡`dependabot[bot]` normalization; `_normalize_author` unit matrix; draft guard; `ul-` lookalike (non-factory) stays ignored.
- Updated `PRListItem` serialization + `/api/prs` field-set assertions for the new `is_bot` field.
- Full `make quality` green (17865 passed, QUALITY_EXIT=0).

Closes #9843

🤖 Generated with [Claude Code](https://claude.com/claude-code)