### PR TITLE
feat(pricing): price glm-5.2 + kimi-k3 so bg-worker cost tracks alongside telemetry

### DIFF
--- a/src/assets/model_pricing.json
+++ b/src/assets/model_pricing.json
@@ -217,6 +217,28 @@
       "output_cost_per_million": 25.0,
       "cache_write_cost_per_million": 6.25,
       "cache_read_cost_per_million": 0.5
+    },
+    "glm-5.2": {
+      "provider": "zai",
+      "aliases": [
+        "zai/glm-5.2",
+        "glm-5p2"
+      ],
+      "input_cost_per_million": 1.4,
+      "output_cost_per_million": 4.4,
+      "cache_write_cost_per_million": 1.4,
+      "cache_read_cost_per_million": 0.26
+    },
+    "kimi-k3": {
+      "provider": "moonshot",
+      "aliases": [
+        "kimi",
+        "kimi-latest"
+      ],
+      "input_cost_per_million": 2.0,
+      "output_cost_per_million": 5.0,
+      "cache_write_cost_per_million": 2.0,
+      "cache_read_cost_per_million": 0.15
     }
   }
 }

--- a/tests/test_model_pricing.py
+++ b/tests/test_model_pricing.py
@@ -234,3 +234,33 @@ class TestLoadPricing:
         path.write_text(json.dumps({"schema_version": 1, "models": {}}))
         table = load_pricing(path)
         assert isinstance(table, ModelPricingTable)
+
+
+class TestOpenAICompatBackendModelsPriced:
+    """Drift guard (#9856): the OpenAI-compatible one-shot backends send these
+    exact model ids (config: zai -> ``glm-5.2``, kimi -> ``kimi-k3``). Telemetry
+    records the model string, so the shipped pricing table MUST resolve it —
+    otherwise kimi/z.ai bg-worker cost silently records as $0 next to the tracked
+    Claude spend. When a backend model id is bumped, add the new id to
+    src/assets/model_pricing.json AND to this list.
+    """
+
+    # (model_id, min tokens rate must be > 0)
+    _BACKEND_MODEL_IDS = ["glm-5.2", "kimi-k3"]
+
+    @pytest.mark.parametrize("model", _BACKEND_MODEL_IDS)
+    def test_backend_model_is_priced_in_shipped_table(self, model: str) -> None:
+        # load_pricing() with no path loads the real src/assets/model_pricing.json.
+        pricing = load_pricing()
+        cost = pricing.estimate_cost(model, input_tokens=1000, output_tokens=1000)
+        assert cost is not None and cost > 0, (
+            f"{model!r} is not priced in the shipped table — kimi/z.ai bg-worker "
+            "cost telemetry will record $0. Add it to "
+            "src/assets/model_pricing.json (#9856)."
+        )
+
+    def test_provider_prefixed_alias_resolves(self) -> None:
+        # The telemetry model string is bare ``glm-5.2``, but the provider-form
+        # ``zai/glm-5.2`` must resolve too (alias), for robustness.
+        pricing = load_pricing()
+        assert pricing.get_rate("zai/glm-5.2") is not None


### PR DESCRIPTION
## Problem (#9856)
Background-worker calls on the OpenAI-compatible backends (z.ai=`glm-5.2`, kimi=`kimi-k3`) already record **real API token usage** in `PromptTelemetry` (attributed to the provider, `token_source="actual"`). But the pricing table held **only Claude models**, so `estimate_cost()` returned `None` → every kimi/z.ai call logged **$0 cost** next to the tracked Claude spend, undercounting non-Claude spend to zero on the ROI dashboard.

## Fix
Add pricing entries to `src/assets/model_pricing.json` (per-million):
- **glm-5.2**: in 1.4 / out 4.4 / cache-read 0.26 — from LiteLLM's direct `zai/` provider tier (glm-5.1=1.4/4.4/0.26) + cross-provider consensus (`cloudflare/@cf/zai-org/glm-5.2`, `fireworks/glm-5p2` both 1.4/4.4/0.26).
- **kimi-k3**: in 2.0 / out 5.0 / cache-read 0.15 — Moonshot `kimi-latest` tier (aliased `kimi`, `kimi-latest`).

`PricingRefreshLoop` merges (its diff is Anthropic-only), so these **persist across the daily sync** — verified against the refresh diff/scenario tests.

## Verification
`estimate_cost("glm-5.2", 1M, 1M)` → **$5.8** (was `None`); `kimi-k3` → **$7.0**; aliases (`zai/glm-5.2`, `kimi-latest`) resolve.

## Tests
- **Drift guard** (`TestOpenAICompatBackendModelsPriced`): the shipped table must price every backend model id (`glm-5.2`, `kimi-k3`), so a future model bump that forgets pricing **fails CI** instead of silently logging $0.
- Provider-prefixed alias resolves.
- Full `make quality` green (17845 passed, QUALITY_EXIT=0).

Refs #9856 (the loop-side automation — extending `PricingRefreshLoop` to pull Moonshot/Zhipu from LiteLLM — remains a follow-up on that issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)