### PR TITLE
fix(credit-pause): corroborate credit signal with live API probe (false-positive global pauses)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -3277,6 +3277,18 @@ class HydraFlowConfig(BaseModel):
         le=30,
         description="Extra minutes to wait after reported credit reset time",
     )
+    credit_pause_require_probe: bool = Field(
+        default=True,
+        description=(
+            "Before committing a GLOBAL credit pause, corroborate the "
+            "text-detected credit signal with a live Anthropic API probe. "
+            "is_credit_exhaustion matches credit-error PROSE, so a "
+            "diagnostic/reviewer run quoting a prior cap in its analysis would "
+            "otherwise trigger a multi-hour false global pause (#9807). The "
+            "probe is ground truth (False only when the API itself confirms "
+            "exhaustion). Kill-switch: set False to revert to pause-on-text."
+        ),
+    )
 
     # Process timeouts
     agent_timeout: int = Field(

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -51,6 +51,7 @@ from state_restorer import StateRestorer
 from subprocess_util import (
     AuthenticationError,
     CreditExhaustedError,
+    probe_credit_availability,
 )
 
 if TYPE_CHECKING:
@@ -1747,6 +1748,41 @@ class HydraFlowOrchestrator:
                 self._credits_paused_until is not None
                 and self._credits_paused_until > datetime.now(UTC)
             ):
+                return
+
+            # Corroborate the text-detected signal with a live API probe before
+            # committing a GLOBAL pause. ``is_credit_exhaustion`` matches
+            # credit-error PROSE, so a diagnostic/reviewer run that merely quotes
+            # a prior cap in its analysis would otherwise trigger a multi-hour
+            # false global pause (#9807). The probe is ground truth: it returns
+            # False only when the API itself confirms exhaustion, and fails open
+            # (True on no-key/network error) so a flaky probe delays a real pause
+            # by at most one detection cycle rather than masking it. Kill-switch:
+            # ``credit_pause_require_probe=False`` reverts to pause-on-text.
+            # ``and`` short-circuits: with the kill-switch off, the probe is
+            # never called (pause-on-text, the legacy behavior).
+            if (
+                self._config.credit_pause_require_probe
+                and await probe_credit_availability()
+            ):
+                logger.warning(
+                    "Credit-exhaustion signal from %r NOT corroborated by live "
+                    "API probe — treating as a false positive (likely quoted "
+                    "credit-error prose); not pausing.",
+                    source,
+                )
+                await self._bus.publish(
+                    HydraFlowEvent(
+                        type=EventType.SYSTEM_ALERT,
+                        data={
+                            "message": (
+                                "Credit signal not corroborated by API probe "
+                                "— ignoring as a false positive."
+                            ),
+                            "source": source,
+                        },
+                    )
+                )
                 return
 
             resume_at = self._compute_resume_time(exc)

--- a/tests/test_credit_pause.py
+++ b/tests/test_credit_pause.py
@@ -414,6 +414,18 @@ class TestRunStatusCreditsPaused:
 
 
 class TestCreditExhaustionPauseResume:
+    @pytest.fixture(autouse=True)
+    def _probe_confirms_exhaustion(self):
+        """These tests exercise pause/resume mechanics for a REAL credit-out, so
+        the corroborating probe in ``_pause_for_credits`` (#9807) must confirm
+        exhaustion (returns False); otherwise it correctly treats the signal as a
+        false positive and skips the pause."""
+        with patch(
+            "orchestrator.probe_credit_availability",
+            AsyncMock(return_value=False),
+        ):
+            yield
+
     @pytest.mark.asyncio
     async def test_credit_exhaustion_publishes_system_alert(
         self, config: HydraFlowConfig, event_bus
@@ -718,6 +730,18 @@ class TestConfigCreditPauseBuffer:
 
 
 class TestTryClearCreditPause:
+    @pytest.fixture(autouse=True)
+    def _probe_confirms_exhaustion(self):
+        """Tests here that TRIGGER a pause need the corroborating probe in
+        ``_pause_for_credits`` (#9807) to confirm exhaustion. try_clear's own
+        probe tests patch ``subprocess_util.probe_credit_availability`` (a
+        different reference), so this orchestrator-side patch never collides."""
+        with patch(
+            "orchestrator.probe_credit_availability",
+            AsyncMock(return_value=False),
+        ):
+            yield
+
     def test_returns_false_when_not_paused(self, config: HydraFlowConfig) -> None:
         """try_clear_credit_pause returns False when no pause is active."""
         orch = HydraFlowOrchestrator(config)

--- a/tests/test_orchestrator_integration.py
+++ b/tests/test_orchestrator_integration.py
@@ -7,7 +7,7 @@ import contextlib
 from collections.abc import Callable, Coroutine, Iterator
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -174,7 +174,13 @@ async def test_credit_pause_publishes_alerts_and_restores_loops(tmp_path) -> Non
         resume_at = datetime.now(UTC) + timedelta(seconds=0.02)
         exc = CreditExhaustedError("limit reached", resume_at=resume_at)
 
-        await orch._pause_for_credits(exc, "triage", tasks, loop_factories)
+        # Probe confirms the cap is real (#9807), so the pause/resume flow runs
+        # instead of being treated as a false-positive and skipped.
+        with patch(
+            "orchestrator.probe_credit_availability",
+            AsyncMock(return_value=False),
+        ):
+            await orch._pause_for_credits(exc, "triage", tasks, loop_factories)
 
         assert orch._credits_paused_until is None
         assert tasks["triage"].get_name().startswith("hydraflow")

--- a/tests/test_orchestrator_loops.py
+++ b/tests/test_orchestrator_loops.py
@@ -827,6 +827,83 @@ class TestHandleLoopException:
         orch._pause_for_credits.assert_awaited_once_with(exc, "plan", tasks, factories)
 
     @pytest.mark.asyncio
+    async def test_pause_skipped_when_probe_says_credits_available(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """#9807: is_credit_exhaustion matches credit-error PROSE, so a diagnostic
+        run quoting a prior cap trips a false signal. If the live API probe says
+        credits are available, _pause_for_credits must NOT commit a global pause.
+        """
+        from subprocess_util import CreditExhaustedError
+
+        bus = EventBus()
+        orch = HydraFlowOrchestrator(config, event_bus=bus)
+        orch._cancel_all_loops_and_runners = AsyncMock()  # type: ignore[method-assign]
+        tasks: dict[str, asyncio.Task[None]] = {}
+        factories: list = [("plan", AsyncMock())]
+        exc = CreditExhaustedError("Your credit balance is too low")
+
+        with patch(
+            "orchestrator.probe_credit_availability",
+            AsyncMock(return_value=True),
+        ):
+            await orch._pause_for_credits(exc, "diagnostic", tasks, factories)
+
+        assert orch._credits_paused_until is None  # no pause committed
+        orch._cancel_all_loops_and_runners.assert_not_awaited()
+        alerts = [e for e in bus.get_history() if e.type == EventType.SYSTEM_ALERT]
+        assert any(
+            "not corroborated" in str(a.data.get("message", "")).lower() for a in alerts
+        )
+
+    @pytest.mark.asyncio
+    async def test_pause_proceeds_when_probe_confirms_exhaustion(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """A real cap (probe returns False) still pauses."""
+        from subprocess_util import CreditExhaustedError
+
+        orch = HydraFlowOrchestrator(config)
+        orch._cancel_all_loops_and_runners = AsyncMock()  # type: ignore[method-assign]
+        orch._sleep_until_resume = AsyncMock()  # type: ignore[method-assign]
+        orch._resume_loops_after_credit_pause = AsyncMock()  # type: ignore[method-assign]
+        tasks: dict[str, asyncio.Task[None]] = {}
+        factories: list = [("plan", AsyncMock())]
+        exc = CreditExhaustedError("usage limit reached")
+
+        with patch(
+            "orchestrator.probe_credit_availability",
+            AsyncMock(return_value=False),
+        ):
+            await orch._pause_for_credits(exc, "plan", tasks, factories)
+
+        assert orch._credits_paused_until is not None  # pause committed
+        orch._cancel_all_loops_and_runners.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_probe_kill_switch_pauses_without_probing(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """credit_pause_require_probe=False reverts to pause-on-text (no probe)."""
+        from subprocess_util import CreditExhaustedError
+
+        object.__setattr__(config, "credit_pause_require_probe", False)
+        orch = HydraFlowOrchestrator(config)
+        orch._cancel_all_loops_and_runners = AsyncMock()  # type: ignore[method-assign]
+        orch._sleep_until_resume = AsyncMock()  # type: ignore[method-assign]
+        orch._resume_loops_after_credit_pause = AsyncMock()  # type: ignore[method-assign]
+        tasks: dict[str, asyncio.Task[None]] = {}
+        factories: list = [("plan", AsyncMock())]
+        exc = CreditExhaustedError("usage limit reached")
+        probe = AsyncMock(return_value=True)
+
+        with patch("orchestrator.probe_credit_availability", probe):
+            await orch._pause_for_credits(exc, "plan", tasks, factories)
+
+        probe.assert_not_awaited()  # kill-switch: probe skipped
+        assert orch._credits_paused_until is not None  # paused on text alone
+
+    @pytest.mark.asyncio
     async def test_generic_error_restarts_loop(self, config: HydraFlowConfig) -> None:
         """Generic exception should restart the crashed loop task."""
         bus = EventBus()


### PR DESCRIPTION
## Problem (#9807)
`is_credit_exhaustion()` matches credit-error **prose**. A `diagnostic`/reviewer run that merely **quotes a prior cap** in its analysis (e.g. a transcript containing "usage limit reached") tripped a **5-hour GLOBAL pause** — halting every loop, including the z.ai/kimi backends. Observed repeatedly today ("Credit limit reached (detected in 'diagnostic')") while credits were fine.

The auth path was already hardened against this exact class (`_is_auth_failure`: match the CLI's own signal, not agent prose). Credit never was — and it can't cleanly separate real-vs-quoted by channel, because real API caps ("Your credit balance is too low", the 400 spend-cap JSON) legitimately land in `accumulated_text` too (pinned by existing tests).

## Fix
Before committing a global pause, `_pause_for_credits` **corroborates the text signal with a live Anthropic API probe** (`probe_credit_availability`) — ground truth: it returns `False` only when the API itself confirms exhaustion. If the probe says credits are available, the signal is treated as a false positive and **no pause is committed** (a `SYSTEM_ALERT` notes it).

- **Source-agnostic**: gates every pause trigger, not just diagnostic.
- **Fails open**: probe returns `True` on no-key/network error, so a flaky probe delays a *real* pause by at most one detection cycle rather than masking it.
- **Kill-switch**: `credit_pause_require_probe` (default `True`) → set `False` to revert to pause-on-text.

## Tests
- probe-available → pause skipped + alert; probe-confirms → pause proceeds; kill-switch → pause-on-text (probe not called).
- Updated the pre-existing pause/resume mechanics tests (unit + integration) to mock the probe as confirming exhaustion.
- Full `make quality` re-running as final confirmation.

Refs #9807

🤖 Generated with [Claude Code](https://claude.com/claude-code)