### PR TITLE
fix(adr-touchpoint-auditor): suppress ProcessLookupError from proc.kill() in reap path

### DIFF
--- a/src/adr_touchpoint_auditor_loop.py
+++ b/src/adr_touchpoint_auditor_loop.py
@@ -64,8 +64,12 @@ async def _communicate_bounded(
     try:
         return await asyncio.wait_for(proc.communicate(), timeout=_GH_TIMEOUT_SECONDS)
     except TimeoutError:
-        proc.kill()
+        # proc.kill() itself raises ProcessLookupError when the child already
+        # exited — suppress it too, not just proc.wait() — so the TimeoutError
+        # (the intended failed-read signal) propagates instead of crashing the
+        # caller with ProcessLookupError. (#9794/#9814)
         with contextlib.suppress(ProcessLookupError):
+            proc.kill()
             await proc.wait()
         raise
 

--- a/tests/regressions/test_reap_processlookuperror.py
+++ b/tests/regressions/test_reap_processlookuperror.py
@@ -46,6 +46,7 @@ class _DeadProc:
         ("flake_tracker_loop", "_GH_TIMEOUT_SECONDS"),
         ("rc_budget_loop", "_GH_TIMEOUT_SECONDS"),
         ("fake_coverage_auditor_loop", "_SUBPROCESS_TIMEOUT_SECONDS"),
+        ("adr_touchpoint_auditor_loop", "_GH_TIMEOUT_SECONDS"),
     ],
 )
 async def test_communicate_bounded_surfaces_timeout_not_processlookup(


### PR DESCRIPTION
## Summary

Closes #9656.

The issue reported `_list_recent_merged_prs`/`_reconcile_closed_escalations` in `AdrTouchpointAuditorLoop` as issuing unbounded `gh` subprocess reads. That literal claim is already fixed: both calls go through `_communicate_bounded`, which wraps `proc.communicate()` in `asyncio.wait_for(..., timeout=_GH_TIMEOUT_SECONDS)` (120s), and both fleet-wide AST regression guards (`tests/regressions/test_issue_9454.py`, `tests/regressions/test_issue_9508.py`) already cover this module and pass.

Digging into the same helper turned up a real, narrower gap instead: PR #9794/#9816 moved `proc.kill()` inside `contextlib.suppress(ProcessLookupError)` at 4 reap sites (`execution.py`, `fake_coverage_auditor_loop.py`, `flake_tracker_loop.py`, `rc_budget_loop.py`) so that a child which already exited between timeout and kill doesn't crash the loop with `ProcessLookupError` instead of surfacing the intended `TimeoutError`. `adr_touchpoint_auditor_loop.py`'s identical `_communicate_bounded` helper was not part of that sweep and still has `proc.kill()` outside the suppress block — the same crash class described in that PR ("a gh-timeout storm crashed ~6 loops").

- `src/adr_touchpoint_auditor_loop.py`: move `proc.kill()` inside `contextlib.suppress(ProcessLookupError)`, matching the hardened pattern in `flake_tracker_loop.py`/`rc_budget_loop.py`/`fake_coverage_auditor_loop.py`.
- `tests/regressions/test_reap_processlookuperror.py`: add `adr_touchpoint_auditor_loop` to the existing parametrized regression (drives `_communicate_bounded` with a proc that times out and is already-dead on kill; asserts `TimeoutError`, not `ProcessLookupError`) — this is the reintroduction guard the issue asked for.

## Test plan
- [x] `pytest tests/regressions/test_reap_processlookuperror.py` — 5/5 green (new case included)
- [x] `pytest tests/test_adr_touchpoint_auditor_loop.py tests/scenarios/test_adr_touchpoint_auditor_scenario.py tests/regressions/test_issue_9454.py tests/regressions/test_issue_9508.py` — all green
- [x] `make quality` — full suite (17872 tests) + lint/arch/security checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)