### PR TITLE
chore(audit): regression tests for #9857/#9869 + advance P10.3 baseline (unblock fix PRs)

### DIFF
--- a/.hydraflow-audit-baseline
+++ b/.hydraflow-audit-baseline
@@ -73,4 +73,19 @@
 #     makes pass. New product behavior (the terminal/council/decomposer) ships
 #     with unit + MockWorld-scenario + s54 sandbox e2e coverage.
 # Forward-enforcement restarts here.
-2026-07-13T02:12:00Z
+#
+# Reset 2026-07-18 (overnight stabilization, user-authorized): three fix(...)
+# commits landed tonight whose regression coverage is in test_*.py, not
+# tests/regressions/, so the P10.3 per-commit heuristic can't attribute them.
+# Proper tests/regressions/ tests for the two product fixes are added in the
+# same change; enumerated so this reset provably hides no untested work:
+#   - c24d1f0 fix(dependabot-merge): is_bot + factory branch-prefix selection
+#     (#9857) -> tests/regressions/test_issue_9843_botpr_merge_selection.py
+#     (also tests/test_dependabot_merge_loop.py, extensive).
+#   - 045a10b fix(credit-pause): live-probe corroboration (#9869) ->
+#     tests/regressions/test_issue_9807_credit_probe_false_positive.py
+#     (also tests/test_orchestrator_loops.py, tests/test_credit_pause.py).
+#   - ce6e609 fix(ui): benign credit-false-positive alert renders yellow
+#     (#9884) -> UI-only; covered by src/ui App.test.jsx severity assertions.
+# Forward-enforcement restarts here.
+2026-07-18T19:00:00Z

--- a/tests/regressions/test_issue_9807_credit_probe_false_positive.py
+++ b/tests/regressions/test_issue_9807_credit_probe_false_positive.py
@@ -1,0 +1,57 @@
+"""Regression: a false credit signal triggered a 5-hour GLOBAL pause (#9807,
+fixed in #9869).
+
+``is_credit_exhaustion`` matches credit-error *prose*, so a diagnostic/reviewer
+run that merely quoted a prior cap in its analysis raised ``CreditExhaustedError``
+and ``_pause_for_credits`` cancelled every loop for hours — while credits were
+actually fine.
+
+The fix corroborates the text-detected signal with a live API probe before
+committing a global pause: if ``probe_credit_availability`` reports credits are
+available, the signal is treated as a false positive and **no pause is
+committed**. This pins that behaviour (and the kill-switch that reverts it).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from orchestrator import HydraFlowOrchestrator
+from subprocess_util import CreditExhaustedError
+
+
+@pytest.mark.asyncio
+async def test_false_credit_signal_not_paused_when_probe_says_available(config) -> None:
+    """Quoted credit-error prose (probe reports available) must NOT pause."""
+    orch = HydraFlowOrchestrator(config)
+    orch._cancel_all_loops_and_runners = AsyncMock()  # type: ignore[method-assign]
+    tasks: dict[str, asyncio.Task[None]] = {}
+    factories: list = [("plan", AsyncMock())]
+    exc = CreditExhaustedError("Your credit balance is too low")
+
+    with patch("orchestrator.probe_credit_availability", AsyncMock(return_value=True)):
+        await orch._pause_for_credits(exc, "diagnostic", tasks, factories)
+
+    assert orch._credits_paused_until is None  # no global pause committed
+    orch._cancel_all_loops_and_runners.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_real_credit_out_still_pauses_when_probe_confirms(config) -> None:
+    """A genuine cap (probe reports exhausted) must still pause."""
+    orch = HydraFlowOrchestrator(config)
+    orch._cancel_all_loops_and_runners = AsyncMock()  # type: ignore[method-assign]
+    orch._sleep_until_resume = AsyncMock()  # type: ignore[method-assign]
+    orch._resume_loops_after_credit_pause = AsyncMock()  # type: ignore[method-assign]
+    tasks: dict[str, asyncio.Task[None]] = {}
+    factories: list = [("plan", AsyncMock())]
+    exc = CreditExhaustedError("usage limit reached")
+
+    with patch("orchestrator.probe_credit_availability", AsyncMock(return_value=False)):
+        await orch._pause_for_credits(exc, "plan", tasks, factories)
+
+    assert orch._credits_paused_until is not None  # pause committed
+    orch._cancel_all_loops_and_runners.assert_awaited_once()

--- a/tests/regressions/test_issue_9843_botpr_merge_selection.py
+++ b/tests/regressions/test_issue_9843_botpr_merge_selection.py
@@ -1,0 +1,54 @@
+"""Regression: DependabotMergeLoop merged nothing (#9843, fixed in #9857).
+
+Selection dropped every eligible bot PR:
+- ``gh --json author`` renders a GitHub App as ``app/dependabot``, which never
+  equals the configured ``dependabot[bot]`` — so even real Dependabot PRs were
+  skipped.
+- The UL/pricing/wiki maintenance loops open PRs under a *user* token
+  (``HydraOps-T-rav`` / ``T-rav``, ``is_bot=False``) on ``ul-*`` / ``pricing`` /
+  ``wiki`` branches that matched neither the author allowlist nor the
+  ``agent/auto-agent-`` prefix.
+
+The fix (#9857) detects bots via ``author.is_bot`` + a normalized author
+comparison + a set of factory-maintenance branch prefixes. This pins those two
+selection primitives so the flagship regression (loop selects zero PRs) can't
+silently return.
+"""
+
+from __future__ import annotations
+
+from dependabot_merge_loop import (
+    _FACTORY_MAINTENANCE_BRANCH_PREFIXES,
+    _normalize_author,
+)
+
+
+def test_app_prefixed_bot_login_matches_configured_bot() -> None:
+    """gh's ``app/dependabot`` must normalize to the same key as the configured
+    ``dependabot[bot]`` — otherwise real Dependabot PRs are never selected."""
+    assert _normalize_author("app/dependabot") == _normalize_author("dependabot[bot]")
+    assert _normalize_author("app/dependabot") == "dependabot"
+    # Case-insensitive + Renovate too.
+    assert _normalize_author("Renovate[bot]") == _normalize_author("app/renovate")
+
+
+def test_factory_maintenance_branches_are_selectable() -> None:
+    """Every UL/pricing/wiki maintenance branch namespace must be recognized so
+    those PRs (opened under a user token, ``is_bot=False``) get an auto-merge
+    path."""
+    for branch in (
+        "ul-proposer/abc123",
+        "ul-evidence/abc123",
+        "ul-edges/abc123",
+        "ul-pruner/abc123",
+        "pricing-refresh-auto",
+        "hydraflow/wiki-maint-20260718-1200",
+    ):
+        assert branch.startswith(_FACTORY_MAINTENANCE_BRANCH_PREFIXES), branch
+
+
+def test_human_and_lookalike_branches_not_selectable() -> None:
+    """Human branches (and ``ul-`` look-alikes without the exact prefix) must
+    NOT be auto-merge-selectable."""
+    for branch in ("fix/manual-thing", "agent/issue-42", "ul-cleanup-notes"):
+        assert not branch.startswith(_FACTORY_MAINTENANCE_BRANCH_PREFIXES), branch


### PR DESCRIPTION
## Problem
Tonight's stabilization fixes (#9857 merge-loop, #9869 credit-probe, #9884 yellow-alert) landed with tests in `test_*.py` but **not `tests/regressions/`**. The P10.3 audit is a *per-commit* check (does each `fix(...)` commit touch `tests/regressions/`?), so it can't attribute them → WARN (3/6 < 60%) → **every fix PR is blocked** (incl. #9884).

## Fix (per operator's choice — add the tests; the commits are immutable so also advance the baseline, as the file's precedent prescribes)
- **Real `tests/regressions/` coverage** for the two product fixes:
  - `test_issue_9843_botpr_merge_selection.py` — pins `is_bot` + normalized-author + factory branch-prefix selection (the #9857 fix).
  - `test_issue_9807_credit_probe_false_positive.py` — pins probe-corroborated pause (false signal → no pause; real cap → pause) (the #9869 fix).
- **Advance `.hydraflow-audit-baseline`** past tonight's commits with an enumerated justification (matching the file's established resets) — the 3 commits ARE tested, just not per-commit in `tests/regressions/`.

## Verification
`python -m scripts.hydraflow_audit .` → **P10 PASS 5 / WARN 0 / FAIL 0** (exit 0). New tests 5/5 pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)