### PR TITLE
fix(diagnostic): default DiagnosticLoop OFF — stops the credit-flood for good (#9895)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -559,7 +559,7 @@ _ENV_BOOL_OVERRIDES: list[tuple[str, str, bool]] = [
         True,
     ),
     ("dependabot_merge_loop_enabled", "HYDRAFLOW_DEPENDABOT_MERGE_LOOP_ENABLED", True),
-    ("diagnostic_loop_enabled", "HYDRAFLOW_DIAGNOSTIC_LOOP_ENABLED", True),
+    ("diagnostic_loop_enabled", "HYDRAFLOW_DIAGNOSTIC_LOOP_ENABLED", False),
     ("diagram_loop_enabled", "HYDRAFLOW_DIAGRAM_LOOP_ENABLED", True),
     ("entry_evidence_enabled", "HYDRAFLOW_ENTRY_EVIDENCE_ENABLED", True),
     ("epic_monitor_loop_enabled", "HYDRAFLOW_EPIC_MONITOR_LOOP_ENABLED", True),
@@ -3448,8 +3448,16 @@ class HydraFlowConfig(BaseModel):
         description="Deploy-time kill-switch for DependabotMergeLoop.",
     )
     diagnostic_loop_enabled: bool = Field(
-        default=True,
-        description="Deploy-time kill-switch for DiagnosticLoop.",
+        default=False,
+        description=(
+            "Deploy-time kill-switch for DiagnosticLoop. Defaulted OFF (#9895): "
+            "the loop analyzes failed-issue transcripts that quote credit-error "
+            "prose, so its streaming runner false-detects credit exhaustion on "
+            "nearly every run — tight-restart flooding the log + starving the "
+            "event loop (#9888), and cost_budget kept re-enabling the runtime "
+            "kill-switch. Re-enable only after #9879/#9888 and the "
+            "transcript-analysis credit-detection fix land."
+        ),
     )
     diagram_loop_enabled: bool = Field(
         default=True,

--- a/tests/regressions/test_issue_6474.py
+++ b/tests/regressions/test_issue_6474.py
@@ -46,6 +46,8 @@ def _make_diagnostic_loop(
 ) -> tuple[DiagnosticLoop, MagicMock]:
     """Build a DiagnosticLoop with its PRPort mock."""
     deps = make_bg_loop_deps(tmp_path, enabled=True)
+    # DiagnosticLoop defaults OFF (#9895); enable the kill-switch to exercise it.
+    object.__setattr__(deps.config, "diagnostic_loop_enabled", True)
 
     runner = MagicMock()
     runner.diagnose = AsyncMock()

--- a/tests/regressions/test_issue_6606.py
+++ b/tests/regressions/test_issue_6606.py
@@ -60,6 +60,9 @@ def _make_loop(
     Returns (loop, runner_mock, prs_mock, state_mock).
     """
     deps = make_bg_loop_deps(tmp_path, enabled=True)
+    # DiagnosticLoop now defaults OFF (#9895); these tests exercise its _do_work
+    # logic, so enable the deploy-time kill-switch for the test config.
+    object.__setattr__(deps.config, "diagnostic_loop_enabled", True)
 
     runner = MagicMock()
     runner.diagnose = AsyncMock(return_value=_make_diagnosis())

--- a/tests/regressions/test_issue_9895_diagnostic_default_off.py
+++ b/tests/regressions/test_issue_9895_diagnostic_default_off.py
@@ -1,0 +1,26 @@
+"""Regression: DiagnosticLoop credit-flood → default the loop OFF (#9895).
+
+DiagnosticLoop analyzes failed-issue *transcripts*, which quote credit-error
+prose ("usage limit reached", "credit balance is too low"). Its streaming
+runner's ``is_credit_exhaustion`` matched that quoted prose → a false
+``CreditExhaustedError`` on nearly every run → the orchestrator suppressed the
+pause (credit-probe fix) but the loop tight-restarted → a log flood (36k+ lines,
+550MB events.jsonl, event loop starved), plus event-loop blocking (#9879).
+
+Runtime kill-switches didn't hold: ``CostBudgetWatcher`` re-enabled the runtime
+bg-worker, and the base ``config.json`` override didn't reach the per-repo
+runtime's ``HydraFlowConfig`` (which inherited the default). The fix defaults the
+deploy-time kill-switch OFF so *every* config construction — base and per-repo
+runtime — inherits it, above the runtime enable (cost-budget-proof) and
+restart-proof. Re-enable only after #9879/#9888 + the transcript-analysis
+credit-detection fix land.
+"""
+
+from __future__ import annotations
+
+from config import HydraFlowConfig
+
+
+def test_diagnostic_loop_disabled_by_default() -> None:
+    """A fresh config (no override) must have the DiagnosticLoop kill-switch OFF."""
+    assert HydraFlowConfig().diagnostic_loop_enabled is False

--- a/tests/scenarios/fakes/mock_world.py
+++ b/tests/scenarios/fakes/mock_world.py
@@ -734,6 +734,14 @@ class MockWorld:
             sleep_fn=_counting_sleep,
         )
         config = bg.config
+        # The caller explicitly asked to run these loops, so enable any
+        # deploy-time kill-switch they gate on (e.g. diagnostic_loop_enabled
+        # defaults OFF, #9895). Otherwise _do_work short-circuits to
+        # config_disabled and the scenario can't exercise the loop.
+        for _name in loops:
+            _flag = f"{_name}_loop_enabled"
+            if hasattr(config, _flag):
+                object.__setattr__(config, _flag, True)
 
         # Persistent ports dict so catalog-allocated mocks survive across calls
         if not hasattr(self, "_loop_ports"):

--- a/tests/test_diagnostic_loop.py
+++ b/tests/test_diagnostic_loop.py
@@ -56,6 +56,9 @@ def _make_loop(
     Returns (loop, runner_mock, prs_mock, state_mock, workspaces_mock).
     """
     deps = make_bg_loop_deps(tmp_path, enabled=enabled)
+    # DiagnosticLoop now defaults OFF (#9895); these tests exercise its _do_work
+    # logic, so enable the deploy-time kill-switch for the test config.
+    object.__setattr__(deps.config, "diagnostic_loop_enabled", True)
 
     runner = MagicMock()
     runner.diagnose = AsyncMock(return_value=_make_diagnosis())


### PR DESCRIPTION
## Problem
The DiagnosticLoop analyzes failed-issue **transcripts**, which quote credit-error prose. Its streaming runner's `is_credit_exhaustion` matches that prose → false `CreditExhaustedError` on nearly every run → the orchestrator suppresses the pause (credit-probe fix) but the loop tight-restarts → **flood** (36k+ log lines in minutes, **550MB `events.jsonl`**, event loop starved, dashboard shows a "credit issue" that isn't real). Also blocks the event loop (#9879).

**Why runtime disables didn't hold:** `CostBudgetWatcher._reenable_caretakers` re-enables the runtime bg-worker; and the base `config.json` override of `diagnostic_loop_enabled` **doesn't reach the per-repo `T-rav-hydraflow` runtime's `HydraFlowConfig`**, which inherited the default `True`. (`load_runtime_config()` returns False, but the per-repo runtime constructs its own config.)

## Fix
Flip the **default** `diagnostic_loop_enabled` → `False` (both the env-tuple and the Field). The default is inherited by *every* `HydraFlowConfig` construction — base and per-repo runtime — and the config check (`diagnostic_loop.py:97`) sits under the runtime enable, so it's **cost-budget-proof and restart-proof**.

## Re-enable path (#9895)
Turn it back on only after: (1) transcript-analysis no longer triggers global credit detection, (2) the flood backoff #9888, (3) the event-loop block #9879.

## Verify
`HydraFlowConfig().diagnostic_loop_enabled == False`; ruff clean; full `make quality` running. No test asserts the old default.

Refs #9895, #9879, #9888

🤖 Generated with [Claude Code](https://claude.com/claude-code)