### PR TITLE
chore(audit): advance P10.3 baseline past e7c374e (squash sha of enumerated #9884)

### DIFF
--- a/.hydraflow-audit-baseline
+++ b/.hydraflow-audit-baseline
@@ -88,4 +88,16 @@
 #   - ce6e609 fix(ui): benign credit-false-positive alert renders yellow
 #     (#9884) -> UI-only; covered by src/ui App.test.jsx severity assertions.
 # Forward-enforcement restarts here.
-2026-07-18T19:00:00Z
+#
+# Reset 2026-07-18 (follow-up to the 19:00 reset above): the ce6e609 entry
+# enumerated #9884 by its branch sha, but the squash-merge minted a new
+# commit e7c374e (2026-07-18T20:07:45Z) on staging — after the 19:00 baseline
+# — so P10.3 re-flags the SAME already-enumerated change and blocks every PR
+# that syncs with staging. No new work is hidden by this advance:
+#   - e7c374e fix(ui): benign credit-false-positive alert renders yellow
+#     (#9884, squash of ce6e609) -> UI-only + alert-payload severity metadata;
+#     covered by src/ui App.test.jsx severity assertions (added in #9884) and
+#     the suppression path is pinned by
+#     tests/regressions/test_issue_9807_credit_probe_false_positive.py.
+# Forward-enforcement restarts here.
+2026-07-18T20:08:00Z


### PR DESCRIPTION
## Problem

The 19:00 baseline reset (#9892) enumerated #9884 by its **branch** sha `ce6e609`, but squash-merging #9884 minted a new commit `e7c374e` on staging at 20:07:45Z — after the baseline — so the P10.3 per-commit scan re-flags the **same already-enumerated change** and fails Principles Audit on every PR that syncs with staging. First casualty: #9896 (`1/2 fix commits since baseline ... (e7c374e)`); #9898 and any future fix PR hit it on their next branch update.

## Change

Advance `.hydraflow-audit-baseline` to `2026-07-18T20:08:00Z` with an enumerated justification block, per the file's precedent. No new work is hidden: e7c374e is UI + alert-payload severity metadata, covered by `src/ui` App.test.jsx severity assertions (added in #9884 itself) and the suppression path pinned by `tests/regressions/test_issue_9807_credit_probe_false_positive.py` (#9892).

## Lesson for the next reset

A baseline set **before** an enumerated fix PR merges will re-flag it under its new squash sha. Either date the baseline after the last enumerated PR's merge, or land the baseline advance after those PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)