### PR TITLE
chore(ci): fix core_python paths-filter — negations matched every file (#9908)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       python: ${{ steps.filter.outputs.python }}
-      core_python: ${{ steps.filter.outputs.core_python }}
+      core_python: ${{ steps.core_filter.outputs.core_python }}
       arch: ${{ steps.filter.outputs.arch }}
       scenario_tests: ${{ steps.filter.outputs.scenario_tests }}
       regression_tests: ${{ steps.filter.outputs.regression_tests }}
@@ -39,16 +39,6 @@ jobs:
             python:
               - 'src/**/*.py'
               - 'tests/**'
-              - 'pyproject.toml'
-              - 'uv.lock'
-            core_python:
-              - 'src/**/*.py'
-              - '!src/arch/**'
-              - 'tests/**'
-              - '!tests/architecture/**'
-              - '!tests/regressions/**'
-              - '!tests/scenarios/**'
-              - '!tests/sandbox_scenarios/**'
               - 'pyproject.toml'
               - 'uv.lock'
             arch:
@@ -92,6 +82,37 @@ jobs:
               - 'src/route_types.py'
               - 'tests/scenarios/browser/**'
               - 'tests/scenarios/fakes/mock_world.py'
+      # core_python lives in its OWN paths-filter step because it is the only
+      # filter with `!` negations, and negation semantics depend on the
+      # quantifier. Under the default `some`, each `!glob` independently
+      # matches every file NOT under glob — so `!src/arch/**` matched any
+      # docs file and core_python fired on EVERY PR (Tests/Smoke/Scenario ran
+      # on docs-only bot PRs; #9908). Under `every`, a file counts only if it
+      # matches ALL patterns: inside the brace-glob include AND outside each
+      # negated dir — the subtraction the filter always intended. The include
+      # must stay a single brace-glob: with `every`, separate include lines
+      # would demand a file match all of them at once (impossible).
+      - uses: dorny/paths-filter@v3
+        id: core_filter
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            core_python:
+              - '{src/**/*.py,tests/**,pyproject.toml,uv.lock}'
+              - '!src/arch/**'
+              - '!tests/architecture/**'
+              - '!tests/regressions/**'
+              - '!tests/scenarios/**'
+              - '!tests/sandbox_scenarios/**'
+      # Subset invariant: core_python ⊆ python by construction, so
+      # core_python=true with python=false can only mean filter semantics
+      # regressed (#9908's smoking gun). Fail loudly instead of silently
+      # running (or skipping) the wrong jobs.
+      - name: Filter subset invariant (core_python implies python)
+        if: steps.core_filter.outputs.core_python == 'true' && steps.filter.outputs.python != 'true'
+        run: |
+          echo "::error::core_python=true while python=false — paths-filter negation semantics regressed (see #9908)"
+          exit 1
 
   # Universal backstop (#9482): reject leftover git conflict markers on EVERY
   # PR/push, ungated by `changes` — a docs-only commit (e.g. a bot wiki write)


### PR DESCRIPTION
## Problem (#9908)

`dorny/paths-filter` under the default `predicate-quantifier: some` treats each `!glob` as an independent **everything-but** matcher — not a subtraction. `!src/arch/**` therefore matched any docs file, making `core_python` fire on **every PR**: Tests (~20 min), Smoke, Scenario, and Regression ran on docs-only bot PRs all day. Smoking gun (run 29660553674 on #9896): `Filter python = false` + `Filter core_python = true`, matched on `docs/wiki/terms/actuator.md` — impossible for a strict subset under correct semantics.

## Change

- `core_python` moves to its **own** `paths-filter` step with `predicate-quantifier: 'every'` and a single brace-glob include (`{src/**/*.py,tests/**,pyproject.toml,uv.lock}`) + the existing negations. Under `every`, a file counts only if it's inside the include AND outside every negated dir — the intended subtraction. (Own step because the quantifier is action-level; the other, negation-free filters keep `some`.)
- New **subset-invariant guard** step: fails Detect Changes if `core_python=true` while `python=false`, so this class of regression can never be silent again.

## Verification

- YAML parses; `changes` job outputs now read `core_python` from the new step.
- **In-PR evidence:** this PR touches only `.github/workflows/` — its own Detect Changes log should show `core_python = false` (old semantics showed `true` for any file). Jobs still run here via the `ci` filter, by design.
- **Post-merge evidence:** the next docs-only bot PR (ul-edges / wiki-maint) should SKIP Tests/Smoke/Scenario/Regression while Architecture Check still runs; the next `src/**` PR runs the full suite. Will attach run links on #9908.

Closes #9908

🤖 Generated with [Claude Code](https://claude.com/claude-code)