### PR TITLE
fix(sandbox): DiscoverRunner + ShapeRunner wedge the air-gapped sandbox — s51 never green, blocks every RC

### DIFF
--- a/src/discover_runner.py
+++ b/src/discover_runner.py
@@ -39,6 +39,19 @@ _ESCALATION_LABEL_STUCK = "discover-stuck"
 _ESCALATION_LABEL_HITL = "hitl-escalation"
 
 
+def _mockworld_sentinel_active(runner: DiscoverRunner) -> bool:
+    """True when the ADR-0063 MockWorld sentinel is attached to *runner*.
+
+    Under the sentinel the runner must NEVER dispatch a subprocess: in the
+    air-gapped docker sandbox a real ``claude -p`` spawn blocks for the full
+    ``agent_timeout``, wedging the discover phase loop mid-tick (frozen
+    heartbeat) and starving every scenario that routes an issue through
+    discover (#9796 — s51 failed every rc/* promotion this way).
+    """
+    fake_llm = getattr(runner, "_mockworld_fake_llm", None)
+    return fake_llm is not None and bool(getattr(fake_llm, "_is_fake_adapter", False))
+
+
 def _consume_mockworld_discover_script(
     runner: DiscoverRunner, issue_number: int
 ) -> tuple[bool, str, list[str]] | None:
@@ -273,6 +286,20 @@ class DiscoverRunner(BaseRunner):
         result = DiscoverResult(issue_number=task.id)
         transcript = ""
 
+        # MockWorld bypass (ADR-0063 sentinel): never spawn a subprocess in
+        # the sandbox. Without this, the air-gapped ``claude -p`` spawn blocks
+        # for the full agent_timeout and wedges the discover loop (#9796).
+        # ``_evaluate_brief`` still consumes any scripted coherence verdict,
+        # so failure-path scenarios keep working against this stub brief.
+        if _mockworld_sentinel_active(self):
+            result.research_brief = (
+                f"MockWorld discovery brief for issue #{task.id} (attempt "
+                f"{attempt}). Deterministic sandbox stub — no subprocess was "
+                f"dispatched."
+            )
+            result.opportunities = ["MockWorld sandbox stub"]
+            return result
+
         try:
             cmd = self._build_command()
             prompt = self._build_prompt(task, guidance=guidance)
@@ -373,6 +400,14 @@ class DiscoverRunner(BaseRunner):
         scripted = _consume_mockworld_discover_script(self, task.id)
         if scripted is not None:
             return scripted
+
+        # MockWorld fail-open (companion to the ``_run_discovery_once``
+        # bypass): a scenario that seeded no ``discover`` script must not
+        # fall through to a real evaluator subprocess — that spawn wedges
+        # the air-gapped sandbox exactly like the main discovery pass
+        # (#9796). Scripted verdicts were already consumed above.
+        if _mockworld_sentinel_active(self):
+            return True, "MockWorld sandbox: no scripted verdict — fail open", []
 
         skill = next((s for s in BUILTIN_SKILLS if s.name == _SKILL_NAME), None)
         if skill is None:

--- a/src/mockworld/sandbox_main.py
+++ b/src/mockworld/sandbox_main.py
@@ -312,6 +312,16 @@ async def main() -> None:
     expert_council = getattr(svc.shape_phase, "_council", None)
     if expert_council is not None:
         expert_council._mockworld_fake_llm = fake_llm  # type: ignore[attr-defined]
+    # ShapeRunner post-dates the ``runners=fake_llm`` rebinding seam (which
+    # covers only triage/plan/implement/review), so build_services constructs
+    # a REAL one whose ``run_turn`` subprocess wedges the air-gapped sandbox
+    # exactly like the DiscoverRunner spawn (#9796 — froze the shape loop
+    # heartbeat once discover was unblocked). Drop it to None: ShapePhase's
+    # no-runner path posts stub Direction A/B options and the scripted
+    # ExpertCouncil (sentinel attached above) selects the direction —
+    # mirroring the Tier-1 in-process harness, which wires no shape runner
+    # either (tests/scenarios/fakes/mock_world.py).
+    svc.shape_phase._runner = None
     spec_reviewer = getattr(svc.implementer, "_spec_reviewer", None)
     if spec_reviewer is not None:
         spec_reviewer._mockworld_fake_llm = fake_llm  # type: ignore[attr-defined]

--- a/tests/regressions/test_issue_9796_discover_sandbox_bypass.py
+++ b/tests/regressions/test_issue_9796_discover_sandbox_bypass.py
@@ -1,0 +1,127 @@
+"""Regression: DiscoverRunner wedged the sandbox discover loop (#9796/#9867).
+
+Every rc/* promotion since s51's introduction failed because
+``DiscoverRunner._run_discovery_once`` had NO MockWorld bypass: with the
+``_mockworld_fake_llm`` sentinel attached (docker sandbox, air-gapped
+network) it still spawned a real ``claude -p`` subprocess via
+``BaseRunner._execute``, which blocked for the full ``agent_timeout``.
+The discover phase loop wedged mid-tick (frozen ``last_run`` heartbeat),
+the issue never reached plan, and s51's two-LOOP-BACK oscillation
+snapshot never formed. ``_evaluate_brief`` had the same exposure when a
+scenario seeded no ``discover`` script (bypass returned None → real
+subprocess dispatch).
+
+These tests pin the sentinel contract: with ``_mockworld_fake_llm``
+attached, ``DiscoverRunner`` must NEVER dispatch a subprocess — the
+discovery pass returns a deterministic stub brief and an unscripted
+evaluator fails open. Scripted coherence verdicts keep working.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from discover_runner import DiscoverRunner
+from events import EventBus
+from models import Task
+
+
+def _make_task(issue_id: int = 1) -> Task:
+    return Task(
+        id=issue_id,
+        title="Investigate recurring churn in auth module",
+        body="Needs discovery first.",
+        tags=[],
+        comments=[],
+        source_url="",
+        links=[],
+        complexity_score=0,
+        created_at="",
+        metadata={},
+    )
+
+
+class _FakeLLMSentinel:
+    """Minimal stand-in for mockworld.fakes.fake_llm.FakeLLM."""
+
+    _is_fake_adapter = True
+
+    def __init__(self, scripted: list[object] | None = None) -> None:
+        self._scripted = list(scripted or [])
+
+    def pop_discover_script(self, issue_number: int) -> object | None:
+        _ = issue_number
+        if self._scripted:
+            return self._scripted.pop(0)
+        return None
+
+
+def _make_runner(config, *, max_attempts: int = 2) -> DiscoverRunner:
+    config.max_discover_attempts = max_attempts
+    config.max_discover_expansions = 0
+    config.repo_root = Path("/tmp")
+    config.dry_run = False
+    runner = DiscoverRunner(config=config, event_bus=MagicMock(spec=EventBus))
+    # Any subprocess dispatch under the sentinel is the regression.
+    runner._execute = AsyncMock(  # type: ignore[method-assign]
+        side_effect=AssertionError(
+            "DiscoverRunner dispatched a subprocess despite the "
+            "_mockworld_fake_llm sentinel — this wedges the air-gapped sandbox"
+        )
+    )
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_discover_never_spawns_subprocess_under_sentinel(config) -> None:
+    """Sentinel attached → discover() completes with a stub brief, zero spawns."""
+    runner = _make_runner(config)
+    runner._mockworld_fake_llm = _FakeLLMSentinel()  # type: ignore[attr-defined]
+
+    result = await runner.discover(_make_task())
+
+    assert result.research_brief  # deterministic stub, never empty
+    runner._execute.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_unscripted_evaluator_fails_open_under_sentinel(config) -> None:
+    """No scripted coherence verdict → evaluator passes without dispatching."""
+    runner = _make_runner(config)
+    runner._mockworld_fake_llm = _FakeLLMSentinel()  # type: ignore[attr-defined]
+
+    passed, summary, findings = await runner._evaluate_brief(_make_task(), "stub brief")
+
+    assert passed is True
+    assert findings == []
+    assert summary  # explains the fail-open so operators can grep it
+    runner._execute.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_scripted_coherence_failure_still_consumed_under_sentinel(
+    config,
+) -> None:
+    """A seeded coherence rejection still drives the retry path unchanged."""
+    from mockworld.fakes.fake_llm import FakeLLM
+
+    fake = FakeLLM()
+    fake.script_discover(
+        1,
+        coherent=False,
+        queries_required=[],
+        summary="scripted coherence rejection",
+        findings=["missing user research"],
+    )
+    runner = _make_runner(config)
+    runner._mockworld_fake_llm = fake  # type: ignore[attr-defined]
+
+    passed, summary, findings = await runner._evaluate_brief(_make_task(), "stub brief")
+
+    assert passed is False
+    assert summary == "scripted coherence rejection"
+    assert findings == ["missing user research"]
+    runner._execute.assert_not_awaited()  # type: ignore[attr-defined]

--- a/tests/sandbox_scenarios/scenarios/s51_convergence_oscillation.py
+++ b/tests/sandbox_scenarios/scenarios/s51_convergence_oscillation.py
@@ -36,8 +36,11 @@ PIPELINE ROUTE THAT PRODUCES BOTH LOOP_BACKs SIMULTANEOUSLY
 2. Triage scripts ``needs_discovery=True`` → routing outcome ``"discover"`` →
    ``_TRIAGE_VERDICT_MAP["discover"] == "LOOP_BACK"`` recorded for stage
    ``"triage"``.  Issue gets ``hydraflow-discover`` label.
-3. DiscoverPhase runs with no real runner (sandbox) → stub brief → routes
-   issue to ``hydraflow-shape``.
+3. DiscoverPhase runs its DiscoverRunner under the MockWorld sentinel
+   (``_mockworld_fake_llm``) → the ``_run_discovery_once`` bypass returns a
+   deterministic stub brief with NO subprocess spawn, and the unscripted
+   evaluator fails open (#9796 — a real spawn wedges the air-gapped
+   sandbox for the full agent_timeout) → routes issue to ``hydraflow-shape``.
 4. ShapePhase runs with a shape runner (FakeSubprocessRunner, success) and
    the ExpertCouncil wired up via ``expert_council._mockworld_fake_llm``.
    ``phase_scripts={"shape_council": {1: {1: "consensus"}}}`` returns


### PR DESCRIPTION
## Problem (#9796 / #9867)

s51_convergence_oscillation has failed **every** rc/* full-suite run since its introduction on July 1 (#9683) — 3/3 today — keeping `main` frozen. It was born broken and invisible: its own PR ran only the fast subset, and the nightly sandbox checks out `ref: main` (separate defect, see #9796 comment thread).

**Root cause:** `DiscoverRunner` and `ShapeRunner` post-date the `runners=fake_llm` rebinding seam in `build_services` (it covers only triage/plan/implement/review), so the docker sandbox constructs REAL runners:
- `DiscoverRunner._run_discovery_once` had no MockWorld bypass (only the evaluator/expander did) → real `claude -p` spawn blocks for the full `agent_timeout` under the air gap → **discover loop wedges mid-tick** (frozen heartbeat, `discovered: 0`). `_evaluate_brief` had the same exposure when no `discover` script was seeded.
- Once discover was fixed, `ShapeRunner.run_turn` wedged the shape loop identically (`shaped: 0`, frozen heartbeat).

## Fix

- Sentinel-guard both `DiscoverRunner` dispatch sites: `_run_discovery_once` returns a deterministic stub brief; an unscripted `_evaluate_brief` fails open. Scripted coherence verdicts are consumed exactly as before.
- `sandbox_main` drops `ShapePhase._runner` to `None` — the no-runner path posts stub Direction options and the scripted `ExpertCouncil` selects, mirroring the Tier-1 in-process harness (which wires no shape runner either).
- s51 docstring premise corrected.

## Verification

- Local docker: s51 reproduced **FAILED** on unfixed staging, **PASSES in 56s** with this fix (staging CI can't show this — s51 only runs on rc/* PRs).
- `tests/regressions/test_issue_9796_discover_sandbox_bypass.py` pins sentinel ⇒ zero subprocess spawns (fails red on pre-fix code).
- Full `make quality`: 17,884 passed / 1 ratchet failure fixed by dropping an unnecessary noqa; ratchet + ruff re-verified green.

## Follow-up worth its own issue

`runners=fake_llm` silently excludes every runner added after the original four — the next new phase runner will repeat this bug class. Candidate for the #9792 harness work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)