### PR TITLE
fix(ci-gate): don't block RC auto-merge on advisory (non-required) checks (#9910)

### DIFF
--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -2510,6 +2510,51 @@ class PRManager:
             return False, f"Failed checks: {', '.join(str(n) for n in failed)}"
         return True, f"All {len(checks)} checks passed"
 
+    async def _advisory_failures_only(self, pr_number: int) -> bool:
+        """Return True if only advisory (non-required) checks are non-passing.
+
+        ``_evaluate_ci_checks`` counts *every* non-passing check as a failure,
+        but a check that is not in the base branch's required-status-check set
+        must not block the merge — GitHub already allows it. Rather than parse
+        the base branch's ruleset (``main`` uses a ruleset, not classic branch
+        protection), we consult GitHub's own verdict: when all *required*
+        checks pass and only advisory checks fail, GitHub reports
+        ``mergeable=MERGEABLE`` with ``mergeStateStatus=UNSTABLE``. Any other
+        state — or an unreadable response — returns False (fail-closed) so a
+        real required-check failure never merges by accident. See #9910.
+        """
+        if self._config.dry_run:
+            return False
+        try:
+            raw = await self._run_gh(
+                "gh",
+                "pr",
+                "view",
+                str(pr_number),
+                "--repo",
+                self._repo,
+                "--json",
+                "mergeable,mergeStateStatus",
+            )
+        except Exception:  # noqa: BLE001 — fail-closed: any probe error keeps the failure verdict
+            logger.debug(
+                "Could not fetch merge-state for PR #%d (advisory-check gate)",
+                pr_number,
+                exc_info=True,
+            )
+            return False
+        try:
+            data = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return False
+        mergeable = str(data.get("mergeable", "")).upper()
+        merge_state = str(data.get("mergeStateStatus", "")).upper()
+        return mergeable == "MERGEABLE" and merge_state in {
+            "CLEAN",
+            "UNSTABLE",
+            "HAS_HOOKS",
+        }
+
     async def wait_for_ci(
         self,
         pr_number: int,
@@ -2578,6 +2623,24 @@ class PRManager:
                     continue
 
             passed, msg = verdict
+            if not passed and await self._advisory_failures_only(pr_number):
+                advisory = [
+                    c["name"]
+                    for c in checks
+                    if c.get("state", "").upper() not in self._PASSING_STATES
+                ]
+                logger.info(
+                    "PR #%d: all required checks satisfied; %d advisory "
+                    "check(s) failing but non-blocking "
+                    "(mergeStateStatus=UNSTABLE): %s",
+                    pr_number,
+                    len(advisory),
+                    ", ".join(advisory),
+                )
+                passed, msg = (
+                    True,
+                    f"Required checks passed; advisory failing: {', '.join(advisory)}",
+                )
             data: CICheckPayload = CICheckPayload(
                 pr=pr_number,
                 status="passed" if passed else "failed",

--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -2536,7 +2536,8 @@ class PRManager:
                 "--json",
                 "mergeable,mergeStateStatus",
             )
-        except Exception:  # noqa: BLE001 — fail-closed: any probe error keeps the failure verdict
+        # Fail-closed: any probe error keeps the failure verdict.
+        except Exception:
             logger.debug(
                 "Could not fetch merge-state for PR #%d (advisory-check gate)",
                 pr_number,

--- a/tests/regressions/test_issue_9910_advisory_checks_nonblocking.py
+++ b/tests/regressions/test_issue_9910_advisory_checks_nonblocking.py
@@ -1,0 +1,104 @@
+"""Regression: RC/merge CI gate must not block on advisory checks (#9910).
+
+``wait_for_ci`` treated ANY non-passing check as a failure, so an *advisory*
+check — one NOT in the base branch's required-status-check set — blocked
+``StagingPromotionLoop`` from auto-merging RC promotion PRs even though GitHub
+itself reported them ``MERGEABLE``. The concrete trigger was the ``CodeQL``
+github-advanced-security check on ``main`` (a ruleset that does not require
+it): a false-positive alert failed that advisory check on every staging->main
+RC, stalling promotion for ~12 days.
+
+The fix consults GitHub's own ``mergeStateStatus``: when all *required* checks
+are satisfied and only advisory checks fail, GitHub reports
+``mergeable=MERGEABLE`` + ``mergeStateStatus=UNSTABLE``, so ``wait_for_ci``
+treats the run as passed (advisory failures reported, not blocking). GitHub is
+the authority on which contexts are required (rulesets included), so no
+ruleset parsing is needed. Fail-closed: a required-check failure yields
+``mergeStateStatus=BLOCKED`` and still fails the gate, and an
+undeterminable merge-state never merges on uncertainty.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tests.helpers import make_pr_manager
+
+
+def _merge_state_json(mergeable: str, mss: str) -> str:
+    return json.dumps({"mergeable": mergeable, "mergeStateStatus": mss})
+
+
+@pytest.mark.asyncio
+async def test_advisory_failure_with_unstable_mergestate_passes(config, event_bus):
+    """Required green + advisory red + mergeStateStatus=UNSTABLE → passed=True."""
+    mgr = make_pr_manager(config, event_bus)
+    mgr.get_pr_checks = AsyncMock(
+        return_value=[
+            {"name": "Tests", "state": "SUCCESS"},
+            {"name": "CodeQL", "state": "FAILURE"},
+        ]
+    )
+    mgr._run_gh = AsyncMock(return_value=_merge_state_json("MERGEABLE", "UNSTABLE"))
+
+    passed, msg = await mgr.wait_for_ci(
+        123, timeout=30, poll_interval=1, stop_event=asyncio.Event()
+    )
+
+    assert passed is True
+    assert "CodeQL" in msg  # advisory failure still surfaced in the summary
+
+
+@pytest.mark.asyncio
+async def test_required_failure_with_blocked_mergestate_fails(config, event_bus):
+    """A required check red + mergeStateStatus=BLOCKED → passed=False."""
+    mgr = make_pr_manager(config, event_bus)
+    mgr.get_pr_checks = AsyncMock(return_value=[{"name": "Tests", "state": "FAILURE"}])
+    mgr._run_gh = AsyncMock(return_value=_merge_state_json("MERGEABLE", "BLOCKED"))
+
+    passed, msg = await mgr.wait_for_ci(
+        123, timeout=30, poll_interval=1, stop_event=asyncio.Event()
+    )
+
+    assert passed is False
+    assert "Tests" in msg
+
+
+@pytest.mark.asyncio
+async def test_advisory_failure_but_unknown_mergestate_fails_closed(config, event_bus):
+    """Undeterminable merge-state → fail closed (never merge on uncertainty)."""
+    mgr = make_pr_manager(config, event_bus)
+    mgr.get_pr_checks = AsyncMock(
+        return_value=[
+            {"name": "Tests", "state": "SUCCESS"},
+            {"name": "CodeQL", "state": "FAILURE"},
+        ]
+    )
+    mgr._run_gh = AsyncMock(return_value=_merge_state_json("UNKNOWN", "UNKNOWN"))
+
+    passed, _ = await mgr.wait_for_ci(
+        123, timeout=30, poll_interval=1, stop_event=asyncio.Event()
+    )
+
+    assert passed is False
+
+
+@pytest.mark.asyncio
+async def test_all_required_pass_no_merge_state_probe(config, event_bus):
+    """All checks green → passed=True WITHOUT probing merge-state (no advisory
+    override path needed; the probe only fires on a failure)."""
+    mgr = make_pr_manager(config, event_bus)
+    mgr.get_pr_checks = AsyncMock(return_value=[{"name": "Tests", "state": "SUCCESS"}])
+    mgr._run_gh = AsyncMock(
+        side_effect=AssertionError("merge-state must not be probed on all-green")
+    )
+
+    passed, _ = await mgr.wait_for_ci(
+        123, timeout=30, poll_interval=1, stop_event=asyncio.Event()
+    )
+
+    assert passed is True


### PR DESCRIPTION
Fixes #9910.

## Problem
`PRManager.wait_for_ci` (via `_evaluate_ci_checks`) treated **any** non-passing check as a failure — it did not distinguish *required* from *advisory* (non-required) status checks. So an advisory check failing blocked `StagingPromotionLoop` from auto-merging RC promotion PRs **even though GitHub itself reported them `MERGEABLE`**.

Concrete trigger: the `CodeQL` github-advanced-security check on `main` (a **ruleset** that does not require it). A false-positive CodeQL alert failed that advisory check on every staging→main RC, stalling promotion for ~12 days.

## Fix
Consult GitHub's own `mergeStateStatus`. When all **required** checks pass and only advisory checks fail, GitHub reports `mergeable=MERGEABLE` + `mergeStateStatus=UNSTABLE`. In that case `wait_for_ci` treats the run as **passed** (advisory failures still surfaced in the summary + `CICheckPayload` event, just non-blocking).

GitHub is the authority on which contexts are required — this handles **rulesets** natively, with no fragile ruleset/branch-protection parsing. (`main` isn't classic-protected; the branch-protection API 404s.)

**Fail-closed:** any other merge-state (`BLOCKED`, `UNKNOWN`, `DIRTY`, …) or an unreadable/failed probe keeps the failure verdict — a real required-check failure never merges by accident.

## Changes
- `src/pr_manager.py`: new `_advisory_failures_only(pr_number)` helper; wired into `wait_for_ci`'s verdict path (only probes on a failure, never on all-green).

## Tests
Regression tests in `tests/regressions/test_issue_9910_advisory_checks_nonblocking.py`:
- advisory-fail + `UNSTABLE`/`MERGEABLE` → **passes** (advisory name surfaced in summary)
- required-fail + `BLOCKED` → **fails** (real failures still block)
- undeterminable merge-state → **fail-closed**
- all-green → passes **without** probing merge-state

All 4 pass; `test_pr_manager_core.py`, `test_review_phase_ci.py`, `test_staging_promotion_loop.py` (248 tests) green. Pre-commit lint + arch-check passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)