### PR TITLE
fix(credit): restart crashed loop on a probe-refuted credit signal — stop the hot-loop/alert-storm (#9924)

### DIFF
--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -1095,8 +1095,19 @@ class HydraFlowOrchestrator:
         tasks: dict[str, asyncio.Task[None]],
         loop_factories: list[tuple[str, Callable[[], Coroutine[Any, Any, None]]]],
     ) -> None:
-        """Delegate to _pause_for_credits."""
-        await self._pause_for_credits(exc, loop_name, tasks, loop_factories)
+        """Pause on a corroborated credit signal; otherwise restart the loop.
+
+        A probe-refuted (false-positive) signal must not leave the crashed
+        loop's completed-with-exception task orphaned in ``_supervise_loops``'s
+        task map: the supervisor would re-observe the same dead task every
+        iteration and hot-loop the credit handler (alert storm), and the phase
+        would stay permanently dead. Recreating the task via ``_restart_loop``
+        — the same path used for any other loop crash — kills the hot loop and
+        self-heals the phase. See #9924.
+        """
+        paused = await self._pause_for_credits(exc, loop_name, tasks, loop_factories)
+        if not paused:
+            await self._restart_loop(loop_name, exc, tasks, loop_factories)
 
     async def _restart_loop(
         self,
@@ -1736,11 +1747,16 @@ class HydraFlowOrchestrator:
         source: str,
         tasks: dict[str, asyncio.Task[None]],
         loop_factories: list[tuple[str, Callable[[], Coroutine[Any, Any, None]]]],
-    ) -> None:
+    ) -> bool:
         """Pause all loops until API credits reset, then restart them.
 
         Uses ``asyncio.Lock`` to prevent multiple loops from racing into
         the pause logic simultaneously.
+
+        Returns ``True`` when a pause is committed (or one is already active) —
+        the crashed task will be recreated by the resume path — and ``False``
+        when the probe refutes the signal as a false positive and no pause
+        happens, so the caller must restart the crashed loop itself (#9924).
         """
         async with self._credit_pause_lock:
             # If another loop already triggered a pause, skip
@@ -1748,7 +1764,7 @@ class HydraFlowOrchestrator:
                 self._credits_paused_until is not None
                 and self._credits_paused_until > datetime.now(UTC)
             ):
-                return
+                return True
 
             # Corroborate the text-detected signal with a live API probe before
             # committing a GLOBAL pause. ``is_credit_exhaustion`` matches
@@ -1786,7 +1802,7 @@ class HydraFlowOrchestrator:
                         },
                     )
                 )
-                return
+                return False
 
             resume_at = self._compute_resume_time(exc)
             self._credits_paused_until = resume_at
@@ -1819,9 +1835,10 @@ class HydraFlowOrchestrator:
         if self._stop_event.is_set():
             self._credits_paused_until = None
             self._credit_resume_event.clear()
-            return
+            return True
 
         await self._resume_loops_after_credit_pause(tasks, loop_factories, source)
+        return True
 
     async def _resume_loops_after_credit_pause(
         self,

--- a/tests/regressions/test_issue_9924_credit_false_positive_restart.py
+++ b/tests/regressions/test_issue_9924_credit_false_positive_restart.py
@@ -1,0 +1,81 @@
+"""Regression: a non-corroborated credit signal orphaned the crashed loop,
+hot-looping the supervisor and killing the phase (#9924).
+
+``_pause_for_credits``'s "not corroborated / false positive" branch returned
+without recreating the crashed loop's task. The completed-with-exception task
+stayed in ``_supervise_loops``'s ``tasks`` dict, so the supervisor re-observed
+the same dead task every iteration → re-ran the credit handler in a tight hot
+loop (an alert storm, ~9 WARNING lines in one second) and left the phase (e.g.
+``plan``) permanently dead — no restart ever happened. The alert storm is what
+prompted the operator "Stop" that took the whole factory (all repos) down.
+
+The fix: ``_pause_for_credits`` returns whether it paused; on a false positive
+``_handle_credit_exhaustion`` restarts the loop via ``_restart_loop`` — exactly
+like any other transient crash — so the task is recreated (no orphan, no hot
+loop, no dead phase), bounded by the poll interval on the next cycle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from orchestrator import HydraFlowOrchestrator
+from subprocess_util import CreditExhaustedError
+
+
+async def _noop_loop() -> None:
+    await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_false_positive_restarts_loop_not_orphaned(config) -> None:
+    """Probe says available → the crashed loop's task is RECREATED, not orphaned."""
+    orch = HydraFlowOrchestrator(config)
+    orch._cancel_all_loops_and_runners = AsyncMock()  # type: ignore[method-assign]
+
+    old = asyncio.create_task(_noop_loop())
+    await old  # simulate the crashed-and-completed 'plan' task
+    tasks: dict[str, asyncio.Task[None]] = {"plan": old}
+    factories: list = [("plan", _noop_loop)]
+    exc = CreditExhaustedError("Your credit balance is too low")
+
+    with patch("orchestrator.probe_credit_availability", AsyncMock(return_value=True)):
+        await orch._handle_credit_exhaustion(exc, "plan", tasks, factories)
+
+    assert tasks["plan"] is not old  # restarted — not left pointing at the dead task
+    assert orch._credits_paused_until is None  # no global pause committed
+    tasks["plan"].cancel()
+    await asyncio.gather(tasks["plan"], return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_pause_for_credits_returns_false_on_false_positive(config) -> None:
+    """``_pause_for_credits`` reports False (not paused) when the probe says available."""
+    orch = HydraFlowOrchestrator(config)
+    orch._cancel_all_loops_and_runners = AsyncMock()  # type: ignore[method-assign]
+    factories: list = [("plan", _noop_loop)]
+    exc = CreditExhaustedError("usage limit reached")
+
+    with patch("orchestrator.probe_credit_availability", AsyncMock(return_value=True)):
+        paused = await orch._pause_for_credits(exc, "plan", {}, factories)
+
+    assert paused is False
+
+
+@pytest.mark.asyncio
+async def test_pause_for_credits_returns_true_on_real_exhaustion(config) -> None:
+    """``_pause_for_credits`` reports True (paused) when the probe confirms exhaustion."""
+    orch = HydraFlowOrchestrator(config)
+    orch._cancel_all_loops_and_runners = AsyncMock()  # type: ignore[method-assign]
+    orch._sleep_until_resume = AsyncMock()  # type: ignore[method-assign]
+    orch._resume_loops_after_credit_pause = AsyncMock()  # type: ignore[method-assign]
+    factories: list = [("plan", _noop_loop)]
+    exc = CreditExhaustedError("usage limit reached")
+
+    with patch("orchestrator.probe_credit_availability", AsyncMock(return_value=False)):
+        paused = await orch._pause_for_credits(exc, "plan", {}, factories)
+
+    assert paused is True


### PR DESCRIPTION
Fixes #9924.

## Problem
A non-corroborated (probe says credits are fine) `CreditExhaustedError` left the crashed loop **orphaned**: `_pause_for_credits`'s "false positive" branch returned **without recreating the task**. The completed-with-exception task stayed in `_supervise_loops`'s `tasks` dict, so the supervisor re-observed the same dead task every iteration and re-ran the credit handler in a **tight hot loop** — the "~9 WARNING lines in one second" alert storm — while leaving the phase (`plan`) **permanently dead**.

Every *other* crash path recreates the task (`_restart_loop`, `_resume_loops_after_credit_pause`); only the false-positive branch forgot to. The alert storm is what prompted the operator **Stop** (the only thing that calls `registry.stop_all()`) that took the whole factory — all repos — down ~every 1.5h overnight.

## Fix
- `_pause_for_credits` now returns `bool`: `True` when a pause is committed (or already active — the resume path recreates the task), `False` when the probe refutes the signal and no pause happens.
- `_handle_credit_exhaustion` restarts the loop via the existing `_restart_loop` helper when it was a false positive — **symmetric with the other crash paths**.

Result: a false-positive credit signal is fully non-fatal — no orphan, no hot loop, no dead phase, no alert storm (so nothing prompts the Stop). Retries are bounded by `poll_interval` on the next cycle instead of an unbounded spin.

Root cause confirmed by a full trace of the credit-signal → stop path.

## Tests
`tests/regressions/test_issue_9924_credit_false_positive_restart.py`:
- false positive → the crashed loop's task is **recreated** (not the orphaned dead one) + no global pause
- `_pause_for_credits` returns `False` on false positive, `True` on a probe-confirmed real exhaustion

All green; `test_credit_pause.py`, `test_issue_9807_credit_probe_false_positive.py`, `test_orchestrator_loops.py`, `test_orchestrator_integration.py` all pass. Pre-commit lint + arch-check passed.

## Follow-up (not in this PR)
The trace flagged a latent risk: `probe_credit_availability()` deliberately lets a malformed-response bug propagate, which would escape `_handle_loop_exception` uncaught and kill one orchestrator. Separate, lower-probability hardening — worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)