### PR TITLE
chore(sandbox): quarantine s55_nested_decompose pending #9925 race fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,13 +397,16 @@ jobs:
           python-version: "3.11"
       - run: pip install uv && uv pip install --system -e ".[dev]"
       - run: docker compose -f docker-compose.sandbox.yml build hydraflow ui playwright
-      - name: Run fast subset (s01, s06, s53)
+      - name: Run fast subset (s01, s06, s53, s54)
         run: |
           # Run every scenario and aggregate failures — do NOT early-exit on the
           # first red, or a broken leading scenario (e.g. s01, #9754) silently
           # hides the status of the ones after it. Report which failed.
+          # s55_nested_decompose is QUARANTINED (#9925, born-racy) — keep this
+          # list in sync with the scenario-file markers until the loader drives
+          # this step's selection too.
           rc=0
-          for s in s01_happy_single_issue s06_kill_switch_via_ui s53_model_routing_settings_ui s54_decompose_to_converge s55_nested_decompose; do
+          for s in s01_happy_single_issue s06_kill_switch_via_ui s53_model_routing_settings_ui s54_decompose_to_converge; do
             if python scripts/sandbox_scenario.py run "$s"; then
               echo "::notice::sandbox $s PASSED"
             else

--- a/tests/sandbox_scenarios/runner/loader.py
+++ b/tests/sandbox_scenarios/runner/loader.py
@@ -4,12 +4,23 @@ from __future__ import annotations
 
 import importlib
 import pkgutil
+import sys
 from pathlib import Path
 from types import ModuleType
 
 
-def load_all_scenarios() -> list[ModuleType]:
-    """Import every s*.py module under tests/sandbox_scenarios/scenarios/."""
+def load_all_scenarios(*, include_quarantined: bool = False) -> list[ModuleType]:
+    """Import every s*.py module under tests/sandbox_scenarios/scenarios/.
+
+    A scenario module may declare ``QUARANTINED = "#<issue>"`` to pull itself
+    out of COLLECTIVE runs (run-all, the CI fast subset's parametrization)
+    while a tracked defect makes its signal unreliable. Quarantined scenarios
+    are skipped LOUDLY (one stderr line naming the tracking issue) so the gap
+    in coverage is visible in every log, and they remain runnable one-off via
+    ``sandbox_scenario.py run <name>`` / ``include_quarantined=True`` for
+    debugging. The marker must die with its tracking issue — removing it is
+    part of that issue's acceptance criteria.
+    """
     import tests.sandbox_scenarios.scenarios as scenarios_pkg
 
     out: list[ModuleType] = []
@@ -18,5 +29,13 @@ def load_all_scenarios() -> list[ModuleType]:
         if not name.startswith("s"):
             continue
         mod = importlib.import_module(f"tests.sandbox_scenarios.scenarios.{name}")
+        marker = getattr(mod, "QUARANTINED", None)
+        if marker and not include_quarantined:
+            print(
+                f"[scenario-loader] QUARANTINED scenario skipped: {name} "
+                f"(tracking {marker})",
+                file=sys.stderr,
+            )
+            continue
         out.append(mod)
     return sorted(out, key=lambda m: m.NAME)

--- a/tests/sandbox_scenarios/runner/test_scenarios.py
+++ b/tests/sandbox_scenarios/runner/test_scenarios.py
@@ -13,8 +13,15 @@ import pytest
 from tests.sandbox_scenarios.runner.loader import load_all_scenarios
 
 # Filter out s00_smoke — that's parity-only (no assert_outcome).
-_SCENARIOS = [s for s in load_all_scenarios() if hasattr(s, "assert_outcome")]
+# An explicit SCENARIO_NAME request (the ``run <name>`` CLI path) overrides
+# quarantine: a human debugging a quarantined scenario must still be able to
+# run it one-off; only COLLECTIVE runs honor the marker.
 _ONLY = os.environ.get("SCENARIO_NAME")
+_SCENARIOS = [
+    s
+    for s in load_all_scenarios(include_quarantined=bool(_ONLY))
+    if hasattr(s, "assert_outcome")
+]
 if _ONLY:
     _SCENARIOS = [s for s in _SCENARIOS if s.NAME == _ONLY]
 

--- a/tests/sandbox_scenarios/scenarios/s55_nested_decompose.py
+++ b/tests/sandbox_scenarios/scenarios/s55_nested_decompose.py
@@ -27,6 +27,15 @@ import json
 from mockworld.seed import MockWorldSeed
 
 NAME = "s55_nested_decompose"
+
+# Born-racy: the review-convergence escalation → hop-2 decompose handoff is
+# nondeterministic (~80% red 2026-07-18; blocked every rc/* promotion and all
+# staging code PRs). Full evidence dossier, mitigation design, and the
+# real-fix acceptance bar (10 consecutive green docker runs) live in #9925.
+# REMOVING this marker is part of #9925's acceptance criteria — do not remove
+# it without the race fix. Collective runs (run-all, CI fast subset) exclude
+# this scenario LOUDLY; explicit `run s55_nested_decompose` still works.
+QUARANTINED = "#9925"
 DESCRIPTION = (
     "Depth-2 nested decompose: a stalled decomposed child re-decomposes and the "
     "root epic converges via epic-to-epic lineage."

--- a/tests/test_sandbox_scenario_contract.py
+++ b/tests/test_sandbox_scenario_contract.py
@@ -124,9 +124,23 @@ def test_sandbox_scenarios_are_not_placeholders(module_name: str) -> None:
 def test_sandbox_runner_catalog_matches_scenario_files() -> None:
     from tests.sandbox_scenarios.runner.loader import load_all_scenarios
 
-    discovered = {module.NAME for module in load_all_scenarios()}
+    # Full-catalog integrity: every scenario file on disk must be importable
+    # and enumerable — a quarantined scenario is still part of the catalog
+    # (it stays runnable one-off), it is only excluded from COLLECTIVE runs.
+    full = {module.NAME for module in load_all_scenarios(include_quarantined=True)}
     expected = set(_scenario_module_names())
-    assert discovered == expected
+    assert full == expected
+
+    # Collective-run set == catalog minus the explicitly quarantined modules.
+    # Quarantine semantics (marker format, loud skip, exact hidden set) are
+    # pinned in tests/test_sandbox_scenario_quarantine.py.
+    quarantined = {
+        module.NAME
+        for module in load_all_scenarios(include_quarantined=True)
+        if getattr(module, "QUARANTINED", None)
+    }
+    collective = {module.NAME for module in load_all_scenarios()}
+    assert collective == expected - quarantined
 
 
 def test_every_tier2_scenario_has_assert_outcome_except_smoke() -> None:

--- a/tests/test_sandbox_scenario_quarantine.py
+++ b/tests/test_sandbox_scenario_quarantine.py
@@ -1,0 +1,51 @@
+"""Quarantine contract for sandbox scenarios (#9925).
+
+A scenario module may declare ``QUARANTINED = "#<issue>"`` to pull itself out
+of collective runs (``run-all``, the CI fast subset) while a tracked defect
+makes its signal unreliable. These tests pin the contract so a quarantine can
+neither silently widen (marker without a tracking-issue reference) nor
+silently leak back into collective runs.
+"""
+
+from __future__ import annotations
+
+import re
+
+from tests.sandbox_scenarios.runner.loader import load_all_scenarios
+
+_MARKER_RE = re.compile(r"^#\d+$")
+
+
+def test_collective_load_excludes_quarantined_scenarios() -> None:
+    names = {m.NAME for m in load_all_scenarios()}
+    quarantined = {m.NAME for m in load_all_scenarios(include_quarantined=True)} - names
+    for name in quarantined:
+        assert name not in names
+    assert "s55_nested_decompose" in quarantined  # #9925 — drop with the fix
+
+
+def test_explicit_load_includes_quarantined_scenarios() -> None:
+    names = {m.NAME for m in load_all_scenarios(include_quarantined=True)}
+    assert "s55_nested_decompose" in names
+
+
+def test_every_quarantine_marker_references_a_tracking_issue() -> None:
+    for mod in load_all_scenarios(include_quarantined=True):
+        marker = getattr(mod, "QUARANTINED", None)
+        if marker is None:
+            continue
+        assert isinstance(marker, str) and _MARKER_RE.match(marker), (
+            f"{mod.NAME}: QUARANTINED must be an issue reference like '#9925', "
+            f"got {marker!r} — an untracked quarantine is silent coverage loss"
+        )
+
+
+def test_quarantine_does_not_hide_more_than_the_known_set() -> None:
+    all_mods = load_all_scenarios(include_quarantined=True)
+    collective = load_all_scenarios()
+    hidden = {m.NAME for m in all_mods} - {m.NAME for m in collective}
+    assert hidden == {"s55_nested_decompose"}, (
+        f"unexpected quarantine set {hidden} — adding a quarantine requires "
+        f"updating this pin (and a tracking issue), removing one means the "
+        f"fix landed: update both here"
+    )


### PR DESCRIPTION
## Why

s55_nested_decompose is born-racy (~80% red today; full evidence dossier in #9925) and sits in BOTH CI gates — it is the only blocker for #9919, every staging code PR, and rc/* promotion. Operator-approved quarantine (Travis, this session).

## Mechanism

- `QUARANTINED = "#9925"` marker on the scenario module — removing it is part of #9925's acceptance criteria (10 consecutive green docker runs on the race fix).
- `load_all_scenarios` skips quarantined scenarios in COLLECTIVE runs with a loud stderr line naming the issue; `include_quarantined=True` + the `SCENARIO_NAME` path keep explicit `run s55...` debugging fully working.
- ci.yml fast list drops s55; step name finally matches the actual list (s01, s06, s53, s54).
- `tests/test_sandbox_scenario_quarantine.py` pins the contract: marker must reference an issue, hidden set is exactly {s55}, explicit loads still include it.
- `test_sandbox_scenario_contract.py` catalog check now validates the FULL catalog (quarantined included — no orphan files) plus collective = catalog − quarantined, preserving the no-silently-ignored-tests intent.

## Verification

Full `make quality` green (17,884 passed). Quarantine + contract suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)