### PR TITLE
chore(wiki): maintenance 2026-07-19

### DIFF
--- a/repo_wiki/T-rav/hydraflow/gotchas/0112-issue-synthesis-error-tolerance-tests-must-cover-creditexhausteder.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0112-issue-synthesis-error-tolerance-tests-must-cover-creditexhausteder.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.596516+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Error-tolerance tests must cover CreditExhaustedError re-raise

--- a/repo_wiki/T-rav/hydraflow/gotchas/0113-issue-synthesis-use-type-checking-guards-for-forward-reference-ann.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0113-issue-synthesis-use-type-checking-guards-for-forward-reference-ann.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.596937+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Use TYPE_CHECKING guards for forward-reference annotations

--- a/repo_wiki/T-rav/hydraflow/gotchas/0114-issue-synthesis-update-emit-trace-command-strings-when-migrating-s.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0114-issue-synthesis-update-emit-trace-command-strings-when-migrating-s.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.597490+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Update _emit_trace command strings when migrating subprocess to Port

--- a/repo_wiki/T-rav/hydraflow/gotchas/0115-issue-synthesis-grep-for-runtime-references-before-removing-an-imp.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0115-issue-synthesis-grep-for-runtime-references-before-removing-an-imp.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.597919+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Grep for runtime references before removing an import

--- a/repo_wiki/T-rav/hydraflow/gotchas/0116-issue-synthesis-use-is-none-is-not-none-for-optional-sentinels.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0116-issue-synthesis-use-is-none-is-not-none-for-optional-sentinels.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.598263+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Use `is None` / `is not None` for optional sentinels

--- a/repo_wiki/T-rav/hydraflow/gotchas/0117-issue-synthesis-sync-all-protocol-implementations-in-one-pr-on-sig.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0117-issue-synthesis-sync-all-protocol-implementations-in-one-pr-on-sig.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.598607+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Sync all protocol implementations in one PR on signature change

--- a/repo_wiki/T-rav/hydraflow/gotchas/0118-issue-synthesis-delete-code-blocks-bottom-to-top-to-avoid-line-num.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0118-issue-synthesis-delete-code-blocks-bottom-to-top-to-avoid-line-num.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.598949+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Delete code blocks bottom-to-top to avoid line-number shifting

--- a/repo_wiki/T-rav/hydraflow/gotchas/0119-issue-synthesis-patch-functions-at-their-definition-site-not-the-i.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0119-issue-synthesis-patch-functions-at-their-definition-site-not-the-i.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.599284+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Patch functions at their definition site, not the import site

--- a/repo_wiki/T-rav/hydraflow/gotchas/0120-issue-synthesis-verify-a-file-exists-before-writing-a-plan-task-th.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0120-issue-synthesis-verify-a-file-exists-before-writing-a-plan-task-th.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.599625+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Verify a file exists before writing a plan task that modifies it

--- a/repo_wiki/T-rav/hydraflow/gotchas/0121-issue-synthesis-test-pydantic-serialization-with-round-trip-and-sa.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0121-issue-synthesis-test-pydantic-serialization-with-round-trip-and-sa.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.599965+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Test Pydantic serialization with round-trip AND save/load tests

--- a/repo_wiki/T-rav/hydraflow/gotchas/0122-issue-synthesis-run-full-make-quality-before-declaring-implementat.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0122-issue-synthesis-run-full-make-quality-before-declaring-implementat.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.600296+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Run full `make quality` before declaring implementation complete

--- a/repo_wiki/T-rav/hydraflow/gotchas/0123-issue-synthesis-use-log-exception-with-bug-classification-for-bugs.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0123-issue-synthesis-use-log-exception-with-bug-classification-for-bugs.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.600638+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Use `log_exception_with_bug_classification()` for bugs vs transient

--- a/repo_wiki/T-rav/hydraflow/gotchas/0124-issue-synthesis-use-logger-warning-exc-info-true-for-transient-err.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0124-issue-synthesis-use-logger-warning-exc-info-true-for-transient-err.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.600969+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Use `logger.warning(..., exc_info=True)` for transient errors

--- a/repo_wiki/T-rav/hydraflow/gotchas/0125-issue-synthesis-catch-both-timeoutexpired-and-calledprocesserror-t.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0125-issue-synthesis-catch-both-timeoutexpired-and-calledprocesserror-t.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.601308+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Catch both TimeoutExpired and CalledProcessError — they're siblings

--- a/repo_wiki/T-rav/hydraflow/gotchas/0126-issue-synthesis-omitting-await-on-async-calls-silently-returns-a-c.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0126-issue-synthesis-omitting-await-on-async-calls-silently-returns-a-c.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.601630+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Omitting `await` on async calls silently returns a coroutine

--- a/repo_wiki/T-rav/hydraflow/gotchas/0127-issue-synthesis-store-asyncio-create-task-results-unreferenced-tas.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0127-issue-synthesis-store-asyncio-create-task-results-unreferenced-tas.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.601967+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Store `asyncio.create_task()` results — unreferenced tasks are GC'd

--- a/repo_wiki/T-rav/hydraflow/gotchas/0128-issue-synthesis-new-pydantic-fields-must-have-defaults-for-existin.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0128-issue-synthesis-new-pydantic-fields-must-have-defaults-for-existin.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.602321+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # New Pydantic fields must have defaults for existing state compat

--- a/repo_wiki/T-rav/hydraflow/gotchas/0129-issue-synthesis-use-atomic-write-instead-of-path-write-text-for-js.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0129-issue-synthesis-use-atomic-write-instead-of-path-write-text-for-js.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.602663+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Use `atomic_write()` instead of `Path.write_text()` for JSON state

--- a/repo_wiki/T-rav/hydraflow/gotchas/0130-issue-synthesis-use-typeddict-total-false-for-backward-compatible-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0130-issue-synthesis-use-typeddict-total-false-for-backward-compatible-.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.602997+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Use `TypedDict(total=False)` for backward-compatible payloads

--- a/repo_wiki/T-rav/hydraflow/gotchas/0131-issue-synthesis-new-hydraflowconfig-label-fields-must-be-optional-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0131-issue-synthesis-new-hydraflowconfig-label-fields-must-be-optional-.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.603354+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # New HydraFlowConfig label fields must be optional in ConfigFactory

--- a/repo_wiki/T-rav/hydraflow/gotchas/0132-issue-synthesis-reverse-state-transitions-on-non-fatal-exceptions-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0132-issue-synthesis-reverse-state-transitions-on-non-fatal-exceptions-.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.603703+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Reverse state transitions on non-fatal exceptions to avoid stuck

--- a/repo_wiki/T-rav/hydraflow/gotchas/0133-issue-synthesis-use-same-id-extraction-logic-everywhere-files-are-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0133-issue-synthesis-use-same-id-extraction-logic-everywhere-files-are-.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.604047+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Use same ID extraction logic everywhere files are keyed by issue

--- a/repo_wiki/T-rav/hydraflow/gotchas/0134-issue-synthesis-join-factory-pipeline-metrics-by-issue-number-not-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0134-issue-synthesis-join-factory-pipeline-metrics-by-issue-number-not-.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.604390+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Join factory pipeline metrics by issue_number, not pr_number

--- a/repo_wiki/T-rav/hydraflow/gotchas/0135-issue-synthesis-test-pipeline-stage-ordering-not-just-status-after.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0135-issue-synthesis-test-pipeline-stage-ordering-not-just-status-after.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.604760+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Test pipeline stage ordering, not just status, after inserting stage

--- a/repo_wiki/T-rav/hydraflow/gotchas/0136-issue-synthesis-filter-evicted-memories-on-both-content-prefix-and.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0136-issue-synthesis-filter-evicted-memories-on-both-content-prefix-and.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.605110+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Filter evicted memories on both content prefix AND metadata status

--- a/repo_wiki/T-rav/hydraflow/gotchas/0137-issue-synthesis-new-automated-skills-must-start-with-blocking-fals.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0137-issue-synthesis-new-automated-skills-must-start-with-blocking-fals.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.605452+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # New automated skills must start with blocking=False until stable

--- a/repo_wiki/T-rav/hydraflow/gotchas/0138-issue-synthesis-validate-parsers-against-realistic-multi-paragraph.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0138-issue-synthesis-validate-parsers-against-realistic-multi-paragraph.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.606095+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Validate parsers against realistic multi-paragraph agent output

--- a/repo_wiki/T-rav/hydraflow/gotchas/0139-issue-synthesis-log-warning-on-zero-match-transcript-extraction-fr.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0139-issue-synthesis-log-warning-on-zero-match-transcript-extraction-fr.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.606538+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Log warning on zero-match transcript extraction from non-empty input

--- a/repo_wiki/T-rav/hydraflow/gotchas/0140-issue-synthesis-use-portable-shell-commands-in-alpine-containers-p.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0140-issue-synthesis-use-portable-shell-commands-in-alpine-containers-p.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.606982+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Use portable shell commands in Alpine containers — Python is absent

--- a/repo_wiki/T-rav/hydraflow/gotchas/0141-issue-synthesis-separate-silent-with-result-events-from-purely-sil.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0141-issue-synthesis-separate-silent-with-result-events-from-purely-sil.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.607378+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Separate silent-with-result events from purely silent in dispatch

--- a/repo_wiki/T-rav/hydraflow/gotchas/0142-issue-synthesis-create-a-specialized-method-rather-than-overloadin.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0142-issue-synthesis-create-a-specialized-method-rather-than-overloadin.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.607769+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Create a specialized method rather than overloading a general one

--- a/repo_wiki/T-rav/hydraflow/gotchas/0143-issue-synthesis-ruff-strips-unused-imports-mid-tdd-cycle.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0143-issue-synthesis-ruff-strips-unused-imports-mid-tdd-cycle.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.608144+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Ruff strips unused imports mid-TDD cycle

--- a/repo_wiki/T-rav/hydraflow/gotchas/0144-issue-synthesis-verify-implementation-files-are-in-the-diff-before.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0144-issue-synthesis-verify-implementation-files-are-in-the-diff-before.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.608510+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Verify implementation files are in the diff before merging

--- a/repo_wiki/T-rav/hydraflow/gotchas/0145-issue-synthesis-coverage-delta-gate-is-asymmetric-gaps-block-clean.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0145-issue-synthesis-coverage-delta-gate-is-asymmetric-gaps-block-clean.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:54:44.608905+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0078,0079,0080,0081,0082,0083,0084,0085,0086,0087,0088,0089,0090,0091,0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111
+superseded_by: 0146
 ---
 
 # Coverage-delta gate is asymmetric: gaps block, clean defers to LLM

--- a/repo_wiki/T-rav/hydraflow/gotchas/0146-issue-synthesis-error-tolerance-tests-must-cover-creditexhausteder.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0146-issue-synthesis-error-tolerance-tests-must-cover-creditexhausteder.md
@@ -1,0 +1,18 @@
+---
+id: 0146
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.947225+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Error-tolerance tests must cover CreditExhaustedError re-raise
+
+When testing that a loop tolerates port failures, always include a second case asserting `CreditExhaustedError` is *not* swallowed.
+
+Example: `port.side_effect = CreditExhaustedError("exhausted")` followed by `with pytest.raises(CreditExhaustedError): await loop._reconcile(...)`. See `test_review_phase_core.py:1919`.
+
+**Why:** `reraise_on_credit_or_bug` is a load-bearing call mandated by CLAUDE.md; testing only the swallow path leaves the re-raise contract unchecked.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0147-issue-synthesis-use-type-checking-guards-for-forward-reference-ann.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0147-issue-synthesis-use-type-checking-guards-for-forward-reference-ann.md
@@ -1,0 +1,18 @@
+---
+id: 0147
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.947592+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Use TYPE_CHECKING guards for forward-reference annotations
+
+Use `from __future__ import annotations` with `TYPE_CHECKING` guards for forward-reference type annotations.
+
+Example: `if TYPE_CHECKING: from mymodule import MyType` keeps the import from executing at runtime.
+
+**Why:** Without the guard the symbol is evaluated at import time, creating circular imports or `ImportError` in modules that aren't always available.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0148-issue-synthesis-update-emit-trace-command-strings-when-migrating-s.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0148-issue-synthesis-update-emit-trace-command-strings-when-migrating-s.md
@@ -1,0 +1,18 @@
+---
+id: 0148
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.947899+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Update _emit_trace command strings when migrating subprocess to Port
+
+After replacing a `gh`/subprocess call with a Port method, update any `_emit_trace` or telemetry command strings to reflect the new surface.
+
+Example: Old: `command=["gh", "issue", "list", "--label", "wiki-rot-stuck"]`. New: `PRPort.list_closed_issues_by_label("wiki-rot-stuck", limit=50)`.
+
+**Why:** Observability consumers rely on command strings to diagnose failures; stale strings misdirect operators toward subprocess debugging when the actual call path is a Port method.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0149-issue-synthesis-grep-for-runtime-references-before-removing-an-imp.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0149-issue-synthesis-grep-for-runtime-references-before-removing-an-imp.md
@@ -1,0 +1,18 @@
+---
+id: 0149
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.948195+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Grep for runtime references before removing an import
+
+Before deleting an import, grep the file for runtime uses: `isinstance()` calls, variable assignments, and decorator calls.
+
+Example: `grep -n 'MyClass' src/foo.py` — a hit in `isinstance(x, MyClass)` means the import is load-bearing even if type checkers flag it as unused.
+
+**Why:** Ruff's `F401` rule does not inspect `isinstance` call sites; removing an apparently-unused import that is used at runtime produces `NameError`.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0150-issue-synthesis-use-is-none-is-not-none-for-optional-sentinels.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0150-issue-synthesis-use-is-none-is-not-none-for-optional-sentinels.md
@@ -1,0 +1,18 @@
+---
+id: 0150
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.948484+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Use `is None` / `is not None` for optional sentinels
+
+Prefer identity checks (`is None`, `is not None`) over equality checks for optional objects, especially callables and stores.
+
+Example: `if callback is None: return` — not `if callback == None`.
+
+**Why:** Identity checks are O(1) and immune to overridden `__eq__`; equality checks against `None` can accidentally match falsy custom objects with a permissive `__eq__`.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0151-issue-synthesis-sync-all-protocol-implementations-in-one-pr-on-sig.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0151-issue-synthesis-sync-all-protocol-implementations-in-one-pr-on-sig.md
@@ -1,0 +1,18 @@
+---
+id: 0151
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.948967+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Sync all protocol implementations in one PR on signature change
+
+When a port or protocol method signature changes, update every concrete implementation atomically in the same PR — never staggered across tasks.
+
+Example: adding `ctx: Context` to `def process(self, item)` requires changing every class implementing the protocol before merging.
+
+**Why:** Staggered updates leave implementations out of sync with the protocol, causing Pyright errors that block CI until every site is updated.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0152-issue-synthesis-delete-code-blocks-bottom-to-top-to-avoid-line-num.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0152-issue-synthesis-delete-code-blocks-bottom-to-top-to-avoid-line-num.md
@@ -1,0 +1,18 @@
+---
+id: 0152
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.949329+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Delete code blocks bottom-to-top to avoid line-number shifting
+
+When removing multiple code blocks from the same file in a single session, delete the lowest block first (highest line number) and work upward.
+
+Example: delete lines 120–130 before deleting lines 80–90; reversing the order shifts targets for the second deletion.
+
+**Why:** Deleting a higher block shifts all lower line numbers; later deletions then target wrong lines or miss content entirely.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0153-issue-synthesis-patch-functions-at-their-definition-site-not-the-i.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0153-issue-synthesis-patch-functions-at-their-definition-site-not-the-i.md
@@ -1,0 +1,18 @@
+---
+id: 0153
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.949658+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Patch functions at their definition site, not the import site
+
+Always patch functions at where they are defined, not where they are imported into the module under test.
+
+Example: `@patch('hindsight.retain_safe')` not `@patch('my_module.retain_safe')` when `my_module` imports from `hindsight`.
+
+**Why:** Patching the import site only replaces that module's local reference; all other callers continue using the real function, making the mock ineffective.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0154-issue-synthesis-verify-a-file-exists-before-writing-a-plan-task-th.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0154-issue-synthesis-verify-a-file-exists-before-writing-a-plan-task-th.md
@@ -1,0 +1,18 @@
+---
+id: 0154
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.949956+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Verify a file exists before writing a plan task that modifies it
+
+Before adding a plan task that edits a specific file, confirm the file exists via `git ls-files <path>` or grep.
+
+Example: `git ls-files src/shared_prompt_prefix.py` returns empty → file never existed; update the plan before implementation starts.
+
+**Why:** Planning tasks against nonexistent files wastes implementation work and causes confusing "file not found" failures mid-execution.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0155-issue-synthesis-test-pydantic-serialization-with-round-trip-and-sa.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0155-issue-synthesis-test-pydantic-serialization-with-round-trip-and-sa.md
@@ -1,0 +1,18 @@
+---
+id: 0155
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.950246+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Test Pydantic serialization with round-trip AND save/load tests
+
+Validate Pydantic models with both a `model_dump_json() → model_validate_json()` round-trip and a full save/load cycle.
+
+Example: a JSON round-trip catches field-name mismatches; a save/load test catches type coercion surprises from JSONL storage.
+
+**Why:** JSON round-trips can pass while save/load fails due to type coercion or missing `model_config` settings at the persistence layer.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0156-issue-synthesis-run-full-make-quality-before-declaring-implementat.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0156-issue-synthesis-run-full-make-quality-before-declaring-implementat.md
@@ -1,0 +1,18 @@
+---
+id: 0156
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.950536+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Run full `make quality` before declaring implementation complete
+
+Always run the full `make quality` gate — never a file-targeted test subset — before declaring a task done.
+
+Example: `pytest tests/test_foo.py` passes; `make quality` reveals 7 failures in `test_audit_prompts.py` caused by the same change.
+
+**Why:** Targeted runs miss cross-module regressions; cleanup PRs have higher blast radius than their diffs suggest.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0157-issue-synthesis-use-log-exception-with-bug-classification-for-bugs.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0157-issue-synthesis-use-log-exception-with-bug-classification-for-bugs.md
@@ -1,0 +1,18 @@
+---
+id: 0157
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.950853+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Use `log_exception_with_bug_classification()` for bugs vs transient
+
+Use `log_exception_with_bug_classification()` or `is_likely_bug()` to distinguish bug exceptions from transient errors.
+
+Example: in `finally` blocks use `log_exception_with_bug_classification(exc)` rather than `reraise`, to preserve finally semantics while still classifying.
+
+**Why:** Logging all exceptions as bugs floods Sentry with transient noise; wrong classification makes signal-to-noise ratio useless.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0158-issue-synthesis-use-logger-warning-exc-info-true-for-transient-err.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0158-issue-synthesis-use-logger-warning-exc-info-true-for-transient-err.md
@@ -1,0 +1,18 @@
+---
+id: 0158
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.951139+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Use `logger.warning(..., exc_info=True)` for transient errors
+
+Log transient operational failures with `logger.warning(msg, exc_info=True)`. Reserve `logger.exception()` for genuine bugs.
+
+Example: `except (OSError, httpx.NetworkError) as exc: logger.warning('fetch failed', exc_info=True)`.
+
+**Why:** When migrating from `logger.exception()` to `logger.warning()`, forgetting `exc_info=True` silently drops the traceback, making failures undebuggable.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0159-issue-synthesis-catch-both-timeoutexpired-and-calledprocesserror-t.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0159-issue-synthesis-catch-both-timeoutexpired-and-calledprocesserror-t.md
@@ -1,0 +1,18 @@
+---
+id: 0159
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.951432+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Catch both TimeoutExpired and CalledProcessError — they're siblings
+
+Catch `subprocess.TimeoutExpired` and `subprocess.CalledProcessError` in separate `except` clauses.
+
+Example: `except subprocess.TimeoutExpired: handle_timeout()` followed by `except subprocess.CalledProcessError: handle_failure()`.
+
+**Why:** `TimeoutExpired` is not a subclass of `CalledProcessError`; a single `except CalledProcessError` silently misses timeouts, letting them propagate unhandled.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0160-issue-synthesis-omitting-await-on-async-calls-silently-returns-a-c.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0160-issue-synthesis-omitting-await-on-async-calls-silently-returns-a-c.md
@@ -1,0 +1,18 @@
+---
+id: 0160
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.951729+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Omitting `await` on async calls silently returns a coroutine
+
+Always `await` async method calls; storing an unawaited coroutine silently never executes its body.
+
+Example: `result = fetch_data()` stores a `Coroutine` object; `result = await fetch_data()` executes it.
+
+**Why:** Unawaited coroutines silently no-op; Pyright only catches them at `make typecheck` time when call sites have annotations.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0161-issue-synthesis-store-asyncio-create-task-results-unreferenced-tas.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0161-issue-synthesis-store-asyncio-create-task-results-unreferenced-tas.md
@@ -1,0 +1,18 @@
+---
+id: 0161
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.952040+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Store `asyncio.create_task()` results — unreferenced tasks are GC'd
+
+Assign every `asyncio.create_task()` result to a set and add a done callback for error logging.
+
+Example: `self._tasks.add(t := asyncio.create_task(work())); t.add_done_callback(self._tasks.discard)`.
+
+**Why:** Tasks without a live reference are garbage-collected mid-execution, silently dropping their work and exceptions with no observable signal.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0162-issue-synthesis-new-pydantic-fields-must-have-defaults-for-existin.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0162-issue-synthesis-new-pydantic-fields-must-have-defaults-for-existin.md
@@ -1,0 +1,18 @@
+---
+id: 0162
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.952326+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# New Pydantic fields must have defaults for existing state compat
+
+Add new fields to Pydantic models as `field: Type = default_value` — never as required fields — so existing serialized state files continue to deserialize.
+
+Example: `retry_count: int = 0` allows old state JSONs that lack the key to load without error.
+
+**Why:** A required field with no default causes `ValidationError` on every existing persisted object, breaking recovery from saved state on the first restart after deploy.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0163-issue-synthesis-use-atomic-write-instead-of-path-write-text-for-js.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0163-issue-synthesis-use-atomic-write-instead-of-path-write-text-for-js.md
@@ -1,0 +1,18 @@
+---
+id: 0163
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.952620+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Use `atomic_write()` instead of `Path.write_text()` for JSON state
+
+Write JSON state files via `file_util.atomic_write()`, not `Path.write_text()`.
+
+Example: `atomic_write(state_path, json_str)` writes to a `.tmp` sibling then renames atomically — a crash mid-write leaves the original intact.
+
+**Why:** `Path.write_text()` truncates before writing; a crash mid-operation produces a zero-byte or partial JSON that fails to parse on restart, corrupting persisted state.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0164-issue-synthesis-use-typeddict-total-false-for-backward-compatible-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0164-issue-synthesis-use-typeddict-total-false-for-backward-compatible-.md
@@ -1,0 +1,18 @@
+---
+id: 0164
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.952918+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Use `TypedDict(total=False)` for backward-compatible payloads
+
+Define event payload TypedDicts with `total=False` so all fields are optional, allowing old producers and new consumers to interoperate.
+
+Example: `class MergePayload(TypedDict, total=False): pr_number: int; labels: list[str]`.
+
+**Why:** A `total=True` TypedDict requires all fields; adding a new field breaks any existing producer that doesn't include it, preventing rolling deployments.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0165-issue-synthesis-new-hydraflowconfig-label-fields-must-be-optional-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0165-issue-synthesis-new-hydraflowconfig-label-fields-must-be-optional-.md
@@ -1,0 +1,18 @@
+---
+id: 0165
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.953224+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# New HydraFlowConfig label fields must be optional in ConfigFactory
+
+When adding a `list[str]` label field to `HydraFlowConfig`, add it as an optional `ConfigFactory.create()` parameter with a sensible default.
+
+Example: omitting the parameter causes `TypeError: create() got an unexpected keyword argument` in every test fixture that constructs a config.
+
+**Why:** `ConfigFactory.create()` is called across the entire test suite; missing parameters break all tests that construct a config without the new field.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0166-issue-synthesis-reverse-state-transitions-on-non-fatal-exceptions-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0166-issue-synthesis-reverse-state-transitions-on-non-fatal-exceptions-.md
@@ -1,0 +1,18 @@
+---
+id: 0166
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.953518+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Reverse state transitions on non-fatal exceptions to avoid stuck
+
+Wrap label-swap + operation + cleanup in a try/except that reverses the transition on non-fatal errors.
+
+Example: if a label is swapped `plan → implement` but the API call fails, swap it back to `plan` before re-raising.
+
+**Why:** An exception after a successful state transition but before cleanup leaves issues stuck in intermediate states with no automated recovery path.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0167-issue-synthesis-use-same-id-extraction-logic-everywhere-files-are-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0167-issue-synthesis-use-same-id-extraction-logic-everywhere-files-are-.md
@@ -1,0 +1,18 @@
+---
+id: 0167
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.953808+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Use same ID extraction logic everywhere files are keyed by issue
+
+Define ID prefix lengths as named constants and centralize extraction so every site that keys files by issue uses identical logic.
+
+Example: define `DISCOVER_PREFIX_LEN = 9`; use it in both the writer and the reader rather than hardcoding `fname[9:]` in each.
+
+**Why:** Inconsistent ID logic causes silent lookup failures — a plan is written under key A but read back under key B, producing phantom missing plans.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0168-issue-synthesis-join-factory-pipeline-metrics-by-issue-number-not-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0168-issue-synthesis-join-factory-pipeline-metrics-by-issue-number-not-.md
@@ -1,0 +1,18 @@
+---
+id: 0168
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.954098+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Join factory pipeline metrics by issue_number, not pr_number
+
+When correlating factory metrics or reviews across pipeline tables, join on `issue_number` rather than `pr_number`.
+
+Example: a PR can be closed and recreated with a new number; `issue_number` is stable across the full lifecycle.
+
+**Why:** `pr_number` changes when PRs are recycled; joining on it silently drops or duplicates records for any issue where the PR was recreated.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0169-issue-synthesis-test-pipeline-stage-ordering-not-just-status-after.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0169-issue-synthesis-test-pipeline-stage-ordering-not-just-status-after.md
@@ -1,0 +1,18 @@
+---
+id: 0169
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.954402+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Test pipeline stage ordering, not just status, after inserting stage
+
+After inserting a new stage into `PIPELINE_STAGES`, assert both that the stage's status value is correct and that its array index is correct.
+
+Example: inserting a stage at index 2 shifts all downstream indices; a test checking only `status == 'active'` passes while skip-detection silently breaks.
+
+**Why:** Index-based progression logic produces incorrect skip decisions when stages are reordered, with no immediate test failure.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0170-issue-synthesis-filter-evicted-memories-on-both-content-prefix-and.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0170-issue-synthesis-filter-evicted-memories-on-both-content-prefix-and.md
@@ -1,0 +1,18 @@
+---
+id: 0170
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.954722+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Filter evicted memories on both content prefix AND metadata status
+
+Apply dual filters when loading recalled memories: check both the `[EVICTED]` content prefix and `status: evicted` in metadata before injecting into prompts.
+
+Example: `if mem.content.startswith('[EVICTED]') or mem.metadata.get('status') == 'evicted': skip`.
+
+**Why:** A single filter has a failure path; if one guard is missing or malformed, a tombstone leaks into agent prompts and produces confusing or incorrect agent behavior.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0171-issue-synthesis-new-automated-skills-must-start-with-blocking-fals.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0171-issue-synthesis-new-automated-skills-must-start-with-blocking-fals.md
@@ -1,0 +1,18 @@
+---
+id: 0171
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.955021+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# New automated skills must start with blocking=False until stable
+
+Register new dynamic skills with `blocking=False` and graduate to `blocking=True` only after ≥20 runs at ≥95% success rate.
+
+Example: a new lint-skill marked `blocking=True` on day one fails builds on edge cases the author didn't anticipate.
+
+**Why:** Unproven blocking skills immediately break CI on legitimate code; graduated promotion ensures checks are stable before they can gate merges.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0172-issue-synthesis-validate-parsers-against-realistic-multi-paragraph.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0172-issue-synthesis-validate-parsers-against-realistic-multi-paragraph.md
@@ -1,0 +1,18 @@
+---
+id: 0172
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.955321+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Validate parsers against realistic multi-paragraph agent output
+
+Write parser tests against realistic multi-paragraph transcripts — prose interspersed with structured markers — not bare marker strings.
+
+Example: test input should resemble real `claude` CLI output; assert on structured markers, not prose wording.
+
+**Why:** Bare-marker tests pass even when the parser fails on the surrounding prose context present in real output, hiding real format regressions.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0173-issue-synthesis-log-warning-on-zero-match-transcript-extraction-fr.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0173-issue-synthesis-log-warning-on-zero-match-transcript-extraction-fr.md
@@ -1,0 +1,18 @@
+---
+id: 0173
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.955638+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Log warning on zero-match transcript extraction from non-empty input
+
+When extracting structured data from CLI transcripts, wrap regex in try/except and log a warning on zero matches against non-empty input.
+
+Example: `matches = RE.findall(text); if not matches and text.strip(): logger.warning('parser found 0 matches on non-empty transcript')`.
+
+**Why:** Silent zero-match returns hide format drift between transcript versions; warnings surface parser breakage before it causes downstream data loss.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0174-issue-synthesis-use-portable-shell-commands-in-alpine-containers-p.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0174-issue-synthesis-use-portable-shell-commands-in-alpine-containers-p.md
@@ -1,0 +1,18 @@
+---
+id: 0174
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.955973+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Use portable shell commands in Alpine containers — Python is absent
+
+In Alpine-based Docker containers, avoid Python and non-standard utilities. Use portable POSIX commands for memory/CPU operations.
+
+Example: `dd if=/dev/zero bs=1M count=32 of=/dev/null` instead of a Python `bytearray` allocation.
+
+**Why:** Alpine's minimal tooling excludes Python and many GNU utilities; scripts that rely on them fail with `command not found` in constrained CI environments.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0175-issue-synthesis-separate-silent-with-result-events-from-purely-sil.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0175-issue-synthesis-separate-silent-with-result-events-from-purely-sil.md
@@ -1,0 +1,18 @@
+---
+id: 0175
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.956294+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Separate silent-with-result events from purely silent in dispatch
+
+In event dispatch tables, distinguish events that produce no display output but set a result value from events that are truly silent.
+
+Example: check `_SILENT_WITH_RESULT` before `_SILENT_EVENTS` so result-setting events are routed correctly.
+
+**Why:** Treating silent-with-result events as purely silent discards their return values, causing downstream state to silently receive `None` instead of the real result.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0176-issue-synthesis-create-a-specialized-method-rather-than-overloadin.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0176-issue-synthesis-create-a-specialized-method-rather-than-overloadin.md
@@ -1,0 +1,18 @@
+---
+id: 0176
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.956600+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Create a specialized method rather than overloading a general one
+
+When a general method returns insufficient data for a specific use case, create a separate focused method rather than adding optional parameters.
+
+Example: `list_issues_by_label()` returns basic metadata; `get_issue_updated_at()` handles timestamps in a separate call.
+
+**Why:** Overloading general methods couples unrelated concerns and complicates callers that need only one piece of data.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0177-issue-synthesis-ruff-strips-unused-imports-mid-tdd-cycle.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0177-issue-synthesis-ruff-strips-unused-imports-mid-tdd-cycle.md
@@ -1,0 +1,18 @@
+---
+id: 0177
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.956937+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Ruff strips unused imports mid-TDD cycle
+
+During TDD, write the test body (which uses the new symbol) before adding its import — or use a function-local import inside the test body.
+
+Example: add `from scripts.audit import score_rule` only after `score_rule` appears in the test function body.
+
+**Why:** Pre-commit `ruff --fix` removes imports not yet referenced on the first save, producing `NameError` on the second save and breaking the TDD red-phase.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0178-issue-synthesis-verify-implementation-files-are-in-the-diff-before.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0178-issue-synthesis-verify-implementation-files-are-in-the-diff-before.md
@@ -1,0 +1,18 @@
+---
+id: 0178
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.957252+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Verify implementation files are in the diff before merging
+
+Before merging, confirm the target source file appears in `git diff --name-only origin/main`.
+
+Example: PR closes #7644 but `git diff --name-only` shows only `docs/` and `tests/` — `src/makefile_scaffold.py` has 0 changes.
+
+**Why:** Tests can pass against stubs or unchanged code; a green CI with no implementation changes ships dead-end work that silently does nothing.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0179-issue-synthesis-coverage-delta-gate-is-asymmetric-gaps-block-clean.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0179-issue-synthesis-coverage-delta-gate-is-asymmetric-gaps-block-clean.md
@@ -1,0 +1,18 @@
+---
+id: 0179
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:23:52.957590+00:00
+status: active
+corroborations: 1
+supersedes: 0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145
+---
+
+# Coverage-delta gate is asymmetric: gaps block, clean defers to LLM
+
+The coverage-delta gate overrides LLM verdict only in one direction: uncovered changed lines force FAIL; clean coverage does NOT override an LLM RETRY or FAIL.
+
+Example: Uncovered lines found → FAIL (override). Clean coverage + LLM RETRY → RETRY (defer to LLM).
+
+**Why:** Symmetric override would allow a coverage pass to rescue an LLM RETRY, defeating the purpose of independent verification; the gate is a one-way ratchet against self-grading.

--- a/repo_wiki/T-rav/hydraflow/patterns/0134-issue-synthesis-use-optional-fields-with-defaults-for-backward-com.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0134-issue-synthesis-use-optional-fields-with-defaults-for-backward-com.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.020869+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Use optional fields with defaults for backward-compatible schema changes

--- a/repo_wiki/T-rav/hydraflow/patterns/0135-issue-synthesis-distinguish-bare-str-from-str-none-before-narrowin.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0135-issue-synthesis-distinguish-bare-str-from-str-none-before-narrowin.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.021197+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Distinguish bare `str` from `str | None` before narrowing a field type

--- a/repo_wiki/T-rav/hydraflow/patterns/0136-issue-synthesis-use-strenum-coercion-to-auto-convert-stored-string.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0136-issue-synthesis-use-strenum-coercion-to-auto-convert-stored-string.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.021487+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Use StrEnum coercion to auto-convert stored string values on load

--- a/repo_wiki/T-rav/hydraflow/patterns/0137-issue-synthesis-define-canonical-constants-as-single-source-of-tru.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0137-issue-synthesis-define-canonical-constants-as-single-source-of-tru.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.021780+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Define canonical constants as single source of truth for label lists

--- a/repo_wiki/T-rav/hydraflow/patterns/0138-issue-synthesis-use-metadata-tags-instead-of-enum-variants-for-sha.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0138-issue-synthesis-use-metadata-tags-instead-of-enum-variants-for-sha.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.022082+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Use metadata tags instead of enum variants for shared-bank categorization

--- a/repo_wiki/T-rav/hydraflow/patterns/0139-issue-synthesis-grep-all-call-sites-before-changing-a-function-sig.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0139-issue-synthesis-grep-all-call-sites-before-changing-a-function-sig.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.022368+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Grep all call sites before changing a function signature

--- a/repo_wiki/T-rav/hydraflow/patterns/0140-issue-synthesis-update-all-callers-atomically-when-a-return-type-c.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0140-issue-synthesis-update-all-callers-atomically-when-a-return-type-c.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.022653+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Update all callers atomically when a return type changes

--- a/repo_wiki/T-rav/hydraflow/patterns/0141-issue-synthesis-preserve-public-api-during-extraction-via-thin-del.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0141-issue-synthesis-preserve-public-api-during-extraction-via-thin-del.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.022970+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Preserve public API during extraction via thin delegation stubs

--- a/repo_wiki/T-rav/hydraflow/patterns/0142-issue-synthesis-extract-pure-transform-functions-before-moving-cod.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0142-issue-synthesis-extract-pure-transform-functions-before-moving-cod.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.023265+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Extract pure transform functions before moving code to new classes

--- a/repo_wiki/T-rav/hydraflow/patterns/0143-issue-synthesis-preserve-per-concern-try-except-blocks-during-refa.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0143-issue-synthesis-preserve-per-concern-try-except-blocks-during-refa.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.023559+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Preserve per-concern try/except blocks during refactoring

--- a/repo_wiki/T-rav/hydraflow/patterns/0144-issue-synthesis-extract-duplicated-jsonl-reading-logic-to-a-shared.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0144-issue-synthesis-extract-duplicated-jsonl-reading-logic-to-a-shared.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.023844+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Extract duplicated JSONL-reading logic to a shared `_load_jsonl()` helper

--- a/repo_wiki/T-rav/hydraflow/patterns/0145-issue-synthesis-mock-at-the-definition-site-not-the-import-site.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0145-issue-synthesis-mock-at-the-definition-site-not-the-import-site.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.024118+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Mock at the definition site, not the import site

--- a/repo_wiki/T-rav/hydraflow/patterns/0146-issue-synthesis-retarget-mock-patches-to-the-new-location-before-m.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0146-issue-synthesis-retarget-mock-patches-to-the-new-location-before-m.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.024404+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Retarget mock patches to the new location before moving a method

--- a/repo_wiki/T-rav/hydraflow/patterns/0147-issue-synthesis-generated-test-content-must-reference-function-nam.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0147-issue-synthesis-generated-test-content-must-reference-function-nam.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.024683+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Generated test content must reference function names, not line numbers

--- a/repo_wiki/T-rav/hydraflow/patterns/0148-issue-synthesis-use-meta-tests-to-enforce-anti-pattern-absence-acr.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0148-issue-synthesis-use-meta-tests-to-enforce-anti-pattern-absence-acr.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.024965+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Use meta-tests to enforce anti-pattern absence across the test suite

--- a/repo_wiki/T-rav/hydraflow/patterns/0149-issue-synthesis-use-threading-lock-for-thread-pool-code-asyncio-lo.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0149-issue-synthesis-use-threading-lock-for-thread-pool-code-asyncio-lo.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.025273+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Use `threading.Lock` for thread-pool code; `asyncio.Lock` only for pure coroutines

--- a/repo_wiki/T-rav/hydraflow/patterns/0150-issue-synthesis-extract-unlocked-helpers-to-prevent-re-entrant-loc.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0150-issue-synthesis-extract-unlocked-helpers-to-prevent-re-entrant-loc.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.025586+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Extract `_unlocked()` helpers to prevent re-entrant lock attempts

--- a/repo_wiki/T-rav/hydraflow/patterns/0151-issue-synthesis-use-file-util-append-jsonl-for-crash-safe-jsonl-ap.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0151-issue-synthesis-use-file-util-append-jsonl-for-crash-safe-jsonl-ap.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.025870+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Use `file_util.append_jsonl()` for crash-safe JSONL appends

--- a/repo_wiki/T-rav/hydraflow/patterns/0152-issue-synthesis-use-file-util-atomic-write-for-critical-state-file.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0152-issue-synthesis-use-file-util-atomic-write-for-critical-state-file.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.026160+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Use `file_util.atomic_write()` for critical state file updates

--- a/repo_wiki/T-rav/hydraflow/patterns/0153-issue-synthesis-use-claim-then-merge-for-async-queue-processing-to.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0153-issue-synthesis-use-claim-then-merge-for-async-queue-processing-to.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.026456+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Use claim-then-merge for async queue processing to prevent lost entries

--- a/repo_wiki/T-rav/hydraflow/patterns/0154-issue-synthesis-set-and-clear-trace-context-in-a-single-try-finall.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0154-issue-synthesis-set-and-clear-trace-context-in-a-single-try-finall.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.026740+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Set and clear trace context in a single try/finally block

--- a/repo_wiki/T-rav/hydraflow/patterns/0155-issue-synthesis-keep-event-publishing-coupled-with-the-condition-t.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0155-issue-synthesis-keep-event-publishing-coupled-with-the-condition-t.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.027025+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Keep event publishing coupled with the condition that gates it

--- a/repo_wiki/T-rav/hydraflow/patterns/0156-issue-synthesis-preserve-exact-retry-counter-state-during-dispatch.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0156-issue-synthesis-preserve-exact-retry-counter-state-during-dispatch.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.027310+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Preserve exact retry counter state during dispatcher refactoring

--- a/repo_wiki/T-rav/hydraflow/patterns/0157-issue-synthesis-dry-run-mode-must-not-emit-state-changing-events.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0157-issue-synthesis-dry-run-mode-must-not-emit-state-changing-events.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.027591+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Dry-run mode must not emit state-changing events

--- a/repo_wiki/T-rav/hydraflow/patterns/0158-issue-synthesis-maintain-immutable-return-contract-for-parse-tuple.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0158-issue-synthesis-maintain-immutable-return-contract-for-parse-tuple.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.027876+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Maintain immutable return contract for `parse()` — `tuple[str, str | None]`

--- a/repo_wiki/T-rav/hydraflow/patterns/0159-issue-synthesis-define-event-to-stage-and-source-to-stage-mappings.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0159-issue-synthesis-define-event-to-stage-and-source-to-stage-mappings.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.028183+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Define EVENT_TO_STAGE and SOURCE_TO_STAGE mappings before skip detection

--- a/repo_wiki/T-rav/hydraflow/patterns/0160-issue-synthesis-pre-allocate-memory-budget-upfront-before-prompt-a.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0160-issue-synthesis-pre-allocate-memory-budget-upfront-before-prompt-a.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.028523+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Pre-allocate memory budget upfront before prompt assembly

--- a/repo_wiki/T-rav/hydraflow/patterns/0161-issue-synthesis-use-a-two-round-allocator-section-minimums-first-t.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0161-issue-synthesis-use-a-two-round-allocator-section-minimums-first-t.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.028826+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Use a two-round allocator: section minimums first, then proportional surplus

--- a/repo_wiki/T-rav/hydraflow/patterns/0162-issue-synthesis-deduct-wiki-budget-from-memory-surplus-before-redi.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0162-issue-synthesis-deduct-wiki-budget-from-memory-surplus-before-redi.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.029122+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Deduct wiki budget from memory surplus before redistributing

--- a/repo_wiki/T-rav/hydraflow/patterns/0163-issue-synthesis-lazy-load-memory-context-on-explicit-user-action-n.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0163-issue-synthesis-lazy-load-memory-context-on-explicit-user-action-n.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.029464+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Lazy-load memory context on explicit user action, not on list render

--- a/repo_wiki/T-rav/hydraflow/patterns/0164-issue-synthesis-use-sha-256-truncated-to-16-chars-for-memory-dedup.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0164-issue-synthesis-use-sha-256-truncated-to-16-chars-for-memory-dedup.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.029789+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Use SHA-256 truncated to 16 chars for memory dedup keys

--- a/repo_wiki/T-rav/hydraflow/patterns/0165-issue-synthesis-use-asymmetric-word-set-overlap-for-memory-dedupli.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0165-issue-synthesis-use-asymmetric-word-set-overlap-for-memory-dedupli.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.030103+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Use asymmetric word-set overlap for memory deduplication

--- a/repo_wiki/T-rav/hydraflow/patterns/0166-issue-synthesis-batch-load-scoring-data-once-per-eviction-operatio.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0166-issue-synthesis-batch-load-scoring-data-once-per-eviction-operatio.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.030404+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Batch-load scoring data once per eviction operation, not per item

--- a/repo_wiki/T-rav/hydraflow/patterns/0167-issue-synthesis-use-true-not-is-true-for-retain-metadata-booleans.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0167-issue-synthesis-use-true-not-is-true-for-retain-metadata-booleans.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.030711+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Use `== "true"`, not `is True` for `retain()` metadata booleans

--- a/repo_wiki/T-rav/hydraflow/patterns/0168-issue-synthesis-memory-contradiction-resolution-provenance-wins-ov.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0168-issue-synthesis-memory-contradiction-resolution-provenance-wins-ov.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.031025+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Memory contradiction resolution: provenance wins over recency

--- a/repo_wiki/T-rav/hydraflow/patterns/0169-issue-synthesis-memory-eviction-must-atomically-update-scores-and-.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0169-issue-synthesis-memory-eviction-must-atomically-update-scores-and-.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.031353+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Memory eviction must atomically update scores and items files

--- a/repo_wiki/T-rav/hydraflow/patterns/0170-issue-synthesis-guard-close-with-a-closed-flag-to-make-it-idempote.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0170-issue-synthesis-guard-close-with-a-closed-flag-to-make-it-idempote.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.031688+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Guard `close()` with a `_closed` flag to make it idempotent

--- a/repo_wiki/T-rav/hydraflow/patterns/0171-issue-synthesis-memory-staleness-detection-should-emit-events-not-.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0171-issue-synthesis-memory-staleness-detection-should-emit-events-not-.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.032009+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Memory staleness detection should emit events, not silently mutate state

--- a/repo_wiki/T-rav/hydraflow/patterns/0172-issue-synthesis-adr-files-without-readme-entries-are-invisible-to-.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0172-issue-synthesis-adr-files-without-readme-entries-are-invisible-to-.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.032314+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # ADR files without README entries are invisible to tooling

--- a/repo_wiki/T-rav/hydraflow/patterns/0173-issue-synthesis-preserve-the-hf-namespace-prefix-when-renaming-ski.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0173-issue-synthesis-preserve-the-hf-namespace-prefix-when-renaming-ski.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.032624+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Preserve the `hf.` namespace prefix when renaming skill or command files

--- a/repo_wiki/T-rav/hydraflow/patterns/0174-issue-synthesis-keep-skill-prompts-in-sync-across-all-four-backend.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0174-issue-synthesis-keep-skill-prompts-in-sync-across-all-four-backend.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.032948+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # Keep skill prompts in sync across all four backend locations

--- a/repo_wiki/T-rav/hydraflow/patterns/0175-issue-synthesis-in-place-diff-truncation-silently-corrupts-downstr.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0175-issue-synthesis-in-place-diff-truncation-silently-corrupts-downstr.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:52:49.033282+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0092,0093,0094,0095,0096,0097,0098,0099,0100,0101,0102,0103,0104,0105,0106,0107,0108,0109,0110,0111,0112,0113,0114,0115,0116,0117,0118,0119,0120,0121,0122,0123,0124,0125,0126,0127,0128,0129,0130,0131,0132,0133
+superseded_by: 0176
 ---
 
 # In-place diff truncation silently corrupts downstream non-LLM consumers

--- a/repo_wiki/T-rav/hydraflow/patterns/0176-issue-synthesis-use-optional-fields-with-defaults-for-backward-com.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0176-issue-synthesis-use-optional-fields-with-defaults-for-backward-com.md
@@ -1,0 +1,18 @@
+---
+id: 0176
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.628445+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Use optional fields with defaults for backward-compatible schema changes
+
+New Pydantic fields must be optional with sensible defaults so existing state.json files load without migration validators.
+
+Example: `field: str = "default"` or `field: str | None = None`; read with `.get("scope", "repo")`.
+
+**Why:** Pydantic v2 auto-coerces raw dicts from state.json into typed models — no migration step exists, so non-optional new fields crash on load.

--- a/repo_wiki/T-rav/hydraflow/patterns/0177-issue-synthesis-distinguish-bare-str-from-str-none-before-narrowin.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0177-issue-synthesis-distinguish-bare-str-from-str-none-before-narrowin.md
@@ -1,0 +1,18 @@
+---
+id: 0177
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.628802+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Distinguish bare `str` from `str | None` before narrowing a field type
+
+Narrowing a bare `str` field to a StrEnum is safe when all stored values already conform. Narrowing a union like `str | None` requires union narrowing, not direct replacement.
+
+Example: grep all state.json consumers and call sites exhaustively before narrowing; treat union fields separately.
+
+**Why:** Narrowing a union type as if it were a bare type causes `ValidationError` on load for any stored `None` values.

--- a/repo_wiki/T-rav/hydraflow/patterns/0178-issue-synthesis-use-strenum-coercion-to-auto-convert-stored-string.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0178-issue-synthesis-use-strenum-coercion-to-auto-convert-stored-string.md
@@ -1,0 +1,18 @@
+---
+id: 0178
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.629134+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Use StrEnum coercion to auto-convert stored string values on load
+
+Declare Pydantic fields as StrEnum when values already conform, so Pydantic v2 auto-coerces stored strings at load time.
+
+Example: `class Phase(StrEnum): READY = "hydraflow-ready"` — field `phase: Phase` coerces `"hydraflow-ready"` from state.json automatically.
+
+**Why:** Manual `Phase(raw)` coercions at every read site diverge when new read paths are added; StrEnum coercion centralises conversion.

--- a/repo_wiki/T-rav/hydraflow/patterns/0179-issue-synthesis-define-canonical-constants-as-single-source-of-tru.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0179-issue-synthesis-define-canonical-constants-as-single-source-of-tru.md
@@ -1,0 +1,18 @@
+---
+id: 0179
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.629464+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Define canonical constants as single source of truth for label lists
+
+Establish a canonical constant (e.g., `ALL_LIFECYCLE_LABEL_FIELDS`) and derive every label list from it; never duplicate the list inline.
+
+Example: reset code, validators, and display logic all reference `ALL_LIFECYCLE_LABEL_FIELDS` — no magic strings.
+
+**Why:** Duplicated label lists diverge silently; a canonical constant makes omissions a grep-findable gap, not a runtime miss.

--- a/repo_wiki/T-rav/hydraflow/patterns/0180-issue-synthesis-use-metadata-tags-instead-of-enum-variants-for-sha.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0180-issue-synthesis-use-metadata-tags-instead-of-enum-variants-for-sha.md
@@ -1,0 +1,18 @@
+---
+id: 0180
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.629788+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Use metadata tags instead of enum variants for shared-bank categorization
+
+Tag items with metadata (e.g., `{"source": "adr_council"}`) rather than adding new enum variants for each category.
+
+Example: `retain(bank=Bank.LEARNINGS, metadata={"source": "adr_council"})` — no new enum variant needed.
+
+**Why:** Enum variants require syncing type checks, prompts, and display order across the codebase; a metadata tag adds a category with no schema change.

--- a/repo_wiki/T-rav/hydraflow/patterns/0181-issue-synthesis-grep-all-call-sites-before-changing-a-function-sig.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0181-issue-synthesis-grep-all-call-sites-before-changing-a-function-sig.md
@@ -1,0 +1,18 @@
+---
+id: 0181
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.630102+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Grep all call sites before changing a function signature
+
+Run `git grep <function_name>` before modifying any signature; for public functions, verify zero remaining unpatched matches after the change.
+
+Example: `git grep 'load_state'` before changing its return type — update every caller in the same commit.
+
+**Why:** Missing even one call site causes `TypeError` at runtime; exhaustive grep audit is the only way to confirm full coverage.

--- a/repo_wiki/T-rav/hydraflow/patterns/0182-issue-synthesis-update-all-callers-atomically-when-a-return-type-c.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0182-issue-synthesis-update-all-callers-atomically-when-a-return-type-c.md
@@ -1,0 +1,18 @@
+---
+id: 0182
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.630414+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Update all callers atomically when a return type changes
+
+When a function's return type changes (e.g., `str | None` → `dict | None`), update every caller in a single commit — never in separate PRs.
+
+Example: change `parse()` return type and grep + update all `result[0]` / `result[1]` unpack sites before committing.
+
+**Why:** A partially-migrated codebase compiles but crashes at runtime on unpatched callers.

--- a/repo_wiki/T-rav/hydraflow/patterns/0183-issue-synthesis-preserve-public-api-during-extraction-via-thin-del.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0183-issue-synthesis-preserve-public-api-during-extraction-via-thin-del.md
@@ -1,0 +1,18 @@
+---
+id: 0183
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.630746+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Preserve public API during extraction via thin delegation stubs
+
+When extracting code that tests or external callers depend on, keep the original method as a thin stub delegating to the new location.
+
+Example: leave `Client.old_method(self, x)` calling `new_module.old_method(x)` after extraction.
+
+**Why:** Removing public/semi-public methods during refactoring breaks callers that aren't visible in local grep (e.g., dynamically assembled call sites or test mocks).

--- a/repo_wiki/T-rav/hydraflow/patterns/0184-issue-synthesis-extract-pure-transform-functions-before-moving-cod.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0184-issue-synthesis-extract-pure-transform-functions-before-moving-cod.md
@@ -1,0 +1,18 @@
+---
+id: 0184
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.631070+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Extract pure transform functions before moving code to new classes
+
+Identify pure functions (no mutable closure state, no side effects) and extract them to module-level first; only then move to a class if ownership is clear.
+
+Example: extract `_format_label(name)` before creating `LabelFormatter` — the extracted form is independently testable.
+
+**Why:** Pure functions have the smallest blast radius and validate the extraction boundary before higher-risk class restructuring.

--- a/repo_wiki/T-rav/hydraflow/patterns/0185-issue-synthesis-preserve-per-concern-try-except-blocks-during-refa.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0185-issue-synthesis-preserve-per-concern-try-except-blocks-during-refa.md
@@ -1,0 +1,18 @@
+---
+id: 0185
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.631402+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Preserve per-concern try/except blocks during refactoring
+
+Do not merge or widen separate try/except blocks that each guard a specific concern — keep them as-is when extracting surrounding code.
+
+Example: if `fetch_labels()` and `post_comment()` each have their own try/except, extracted helpers must not share a single outer handler.
+
+**Why:** Merging exception scopes lets a failure in one concern silently suppress or skip a different concern.

--- a/repo_wiki/T-rav/hydraflow/patterns/0186-issue-synthesis-extract-duplicated-jsonl-reading-logic-to-a-shared.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0186-issue-synthesis-extract-duplicated-jsonl-reading-logic-to-a-shared.md
@@ -1,0 +1,18 @@
+---
+id: 0186
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.631730+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Extract duplicated JSONL-reading logic to a shared `_load_jsonl()` helper
+
+Shared JSONL-reading logic must be extracted to a `_load_jsonl(path, label)` helper rather than duplicated inline.
+
+Example: `records = _load_jsonl(path, "events")` — one implementation, multiple callers.
+
+**Why:** Inline duplication causes silent divergence when one copy gets a bug fix (e.g., empty-file guard) that the other copies miss.

--- a/repo_wiki/T-rav/hydraflow/patterns/0187-issue-synthesis-mock-at-the-definition-site-not-the-import-site.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0187-issue-synthesis-mock-at-the-definition-site-not-the-import-site.md
@@ -1,0 +1,18 @@
+---
+id: 0187
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.632051+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Mock at the definition site, not the import site
+
+Patch `hindsight.tombstone_safe`, not `module_under_test.tombstone_safe`; combine with deferred imports inside test methods.
+
+Example: `@patch('hindsight.tombstone_safe')` not `@patch('mymodule.tombstone_safe')`.
+
+**Why:** Import-site patches fail when the import is deferred or when optional dependencies are conditionally loaded — definition-site patches intercept regardless of import order.

--- a/repo_wiki/T-rav/hydraflow/patterns/0188-issue-synthesis-retarget-mock-patches-to-the-new-location-before-m.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0188-issue-synthesis-retarget-mock-patches-to-the-new-location-before-m.md
@@ -1,0 +1,18 @@
+---
+id: 0188
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.632378+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Retarget mock patches to the new location before moving a method
+
+Before moving a method to a new module, update all `@patch` decorators in tests to point to the destination path, then move the implementation.
+
+Example: change `@patch('old.module.Method')` → `@patch('new.module.Method')` before the move commit.
+
+**Why:** Moving a method without updating patches leaves tests patching a now-unused import, so the live code runs unpatched and the test silently stops covering the real path.

--- a/repo_wiki/T-rav/hydraflow/patterns/0189-issue-synthesis-generated-test-content-must-reference-function-nam.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0189-issue-synthesis-generated-test-content-must-reference-function-nam.md
@@ -1,0 +1,18 @@
+---
+id: 0189
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.632707+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Generated test content must reference function names, not line numbers
+
+Test skeletons, comments, and generated assertions must use exact function/class names for stability across refactors.
+
+Example: `# tests path through calculate_drift()` not `# tests line 42 in drift.py`.
+
+**Why:** Line numbers shift on every edit, making generated references immediately stale and misleading.

--- a/repo_wiki/T-rav/hydraflow/patterns/0190-issue-synthesis-use-meta-tests-to-enforce-anti-pattern-absence-acr.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0190-issue-synthesis-use-meta-tests-to-enforce-anti-pattern-absence-acr.md
@@ -1,0 +1,18 @@
+---
+id: 0190
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.633026+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Use meta-tests to enforce anti-pattern absence across the test suite
+
+Write meta-tests that scan `tests/test_*.py` for forbidden patterns (e.g., `sys.path.insert`, "Should..." docstrings, AAA comments) and fail CI if any are found.
+
+Example: `assert not any('sys.path.insert' in line for line in test_files)` as a standalone test.
+
+**Why:** Manual review misses anti-patterns introduced across hundreds of test files; a meta-test turns the check into a permanent CI gate.

--- a/repo_wiki/T-rav/hydraflow/patterns/0191-issue-synthesis-use-threading-lock-for-thread-pool-code-asyncio-lo.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0191-issue-synthesis-use-threading-lock-for-thread-pool-code-asyncio-lo.md
@@ -1,0 +1,18 @@
+---
+id: 0191
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.633355+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Use `threading.Lock` for thread-pool code; `asyncio.Lock` only for pure coroutines
+
+When code runs via `asyncio.to_thread()` or is called from both sync and async contexts, use `threading.Lock`. Use `asyncio.Lock` only for coordinating pure coroutines without thread-pool involvement.
+
+Example: `self._lock = threading.Lock()` for a cache shared between thread-pool workers.
+
+**Why:** `asyncio.Lock` is not thread-safe — acquiring it from a thread pool raises or silently corrupts state.

--- a/repo_wiki/T-rav/hydraflow/patterns/0192-issue-synthesis-extract-unlocked-helpers-to-prevent-re-entrant-loc.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0192-issue-synthesis-extract-unlocked-helpers-to-prevent-re-entrant-loc.md
@@ -1,0 +1,18 @@
+---
+id: 0192
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.633696+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Extract `_unlocked()` helpers to prevent re-entrant lock attempts
+
+When a lock-holding method needs to call another method that also acquires the same lock, extract an `_unlocked()` variant and call that from both.
+
+Example: `def update(self): with self._lock: self._update_unlocked()` — `batch_update` calls `_update_unlocked()` too.
+
+**Why:** Re-entrant `threading.Lock` acquisition deadlocks; re-entrant `asyncio.Lock` raises — `_unlocked()` variants eliminate both failure modes.

--- a/repo_wiki/T-rav/hydraflow/patterns/0193-issue-synthesis-use-file-util-append-jsonl-for-crash-safe-jsonl-ap.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0193-issue-synthesis-use-file-util-append-jsonl-for-crash-safe-jsonl-ap.md
@@ -1,0 +1,18 @@
+---
+id: 0193
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.634023+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Use `file_util.append_jsonl()` for crash-safe JSONL appends
+
+Wrap JSONL appends in `file_util.append_jsonl()`, which calls `flush()` + `os.fsync()` inside a `file_lock()`.
+
+Example: `file_util.append_jsonl(path, record)` — not `with open(path, 'a') as f: f.write(...)`.
+
+**Why:** Bare `open(..., 'a')` without fsync loses the last record on crash; the lock prevents interleaved writes from concurrent processes.

--- a/repo_wiki/T-rav/hydraflow/patterns/0194-issue-synthesis-use-file-util-atomic-write-for-critical-state-file.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0194-issue-synthesis-use-file-util-atomic-write-for-critical-state-file.md
@@ -1,0 +1,18 @@
+---
+id: 0194
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.634347+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Use `file_util.atomic_write()` for critical state file updates
+
+Write critical state via `file_util.atomic_write()`, which writes to a temp file then calls `os.replace()` atomically.
+
+Example: `file_util.atomic_write(state_path, json.dumps(state))` — not `open(path, 'w').write(...)`.
+
+**Why:** A crash mid-write with `open(..., 'w')` truncates the file, producing an empty or partial state that cannot be loaded.

--- a/repo_wiki/T-rav/hydraflow/patterns/0195-issue-synthesis-use-claim-then-merge-for-async-queue-processing-to.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0195-issue-synthesis-use-claim-then-merge-for-async-queue-processing-to.md
@@ -1,0 +1,18 @@
+---
+id: 0195
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.634686+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Use claim-then-merge for async queue processing to prevent lost entries
+
+Atomically claim queue items (clear/load under lock), release lock, perform async work, re-acquire lock, reload new items, merge, then atomically write.
+
+Example: `with lock: batch = queue.copy(); queue.clear()` → async work → `with lock: queue.update(new); queue.update(results); write(queue)`.
+
+**Why:** Releasing the lock during async work is needed to avoid deadlock, but re-acquiring before write prevents entries appended during the async gap from being lost.

--- a/repo_wiki/T-rav/hydraflow/patterns/0196-issue-synthesis-set-and-clear-trace-context-in-a-single-try-finall.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0196-issue-synthesis-set-and-clear-trace-context-in-a-single-try-finall.md
@@ -1,0 +1,18 @@
+---
+id: 0196
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.635018+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Set and clear trace context in a single try/finally block
+
+Set/clear or begin/end pairs for tracing context MUST execute within a single try/finally — never split across separate methods.
+
+Example: `token = ctx.set(val); try: ... finally: ctx.reset(token)` — both in one scope.
+
+**Why:** Splitting the set/clear across call boundaries leaks trace state across issues or loop iterations, corrupting span attribution.

--- a/repo_wiki/T-rav/hydraflow/patterns/0197-issue-synthesis-keep-event-publishing-coupled-with-the-condition-t.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0197-issue-synthesis-keep-event-publishing-coupled-with-the-condition-t.md
@@ -1,0 +1,18 @@
+---
+id: 0197
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.635352+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Keep event publishing coupled with the condition that gates it
+
+The `if should_alert:` check and `event_bus.publish(ALERT)` must live in the same method body — never separated into different methods.
+
+Example: inline both in `_check_and_notify()` rather than calling `_check()` then `_publish()`.
+
+**Why:** Separating them creates code paths where the gate is checked but the event isn't fired (or vice versa), breaking observability silently.

--- a/repo_wiki/T-rav/hydraflow/patterns/0198-issue-synthesis-preserve-exact-retry-counter-state-during-dispatch.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0198-issue-synthesis-preserve-exact-retry-counter-state-during-dispatch.md
@@ -1,0 +1,18 @@
+---
+id: 0198
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.635706+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Preserve exact retry counter state during dispatcher refactoring
+
+When refactoring state machine dispatchers, carry over retry counters and escalation conditions (e.g., epic-child label swaps) exactly — do not reset or re-derive them.
+
+Example: copy `issue.attempt_count` and `issue.escalation_triggered` into the refactored handler without modification.
+
+**Why:** Dropping retry state silently resets attempt budgets, allowing previously-exhausted issues to cycle again or miss escalation thresholds.

--- a/repo_wiki/T-rav/hydraflow/patterns/0199-issue-synthesis-dry-run-mode-must-not-emit-state-changing-events.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0199-issue-synthesis-dry-run-mode-must-not-emit-state-changing-events.md
@@ -1,0 +1,18 @@
+---
+id: 0199
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.636044+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Dry-run mode must not emit state-changing events
+
+Gate every side-effecting event bus publish behind `if not self.dry_run:` to ensure dry-run has no observable side effects.
+
+Example: `if not self.dry_run: self.event_bus.publish(TRIAGE_ROUTING, ...)` — not emitted during dry-run.
+
+**Why:** An emitted event in dry-run triggers downstream label mutations and state transitions, making dry-run non-idempotent.

--- a/repo_wiki/T-rav/hydraflow/patterns/0200-issue-synthesis-maintain-immutable-return-contract-for-parse-tuple.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0200-issue-synthesis-maintain-immutable-return-contract-for-parse-tuple.md
@@ -1,0 +1,18 @@
+---
+id: 0200
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.636387+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Maintain immutable return contract for `parse()` — `tuple[str, str | None]`
+
+Phase result `parse()` must always return `tuple[str, str | None]`; refactors that widen or change this shape break all callers.
+
+Example: return `("approved", None)` or `("rejected", "reason")` — never a plain `str` or `dict`.
+
+**Why:** Callers destructure the tuple positionally; a shape change produces `TypeError` or silent data corruption at the unpack site.

--- a/repo_wiki/T-rav/hydraflow/patterns/0201-issue-synthesis-define-event-to-stage-and-source-to-stage-mappings.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0201-issue-synthesis-define-event-to-stage-and-source-to-stage-mappings.md
@@ -1,0 +1,18 @@
+---
+id: 0201
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.636719+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Define EVENT_TO_STAGE and SOURCE_TO_STAGE mappings before skip detection
+
+Implement event/worker-to-stage mappings together with skip detection logic — never add a mapping after skip detection is wired.
+
+Example: define `EVENT_TO_STAGE = {...}` and `SOURCE_TO_STAGE = {...}` before the `if event in skip_set: return` guard.
+
+**Why:** Mappings added after the early-return guard are never evaluated, making the new stage silently unreachable.

--- a/repo_wiki/T-rav/hydraflow/patterns/0202-issue-synthesis-pre-allocate-memory-budget-upfront-before-prompt-a.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0202-issue-synthesis-pre-allocate-memory-budget-upfront-before-prompt-a.md
@@ -1,0 +1,18 @@
+---
+id: 0202
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.637077+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Pre-allocate memory budget upfront before prompt assembly
+
+Call `get_allocation()` and consume all budget caps before starting `_inject_memory()` — post-hoc surplus reclamation is not possible.
+
+Example: allocate wiki budget first, deduct from surplus, then distribute remaining memory budget proportionally.
+
+**Why:** Prompt assembly is streaming; once a section is written, its token budget cannot be reclaimed for a different section.

--- a/repo_wiki/T-rav/hydraflow/patterns/0203-issue-synthesis-use-a-two-round-allocator-section-minimums-first-t.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0203-issue-synthesis-use-a-two-round-allocator-section-minimums-first-t.md
@@ -1,0 +1,18 @@
+---
+id: 0203
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.637415+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Use a two-round allocator: section minimums first, then proportional surplus
+
+Round one gives each memory section its minimum budget; round two distributes the remainder proportionally by `_DEFAULT_PRIORITIES` label.
+
+Example: `min_alloc = {k: MINIMUMS[k] for k in sections}; surplus = total - sum(min_alloc.values()); prop += surplus * weights`.
+
+**Why:** A single-round proportional allocator can starve low-priority sections below their functional minimum, breaking prompt structure.

--- a/repo_wiki/T-rav/hydraflow/patterns/0204-issue-synthesis-deduct-wiki-budget-from-memory-surplus-before-redi.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0204-issue-synthesis-deduct-wiki-budget-from-memory-surplus-before-redi.md
@@ -1,0 +1,18 @@
+---
+id: 0204
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.637798+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Deduct wiki budget from memory surplus before redistributing
+
+Compute the wiki budget (`max_repo_wiki_chars`) and subtract it from the memory surplus BEFORE distributing the remainder proportionally across memory sections.
+
+Example: `surplus -= wiki_budget; memory_alloc = distribute(surplus, weights)`.
+
+**Why:** Not deducting first causes memory sections to over-allocate, then the wiki gets truncated when both compete for the same token pool.

--- a/repo_wiki/T-rav/hydraflow/patterns/0205-issue-synthesis-lazy-load-memory-context-on-explicit-user-action-n.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0205-issue-synthesis-lazy-load-memory-context-on-explicit-user-action-n.md
@@ -1,0 +1,18 @@
+---
+id: 0205
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.638184+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Lazy-load memory context on explicit user action, not on list render
+
+Fetch memory context only when the user expands a section — not when the HITL list view renders.
+
+Example: expand button triggers `fetchMemoryContext(issueId)` — the list view fires no memory API calls.
+
+**Why:** Pre-fetching on render causes N+1 API calls on every HITL list load, amplified by the number of open issues.

--- a/repo_wiki/T-rav/hydraflow/patterns/0206-issue-synthesis-use-sha-256-truncated-to-16-chars-for-memory-dedup.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0206-issue-synthesis-use-sha-256-truncated-to-16-chars-for-memory-dedup.md
@@ -1,0 +1,18 @@
+---
+id: 0206
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.638570+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Use SHA-256 truncated to 16 chars for memory dedup keys
+
+Compute dedup keys and recall-hit tracking via `SHA-256(content)[:16]`.
+
+Example: `key = hashlib.sha256(item['text'].encode()).hexdigest()[:16]`.
+
+**Why:** Consistent hashing ensures the same content maps to the same key across process restarts; truncation keeps keys human-scannable in logs.

--- a/repo_wiki/T-rav/hydraflow/patterns/0207-issue-synthesis-use-asymmetric-word-set-overlap-for-memory-dedupli.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0207-issue-synthesis-use-asymmetric-word-set-overlap-for-memory-dedupli.md
@@ -1,0 +1,18 @@
+---
+id: 0207
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.638974+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Use asymmetric word-set overlap for memory deduplication
+
+Compute dedup similarity as `len(words & existing) / max(len(words), 1)` with a configurable threshold (default 0.85).
+
+Example: new item with 10 words sharing 9 with an existing item → score 0.9 → suppress.
+
+**Why:** Symmetric Jaccard penalises short additions to long entries; asymmetric overlap correctly identifies content that's mostly a subset of existing memory.

--- a/repo_wiki/T-rav/hydraflow/patterns/0208-issue-synthesis-batch-load-scoring-data-once-per-eviction-operatio.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0208-issue-synthesis-batch-load-scoring-data-once-per-eviction-operatio.md
@@ -1,0 +1,18 @@
+---
+id: 0208
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.639429+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Batch-load scoring data once per eviction operation, not per item
+
+Call `MemoryScorer.load_item_scores()` once per eviction pass and reuse the result across all items.
+
+Example: `scores = scorer.load_item_scores(); for item in items: rank(item, scores)`.
+
+**Why:** Per-item score loading reads the same file N times; batch loading makes eviction O(1) in I/O regardless of corpus size.

--- a/repo_wiki/T-rav/hydraflow/patterns/0209-issue-synthesis-use-true-not-is-true-for-retain-metadata-booleans.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0209-issue-synthesis-use-true-not-is-true-for-retain-metadata-booleans.md
@@ -1,0 +1,18 @@
+---
+id: 0209
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.639840+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Use `== "true"`, not `is True` for `retain()` metadata booleans
+
+`HindsightClient.retain()` calls `str(v)` on all metadata values; boolean `True` becomes string `"true"`.
+
+Example: `metadata={"warning": "true"}` not `{"warning": True}`; check with `metadata.get("warning") == "true"`.
+
+**Why:** `metadata.get("warning") is True` always returns `False` after coercion, silently disabling warning-based filtering.

--- a/repo_wiki/T-rav/hydraflow/patterns/0210-issue-synthesis-memory-contradiction-resolution-provenance-wins-ov.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0210-issue-synthesis-memory-contradiction-resolution-provenance-wins-ov.md
@@ -1,0 +1,18 @@
+---
+id: 0210
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.640217+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Memory contradiction resolution: provenance wins over recency
+
+When two memory items contradict, human-sourced wins over agent-sourced regardless of timestamp; among equal provenance, newer wins.
+
+Example: a human-written learning from 2024 beats an agent-written one from 2025.
+
+**Why:** Agent-sourced items can encode hallucinations; provenance-first resolution ensures human corrections are never overwritten by automated entries.

--- a/repo_wiki/T-rav/hydraflow/patterns/0211-issue-synthesis-memory-eviction-must-atomically-update-scores-and-.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0211-issue-synthesis-memory-eviction-must-atomically-update-scores-and-.md
@@ -1,0 +1,18 @@
+---
+id: 0211
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.640593+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Memory eviction must atomically update scores and items files
+
+An eviction operation must write `item_scores.json` and `items.jsonl` together within the same lock scope — never update one without the other.
+
+Example: `atomic_write(scores_path, ...)` then `atomic_write(items_path, ...)` under a single lock acquire.
+
+**Why:** A partial update leaves scores referencing evicted items (or items with stale scores), corrupting ranking on the next eviction pass.

--- a/repo_wiki/T-rav/hydraflow/patterns/0212-issue-synthesis-guard-close-with-a-closed-flag-to-make-it-idempote.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0212-issue-synthesis-guard-close-with-a-closed-flag-to-make-it-idempote.md
@@ -1,0 +1,18 @@
+---
+id: 0212
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.640980+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Guard `close()` with a `_closed` flag to make it idempotent
+
+All cleanup methods must check and set a `_closed` flag as their first step.
+
+Example: `def close(self): if self._closed: return; self._closed = True; await self._resource.aclose()`.
+
+**Why:** Double-close on an async resource (e.g., HTTP session) raises; idempotent close makes teardown order-independent in test fixtures.

--- a/repo_wiki/T-rav/hydraflow/patterns/0213-issue-synthesis-memory-staleness-detection-should-emit-events-not-.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0213-issue-synthesis-memory-staleness-detection-should-emit-events-not-.md
@@ -1,0 +1,18 @@
+---
+id: 0213
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.641354+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Memory staleness detection should emit events, not silently mutate state
+
+Staleness detection must emit events or log warnings rather than silently deleting or modifying stale entries.
+
+Example: `event_bus.publish(STALE_MEMORY, item_id=item.id, age_days=age)` instead of `self._items.pop(item.id)`.
+
+**Why:** Silent mutation removes the operator's ability to review or override staleness decisions; events keep the action reversible.

--- a/repo_wiki/T-rav/hydraflow/patterns/0214-issue-synthesis-adr-files-without-readme-entries-are-invisible-to-.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0214-issue-synthesis-adr-files-without-readme-entries-are-invisible-to-.md
@@ -1,0 +1,18 @@
+---
+id: 0214
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.641721+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# ADR files without README entries are invisible to tooling
+
+Every ADR file in `docs/adr/` must have a corresponding row in `docs/adr/README.md` to be canonically referenceable.
+
+Example: adding `docs/adr/0055-new-decision.md` requires a matching `| 0055 | New Decision | Accepted |` row in README.
+
+**Why:** `scan_adr_directory()` builds its index from README rows; a file without a row is silently skipped by drift detection and cross-reference tooling.

--- a/repo_wiki/T-rav/hydraflow/patterns/0215-issue-synthesis-preserve-the-hf-namespace-prefix-when-renaming-ski.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0215-issue-synthesis-preserve-the-hf-namespace-prefix-when-renaming-ski.md
@@ -1,0 +1,18 @@
+---
+id: 0215
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.642107+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Preserve the `hf.` namespace prefix when renaming skill or command files
+
+When renaming fixture or command files, keep the `hf.` or `hf-` prefix intact.
+
+Example: rename `hf.audit-code.md` → `hf.audit-contracts.md`, not `audit-contracts.md`.
+
+**Why:** Skill lookup strips the prefix at registration; dropping it makes the skill unreachable via `/hf.audit-contracts` and breaks namespace consistency.

--- a/repo_wiki/T-rav/hydraflow/patterns/0216-issue-synthesis-keep-skill-prompts-in-sync-across-all-four-backend.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0216-issue-synthesis-keep-skill-prompts-in-sync-across-all-four-backend.md
@@ -1,0 +1,18 @@
+---
+id: 0216
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.642496+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# Keep skill prompts in sync across all four backend locations
+
+Skill prompt text lives in `src/`, `.claude/commands/`, `.pi/skills/`, and `.codex/skills/` — update all four locations when changing a prompt.
+
+Example: editing `.claude/commands/hf.diff-sanity.md` requires mirroring the change to the other three locations.
+
+**Why:** Missed updates cause the same skill to behave differently depending on which backend routes the request, producing inconsistent LLM behavior.

--- a/repo_wiki/T-rav/hydraflow/patterns/0217-issue-synthesis-in-place-diff-truncation-silently-corrupts-downstr.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0217-issue-synthesis-in-place-diff-truncation-silently-corrupts-downstr.md
@@ -1,0 +1,18 @@
+---
+id: 0217
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:22:06.642864+00:00
+status: active
+corroborations: 1
+supersedes: 0134,0135,0136,0137,0138,0139,0140,0141,0142,0143,0144,0145,0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175
+---
+
+# In-place diff truncation silently corrupts downstream non-LLM consumers
+
+When a diff is truncated for an LLM prompt, rebind to a separate name rather than mutating the original variable.
+
+Example: `prompt_diff = diff[:max_diff] + "[truncated]"` instead of reassigning `diff`, so the full `diff` is still available for structural consumers.
+
+**Why:** In-place truncation causes coverage mapping to silently under-report changed lines in the tail of large diffs, making the gate fail-open on the diffs most likely to need it.

--- a/repo_wiki/T-rav/hydraflow/testing/0295-issue-synthesis-mock-at-definition-site-not-at-usage-site.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0295-issue-synthesis-mock-at-definition-site-not-at-usage-site.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.001409+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Mock at definition site, not at usage site

--- a/repo_wiki/T-rav/hydraflow/testing/0296-issue-synthesis-mark-pytest-mark-integration-only-for-real-externa.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0296-issue-synthesis-mark-pytest-mark-integration-only-for-real-externa.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.002268+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Mark @pytest.mark.integration only for real external deps

--- a/repo_wiki/T-rav/hydraflow/testing/0297-issue-synthesis-await-asyncio-sleep-0-after-create-task-before-ass.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0297-issue-synthesis-await-asyncio-sleep-0-after-create-task-before-ass.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.002964+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Await asyncio.sleep(0) after create_task() before asserting

--- a/repo_wiki/T-rav/hydraflow/testing/0298-issue-synthesis-reset-global-module-level-state-in-both-setup-and-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0298-issue-synthesis-reset-global-module-level-state-in-both-setup-and-.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.003715+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Reset global/module-level state in both setup and teardown

--- a/repo_wiki/T-rav/hydraflow/testing/0299-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0299-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.004385+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Use tmp_path with ConfigFactory for all file-based test I/O

--- a/repo_wiki/T-rav/hydraflow/testing/0300-issue-synthesis-caplog-assertions-must-name-the-exact-logger.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0300-issue-synthesis-caplog-assertions-must-name-the-exact-logger.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.005052+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Caplog assertions must name the exact logger

--- a/repo_wiki/T-rav/hydraflow/testing/0301-issue-synthesis-test-protocol-satisfaction-with-isinstance-and-has.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0301-issue-synthesis-test-protocol-satisfaction-with-isinstance-and-has.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.005698+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Test protocol satisfaction with isinstance and hasattr

--- a/repo_wiki/T-rav/hydraflow/testing/0302-issue-synthesis-facade-tests-cover-routing-error-delegation-and-ba.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0302-issue-synthesis-facade-tests-cover-routing-error-delegation-and-ba.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.006356+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Facade tests: cover routing, error, delegation, and backward compat

--- a/repo_wiki/T-rav/hydraflow/testing/0303-issue-synthesis-browser-rendered-attributes-require-playwright-not.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0303-issue-synthesis-browser-rendered-attributes-require-playwright-not.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.007011+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Browser-rendered attributes require Playwright, not TestClient

--- a/repo_wiki/T-rav/hydraflow/testing/0304-issue-synthesis-subprocess-cli-test-stubs-log-invocations-to-jsonl.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0304-issue-synthesis-subprocess-cli-test-stubs-log-invocations-to-jsonl.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.007679+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Subprocess CLI test stubs: log invocations to JSONL

--- a/repo_wiki/T-rav/hydraflow/testing/0305-issue-synthesis-integration-test-runners-mock-only-execute-wire-re.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0305-issue-synthesis-integration-test-runners-mock-only-execute-wire-re.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.008357+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Integration test runners: mock only _execute(), wire real logic

--- a/repo_wiki/T-rav/hydraflow/testing/0306-issue-synthesis-use-word-boundary-matching-in-coverage-checks-not-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0306-issue-synthesis-use-word-boundary-matching-in-coverage-checks-not-.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.009002+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Use word-boundary matching in coverage checks, not substring

--- a/repo_wiki/T-rav/hydraflow/testing/0307-issue-synthesis-enforce-50-30-line-limits-on-handlers-and-registra.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0307-issue-synthesis-enforce-50-30-line-limits-on-handlers-and-registra.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.009653+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Enforce 50/30-line limits on handlers and registration wiring

--- a/repo_wiki/T-rav/hydraflow/testing/0308-issue-synthesis-assert-relative-event-ordering-not-absolute-id-val.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0308-issue-synthesis-assert-relative-event-ordering-not-absolute-id-val.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.010287+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Assert relative event ordering, not absolute ID values

--- a/repo_wiki/T-rav/hydraflow/testing/0309-issue-synthesis-add-structural-tests-for-transition-graphs-before-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0309-issue-synthesis-add-structural-tests-for-transition-graphs-before-.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.010967+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Add structural tests for transition graphs before property-based tests

--- a/repo_wiki/T-rav/hydraflow/testing/0310-issue-synthesis-sync-test-label-constants-with-production-pipeline.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0310-issue-synthesis-sync-test-label-constants-with-production-pipeline.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.011620+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Sync test label constants with production pipeline definitions

--- a/repo_wiki/T-rav/hydraflow/testing/0311-issue-synthesis-pydantic-typeddict-field-changes-require-updates-i.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0311-issue-synthesis-pydantic-typeddict-field-changes-require-updates-i.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.012272+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Pydantic/TypedDict field changes require updates in 4 places

--- a/repo_wiki/T-rav/hydraflow/testing/0312-issue-synthesis-feature-toggles-need-both-a-config-field-and-env-i.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0312-issue-synthesis-feature-toggles-need-both-a-config-field-and-env-i.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.012928+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Feature toggles need both a config field and _ENV_INT_OVERRIDES entry

--- a/repo_wiki/T-rav/hydraflow/testing/0313-issue-synthesis-dict-to-typeddict-migrations-require-no-new-tests.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0313-issue-synthesis-dict-to-typeddict-migrations-require-no-new-tests.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.013629+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # dict-to-TypedDict migrations require no new tests

--- a/repo_wiki/T-rav/hydraflow/testing/0314-issue-synthesis-concurrent-jsonl-appends-assert-exact-event-counts.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0314-issue-synthesis-concurrent-jsonl-appends-assert-exact-event-counts.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.014291+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Concurrent JSONL appends: assert exact event counts, not timing

--- a/repo_wiki/T-rav/hydraflow/testing/0315-issue-synthesis-memory-bank-keys-must-be-consistent-across-dedup-a.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0315-issue-synthesis-memory-bank-keys-must-be-consistent-across-dedup-a.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.014949+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Memory bank keys must be consistent across dedup and assembly

--- a/repo_wiki/T-rav/hydraflow/testing/0316-issue-synthesis-skill-markers-must-be-present-in-all-4-backend-cop.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0316-issue-synthesis-skill-markers-must-be-present-in-all-4-backend-cop.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.015645+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Skill markers must be present in all 4 backend copies

--- a/repo_wiki/T-rav/hydraflow/testing/0317-issue-synthesis-generate-adr-derived-tests-as-skipped-skeletons-by.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0317-issue-synthesis-generate-adr-derived-tests-as-skipped-skeletons-by.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.016346+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Generate ADR-derived tests as skipped skeletons by default

--- a/repo_wiki/T-rav/hydraflow/testing/0318-issue-synthesis-adr-pre-validator-enforce-required-sections-and-st.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0318-issue-synthesis-adr-pre-validator-enforce-required-sections-and-st.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.017158+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # ADR pre-validator: enforce required sections and status values

--- a/repo_wiki/T-rav/hydraflow/testing/0319-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0319-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.017870+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Never import private helpers at module level in test files

--- a/repo_wiki/T-rav/hydraflow/testing/0320-issue-synthesis-pin-function-signatures-before-writing-callers-or-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0320-issue-synthesis-pin-function-signatures-before-writing-callers-or-.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.018578+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Pin function signatures before writing callers or tests

--- a/repo_wiki/T-rav/hydraflow/testing/0321-issue-synthesis-validate-sys-modules-cleanup-with-multiple-random-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0321-issue-synthesis-validate-sys-modules-cleanup-with-multiple-random-.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.019263+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Validate sys.modules cleanup with multiple random seeds

--- a/repo_wiki/T-rav/hydraflow/testing/0322-issue-synthesis-skip-broken-tests-with-an-issue-reference-remove-a.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0322-issue-synthesis-skip-broken-tests-with-an-issue-reference-remove-a.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.019965+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Skip broken tests with an issue reference; remove after fix

--- a/repo_wiki/T-rav/hydraflow/testing/0323-issue-synthesis-use-is-to-verify-shared-runner-instance-across-com.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0323-issue-synthesis-use-is-to-verify-shared-runner-instance-across-com.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.020664+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Use is to verify shared runner instance across components

--- a/repo_wiki/T-rav/hydraflow/testing/0324-issue-synthesis-memory-dedup-higher-priority-bank-wins-on-collisio.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0324-issue-synthesis-memory-dedup-higher-priority-bank-wins-on-collisio.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.021321+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Memory dedup: higher-priority bank wins on collision

--- a/repo_wiki/T-rav/hydraflow/testing/0325-issue-synthesis-hoist-deterministic-gates-outside-llm-retry-loops.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0325-issue-synthesis-hoist-deterministic-gates-outside-llm-retry-loops.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.021981+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Hoist deterministic gates outside LLM retry loops

--- a/repo_wiki/T-rav/hydraflow/testing/0326-issue-synthesis-use-public-fakegithub-api-in-scenario-tests-never-.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0326-issue-synthesis-use-public-fakegithub-api-in-scenario-tests-never-.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.022692+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Use public FakeGitHub API in scenario tests, never mutate _issues

--- a/repo_wiki/T-rav/hydraflow/testing/0327-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0327-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.023391+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Test async context managers in three standard scenarios

--- a/repo_wiki/T-rav/hydraflow/testing/0328-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels-n.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0328-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels-n.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.024112+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Test direct-swap labels via swap_pipeline_labels(), not transitions

--- a/repo_wiki/T-rav/hydraflow/testing/0329-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0329-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.024846+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Allow ±3 line drift in AST-based structure assertions

--- a/repo_wiki/T-rav/hydraflow/testing/0330-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0330-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.025589+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Existing tests cover private-method extractions; add only new-behavior tests

--- a/repo_wiki/T-rav/hydraflow/testing/0331-issue-synthesis-assert-numeric-values-in-sentry-breadcrumbs-not-ju.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0331-issue-synthesis-assert-numeric-values-in-sentry-breadcrumbs-not-ju.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.026368+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Assert numeric values in Sentry breadcrumbs, not just key presence

--- a/repo_wiki/T-rav/hydraflow/testing/0332-issue-synthesis-test-pydantic-literal-constraints-cover-both-valid.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0332-issue-synthesis-test-pydantic-literal-constraints-cover-both-valid.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.027100+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Test Pydantic Literal constraints: cover both valid and invalid values

--- a/repo_wiki/T-rav/hydraflow/testing/0333-issue-synthesis-verify-fatal-exception-propagation-through-multi-p.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0333-issue-synthesis-verify-fatal-exception-propagation-through-multi-p.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-18T21:56:41.027853+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0256,0257,0258,0259,0260,0261,0262,0263,0264,0265,0266,0267,0268,0269,0270,0271,0272,0273,0274,0275,0276,0277,0278,0279,0280,0281,0282,0283,0284,0285,0286,0287,0288,0289,0290,0291,0292,0293,0294
+superseded_by: 0334
 ---
 
 # Verify fatal exception propagation through multi-phase loops

--- a/repo_wiki/T-rav/hydraflow/testing/0334-issue-synthesis-mock-at-definition-site-not-at-usage-site.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0334-issue-synthesis-mock-at-definition-site-not-at-usage-site.md
@@ -1,0 +1,18 @@
+---
+id: 0334
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.487798+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Mock at definition site, not at usage site
+
+Patch symbols at the module where they are defined, not where they are imported.
+
+Example: Good: `patch('src.foo._cache')`. Bad: `patch('src.consumer._cache')`. For optional deps: `patch.dict("sys.modules", {"sentry_sdk": mock_sdk})`.
+
+**Why:** Usage-site patches intercept only one import; other callers see the real object, producing inconsistent test behavior.

--- a/repo_wiki/T-rav/hydraflow/testing/0335-issue-synthesis-mark-integration-tests-only-for-real-external-deps.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0335-issue-synthesis-mark-integration-tests-only-for-real-external-deps.md
@@ -1,0 +1,18 @@
+---
+id: 0335
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.488412+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Mark integration tests only for real external deps
+
+Apply `@pytest.mark.integration` only when a test exercises Docker, network, filesystem, real worktrees, or live services — not when all deps are mocked.
+
+Example: Use `pytest.mark.skipif(shutil.which("tool") is None, ...)` for optional CLI tools instead of marking as integration.
+
+**Why:** Over-marking slows the fast suite and blurs the unit/integration boundary, making targeted test runs unreliable.

--- a/repo_wiki/T-rav/hydraflow/testing/0336-issue-synthesis-await-asyncio-sleep-0-after-create-task-before-ass.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0336-issue-synthesis-await-asyncio-sleep-0-after-create-task-before-ass.md
@@ -1,0 +1,18 @@
+---
+id: 0336
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.488995+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Await asyncio.sleep(0) after create_task() before asserting
+
+After triggering a fire-and-forget task, yield one event loop tick before asserting.
+
+Example: `task = asyncio.create_task(fn()); await asyncio.sleep(0); mock.assert_called_once()`
+
+**Why:** Without yielding, the scheduled task has not run yet; assertions fire on stale state and produce false negatives.

--- a/repo_wiki/T-rav/hydraflow/testing/0337-issue-synthesis-reset-global-state-in-both-setup-and-teardown.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0337-issue-synthesis-reset-global-state-in-both-setup-and-teardown.md
@@ -1,0 +1,18 @@
+---
+id: 0337
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.489557+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Reset global state in both setup and teardown
+
+Fixtures that touch shared singletons (e.g., `_rate_limit_until`) must reset them at fixture start and at teardown.
+
+Example: Use an autouse conftest fixture to ensure `module._rate_limit_until = 0` runs before and after every test.
+
+**Why:** Stale state from a prior test leaks into later tests, causing order-dependent flakiness invisible in isolation.

--- a/repo_wiki/T-rav/hydraflow/testing/0338-issue-synthesis-use-tmp-path-with-configfactory-for-file-based-tes.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0338-issue-synthesis-use-tmp-path-with-configfactory-for-file-based-tes.md
@@ -1,0 +1,18 @@
+---
+id: 0338
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.490097+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Use tmp_path with ConfigFactory for file-based test I/O
+
+All tests that read or write files must use pytest's `tmp_path` combined with `ConfigFactory.create(base_path=tmp_path)`, never writing to real project paths.
+
+Example: `def test_something(tmp_path): config = ConfigFactory.create(base_path=tmp_path)`
+
+**Why:** Writing to project paths pollutes the working tree and causes cross-test interference, especially under parallel execution.

--- a/repo_wiki/T-rav/hydraflow/testing/0339-issue-synthesis-caplog-assertions-must-name-the-exact-logger.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0339-issue-synthesis-caplog-assertions-must-name-the-exact-logger.md
@@ -1,0 +1,18 @@
+---
+id: 0339
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.490686+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Caplog assertions must name the exact logger
+
+Always pass the exact logger name to `caplog.at_level()` and clear caplog before the action under test.
+
+Example: `with caplog.at_level(logging.WARNING, logger='src.module.name'): trigger_action()`. Assert on message substrings specific to the logged values.
+
+**Why:** Without the logger filter, caplog captures all loggers and assertions may match unrelated log lines, producing false positives.

--- a/repo_wiki/T-rav/hydraflow/testing/0340-issue-synthesis-test-protocols-with-isinstance-and-hasattr.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0340-issue-synthesis-test-protocols-with-isinstance-and-hasattr.md
@@ -1,0 +1,18 @@
+---
+id: 0340
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.491240+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Test protocols with isinstance and hasattr
+
+Use two complementary checks: `isinstance(obj, Protocol)` with `@runtime_checkable`, and `hasattr(obj, 'method_name')` for each protocol method.
+
+Example: Add `inspect.signature()` comparison to catch parameter drift. Parametrize tests over all protocol methods so failures are specific.
+
+**Why:** `isinstance` alone misses methods added at runtime; `hasattr` alone skips type-contract enforcement.

--- a/repo_wiki/T-rav/hydraflow/testing/0341-issue-synthesis-facade-tests-must-cover-routing-error-and-delegati.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0341-issue-synthesis-facade-tests-must-cover-routing-error-and-delegati.md
@@ -1,0 +1,18 @@
+---
+id: 0341
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.491794+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Facade tests must cover routing, error, and delegation
+
+When testing a facade's `__getattr__`, verify four cases: correct method routing, nonexistent method raises `AttributeError`, protocol delegation, and backward compat.
+
+Example: Assert sub-components receive mutable shared-state references, not copies, to verify true delegation.
+
+**Why:** Missing any case allows silent routing failures to ship undetected.

--- a/repo_wiki/T-rav/hydraflow/testing/0342-issue-synthesis-use-playwright-not-testclient-for-js-rendered-attr.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0342-issue-synthesis-use-playwright-not-testclient-for-js-rendered-attr.md
@@ -1,0 +1,18 @@
+---
+id: 0342
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.492332+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Use Playwright, not TestClient, for JS-rendered attrs
+
+Use Playwright for JS-rendered attributes like `aria-labelledby`, as server-side `TestClient` only sees the initial HTML shell.
+
+Example: Delete dead server-side tests that assert JS-rendered HTML; replace with Playwright-based browser tests.
+
+**Why:** TestClient tests for client-rendered attributes always pass vacuously, giving false confidence about real rendering behavior.

--- a/repo_wiki/T-rav/hydraflow/testing/0343-issue-synthesis-subprocess-cli-test-stubs-log-to-jsonl.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0343-issue-synthesis-subprocess-cli-test-stubs-log-to-jsonl.md
@@ -1,0 +1,18 @@
+---
+id: 0343
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.492883+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Subprocess CLI test stubs: log to JSONL
+
+Replace real CLI dependencies in tests with a small Python script that accepts the same arguments, writes each invocation to a JSONL file, and exits 0.
+
+Example: `subprocess_runner = ['python3', 'fake_gh.py']`. Assert behavior by parsing the JSONL log: `json.loads(log_path.read_text())`.
+
+**Why:** Real subprocess boundaries catch shell-quoting, PATH resolution, and argument-passing bugs that mock-based patches cannot detect.

--- a/repo_wiki/T-rav/hydraflow/testing/0344-issue-synthesis-mock-only-execute-in-phase-runner-integration-test.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0344-issue-synthesis-mock-only-execute-in-phase-runner-integration-test.md
@@ -1,0 +1,18 @@
+---
+id: 0344
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.493425+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Mock only _execute() in phase-runner integration tests
+
+In phase-runner integration tests, wire real `StateTracker`, `EventBus`, and `VerificationJudge`. Mock only the `_execute()` subprocess boundary with configurable transcript strings.
+
+Example: Validate state via `StateTracker` APIs and `EventBus.get_history()`, not mock call assertions.
+
+**Why:** Fully-mocked runners hide parser mismatches between test transcripts and real output formats that only real parsers would catch.

--- a/repo_wiki/T-rav/hydraflow/testing/0345-issue-synthesis-use-word-boundary-matching-in-coverage-checks.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0345-issue-synthesis-use-word-boundary-matching-in-coverage-checks.md
@@ -1,0 +1,18 @@
+---
+id: 0345
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.493980+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Use word-boundary matching in coverage checks
+
+When asserting that a name appears in coverage output, use full-name or word-boundary matching.
+
+Example: Bad: `'Foo' in text` — also matches `FooBar`. Good: `re.search(r'\bFoo\b', text)` or full-name match.
+
+**Why:** Short-name collisions silently mark unrelated targets as covered, hiding real gaps in coverage.

--- a/repo_wiki/T-rav/hydraflow/testing/0346-issue-synthesis-enforce-50-30-line-limits-on-handlers-and-wiring.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0346-issue-synthesis-enforce-50-30-line-limits-on-handlers-and-wiring.md
@@ -1,0 +1,18 @@
+---
+id: 0346
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.494541+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Enforce 50/30-line limits on handlers and wiring
+
+Keep handler functions to ≤ 50 lines and registration wiring to ≤ 30 lines. Extract nested closures into instance methods to hold nesting to ≤ 3 levels.
+
+Example: Enforce via AST-based tests with ±3 line tolerance. See also: testing — Allow ±3 line drift in AST-based structure assertions.
+
+**Why:** Functions exceeding these limits are difficult to test in isolation; deeply nested closures cannot be mocked independently.

--- a/repo_wiki/T-rav/hydraflow/testing/0347-issue-synthesis-assert-relative-event-ordering-not-absolute-ids.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0347-issue-synthesis-assert-relative-event-ordering-not-absolute-ids.md
@@ -1,0 +1,18 @@
+---
+id: 0347
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.495084+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Assert relative event ordering, not absolute IDs
+
+Tests must never assert on absolute event counter values — only on relative ordering and uniqueness within a single test run.
+
+Example: Good: `assert event_a.id < event_b.id`. Bad: `assert event_a.id == 1`.
+
+**Why:** Global counters are shared across all test instances; absolute ID assertions are order-dependent and flaky under parallel execution.

--- a/repo_wiki/T-rav/hydraflow/testing/0348-issue-synthesis-add-structural-tests-before-property-based-tests.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0348-issue-synthesis-add-structural-tests-before-property-based-tests.md
@@ -1,0 +1,18 @@
+---
+id: 0348
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.495625+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Add structural tests before property-based tests
+
+Before running property-based tests on a transition graph, add structural tests: every target is a valid stage, every stage has a transition entry, and no dangling references exist.
+
+Example: `assert set(VALID_TRANSITIONS.keys()) == VALID_STAGES`
+
+**Why:** Property-based tests discover transition paths but silently skip unreachable states caused by structural gaps in the graph definition.

--- a/repo_wiki/T-rav/hydraflow/testing/0349-issue-synthesis-sync-test-label-constants-with-production-definiti.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0349-issue-synthesis-sync-test-label-constants-with-production-definiti.md
@@ -1,0 +1,18 @@
+---
+id: 0349
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.496173+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Sync test label constants with production definitions
+
+Keep test constants (`ALL_PIPELINE_LABELS`, `VALID_STAGES`, `VALID_TRANSITIONS`) synchronized with production definitions. Add a sync test asserting set equality.
+
+Example: `assert set(VALID_TRANSITIONS.keys()) == VALID_STAGES`. Test both `EVENT_TYPE_TO_STAGE` and `SOURCE_TO_STAGE` independently. See also: testing — Test direct-swap labels via swap_pipeline_labels(), not transitions.
+
+**Why:** Stale test constants let new label additions pass CI without being exercised by the test suite.

--- a/repo_wiki/T-rav/hydraflow/testing/0350-issue-synthesis-update-4-places-on-pydantic-typeddict-field-change.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0350-issue-synthesis-update-4-places-on-pydantic-typeddict-field-change.md
@@ -1,0 +1,18 @@
+---
+id: 0350
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.496723+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Update 4 places on Pydantic/TypedDict field changes
+
+When adding or removing fields, update: (1) model definition, (2) test factory defaults, (3) field-presence assertions, (4) serialization round-trip tests.
+
+Example: Grep for the model name: `grep -r "ModelName" tests/`. For `NotRequired` fields, update exact-match assertions but not missing-key assertions. See also: testing — dict-to-TypedDict migrations require no new tests.
+
+**Why:** Missing any location leaves tests that silently ignore the new field, giving false coverage confidence.

--- a/repo_wiki/T-rav/hydraflow/testing/0351-issue-synthesis-feature-toggles-need-config-field-and-overrides.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0351-issue-synthesis-feature-toggles-need-config-field-and-overrides.md
@@ -1,0 +1,18 @@
+---
+id: 0351
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.497284+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Feature toggles need config field and overrides
+
+Every toggle requires both a field in `src/config.py` AND an entry in `_ENV_INT_OVERRIDES`. Test both the default value and the env-var override path.
+
+Example: The `_ENV_INT_OVERRIDES` tuple default must equal the Field default or the override silently stops applying. See also: architecture-state-persistence — `_ENV_INT_OVERRIDES` default sync.
+
+**Why:** Without the overrides entry, the env-var has no effect; the toggle appears configurable at runtime but is not.

--- a/repo_wiki/T-rav/hydraflow/testing/0352-issue-synthesis-dict-to-typeddict-migrations-require-no-new-tests.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0352-issue-synthesis-dict-to-typeddict-migrations-require-no-new-tests.md
@@ -1,0 +1,18 @@
+---
+id: 0352
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.497844+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# dict-to-TypedDict migrations require no new tests
+
+Migrating `dict[str, Any]` return types to TypedDicts requires no additional tests; the change is purely static.
+
+Example: TypedDicts are plain dicts at runtime, so existing assertions continue to work identically. Verify via `make quality-lite` and `make test`. See also: testing — Pydantic/TypedDict field changes require updates in 4 places.
+
+**Why:** Adding tests for a purely static type change wastes effort and can introduce false precision assumptions about runtime structure.

--- a/repo_wiki/T-rav/hydraflow/testing/0353-issue-synthesis-concurrent-jsonl-appends-assert-exact-counts.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0353-issue-synthesis-concurrent-jsonl-appends-assert-exact-counts.md
@@ -1,0 +1,18 @@
+---
+id: 0353
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.498399+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Concurrent JSONL appends: assert exact counts
+
+Test concurrent file operations with a fixed thread count and deterministic iteration count, then assert on exact line counts.
+
+Example: `# 10 threads × 20 events = 200 total` followed by `assert len(lines) == 200`.
+
+**Why:** Timing-based assertions are flaky; deterministic event counts make failures reproducible.

--- a/repo_wiki/T-rav/hydraflow/testing/0354-issue-synthesis-keep-memory-bank-keys-consistent-across-dedup.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0354-issue-synthesis-keep-memory-bank-keys-consistent-across-dedup.md
@@ -1,0 +1,18 @@
+---
+id: 0354
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.498950+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Keep memory bank keys consistent across dedup
+
+Use identical string keys (`'review_insights'`, not `'review-insights'`) in both deduplication priority maps and bank-assembly pipelines.
+
+Example: Fallback recall functions must try multiple field names (`learning`, `text`, `content`, `display_text`) when extracting text payload from different bank record formats.
+
+**Why:** Mismatched keys cause entire banks to be silently skipped during validation, producing gaps that look like passing coverage.

--- a/repo_wiki/T-rav/hydraflow/testing/0355-issue-synthesis-validate-skill-markers-across-all-4-backend-copies.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0355-issue-synthesis-validate-skill-markers-across-all-4-backend-copies.md
@@ -1,0 +1,18 @@
+---
+id: 0355
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.499495+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Validate skill markers across all 4 backend copies
+
+Validate marker presence via substring search across `.claude/commands/`, `.pi/skills/`, `.codex/skills/`, and `src/*.py`.
+
+Example: Use a manual `SKILL_MARKERS` mapping, not regex introspection. A single skill addition or removal requires updating 3+ test files.
+
+**Why:** Updating fewer than 4 copies silently diverges behavior across execution environments with no test failure to signal the gap.

--- a/repo_wiki/T-rav/hydraflow/testing/0356-issue-synthesis-generate-adr-derived-tests-as-skipped-skeletons.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0356-issue-synthesis-generate-adr-derived-tests-as-skipped-skeletons.md
@@ -1,0 +1,18 @@
+---
+id: 0356
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.500051+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Generate ADR-derived tests as skipped skeletons
+
+Extract baseline invariants (uniqueness, usage, negative, coverage) from an ADR's Decision section and generate each test as a skipped skeleton.
+
+Example: `@pytest.mark.skip(reason='skeleton: requires human review')`
+
+**Why:** Auto-generating non-skipped tests from ambiguous ADR language creates brittle tests that break on legitimate wording updates.

--- a/repo_wiki/T-rav/hydraflow/testing/0357-issue-synthesis-adr-pre-validator-enforce-required-sections.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0357-issue-synthesis-adr-pre-validator-enforce-required-sections.md
@@ -1,0 +1,18 @@
+---
+id: 0357
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.500597+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# ADR pre-validator: enforce required sections
+
+All ADRs must pass `tests/test_adr_pre_validator.py`, enforcing required sections (Status, Context, Decision, Consequences) and valid status values.
+
+Example: See also: architecture — ADR number collision and README guards.
+
+**Why:** Missing sections or invalid status values make ADRs non-machine-readable, breaking automated drift detection and the ADR README completeness guard.

--- a/repo_wiki/T-rav/hydraflow/testing/0358-issue-synthesis-never-import-private-helpers-at-module-level.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0358-issue-synthesis-never-import-private-helpers-at-module-level.md
@@ -1,0 +1,18 @@
+---
+id: 0358
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.501143+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Never import private helpers at module level
+
+Import private or internal functions (`_foo`) inside the test function or a `pytest.fixture`, never at module top level.
+
+Example: `def test_check_prereq(): from src.makefile_scaffold import _check_prereq_deps`
+
+**Why:** A module-level `ImportError` prevents pytest from collecting the file, silently destroying all passing tests in that module.

--- a/repo_wiki/T-rav/hydraflow/testing/0359-issue-synthesis-pin-function-signatures-before-writing-callers.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0359-issue-synthesis-pin-function-signatures-before-writing-callers.md
@@ -1,0 +1,18 @@
+---
+id: 0359
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.501697+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Pin function signatures before writing callers
+
+Decide the authoritative signature (argument order, return tuple shape) in the source file first; then write docs and tests to match.
+
+Example: 1. Write the function stub. 2. Copy its exact signature into the docstring. 3. Write the test.
+
+**Why:** When docs and tests are authored before implementation, signature drift goes undetected until runtime, and both artifacts may be wrong.

--- a/repo_wiki/T-rav/hydraflow/testing/0360-issue-synthesis-validate-sys-modules-cleanup-with-multiple-seeds.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0360-issue-synthesis-validate-sys-modules-cleanup-with-multiple-seeds.md
@@ -1,0 +1,18 @@
+---
+id: 0360
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.502244+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Validate sys.modules cleanup with multiple seeds
+
+Run `pytest --randomly-seed=<N>` with at least two different seeds to confirm that module-level import side effects do not leak between tests.
+
+Example: Execute the test suite with `--randomly-seed=1` and `--randomly-seed=42` to verify isolation.
+
+**Why:** Cleanup failures only surface under specific test orderings; a single seed may never trigger the problematic sequence.

--- a/repo_wiki/T-rav/hydraflow/testing/0361-issue-synthesis-skip-broken-tests-with-an-issue-reference.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0361-issue-synthesis-skip-broken-tests-with-an-issue-reference.md
@@ -1,0 +1,18 @@
+---
+id: 0361
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.502793+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Skip broken tests with an issue reference
+
+Mark broken tests with a referenced issue, never a bare skip. Remove the skip immediately after the issue is resolved.
+
+Example: `@pytest.mark.skip(reason="documenting bug: #1234")`
+
+**Why:** Without an issue reference, skipped tests become permanent dead weight with no path to removal or triage.

--- a/repo_wiki/T-rav/hydraflow/testing/0362-issue-synthesis-use-is-to-verify-shared-runner-instance.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0362-issue-synthesis-use-is-to-verify-shared-runner-instance.md
@@ -1,0 +1,18 @@
+---
+id: 0362
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.503425+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Use `is` to verify shared runner instance
+
+Assert that two components share the same subprocess runner with `is`, not `==`.
+
+Example: `assert component_a.runner is component_b.runner`
+
+**Why:** `==` may pass even when different instances are created; `is` verifies the exact object reference required by the single-runner design contract.

--- a/repo_wiki/T-rav/hydraflow/testing/0363-issue-synthesis-memory-dedup-higher-priority-bank-wins-on-collisio.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0363-issue-synthesis-memory-dedup-higher-priority-bank-wins-on-collisio.md
@@ -1,0 +1,18 @@
+---
+id: 0363
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.504047+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Memory dedup: higher-priority bank wins on collision
+
+When two near-duplicate items collide, the higher-priority bank's item survives.
+
+Example: Priority order: LEARNINGS (5) > TROUBLESHOOTING (4) > RETROSPECTIVES (3) > REVIEW_INSIGHTS (2) > HARNESS_INSIGHTS (1). Test collision behavior explicitly.
+
+**Why:** Without priority enforcement, a lower-quality retrospective can silently overwrite a load-bearing learning entry.

--- a/repo_wiki/T-rav/hydraflow/testing/0364-issue-synthesis-hoist-deterministic-gates-outside-llm-retry-loops.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0364-issue-synthesis-hoist-deterministic-gates-outside-llm-retry-loops.md
@@ -1,0 +1,18 @@
+---
+id: 0364
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.504683+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Hoist deterministic gates outside LLM retry loops
+
+Run subprocess-based validation (coverage, linting) once after the loop exits, not inside each retry iteration.
+
+Example: `result = run_llm_loop(...); if result == PASS: _run_coverage_delta_check(diff)`
+
+**Why:** Placing an expensive deterministic check inside the retry loop multiplies wall-clock cost by `max_attempts` without any additional signal.

--- a/repo_wiki/T-rav/hydraflow/testing/0365-issue-synthesis-use-public-fakegithub-api-in-scenario-tests.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0365-issue-synthesis-use-public-fakegithub-api-in-scenario-tests.md
@@ -1,0 +1,18 @@
+---
+id: 0365
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.505274+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Use public FakeGitHub API in scenario tests
+
+Always use the public API to mutate `FakeGitHub` state in scenario tests; never write to private attributes directly.
+
+Example: Bad: `world.github._issues[901].state = "closed"`. Good: `await world.github.close_issue(901)`
+
+**Why:** If `FakeIssue` internals change, direct attribute writes silently remain valid Python while the fake's behavior drifts — the public API is the compatibility boundary.

--- a/repo_wiki/T-rav/hydraflow/testing/0366-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0366-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
@@ -1,0 +1,18 @@
+---
+id: 0366
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.505849+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Test async context managers in three standard scenarios
+
+Cover async context managers with three scenarios: (1) idempotent close — calling `close()` twice is safe; (2) `__aexit__` triggers `close()` exactly once; (3) `__aenter__` returns `self`.
+
+Example: `async with resource as r: assert r is resource`
+
+**Why:** Missing any scenario leaves an incomplete behavioral contract, hiding bugs in external-connection or file-handle management.

--- a/repo_wiki/T-rav/hydraflow/testing/0367-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0367-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels.md
@@ -1,0 +1,18 @@
+---
+id: 0367
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.506413+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Test direct-swap labels via swap_pipeline_labels()
+
+Labels set via atomic swap (`hitl-active`, `fixed`) bypass the transition graph and are applied by `swap_pipeline_labels()` — test them on that call path.
+
+Example: Do not test swap labels through `VALID_TRANSITIONS`. See also: testing — Sync test label constants with production pipeline definitions.
+
+**Why:** Testing swap labels through the transition graph masks missing coverage; they have no transition entry by design.

--- a/repo_wiki/T-rav/hydraflow/testing/0368-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0368-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
@@ -1,0 +1,18 @@
+---
+id: 0368
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.506994+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Allow ±3 line drift in AST-based structure assertions
+
+For tests that verify code structure by parsing source ASTs (e.g., checking function length), allow ±3 line tolerance.
+
+Example: Assert `len(func.body) <= 53` rather than `<= 50` to account for blank lines and decorator variations. See also: testing — Enforce 50/30-line limits on handlers and registration wiring.
+
+**Why:** Exact line-count assertions redden CI on whitespace-only diffs, creating maintenance noise without improving correctness.

--- a/repo_wiki/T-rav/hydraflow/testing/0369-issue-synthesis-existing-tests-cover-private-method-extractions.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0369-issue-synthesis-existing-tests-cover-private-method-extractions.md
@@ -1,0 +1,18 @@
+---
+id: 0369
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.507583+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Existing tests cover private-method extractions
+
+When extracting a private method from a public one with an unchanged public API, the existing test suite provides full coverage — no new tests are needed for the extraction itself.
+
+Example: When extracting prompt-building methods, run prompt-assertion tests in isolation immediately after extraction to verify parity.
+
+**Why:** Adding duplicate tests for unchanged behavior inflates the suite; the real regression risk is behavioral, which existing tests already guard.

--- a/repo_wiki/T-rav/hydraflow/testing/0370-issue-synthesis-assert-numeric-values-in-sentry-breadcrumbs.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0370-issue-synthesis-assert-numeric-values-in-sentry-breadcrumbs.md
@@ -1,0 +1,18 @@
+---
+id: 0370
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.508157+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Assert numeric values in Sentry breadcrumbs
+
+When testing Sentry integration, assert actual numeric values in breadcrumbs and metrics, not just that a key exists.
+
+Example: `assert breadcrumb['data']['latency_ms'] == 42`
+
+**Why:** Key-presence assertions pass even when values are wrong or zero; numeric value assertions catch metric miscalculation bugs that presence checks miss entirely.

--- a/repo_wiki/T-rav/hydraflow/testing/0371-issue-synthesis-test-pydantic-literal-constraints-valid-and-invali.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0371-issue-synthesis-test-pydantic-literal-constraints-valid-and-invali.md
@@ -1,0 +1,18 @@
+---
+id: 0371
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.508728+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Test Pydantic Literal constraints: valid and invalid
+
+When adding `Literal` constraints to Pydantic fields, test both valid and invalid values — verify valid values are accepted and invalid values raise `ValidationError`.
+
+Example: For `status: Literal['open', 'closed']`, test `status='open'` passes and `status='unknown'` raises.
+
+**Why:** Literal constraints are invisible at runtime if only valid values are tested; invalid-value tests confirm the constraint is actually enforced.

--- a/repo_wiki/T-rav/hydraflow/testing/0372-issue-synthesis-verify-fatal-exception-propagation-through-loops.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0372-issue-synthesis-verify-fatal-exception-propagation-through-loops.md
@@ -1,0 +1,18 @@
+---
+id: 0372
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T00:25:25.509324+00:00
+status: active
+corroborations: 1
+supersedes: 0295,0296,0297,0298,0299,0300,0301,0302,0303,0304,0305,0306,0307,0308,0309,0310,0311,0312,0313,0314,0315,0316,0317,0318,0319,0320,0321,0322,0323,0324,0325,0326,0327,0328,0329,0330,0331,0332,0333
+---
+
+# Verify fatal exception propagation through loops
+
+Test that fatal exceptions propagate through multi-phase loops by mocking internal methods to raise specific exception types, then asserting the exception reaches the caller.
+
+Example: `mock._execute.side_effect = FatalError(); with pytest.raises(FatalError): await loop.run_once()`
+
+**Why:** Broad `except Exception` blocks in loop runners silently swallow fatal exceptions, making multi-phase loops appear to succeed when they have failed.


### PR DESCRIPTION
Automated wiki maintenance PR opened by `RepoWikiLoop`.

## Actions

- 0 entries marked stale
- 0 entries pruned
- 115 entries compiled / synthesized
- 0 console-triggered tasks drained

## Files changed

- `repo_wiki/T-rav/hydraflow/gotchas/0112-issue-synthesis-error-tolerance-tests-must-cover-creditexhausteder.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0113-issue-synthesis-use-type-checking-guards-for-forward-reference-ann.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0114-issue-synthesis-update-emit-trace-command-strings-when-migrating-s.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0115-issue-synthesis-grep-for-runtime-references-before-removing-an-imp.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0116-issue-synthesis-use-is-none-is-not-none-for-optional-sentinels.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0117-issue-synthesis-sync-all-protocol-implementations-in-one-pr-on-sig.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0118-issue-synthesis-delete-code-blocks-bottom-to-top-to-avoid-line-num.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0119-issue-synthesis-patch-functions-at-their-definition-site-not-the-i.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0120-issue-synthesis-verify-a-file-exists-before-writing-a-plan-task-th.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0121-issue-synthesis-test-pydantic-serialization-with-round-trip-and-sa.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0122-issue-synthesis-run-full-make-quality-before-declaring-implementat.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0123-issue-synthesis-use-log-exception-with-bug-classification-for-bugs.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0124-issue-synthesis-use-logger-warning-exc-info-true-for-transient-err.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0125-issue-synthesis-catch-both-timeoutexpired-and-calledprocesserror-t.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0126-issue-synthesis-omitting-await-on-async-calls-silently-returns-a-c.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0127-issue-synthesis-store-asyncio-create-task-results-unreferenced-tas.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0128-issue-synthesis-new-pydantic-fields-must-have-defaults-for-existin.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0129-issue-synthesis-use-atomic-write-instead-of-path-write-text-for-js.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0130-issue-synthesis-use-typeddict-total-false-for-backward-compatible-.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0131-issue-synthesis-new-hydraflowconfig-label-fields-must-be-optional-.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0132-issue-synthesis-reverse-state-transitions-on-non-fatal-exceptions-.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0133-issue-synthesis-use-same-id-extraction-logic-everywhere-files-are-.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0134-issue-synthesis-join-factory-pipeline-metrics-by-issue-number-not-.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0135-issue-synthesis-test-pipeline-stage-ordering-not-just-status-after.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0136-issue-synthesis-filter-evicted-memories-on-both-content-prefix-and.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0137-issue-synthesis-new-automated-skills-must-start-with-blocking-fals.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0138-issue-synthesis-validate-parsers-against-realistic-multi-paragraph.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0139-issue-synthesis-log-warning-on-zero-match-transcript-extraction-fr.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0140-issue-synthesis-use-portable-shell-commands-in-alpine-containers-p.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0141-issue-synthesis-separate-silent-with-result-events-from-purely-sil.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0142-issue-synthesis-create-a-specialized-method-rather-than-overloadin.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0143-issue-synthesis-ruff-strips-unused-imports-mid-tdd-cycle.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0144-issue-synthesis-verify-implementation-files-are-in-the-diff-before.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0145-issue-synthesis-coverage-delta-gate-is-asymmetric-gaps-block-clean.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0146-issue-synthesis-error-tolerance-tests-must-cover-creditexhausteder.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0147-issue-synthesis-use-type-checking-guards-for-forward-reference-ann.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0148-issue-synthesis-update-emit-trace-command-strings-when-migrating-s.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0149-issue-synthesis-grep-for-runtime-references-before-removing-an-imp.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0150-issue-synthesis-use-is-none-is-not-none-for-optional-sentinels.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0151-issue-synthesis-sync-all-protocol-implementations-in-one-pr-on-sig.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0152-issue-synthesis-delete-code-blocks-bottom-to-top-to-avoid-line-num.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0153-issue-synthesis-patch-functions-at-their-definition-site-not-the-i.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0154-issue-synthesis-verify-a-file-exists-before-writing-a-plan-task-th.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0155-issue-synthesis-test-pydantic-serialization-with-round-trip-and-sa.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0156-issue-synthesis-run-full-make-quality-before-declaring-implementat.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0157-issue-synthesis-use-log-exception-with-bug-classification-for-bugs.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0158-issue-synthesis-use-logger-warning-exc-info-true-for-transient-err.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0159-issue-synthesis-catch-both-timeoutexpired-and-calledprocesserror-t.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0160-issue-synthesis-omitting-await-on-async-calls-silently-returns-a-c.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0161-issue-synthesis-store-asyncio-create-task-results-unreferenced-tas.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0162-issue-synthesis-new-pydantic-fields-must-have-defaults-for-existin.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0163-issue-synthesis-use-atomic-write-instead-of-path-write-text-for-js.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0164-issue-synthesis-use-typeddict-total-false-for-backward-compatible-.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0165-issue-synthesis-new-hydraflowconfig-label-fields-must-be-optional-.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0166-issue-synthesis-reverse-state-transitions-on-non-fatal-exceptions-.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0167-issue-synthesis-use-same-id-extraction-logic-everywhere-files-are-.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0168-issue-synthesis-join-factory-pipeline-metrics-by-issue-number-not-.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0169-issue-synthesis-test-pipeline-stage-ordering-not-just-status-after.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0170-issue-synthesis-filter-evicted-memories-on-both-content-prefix-and.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0171-issue-synthesis-new-automated-skills-must-start-with-blocking-fals.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0172-issue-synthesis-validate-parsers-against-realistic-multi-paragraph.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0173-issue-synthesis-log-warning-on-zero-match-transcript-extraction-fr.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0174-issue-synthesis-use-portable-shell-commands-in-alpine-containers-p.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0175-issue-synthesis-separate-silent-with-result-events-from-purely-sil.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0176-issue-synthesis-create-a-specialized-method-rather-than-overloadin.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0177-issue-synthesis-ruff-strips-unused-imports-mid-tdd-cycle.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0178-issue-synthesis-verify-implementation-files-are-in-the-diff-before.md`
- `repo_wiki/T-rav/hydraflow/gotchas/0179-issue-synthesis-coverage-delta-gate-is-asymmetric-gaps-block-clean.md`
- `repo_wiki/T-rav/hydraflow/patterns/0134-issue-synthesis-use-optional-fields-with-defaults-for-backward-com.md`
- `repo_wiki/T-rav/hydraflow/patterns/0135-issue-synthesis-distinguish-bare-str-from-str-none-before-narrowin.md`
- `repo_wiki/T-rav/hydraflow/patterns/0136-issue-synthesis-use-strenum-coercion-to-auto-convert-stored-string.md`
- `repo_wiki/T-rav/hydraflow/patterns/0137-issue-synthesis-define-canonical-constants-as-single-source-of-tru.md`
- `repo_wiki/T-rav/hydraflow/patterns/0138-issue-synthesis-use-metadata-tags-instead-of-enum-variants-for-sha.md`
- `repo_wiki/T-rav/hydraflow/patterns/0139-issue-synthesis-grep-all-call-sites-before-changing-a-function-sig.md`
- `repo_wiki/T-rav/hydraflow/patterns/0140-issue-synthesis-update-all-callers-atomically-when-a-return-type-c.md`
- `repo_wiki/T-rav/hydraflow/patterns/0141-issue-synthesis-preserve-public-api-during-extraction-via-thin-del.md`
- `repo_wiki/T-rav/hydraflow/patterns/0142-issue-synthesis-extract-pure-transform-functions-before-moving-cod.md`
- `repo_wiki/T-rav/hydraflow/patterns/0143-issue-synthesis-preserve-per-concern-try-except-blocks-during-refa.md`
- `repo_wiki/T-rav/hydraflow/patterns/0144-issue-synthesis-extract-duplicated-jsonl-reading-logic-to-a-shared.md`
- `repo_wiki/T-rav/hydraflow/patterns/0145-issue-synthesis-mock-at-the-definition-site-not-the-import-site.md`
- `repo_wiki/T-rav/hydraflow/patterns/0146-issue-synthesis-retarget-mock-patches-to-the-new-location-before-m.md`
- `repo_wiki/T-rav/hydraflow/patterns/0147-issue-synthesis-generated-test-content-must-reference-function-nam.md`
- `repo_wiki/T-rav/hydraflow/patterns/0148-issue-synthesis-use-meta-tests-to-enforce-anti-pattern-absence-acr.md`
- `repo_wiki/T-rav/hydraflow/patterns/0149-issue-synthesis-use-threading-lock-for-thread-pool-code-asyncio-lo.md`
- `repo_wiki/T-rav/hydraflow/patterns/0150-issue-synthesis-extract-unlocked-helpers-to-prevent-re-entrant-loc.md`
- `repo_wiki/T-rav/hydraflow/patterns/0151-issue-synthesis-use-file-util-append-jsonl-for-crash-safe-jsonl-ap.md`
- `repo_wiki/T-rav/hydraflow/patterns/0152-issue-synthesis-use-file-util-atomic-write-for-critical-state-file.md`
- `repo_wiki/T-rav/hydraflow/patterns/0153-issue-synthesis-use-claim-then-merge-for-async-queue-processing-to.md`
- `repo_wiki/T-rav/hydraflow/patterns/0154-issue-synthesis-set-and-clear-trace-context-in-a-single-try-finall.md`
- `repo_wiki/T-rav/hydraflow/patterns/0155-issue-synthesis-keep-event-publishing-coupled-with-the-condition-t.md`
- `repo_wiki/T-rav/hydraflow/patterns/0156-issue-synthesis-preserve-exact-retry-counter-state-during-dispatch.md`
- `repo_wiki/T-rav/hydraflow/patterns/0157-issue-synthesis-dry-run-mode-must-not-emit-state-changing-events.md`
- `repo_wiki/T-rav/hydraflow/patterns/0158-issue-synthesis-maintain-immutable-return-contract-for-parse-tuple.md`
- `repo_wiki/T-rav/hydraflow/patterns/0159-issue-synthesis-define-event-to-stage-and-source-to-stage-mappings.md`
- `repo_wiki/T-rav/hydraflow/patterns/0160-issue-synthesis-pre-allocate-memory-budget-upfront-before-prompt-a.md`
- `repo_wiki/T-rav/hydraflow/patterns/0161-issue-synthesis-use-a-two-round-allocator-section-minimums-first-t.md`
- `repo_wiki/T-rav/hydraflow/patterns/0162-issue-synthesis-deduct-wiki-budget-from-memory-surplus-before-redi.md`
- `repo_wiki/T-rav/hydraflow/patterns/0163-issue-synthesis-lazy-load-memory-context-on-explicit-user-action-n.md`
- `repo_wiki/T-rav/hydraflow/patterns/0164-issue-synthesis-use-sha-256-truncated-to-16-chars-for-memory-dedup.md`
- `repo_wiki/T-rav/hydraflow/patterns/0165-issue-synthesis-use-asymmetric-word-set-overlap-for-memory-dedupli.md`
- `repo_wiki/T-rav/hydraflow/patterns/0166-issue-synthesis-batch-load-scoring-data-once-per-eviction-operatio.md`
- `repo_wiki/T-rav/hydraflow/patterns/0167-issue-synthesis-use-true-not-is-true-for-retain-metadata-booleans.md`
- `repo_wiki/T-rav/hydraflow/patterns/0168-issue-synthesis-memory-contradiction-resolution-provenance-wins-ov.md`
- `repo_wiki/T-rav/hydraflow/patterns/0169-issue-synthesis-memory-eviction-must-atomically-update-scores-and-.md`
- `repo_wiki/T-rav/hydraflow/patterns/0170-issue-synthesis-guard-close-with-a-closed-flag-to-make-it-idempote.md`
- `repo_wiki/T-rav/hydraflow/patterns/0171-issue-synthesis-memory-staleness-detection-should-emit-events-not-.md`
- `repo_wiki/T-rav/hydraflow/patterns/0172-issue-synthesis-adr-files-without-readme-entries-are-invisible-to-.md`
- `repo_wiki/T-rav/hydraflow/patterns/0173-issue-synthesis-preserve-the-hf-namespace-prefix-when-renaming-ski.md`
- `repo_wiki/T-rav/hydraflow/patterns/0174-issue-synthesis-keep-skill-prompts-in-sync-across-all-four-backend.md`
- `repo_wiki/T-rav/hydraflow/patterns/0175-issue-synthesis-in-place-diff-truncation-silently-corrupts-downstr.md`
- `repo_wiki/T-rav/hydraflow/patterns/0176-issue-synthesis-use-optional-fields-with-defaults-for-backward-com.md`
- `repo_wiki/T-rav/hydraflow/patterns/0177-issue-synthesis-distinguish-bare-str-from-str-none-before-narrowin.md`
- `repo_wiki/T-rav/hydraflow/patterns/0178-issue-synthesis-use-strenum-coercion-to-auto-convert-stored-string.md`
- `repo_wiki/T-rav/hydraflow/patterns/0179-issue-synthesis-define-canonical-constants-as-single-source-of-tru.md`
- `repo_wiki/T-rav/hydraflow/patterns/0180-issue-synthesis-use-metadata-tags-instead-of-enum-variants-for-sha.md`
- `repo_wiki/T-rav/hydraflow/patterns/0181-issue-synthesis-grep-all-call-sites-before-changing-a-function-sig.md`
- `repo_wiki/T-rav/hydraflow/patterns/0182-issue-synthesis-update-all-callers-atomically-when-a-return-type-c.md`
- `repo_wiki/T-rav/hydraflow/patterns/0183-issue-synthesis-preserve-public-api-during-extraction-via-thin-del.md`
- `repo_wiki/T-rav/hydraflow/patterns/0184-issue-synthesis-extract-pure-transform-functions-before-moving-cod.md`
- `repo_wiki/T-rav/hydraflow/patterns/0185-issue-synthesis-preserve-per-concern-try-except-blocks-during-refa.md`
- `repo_wiki/T-rav/hydraflow/patterns/0186-issue-synthesis-extract-duplicated-jsonl-reading-logic-to-a-shared.md`
- `repo_wiki/T-rav/hydraflow/patterns/0187-issue-synthesis-mock-at-the-definition-site-not-the-import-site.md`
- `repo_wiki/T-rav/hydraflow/patterns/0188-issue-synthesis-retarget-mock-patches-to-the-new-location-before-m.md`
- `repo_wiki/T-rav/hydraflow/patterns/0189-issue-synthesis-generated-test-content-must-reference-function-nam.md`
- `repo_wiki/T-rav/hydraflow/patterns/0190-issue-synthesis-use-meta-tests-to-enforce-anti-pattern-absence-acr.md`
- `repo_wiki/T-rav/hydraflow/patterns/0191-issue-synthesis-use-threading-lock-for-thread-pool-code-asyncio-lo.md`
- `repo_wiki/T-rav/hydraflow/patterns/0192-issue-synthesis-extract-unlocked-helpers-to-prevent-re-entrant-loc.md`
- `repo_wiki/T-rav/hydraflow/patterns/0193-issue-synthesis-use-file-util-append-jsonl-for-crash-safe-jsonl-ap.md`
- `repo_wiki/T-rav/hydraflow/patterns/0194-issue-synthesis-use-file-util-atomic-write-for-critical-state-file.md`
- `repo_wiki/T-rav/hydraflow/patterns/0195-issue-synthesis-use-claim-then-merge-for-async-queue-processing-to.md`
- `repo_wiki/T-rav/hydraflow/patterns/0196-issue-synthesis-set-and-clear-trace-context-in-a-single-try-finall.md`
- `repo_wiki/T-rav/hydraflow/patterns/0197-issue-synthesis-keep-event-publishing-coupled-with-the-condition-t.md`
- `repo_wiki/T-rav/hydraflow/patterns/0198-issue-synthesis-preserve-exact-retry-counter-state-during-dispatch.md`
- `repo_wiki/T-rav/hydraflow/patterns/0199-issue-synthesis-dry-run-mode-must-not-emit-state-changing-events.md`
- `repo_wiki/T-rav/hydraflow/patterns/0200-issue-synthesis-maintain-immutable-return-contract-for-parse-tuple.md`
- `repo_wiki/T-rav/hydraflow/patterns/0201-issue-synthesis-define-event-to-stage-and-source-to-stage-mappings.md`
- `repo_wiki/T-rav/hydraflow/patterns/0202-issue-synthesis-pre-allocate-memory-budget-upfront-before-prompt-a.md`
- `repo_wiki/T-rav/hydraflow/patterns/0203-issue-synthesis-use-a-two-round-allocator-section-minimums-first-t.md`
- `repo_wiki/T-rav/hydraflow/patterns/0204-issue-synthesis-deduct-wiki-budget-from-memory-surplus-before-redi.md`
- `repo_wiki/T-rav/hydraflow/patterns/0205-issue-synthesis-lazy-load-memory-context-on-explicit-user-action-n.md`
- `repo_wiki/T-rav/hydraflow/patterns/0206-issue-synthesis-use-sha-256-truncated-to-16-chars-for-memory-dedup.md`
- `repo_wiki/T-rav/hydraflow/patterns/0207-issue-synthesis-use-asymmetric-word-set-overlap-for-memory-dedupli.md`
- `repo_wiki/T-rav/hydraflow/patterns/0208-issue-synthesis-batch-load-scoring-data-once-per-eviction-operatio.md`
- `repo_wiki/T-rav/hydraflow/patterns/0209-issue-synthesis-use-true-not-is-true-for-retain-metadata-booleans.md`
- `repo_wiki/T-rav/hydraflow/patterns/0210-issue-synthesis-memory-contradiction-resolution-provenance-wins-ov.md`
- `repo_wiki/T-rav/hydraflow/patterns/0211-issue-synthesis-memory-eviction-must-atomically-update-scores-and-.md`
- `repo_wiki/T-rav/hydraflow/patterns/0212-issue-synthesis-guard-close-with-a-closed-flag-to-make-it-idempote.md`
- `repo_wiki/T-rav/hydraflow/patterns/0213-issue-synthesis-memory-staleness-detection-should-emit-events-not-.md`
- `repo_wiki/T-rav/hydraflow/patterns/0214-issue-synthesis-adr-files-without-readme-entries-are-invisible-to-.md`
- `repo_wiki/T-rav/hydraflow/patterns/0215-issue-synthesis-preserve-the-hf-namespace-prefix-when-renaming-ski.md`
- `repo_wiki/T-rav/hydraflow/patterns/0216-issue-synthesis-keep-skill-prompts-in-sync-across-all-four-backend.md`
- `repo_wiki/T-rav/hydraflow/patterns/0217-issue-synthesis-in-place-diff-truncation-silently-corrupts-downstr.md`
- `repo_wiki/T-rav/hydraflow/testing/0295-issue-synthesis-mock-at-definition-site-not-at-usage-site.md`
- `repo_wiki/T-rav/hydraflow/testing/0296-issue-synthesis-mark-pytest-mark-integration-only-for-real-externa.md`
- `repo_wiki/T-rav/hydraflow/testing/0297-issue-synthesis-await-asyncio-sleep-0-after-create-task-before-ass.md`
- `repo_wiki/T-rav/hydraflow/testing/0298-issue-synthesis-reset-global-module-level-state-in-both-setup-and-.md`
- `repo_wiki/T-rav/hydraflow/testing/0299-issue-synthesis-use-tmp-path-with-configfactory-for-all-file-based.md`
- `repo_wiki/T-rav/hydraflow/testing/0300-issue-synthesis-caplog-assertions-must-name-the-exact-logger.md`
- `repo_wiki/T-rav/hydraflow/testing/0301-issue-synthesis-test-protocol-satisfaction-with-isinstance-and-has.md`
- `repo_wiki/T-rav/hydraflow/testing/0302-issue-synthesis-facade-tests-cover-routing-error-delegation-and-ba.md`
- `repo_wiki/T-rav/hydraflow/testing/0303-issue-synthesis-browser-rendered-attributes-require-playwright-not.md`
- `repo_wiki/T-rav/hydraflow/testing/0304-issue-synthesis-subprocess-cli-test-stubs-log-invocations-to-jsonl.md`
- `repo_wiki/T-rav/hydraflow/testing/0305-issue-synthesis-integration-test-runners-mock-only-execute-wire-re.md`
- `repo_wiki/T-rav/hydraflow/testing/0306-issue-synthesis-use-word-boundary-matching-in-coverage-checks-not-.md`
- `repo_wiki/T-rav/hydraflow/testing/0307-issue-synthesis-enforce-50-30-line-limits-on-handlers-and-registra.md`
- `repo_wiki/T-rav/hydraflow/testing/0308-issue-synthesis-assert-relative-event-ordering-not-absolute-id-val.md`
- `repo_wiki/T-rav/hydraflow/testing/0309-issue-synthesis-add-structural-tests-for-transition-graphs-before-.md`
- `repo_wiki/T-rav/hydraflow/testing/0310-issue-synthesis-sync-test-label-constants-with-production-pipeline.md`
- `repo_wiki/T-rav/hydraflow/testing/0311-issue-synthesis-pydantic-typeddict-field-changes-require-updates-i.md`
- `repo_wiki/T-rav/hydraflow/testing/0312-issue-synthesis-feature-toggles-need-both-a-config-field-and-env-i.md`
- `repo_wiki/T-rav/hydraflow/testing/0313-issue-synthesis-dict-to-typeddict-migrations-require-no-new-tests.md`
- `repo_wiki/T-rav/hydraflow/testing/0314-issue-synthesis-concurrent-jsonl-appends-assert-exact-event-counts.md`
- `repo_wiki/T-rav/hydraflow/testing/0315-issue-synthesis-memory-bank-keys-must-be-consistent-across-dedup-a.md`
- `repo_wiki/T-rav/hydraflow/testing/0316-issue-synthesis-skill-markers-must-be-present-in-all-4-backend-cop.md`
- `repo_wiki/T-rav/hydraflow/testing/0317-issue-synthesis-generate-adr-derived-tests-as-skipped-skeletons-by.md`
- `repo_wiki/T-rav/hydraflow/testing/0318-issue-synthesis-adr-pre-validator-enforce-required-sections-and-st.md`
- `repo_wiki/T-rav/hydraflow/testing/0319-issue-synthesis-never-import-private-helpers-at-module-level-in-te.md`
- `repo_wiki/T-rav/hydraflow/testing/0320-issue-synthesis-pin-function-signatures-before-writing-callers-or-.md`
- `repo_wiki/T-rav/hydraflow/testing/0321-issue-synthesis-validate-sys-modules-cleanup-with-multiple-random-.md`
- `repo_wiki/T-rav/hydraflow/testing/0322-issue-synthesis-skip-broken-tests-with-an-issue-reference-remove-a.md`
- `repo_wiki/T-rav/hydraflow/testing/0323-issue-synthesis-use-is-to-verify-shared-runner-instance-across-com.md`
- `repo_wiki/T-rav/hydraflow/testing/0324-issue-synthesis-memory-dedup-higher-priority-bank-wins-on-collisio.md`
- `repo_wiki/T-rav/hydraflow/testing/0325-issue-synthesis-hoist-deterministic-gates-outside-llm-retry-loops.md`
- `repo_wiki/T-rav/hydraflow/testing/0326-issue-synthesis-use-public-fakegithub-api-in-scenario-tests-never-.md`
- `repo_wiki/T-rav/hydraflow/testing/0327-issue-synthesis-test-async-context-managers-in-three-standard-scen.md`
- `repo_wiki/T-rav/hydraflow/testing/0328-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels-n.md`
- `repo_wiki/T-rav/hydraflow/testing/0329-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md`
- `repo_wiki/T-rav/hydraflow/testing/0330-issue-synthesis-existing-tests-cover-private-method-extractions-ad.md`
- `repo_wiki/T-rav/hydraflow/testing/0331-issue-synthesis-assert-numeric-values-in-sentry-breadcrumbs-not-ju.md`
- `repo_wiki/T-rav/hydraflow/testing/0332-issue-synthesis-test-pydantic-literal-constraints-cover-both-valid.md`
- `repo_wiki/T-rav/hydraflow/testing/0333-issue-synthesis-verify-fatal-exception-propagation-through-multi-p.md`
- `repo_wiki/T-rav/hydraflow/testing/0334-issue-synthesis-mock-at-definition-site-not-at-usage-site.md`
- `repo_wiki/T-rav/hydraflow/testing/0335-issue-synthesis-mark-integration-tests-only-for-real-external-deps.md`
- `repo_wiki/T-rav/hydraflow/testing/0336-issue-synthesis-await-asyncio-sleep-0-after-create-task-before-ass.md`
- `repo_wiki/T-rav/hydraflow/testing/0337-issue-synthesis-reset-global-state-in-both-setup-and-teardown.md`
- `repo_wiki/T-rav/hydraflow/testing/0338-issue-synthesis-use-tmp-path-with-configfactory-for-file-based-tes.md`
- `repo_wiki/T-rav/hydraflow/testing/0339-issue-synthesis-caplog-assertions-must-name-the-exact-logger.md`
- `repo_wiki/T-rav/hydraflow/testing/0340-issue-synthesis-test-protocols-with-isinstance-and-hasattr.md`
- `repo_wiki/T-rav/hydraflow/testing/0341-issue-synthesis-facade-tests-must-cover-routing-error-and-delegati.md`
- `repo_wiki/T-rav/hydraflow/testing/0342-issue-synthesis-use-playwright-not-testclient-for-js-rendered-attr.md`
- `repo_wiki/T-rav/hydraflow/testing/0343-issue-synthesis-subprocess-cli-test-stubs-log-to-jsonl.md`
- `repo_wiki/T-rav/hydraflow/testing/0344-issue-synthesis-mock-only-execute-in-phase-runner-integration-test.md`
- `repo_wiki/T-rav/hydraflow/testing/0345-issue-synthesis-use-word-boundary-matching-in-coverage-checks.md`
- `repo_wiki/T-rav/hydraflow/testing/0346-issue-synthesis-enforce-50-30-line-limits-on-handlers-and-wiring.md`
- `repo_wiki/T-rav/hydraflow/testing/0347-issue-synthesis-assert-relative-event-ordering-not-absolute-ids.md`
- `repo_wiki/T-rav/hydraflow/testing/0348-issue-synthesis-add-structural-tests-before-property-based-tests.md`
- `repo_wiki/T-rav/hydraflow/testing/0349-issue-synthesis-sync-test-label-constants-with-production-definiti.md`
- `repo_wiki/T-rav/hydraflow/testing/0350-issue-synthesis-update-4-places-on-pydantic-typeddict-field-change.md`
- `repo_wiki/T-rav/hydraflow/testing/0351-issue-synthesis-feature-toggles-need-config-field-and-overrides.md`
- `repo_wiki/T-rav/hydraflow/testing/0352-issue-synthesis-dict-to-typeddict-migrations-require-no-new-tests.md`
- `repo_wiki/T-rav/hydraflow/testing/0353-issue-synthesis-concurrent-jsonl-appends-assert-exact-counts.md`
- `repo_wiki/T-rav/hydraflow/testing/0354-issue-synthesis-keep-memory-bank-keys-consistent-across-dedup.md`
- `repo_wiki/T-rav/hydraflow/testing/0355-issue-synthesis-validate-skill-markers-across-all-4-backend-copies.md`
- `repo_wiki/T-rav/hydraflow/testing/0356-issue-synthesis-generate-adr-derived-tests-as-skipped-skeletons.md`
- `repo_wiki/T-rav/hydraflow/testing/0357-issue-synthesis-adr-pre-validator-enforce-required-sections.md`
- `repo_wiki/T-rav/hydraflow/testing/0358-issue-synthesis-never-import-private-helpers-at-module-level.md`
- `repo_wiki/T-rav/hydraflow/testing/0359-issue-synthesis-pin-function-signatures-before-writing-callers.md`
- `repo_wiki/T-rav/hydraflow/testing/0360-issue-synthesis-validate-sys-modules-cleanup-with-multiple-seeds.md`
- `repo_wiki/T-rav/hydraflow/testing/0361-issue-synthesis-skip-broken-tests-with-an-issue-reference.md`
- `repo_wiki/T-rav/hydraflow/testing/0362-issue-synthesis-use-is-to-verify-shared-runner-instance.md`
- `repo_wiki/T-rav/hydraflow/testing/0363-issue-synthesis-memory-dedup-higher-priority-bank-wins-on-collisio.md`
- `repo_wiki/T-rav/hydraflow/testing/0364-issue-synthesis-hoist-deterministic-gates-outside-llm-retry-loops.md`
- `repo_wiki/T-rav/hydraflow/testing/0365-issue-synthesis-use-public-fakegithub-api-in-scenario-tests.md`
- `repo_wiki/T-rav/hydraflow/testing/0366-issue-synthesis-test-async-context-managers-in-three-standard-scen.md`
- `repo_wiki/T-rav/hydraflow/testing/0367-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels.md`
- `repo_wiki/T-rav/hydraflow/testing/0368-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md`
- `repo_wiki/T-rav/hydraflow/testing/0369-issue-synthesis-existing-tests-cover-private-method-extractions.md`
- `repo_wiki/T-rav/hydraflow/testing/0370-issue-synthesis-assert-numeric-values-in-sentry-breadcrumbs.md`
- `repo_wiki/T-rav/hydraflow/testing/0371-issue-synthesis-test-pydantic-literal-constraints-valid-and-invali.md`
- `repo_wiki/T-rav/hydraflow/testing/0372-issue-synthesis-verify-fatal-exception-propagation-through-loops.md`

Auto-merge is enabled when CI is green; if CI fails, the PR stays open and subsequent ticks will append commits instead of opening a new PR.

## Reproducibility Manifest

```json
{
  "config_snapshot": {
    "agent_unrestricted_tools": false,
    "dry_run": false,
    "epic_gap_review_max_iterations": 2,
    "epic_group_planning": true,
    "implement_two_stage_review_enabled": true,
    "max_review_fix_attempts": 2,
    "research_enabled": true,
    "staging_enabled": true,
    "tdd_max_remediation_loops": 4,
    "use_quality_gate_in_review": true
  },
  "hydraflow_sha": "0e40eb72bd8431c00551e098ca9511d70ce3b300",
  "models": {
    "ac": {
      "model": "sonnet",
      "tool": "claude"
    },
    "adr_review": {
      "model": "sonnet",
      "tool": "claude"
    },
    "background": {
      "model": "sonnet",
      "tool": "claude"
    },
    "corpus_learning_synthesis": {
      "model": "opus",
      "tool": null
    },
    "debug": {
      "model": "opus",
      "tool": "claude"
    },
    "implementation": {
      "model": "sonnet",
      "tool": "claude"
    },
    "planner": {
      "model": "opus",
      "tool": "claude"
    },
    "report_issue": {
      "model": "opus",
      "tool": "claude"
    },
    "review": {
      "model": "sonnet",
      "tool": "claude"
    },
    "sentry": {
      "model": "sonnet",
      "tool": "claude"
    },
    "subskill": {
      "model": "haiku",
      "tool": "claude"
    },
    "system": {
      "model": "",
      "tool": "inherit"
    },
    "transcript_summary": {
      "model": "sonnet",
      "tool": "claude"
    },
    "triage": {
      "model": "sonnet",
      "tool": "claude"
    },
    "verification_judge": {
      "model": "sonnet",
      "tool": "claude"
    },
    "wiki_compilation": {
      "model": "sonnet",
      "tool": "claude"
    }
  },
  "prompt_hash_spec": "prompts/**/*.md + .codex/skills/*/SKILL.md",
  "prompt_hashes": {
    ".codex/skills/continuous-learning-v2/SKILL.md": "sha256:727bdebde88d3f921ee6cbd95eaacb76162292b0dce80360ff3ba4c955d04e54",
    ".codex/skills/eval-harness/SKILL.md": "sha256:0bc29828b0b20c57f1d0904fab2f046155aae9e6d9cf1d7587dd8776a8747f3d",
    ".codex/skills/hf.adr/SKILL.md": "sha256:1e4c17da929ffc6e39ca138e5c422310f15d0dc93e7bdadebe0e7187647fa96f",
    ".codex/skills/hf.audit-code/SKILL.md": "sha256:1415ca494b985cc1f8a070dca3e4043582fcb2231fc13456ad9183dbc25daff6",
    ".codex/skills/hf.audit-hooks/SKILL.md": "sha256:fdf420e9df31e3c7cc7271223ba7d3fa21e0fc50694efd2a701c9a00159a1882",
    ".codex/skills/hf.audit-integration-tests/SKILL.md": "sha256:4ed0c1e5c699c47c8fcf0bea8ca7ff6736fb4e64125bdd61f54d1cd2852a82db",
    ".codex/skills/hf.audit-tests/SKILL.md": "sha256:020e20353ead961eb8fa6b8f4585b22b39a1df46c6ff8b755167a599b6af32f2",
    ".codex/skills/hf.block-destructive-git/SKILL.md": "sha256:4fe0c54910c976cc5c52193895cb3a25742f1dc474c69d90a1800591c51a6a8b",
    ".codex/skills/hf.check-cross-service-impact/SKILL.md": "sha256:c19e25c7a23c4cc0f138880b0fae2dec11963c7e304b023fb5addfd349f5f7cf",
    ".codex/skills/hf.check-reindex-needed/SKILL.md": "sha256:e6f99d2d8686e77ae1ec515c868234b5308df8a89363cdc8c4f8b3dc2244b92b",
    ".codex/skills/hf.check-test-counterpart/SKILL.md": "sha256:68b3244b3651e0486a0c5fa90df30bdab4553c410b237656ef94b8e52891883d",
    ".codex/skills/hf.cleanup-code-change-marker/SKILL.md": "sha256:54da0160dbfcbaaff4756d091a15d66c4f777e76ec6ff4afd92d6c16f1d4f515",
    ".codex/skills/hf.code-quality-enforcer/SKILL.md": "sha256:683d35e6dab3b32fe0f2839d6a7bee8009f971785190e99ac7014d09e1ae6064",
    ".codex/skills/hf.diff-sanity/SKILL.md": "sha256:c9c51395767233759f512c70eb719e8f856ff42f231a8147bc3694ff07b368af",
    ".codex/skills/hf.enforce-migrations/SKILL.md": "sha256:d6e8ad5eb6ec37c55f6f2ce57b35574cdc63ae4ffea4ff4bdf39ae044e1429c4",
    ".codex/skills/hf.enforce-plan-and-explore/SKILL.md": "sha256:0fb13579a24f866a4b3a43530b8420e3051ea5488f84e5cd5c4f01ba322fd483",
    ".codex/skills/hf.gate-stop-agents/SKILL.md": "sha256:74290331c5e0fec2e73d91d0a4b9203ce3895f4ef37480e91ebe9729715556fc",
    ".codex/skills/hf.issue/SKILL.md": "sha256:6dbb9f5f452f7cc307f6820ee6a0adc3eca5040f2ae615a2a49e344014b05fae",
    ".codex/skills/hf.memory/SKILL.md": "sha256:10af7412e3d454e766f69ca17ebd54a469ccd3d8b2f53e09dfde40246f951af3",
    ".codex/skills/hf.scan-secrets-before-commit/SKILL.md": "sha256:df9ab39009bed4ad9107873bbf24be458fc142c7fb32154b4511ab87e360eeca",
    ".codex/skills/hf.test-adequacy/SKILL.md": "sha256:76fe7560b9156bb9adeb32f21c715a3e0c87fbe502c399fca8250bb7b7f4151c",
    ".codex/skills/hf.test-audit/SKILL.md": "sha256:1db8d645a5de1eea16db0130cfabdc24a18f0e2dc13bf2673868a881da1c432e",
    ".codex/skills/hf.track-code-changes/SKILL.md": "sha256:ff3e1ee6f7f24b805052280cc16c0a125d03ebbdc5fee39799e8500b9164e7bf",
    ".codex/skills/hf.track-exploration/SKILL.md": "sha256:1db09bb75e078275eb2c3acfd095f25c7c35a9eaff2f3d7d12a566f10bc09ca1",
    ".codex/skills/hf.track-indexed/SKILL.md": "sha256:5832d0c725f617d39cf00d2ce0d57295a1a66753754d0d357a13e4b9f358dcb4",
    ".codex/skills/hf.track-planning/SKILL.md": "sha256:295c903f1ed95350d64af5273e0456eb57ac1f8a7089158831a14a90941f6a4a",
    ".codex/skills/hf.track-reindex-needed/SKILL.md": "sha256:8a087b89c7cb263f8f022010e0c4d392c81976d923bce2297d12d04f9327d55a",
    ".codex/skills/hf.validate-tests-before-commit/SKILL.md": "sha256:a906ab14c80dc8b25a1cbbdf86eaff02f427bbf560bcb7eae9a88fb32b1380e7",
    ".codex/skills/hf.warn-new-file-creation/SKILL.md": "sha256:2c8ec336bec3643a919b0b44326d70c3dc75754f9ed67e05882e240c505c7648",
    ".codex/skills/skill-stocktake/SKILL.md": "sha256:2964e3b6a11b4d9d76b99a218a5d627c91da63ecc080feb686c895c2e52e37ab",
    ".codex/skills/strategic-compact/SKILL.md": "sha256:a8ac1ec9b56dca7735d54c90dee38860197e71f6eed7e9f12ed9cd720b1ba7ca",
    ".codex/skills/verification-loop/SKILL.md": "sha256:01a9ae310ad4426bb05660dda6cefdeaac9513417585c09c8bb1b94738649a78",
    "prompts/auto_agent/_default.md": "sha256:bd1a34e46bb5cca691ce042c95aea265284a4f2df3a9fddba98c3942b44f8c65",
    "prompts/auto_agent/_envelope.md": "sha256:04f971e041b6811c3566b932ebdef4cc22da577f9d2c62bde11a44ab6b5c3071",
    "prompts/auto_agent/discover-stuck.md": "sha256:79f8f2cbaeb1c44cce76959b8f466da3970296fd380a83fe2f080801920c0452",
    "prompts/auto_agent/fake-coverage-stuck.md": "sha256:8868aa6836bf2d7379ace6471b8516cb7c93edc39af2ff4152fce7ed2328c860",
    "prompts/auto_agent/fake-drift-stuck.md": "sha256:832537b8b3250c80d5e8abe818b1484066a9b91415189d11f675b9a9283b8c16",
    "prompts/auto_agent/flaky-test-stuck.md": "sha256:559afd514324a2148bbf38acb2c81b00d5407d24f43ead4189eed59f8d860523",
    "prompts/auto_agent/implement-stuck.md": "sha256:6ed3f0694b15b64ff79e501cfd9bb03f884c2f21219099e3227177b4a2a98dca",
    "prompts/auto_agent/plan-stuck.md": "sha256:67ceaae9ae4d066e3ae3392d6a13e660366fe8c5a5d41b1ef0108f8a5bc57f88",
    "prompts/auto_agent/rc-duration-stuck.md": "sha256:8812229041e11ca0ecf4a1982af47e5834c517a98c8893b329083e927f0726b0",
    "prompts/auto_agent/rc-red-bisect-exhausted.md": "sha256:35b6c34cdd68aaf3f194503b9dcf23ee1472fff6be10d7c00d8d0639df04cc3b",
    "prompts/auto_agent/revert-conflict.md": "sha256:a44013827625c3d52a5edfd8f0ef1f10e8ae872815b6d7c2a2fab02fc6e5abd5",
    "prompts/auto_agent/review-stuck.md": "sha256:11d658a092b1f37e4693ff47601747321c830d36dbb45fdc6acc08c7471cee6b",
    "prompts/auto_agent/sandbox_fix.md": "sha256:390ba65c0ca227075f43f5b545541d3ec3a1f3f4bfcead605a02d2eb7f6a6fe3",
    "prompts/auto_agent/skill-prompt-stuck.md": "sha256:89921ea3b39d044c1d592e6388aed3e92af1b774f36b120d08cd7683fe9e301e",
    "prompts/auto_agent/triage-stuck.md": "sha256:5e3ac9eb449a175de2ce5a9d8d032a9ca08f7b802e8e871654f804f766b9fe93",
    "prompts/auto_agent/trust-loop-anomaly.md": "sha256:ac2a78e24763a42cc9f200822b08877c7ba84e0a730339311c00dab7e3fd2638",
    "prompts/auto_agent/wiki-rot-stuck.md": "sha256:620cb12bdef2bf95caa09f93045caffea38969e4dec22d8a3493b8f2c37050a1"
  },
  "schema": "hydraflow.repro-manifest/v1"
}
```
