### PR TITLE
chore(sandbox): open DiagnosticLoop static gate — s05 broken since #9898

### DIFF
--- a/docker-compose.sandbox.yml
+++ b/docker-compose.sandbox.yml
@@ -55,6 +55,13 @@ services:
       # s52_human_steering_directive.py).
       HYDRAFLOW_HUMAN_STEERING_ENABLED: "true"
       HYDRAFLOW_HUMAN_STEERING_AUTHORIZED_USERS: "steer-bot"
+      # DiagnosticLoop defaults OFF in production (#9895/#9898 — credit flood),
+      # but s05's escalation chain (review exhaustion → diagnostic → HITL)
+      # needs the STATIC config gate open. The per-seed ADR-0049 kill-switch
+      # (loops_enabled) still decides which scenarios actually run the loop —
+      # only seeds listing "diagnostic" do; the sentinel routes its subprocess
+      # to a scripted not-fixable diagnosis, so no real spawn ever happens.
+      HYDRAFLOW_DIAGNOSTIC_LOOP_ENABLED: "true"
     volumes:
       - ./tests/sandbox_scenarios/seeds:/seed:ro
     networks: [sandbox]


### PR DESCRIPTION
## Problem

s05_hitl_after_review_exhaustion failed both rc/* full-suite runs since 20:41Z (#9907, #9933 — the only remaining RC blocker on #9933). Root cause: #9898 made DiagnosticLoop default OFF via the STATIC config gate `diagnostic_loop_enabled=False`; s05's `loops_enabled=["diagnostic"]` seed flips only the ADR-0049 kill-switch callback and cannot reach the static gate — the loop exits `_do_work` before the sentinel-scripted not-fixable diagnosis fires, so review exhaustion never reaches HITL and `/api/hitl` stays `[]`.

Same docker-only blind-spot class as s51: #9898's own CI patched the unit tests but the fast subset doesn't run s05 and nightly checks out main.

## Change

One env line in docker-compose.sandbox.yml: `HYDRAFLOW_DIAGNOSTIC_LOOP_ENABLED: "true"` (with rationale comment). Per-seed kill-switches still gate which scenarios run the loop; production default stays OFF.

## Verification

s05 reproduced FAILED on #9907/#9933; **PASSES locally in docker** with this line. Main-checkout compose restored after verification.

With this + s51 fix (#9919) + s55 quarantine (#9928) + CodeQL dismissal + advisory gating (#9922): the next RC cut has zero known blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)