### PR TITLE
fix(wiki): adopt open maintenance PR from GitHub after restart (#9894)

### DIFF
--- a/src/repo_wiki_loop.py
+++ b/src/repo_wiki_loop.py
@@ -201,6 +201,13 @@ class RepoWikiLoop(BaseBackgroundLoop):
         closed_issues = self._get_closed_issues()
         stats: dict[str, Any] = {"queue_drained": len(drained)}
 
+        # Restart-safe coalesce (#9894): the tracked open-PR state is
+        # process-local, so a restart forgets an open maintenance PR and the
+        # next tick would open a duplicate (2026-07-18: three same-day maint
+        # PRs coexisted, two went CONFLICTING+HITL). Rediscover from GitHub —
+        # the source of truth — before polling.
+        await self._adopt_open_maintenance_pr(stats)
+
         # Poll/merge any already-open maintenance PR first.
         await self._poll_and_merge_open_pr(stats)
 
@@ -637,6 +644,69 @@ class RepoWikiLoop(BaseBackgroundLoop):
                 branch,
                 result.error,
             )
+
+    async def _adopt_open_maintenance_pr(self, stats: dict[str, Any]) -> None:
+        """Adopt an already-open maintenance PR after a restart (#9894).
+
+        ``_open_pr_branch``/``_open_pr_url`` live in process memory only, so a
+        factory restart forgets an open ``hydraflow-wiki-maintenance`` PR and
+        the coalesce guard never fires — the next tick opens a duplicate that
+        then rots CONFLICTING until a human closes it. GitHub is the source
+        of truth: when nothing is tracked, query for open PRs by label and
+        adopt the newest so the existing poll/approve/merge path owns it.
+
+        Fail-soft on every edge (no token, no repo slug — the #9754 air-gap
+        lesson — or a gh error): log and behave exactly as before this guard
+        existed. Multiple open maintenance PRs (pre-existing duplication)
+        adopt the newest and log a warning; the older ones stay for the
+        operator or the stuck-PR sweep.
+        """
+        if self._open_pr_branch is not None or self._credentials is None:
+            return
+        if not self._config.repo_wiki_maintenance_pr_coalesce:
+            return
+        gh_token = self._credentials.gh_token
+        if not gh_token or not self._config.repo:
+            return
+        try:
+            stdout = await run_subprocess(
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                self._config.repo,
+                "--label",
+                "hydraflow-wiki-maintenance",
+                "--state",
+                "open",
+                "--json",
+                "number,url,headRefName",
+                gh_token=gh_token,
+            )
+            rows = json.loads(stdout or "[]")
+        except (RuntimeError, OSError, ValueError) as exc:
+            logger.warning("Wiki maintenance PR adoption query failed: %s", exc)
+            return
+        if not isinstance(rows, list) or not rows:
+            return
+        rows.sort(key=lambda r: int(r.get("number") or 0))
+        newest = rows[-1]
+        branch = str(newest.get("headRefName") or "")
+        url = str(newest.get("url") or "")
+        if not branch or not url:
+            return
+        self._open_pr_branch = branch
+        self._open_pr_url = url
+        stats["maintenance_pr_adopted"] = url
+        if len(rows) > 1:
+            logger.warning(
+                "Adopted newest of %d open maintenance PRs (%s) — older "
+                "duplicates need closing",
+                len(rows),
+                url,
+            )
+        else:
+            logger.info("Adopted open maintenance PR %s after restart", url)
 
     async def _poll_and_merge_open_pr(  # noqa: PLR0911 — linear state-machine guards
         self, stats: dict[str, Any]

--- a/tests/regressions/test_issue_9894_wiki_maint_adopt.py
+++ b/tests/regressions/test_issue_9894_wiki_maint_adopt.py
@@ -1,0 +1,124 @@
+"""Regression: RepoWikiLoop coalesce state lost on restart (#9894).
+
+``_open_pr_branch``/``_open_pr_url`` are process-local, so a factory restart
+forgot an open ``hydraflow-wiki-maintenance`` PR and the next tick opened a
+duplicate (2026-07-18: three same-day maintenance PRs coexisted; two rotted
+CONFLICTING+HITL and were closed by hand). These tests pin the adopt-on-boot
+contract: with nothing tracked, the loop rediscovers the newest open
+maintenance PR from GitHub (the source of truth) before deciding to heal,
+and every failure edge degrades to the pre-guard behavior.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import repo_wiki_loop as rwl_module
+from base_background_loop import LoopDeps
+from repo_wiki import RepoWikiStore
+from repo_wiki_loop import RepoWikiLoop
+
+
+def _make_loop(tmp_path: Path) -> RepoWikiLoop:
+    config = MagicMock()
+    config.data_path.return_value = tmp_path / "queue"
+    config.repo = "acme/widgets"
+    config.repo_wiki_maintenance_pr_coalesce = True
+    deps = LoopDeps(
+        event_bus=MagicMock(),
+        stop_event=asyncio.Event(),
+        status_cb=MagicMock(),
+        enabled_cb=MagicMock(return_value=True),
+        sleep_fn=MagicMock(),
+        interval_cb=None,
+    )
+    loop = RepoWikiLoop(
+        config=config, wiki_store=RepoWikiStore(tmp_path / "wiki"), deps=deps
+    )
+    creds = MagicMock()
+    creds.gh_token = "tok"
+    loop._credentials = creds
+    return loop
+
+
+def _rows(*numbers: int) -> str:
+    return json.dumps(
+        [
+            {
+                "number": n,
+                "url": f"https://github.com/acme/widgets/pull/{n}",
+                "headRefName": f"hydraflow/wiki-maint-{n}",
+            }
+            for n in numbers
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_restart_adopts_newest_open_maintenance_pr(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    loop = _make_loop(tmp_path)
+    monkeypatch.setattr(
+        rwl_module, "run_subprocess", AsyncMock(return_value=_rows(7, 12))
+    )
+    stats: dict[str, Any] = {}
+
+    await loop._adopt_open_maintenance_pr(stats)
+
+    assert loop._open_pr_url == "https://github.com/acme/widgets/pull/12"
+    assert loop._open_pr_branch == "hydraflow/wiki-maint-12"
+    assert stats["maintenance_pr_adopted"] == loop._open_pr_url
+
+
+@pytest.mark.asyncio
+async def test_nothing_open_leaves_state_untracked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    loop = _make_loop(tmp_path)
+    monkeypatch.setattr(rwl_module, "run_subprocess", AsyncMock(return_value="[]"))
+
+    await loop._adopt_open_maintenance_pr({})
+
+    assert loop._open_pr_branch is None
+    assert loop._open_pr_url is None
+
+
+@pytest.mark.asyncio
+async def test_gh_failure_is_fail_soft(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    loop = _make_loop(tmp_path)
+    monkeypatch.setattr(
+        rwl_module,
+        "run_subprocess",
+        AsyncMock(side_effect=RuntimeError("gh exploded")),
+    )
+
+    await loop._adopt_open_maintenance_pr({})  # must not raise
+
+    assert loop._open_pr_branch is None
+
+
+@pytest.mark.asyncio
+async def test_tracked_state_or_empty_repo_never_queries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    probe = AsyncMock(return_value=_rows(3))
+    monkeypatch.setattr(rwl_module, "run_subprocess", probe)
+
+    tracked = _make_loop(tmp_path)
+    tracked._open_pr_branch = "hydraflow/wiki-maint-3"
+    await tracked._adopt_open_maintenance_pr({})
+
+    airgapped = _make_loop(tmp_path)  # the #9754 lesson: empty repo slug
+    airgapped._config.repo = ""
+    await airgapped._adopt_open_maintenance_pr({})
+
+    probe.assert_not_awaited()


### PR DESCRIPTION
## Problem (#9894)

RepoWikiLoop's coalesce state is process-local; a restart forgets the open `hydraflow-wiki-maintenance` PR and the next tick opens a duplicate — 2026-07-18 had THREE same-day maintenance PRs (#9870 merged, #9882/#9891 rotted CONFLICTING+HITL, closed by hand).

## Change

`_adopt_open_maintenance_pr` at the top of the maintenance tick: when nothing is tracked and coalesce is on, query GitHub (source of truth, DependabotMergeLoop-style) for open label-carrying PRs and adopt the newest into the existing poll/approve/merge path. Fail-soft on every edge — no token, empty repo slug (the #9754 air-gap lesson), gh errors — each degrades to exactly the pre-guard behavior. Multiple open PRs: adopt newest, warn.

## Tests

`tests/regressions/test_issue_9894_wiki_maint_adopt.py`: adopt-newest, none-open, gh-error fail-soft, and never-queries (tracked state / empty repo). Full wiki-loop suites green (38 tests) + lint + pyright.

**Local `make quality` disclosure:** the harness killed the full run twice mid-flight — second attempt died at 98% with zero failures (SIGTERM, not a test failure). Targeted suites + pre-push quality-lite + this PR's CI are the verification chain.

Closes #9894

🤖 Generated with [Claude Code](https://claude.com/claude-code)