### PR TITLE
feat(security): SecurityPatchLoop default severity threshold high → medium

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -354,7 +354,7 @@ _ENV_STR_OVERRIDES: list[tuple[str, str, str]] = [
     (
         "security_patch_severity_threshold",
         "HYDRAFLOW_SECURITY_PATCH_SEVERITY_THRESHOLD",
-        "high",
+        "medium",
     ),
     ("dashboard_host", "HYDRAFLOW_DASHBOARD_HOST", "127.0.0.1"),
     ("test_command", "HYDRAFLOW_TEST_COMMAND", "make test"),
@@ -1850,7 +1850,7 @@ class HydraFlowConfig(BaseModel):
     )
     security_patch_severity_threshold: Literal["critical", "high", "medium", "low"] = (
         Field(
-            default="high",
+            default="medium",
             description="Minimum severity to file issues for",
         )
     )

--- a/tests/regressions/test_security_patch_medium_default.py
+++ b/tests/regressions/test_security_patch_medium_default.py
@@ -1,0 +1,18 @@
+"""Regression: SecurityPatchLoop severity threshold defaults to "medium".
+
+Previously the default was "high", so medium-severity Dependabot/security alerts
+(e.g. the open `idna` and `pymdown-extensions` advisories) fell below the
+threshold and the SecurityPatchLoop never filed a rollup issue for them — they
+sat unactioned. Lowered the default to "medium" (in BOTH the `_ENV_STR_OVERRIDES`
+env tuple and the Pydantic `Field`, so base and per-repo runtime configs agree)
+so medium alerts are surfaced by default.
+"""
+
+from __future__ import annotations
+
+from config import HydraFlowConfig
+
+
+def test_security_patch_threshold_defaults_to_medium() -> None:
+    """A fresh config (no override) files security rollups down to medium."""
+    assert HydraFlowConfig().security_patch_severity_threshold == "medium"


### PR DESCRIPTION
## Why
Three open GitHub security alerts are sitting **unactioned** because they are all **medium** severity and `SecurityPatchLoop` only files rollup issues at **high+** by default:
- Dependabot **#28** `pymdown-extensions` (medium)
- Dependabot **#29** `idna` (medium)
- Code-scanning **#103** `actions/missing-workflow-permissions` (medium)

## Change
Lowered `security_patch_severity_threshold` default `high` → `medium` in **both** locations (env tuple `_ENV_STR_OVERRIDES` + Pydantic `Field`) so base and per-repo runtime configs agree — same dual-location gotcha as #9898. Operators can still tighten via `HYDRAFLOW_SECURITY_PATCH_SEVERITY_THRESHOLD` / the System-tab knob.

Once deployed, `SecurityPatchLoop` will file rollup issues for the two medium Dependabot alerts on its next tick.

## Not covered here
`SecurityPatchLoop` consumes **Dependabot** alerts. The **code-scanning** alert #103 (workflow-permissions on `arch-regen.yml`) is a different alert type — needs a separate actioner or a 2-line `permissions:` block on the workflow. Flagging separately.

## Tests
`tests/regressions/test_security_patch_medium_default.py` asserts the default is `medium`; `test_security_patch_loop.py` + `test_config_env.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)