### PR TITLE
fix(triage): parse stream-json verdicts + fail closed on unparseable (#9798)

### DIFF
--- a/repo_wiki/T-rav/hydraflow/gotchas/0180-issue-synthesis-error-tolerance-tests-must-cover-creditexhausteder.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0180-issue-synthesis-error-tolerance-tests-must-cover-creditexhausteder.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.150523+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Error-tolerance tests must cover CreditExhaustedError re-raise

--- a/repo_wiki/T-rav/hydraflow/gotchas/0181-issue-synthesis-use-type-checking-guards-for-forward-reference-ann.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0181-issue-synthesis-use-type-checking-guards-for-forward-reference-ann.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.150881+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Use TYPE_CHECKING guards for forward-reference annotations

--- a/repo_wiki/T-rav/hydraflow/gotchas/0182-issue-synthesis-update-emit-trace-command-strings-when-migrating-s.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0182-issue-synthesis-update-emit-trace-command-strings-when-migrating-s.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.151207+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Update _emit_trace command strings when migrating subprocess to Port

--- a/repo_wiki/T-rav/hydraflow/gotchas/0183-issue-synthesis-grep-for-runtime-references-before-removing-an-imp.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0183-issue-synthesis-grep-for-runtime-references-before-removing-an-imp.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.151540+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Grep for runtime references before removing an import

--- a/repo_wiki/T-rav/hydraflow/gotchas/0184-issue-synthesis-use-is-none-is-not-none-for-optional-sentinels.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0184-issue-synthesis-use-is-none-is-not-none-for-optional-sentinels.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.151901+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Use `is None` / `is not None` for optional sentinels

--- a/repo_wiki/T-rav/hydraflow/gotchas/0185-issue-synthesis-sync-all-protocol-implementations-in-one-pr-on-sig.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0185-issue-synthesis-sync-all-protocol-implementations-in-one-pr-on-sig.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.152233+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Sync all protocol implementations in one PR on signature change

--- a/repo_wiki/T-rav/hydraflow/gotchas/0186-issue-synthesis-delete-code-blocks-bottom-to-top-to-avoid-line-num.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0186-issue-synthesis-delete-code-blocks-bottom-to-top-to-avoid-line-num.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.152589+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Delete code blocks bottom-to-top to avoid line-number shifting

--- a/repo_wiki/T-rav/hydraflow/gotchas/0187-issue-synthesis-patch-functions-at-their-definition-site-not-the-i.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0187-issue-synthesis-patch-functions-at-their-definition-site-not-the-i.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.152916+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Patch functions at their definition site, not the import site

--- a/repo_wiki/T-rav/hydraflow/gotchas/0188-issue-synthesis-verify-a-file-exists-before-writing-a-plan-task-th.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0188-issue-synthesis-verify-a-file-exists-before-writing-a-plan-task-th.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.153240+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Verify a file exists before writing a plan task that modifies it

--- a/repo_wiki/T-rav/hydraflow/gotchas/0189-issue-synthesis-test-pydantic-serialization-with-round-trip-and-sa.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0189-issue-synthesis-test-pydantic-serialization-with-round-trip-and-sa.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.153559+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Test Pydantic serialization with round-trip AND save/load tests

--- a/repo_wiki/T-rav/hydraflow/gotchas/0190-issue-synthesis-run-full-make-quality-before-declaring-implementat.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0190-issue-synthesis-run-full-make-quality-before-declaring-implementat.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.153877+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Run full `make quality` before declaring implementation complete

--- a/repo_wiki/T-rav/hydraflow/gotchas/0191-issue-synthesis-use-log-exception-with-bug-classification-for-bugs.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0191-issue-synthesis-use-log-exception-with-bug-classification-for-bugs.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.154196+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Use `log_exception_with_bug_classification()` for bugs vs transient

--- a/repo_wiki/T-rav/hydraflow/gotchas/0192-issue-synthesis-use-logger-warning-exc-info-true-for-transient-err.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0192-issue-synthesis-use-logger-warning-exc-info-true-for-transient-err.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.154514+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Use `logger.warning(..., exc_info=True)` for transient errors

--- a/repo_wiki/T-rav/hydraflow/gotchas/0193-issue-synthesis-catch-both-timeoutexpired-and-calledprocesserror-t.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0193-issue-synthesis-catch-both-timeoutexpired-and-calledprocesserror-t.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.154860+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Catch both TimeoutExpired and CalledProcessError — they're siblings

--- a/repo_wiki/T-rav/hydraflow/gotchas/0194-issue-synthesis-omitting-await-on-async-calls-silently-returns-a-c.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0194-issue-synthesis-omitting-await-on-async-calls-silently-returns-a-c.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.155228+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Omitting `await` on async calls silently returns a coroutine

--- a/repo_wiki/T-rav/hydraflow/gotchas/0195-issue-synthesis-store-asyncio-create-task-results-unreferenced-tas.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0195-issue-synthesis-store-asyncio-create-task-results-unreferenced-tas.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.155653+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Store `asyncio.create_task()` results — unreferenced tasks are GC'd

--- a/repo_wiki/T-rav/hydraflow/gotchas/0196-issue-synthesis-new-pydantic-fields-must-have-defaults-for-existin.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0196-issue-synthesis-new-pydantic-fields-must-have-defaults-for-existin.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.155976+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # New Pydantic fields must have defaults for existing state compat

--- a/repo_wiki/T-rav/hydraflow/gotchas/0197-issue-synthesis-use-atomic-write-instead-of-path-write-text-for-js.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0197-issue-synthesis-use-atomic-write-instead-of-path-write-text-for-js.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.156311+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Use `atomic_write()` instead of `Path.write_text()` for JSON state

--- a/repo_wiki/T-rav/hydraflow/gotchas/0198-issue-synthesis-use-typeddict-total-false-for-backward-compatible-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0198-issue-synthesis-use-typeddict-total-false-for-backward-compatible-.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.156658+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Use `TypedDict(total=False)` for backward-compatible payloads

--- a/repo_wiki/T-rav/hydraflow/gotchas/0199-issue-synthesis-new-hydraflowconfig-label-fields-must-be-optional-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0199-issue-synthesis-new-hydraflowconfig-label-fields-must-be-optional-.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.157016+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # New HydraFlowConfig label fields must be optional in ConfigFactory

--- a/repo_wiki/T-rav/hydraflow/gotchas/0200-issue-synthesis-reverse-state-transitions-on-non-fatal-exceptions-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0200-issue-synthesis-reverse-state-transitions-on-non-fatal-exceptions-.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.157347+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Reverse state transitions on non-fatal exceptions to avoid stuck

--- a/repo_wiki/T-rav/hydraflow/gotchas/0201-issue-synthesis-use-same-id-extraction-logic-everywhere-files-are-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0201-issue-synthesis-use-same-id-extraction-logic-everywhere-files-are-.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.157681+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Use same ID extraction logic everywhere files are keyed by issue

--- a/repo_wiki/T-rav/hydraflow/gotchas/0202-issue-synthesis-join-factory-pipeline-metrics-by-issue-number-not-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0202-issue-synthesis-join-factory-pipeline-metrics-by-issue-number-not-.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.158031+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Join factory pipeline metrics by issue_number, not pr_number

--- a/repo_wiki/T-rav/hydraflow/gotchas/0203-issue-synthesis-test-pipeline-stage-ordering-not-just-status-after.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0203-issue-synthesis-test-pipeline-stage-ordering-not-just-status-after.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.158378+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Test pipeline stage ordering, not just status, after inserting stage

--- a/repo_wiki/T-rav/hydraflow/gotchas/0204-issue-synthesis-filter-evicted-memories-on-both-content-prefix-and.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0204-issue-synthesis-filter-evicted-memories-on-both-content-prefix-and.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.158720+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Filter evicted memories on both content prefix AND metadata status

--- a/repo_wiki/T-rav/hydraflow/gotchas/0205-issue-synthesis-new-automated-skills-must-start-with-blocking-fals.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0205-issue-synthesis-new-automated-skills-must-start-with-blocking-fals.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.159052+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # New automated skills must start with blocking=False until stable

--- a/repo_wiki/T-rav/hydraflow/gotchas/0206-issue-synthesis-validate-parsers-against-realistic-multi-paragraph.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0206-issue-synthesis-validate-parsers-against-realistic-multi-paragraph.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.159385+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Validate parsers against realistic multi-paragraph agent output

--- a/repo_wiki/T-rav/hydraflow/gotchas/0207-issue-synthesis-log-warning-on-zero-match-transcript-extraction-fr.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0207-issue-synthesis-log-warning-on-zero-match-transcript-extraction-fr.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.159728+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Log warning on zero-match transcript extraction from non-empty input

--- a/repo_wiki/T-rav/hydraflow/gotchas/0208-issue-synthesis-use-portable-shell-commands-in-alpine-containers-p.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0208-issue-synthesis-use-portable-shell-commands-in-alpine-containers-p.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.160069+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Use portable shell commands in Alpine containers — Python is absent

--- a/repo_wiki/T-rav/hydraflow/gotchas/0209-issue-synthesis-separate-silent-with-result-events-from-purely-sil.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0209-issue-synthesis-separate-silent-with-result-events-from-purely-sil.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.160452+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Separate silent-with-result events from purely silent in dispatch

--- a/repo_wiki/T-rav/hydraflow/gotchas/0210-issue-synthesis-create-a-specialized-method-rather-than-overloadin.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0210-issue-synthesis-create-a-specialized-method-rather-than-overloadin.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.160854+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Create a specialized method rather than overloading a general one

--- a/repo_wiki/T-rav/hydraflow/gotchas/0211-issue-synthesis-ruff-strips-unused-imports-mid-tdd-cycle.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0211-issue-synthesis-ruff-strips-unused-imports-mid-tdd-cycle.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.161260+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Ruff strips unused imports mid-TDD cycle

--- a/repo_wiki/T-rav/hydraflow/gotchas/0212-issue-synthesis-verify-implementation-files-are-in-the-diff-before.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0212-issue-synthesis-verify-implementation-files-are-in-the-diff-before.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.161704+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Verify implementation files are in the diff before merging

--- a/repo_wiki/T-rav/hydraflow/gotchas/0213-issue-synthesis-coverage-delta-gate-is-asymmetric-gaps-block-clean.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0213-issue-synthesis-coverage-delta-gate-is-asymmetric-gaps-block-clean.md
@@ -4,9 +4,10 @@ topic: gotchas
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:47:09.162132+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0146,0147,0148,0149,0150,0151,0152,0153,0154,0155,0156,0157,0158,0159,0160,0161,0162,0163,0164,0165,0166,0167,0168,0169,0170,0171,0172,0173,0174,0175,0176,0177,0178,0179
+superseded_by: 0214
 ---
 
 # Coverage-delta gate is asymmetric: gaps block, clean defers to LLM

--- a/repo_wiki/T-rav/hydraflow/gotchas/0214-issue-synthesis-error-tolerance-tests-must-cover-creditexhausteder.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0214-issue-synthesis-error-tolerance-tests-must-cover-creditexhausteder.md
@@ -1,0 +1,18 @@
+---
+id: 0214
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.791976+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Error-tolerance tests must cover CreditExhaustedError re-raise
+
+When testing that a loop tolerates port failures, always include a second case asserting `CreditExhaustedError` is *not* swallowed.
+
+Example: `port.side_effect = CreditExhaustedError("exhausted")` followed by `with pytest.raises(CreditExhaustedError): await loop._reconcile(...)`. See `test_review_phase_core.py:1919`.
+
+**Why:** `reraise_on_credit_or_bug` is a load-bearing call mandated by CLAUDE.md; testing only the swallow path leaves the re-raise contract unchecked.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0215-issue-synthesis-use-type-checking-guards-for-forward-reference-ann.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0215-issue-synthesis-use-type-checking-guards-for-forward-reference-ann.md
@@ -1,0 +1,18 @@
+---
+id: 0215
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.792430+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Use TYPE_CHECKING guards for forward-reference annotations
+
+Combine `from __future__ import annotations` with `TYPE_CHECKING` guards so forward-reference type imports don't execute at runtime.
+
+Example: `if TYPE_CHECKING: from mymodule import MyType` keeps the symbol available to type checkers while preventing import-time evaluation.
+
+**Why:** Without the guard the symbol is evaluated at import time, creating circular imports or `ImportError` in modules that aren't always available.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0216-issue-synthesis-update-emit-trace-command-strings-when-migrating-s.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0216-issue-synthesis-update-emit-trace-command-strings-when-migrating-s.md
@@ -1,0 +1,18 @@
+---
+id: 0216
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.792867+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Update _emit_trace command strings when migrating subprocess to Port
+
+After replacing a `gh`/subprocess call with a Port method, update any `_emit_trace` or telemetry command strings to reflect the new surface.
+
+Example: Old: `command=["gh", "issue", "list", "--label", "wiki-rot-stuck"]`. New: `PRPort.list_closed_issues_by_label("wiki-rot-stuck", limit=50)`.
+
+**Why:** Observability consumers rely on command strings to diagnose failures; stale strings misdirect operators toward subprocess debugging when the actual call path is a Port method.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0217-issue-synthesis-grep-for-runtime-references-before-removing-an-imp.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0217-issue-synthesis-grep-for-runtime-references-before-removing-an-imp.md
@@ -1,0 +1,20 @@
+---
+id: 0217
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.793266+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Grep for runtime references before removing an import
+
+Before deleting an import, grep the file for runtime uses: `isinstance()` calls, variable assignments, and decorator calls.
+
+Example: `grep -n 'MyClass' src/foo.py` — a hit in `isinstance(x, MyClass)` means the import is load-bearing even if type checkers flag it as unused.
+
+**Why:** Ruff's `F401` rule does not inspect `isinstance` call sites; removing an apparently-unused import that is used at runtime produces `NameError`.
+
+See also: gotchas — Ruff strips unused imports mid-TDD cycle.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0218-issue-synthesis-use-is-none-is-not-none-for-optional-sentinels.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0218-issue-synthesis-use-is-none-is-not-none-for-optional-sentinels.md
@@ -1,0 +1,18 @@
+---
+id: 0218
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.793697+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Use `is None` / `is not None` for optional sentinels
+
+Prefer identity checks (`is None`, `is not None`) over equality checks for optional objects, especially callables and stores.
+
+Example: `if callback is None: return` — not `if callback == None`.
+
+**Why:** Identity checks are O(1) and immune to overridden `__eq__`; equality checks against `None` can accidentally match falsy custom objects with a permissive `__eq__`.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0219-issue-synthesis-sync-all-protocol-implementations-in-one-pr-on-sig.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0219-issue-synthesis-sync-all-protocol-implementations-in-one-pr-on-sig.md
@@ -1,0 +1,18 @@
+---
+id: 0219
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.794093+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Sync all protocol implementations in one PR on signature change
+
+When a port or protocol method signature changes, update every concrete implementation atomically in the same PR — never staggered across tasks.
+
+Example: adding `ctx: Context` to `def process(self, item)` requires changing every class implementing the protocol before merging.
+
+**Why:** Staggered updates leave implementations out of sync with the protocol, causing Pyright errors that block CI until every site is updated.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0220-issue-synthesis-delete-code-blocks-bottom-to-top-to-avoid-line-num.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0220-issue-synthesis-delete-code-blocks-bottom-to-top-to-avoid-line-num.md
@@ -1,0 +1,18 @@
+---
+id: 0220
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.794487+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Delete code blocks bottom-to-top to avoid line-number shifting
+
+When removing multiple code blocks from the same file in a single session, delete the lowest block first (highest line number) and work upward.
+
+Example: delete lines 120–130 before deleting lines 80–90; reversing the order shifts targets for the second deletion.
+
+**Why:** Deleting a higher block shifts all lower line numbers; later deletions then target wrong lines or miss content entirely.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0221-issue-synthesis-patch-functions-at-their-definition-site-not-the-i.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0221-issue-synthesis-patch-functions-at-their-definition-site-not-the-i.md
@@ -1,0 +1,18 @@
+---
+id: 0221
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.794886+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Patch functions at their definition site, not the import site
+
+Always patch functions at where they are defined, not where they are imported into the module under test.
+
+Example: `@patch('hindsight.retain_safe')` not `@patch('my_module.retain_safe')` when `my_module` imports from `hindsight`.
+
+**Why:** Patching the import site only replaces that module's local reference; all other callers continue using the real function, making the mock ineffective.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0222-issue-synthesis-verify-a-file-exists-before-writing-a-plan-task-th.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0222-issue-synthesis-verify-a-file-exists-before-writing-a-plan-task-th.md
@@ -1,0 +1,18 @@
+---
+id: 0222
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.795282+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Verify a file exists before writing a plan task that modifies it
+
+Before adding a plan task that edits a specific file, confirm the file exists via `git ls-files <path>` or grep.
+
+Example: `git ls-files src/shared_prompt_prefix.py` returns empty → file never existed; update the plan before implementation starts.
+
+**Why:** Planning tasks against nonexistent files wastes implementation work and causes confusing "file not found" failures mid-execution.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0223-issue-synthesis-test-pydantic-serialization-with-round-trip-and-sa.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0223-issue-synthesis-test-pydantic-serialization-with-round-trip-and-sa.md
@@ -1,0 +1,18 @@
+---
+id: 0223
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.795693+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Test Pydantic serialization with round-trip AND save/load tests
+
+Validate Pydantic models with both a `model_dump_json() → model_validate_json()` round-trip and a full save/load cycle.
+
+Example: a JSON round-trip catches field-name mismatches; a save/load test catches type coercion surprises from JSONL storage.
+
+**Why:** JSON round-trips can pass while save/load fails due to type coercion or missing `model_config` settings at the persistence layer.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0224-issue-synthesis-run-full-make-quality-before-declaring-implementat.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0224-issue-synthesis-run-full-make-quality-before-declaring-implementat.md
@@ -1,0 +1,18 @@
+---
+id: 0224
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.796125+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Run full `make quality` before declaring implementation complete
+
+Always run the full `make quality` gate — never a file-targeted test subset — before declaring a task done.
+
+Example: `pytest tests/test_foo.py` passes; `make quality` reveals 7 failures in `test_audit_prompts.py` caused by the same change.
+
+**Why:** Targeted runs miss cross-module regressions; cleanup PRs have higher blast radius than their diffs suggest.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0225-issue-synthesis-use-log-exception-with-bug-classification-for-bugs.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0225-issue-synthesis-use-log-exception-with-bug-classification-for-bugs.md
@@ -1,0 +1,20 @@
+---
+id: 0225
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.796514+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Use `log_exception_with_bug_classification()` for bugs vs transient
+
+Use `log_exception_with_bug_classification()` or `is_likely_bug()` to distinguish bug exceptions from transient errors.
+
+Example: in `finally` blocks use `log_exception_with_bug_classification(exc)` rather than `reraise`, to preserve finally semantics while still classifying.
+
+**Why:** Logging all exceptions as bugs floods Sentry with transient noise; wrong classification makes signal-to-noise ratio useless.
+
+See also: gotchas — Use `logger.warning(..., exc_info=True)` for transient errors.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0226-issue-synthesis-use-logger-warning-exc-info-true-for-transient-err.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0226-issue-synthesis-use-logger-warning-exc-info-true-for-transient-err.md
@@ -1,0 +1,20 @@
+---
+id: 0226
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.796898+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Use `logger.warning(..., exc_info=True)` for transient errors
+
+Log transient operational failures with `logger.warning(msg, exc_info=True)`. Reserve `logger.exception()` for genuine bugs.
+
+Example: `except (OSError, httpx.NetworkError) as exc: logger.warning('fetch failed', exc_info=True)`.
+
+**Why:** When migrating from `logger.exception()` to `logger.warning()`, forgetting `exc_info=True` silently drops the traceback, making failures undebuggable.
+
+See also: gotchas — Use `log_exception_with_bug_classification()` for bugs vs transient.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0227-issue-synthesis-catch-both-timeoutexpired-and-calledprocesserror-t.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0227-issue-synthesis-catch-both-timeoutexpired-and-calledprocesserror-t.md
@@ -1,0 +1,18 @@
+---
+id: 0227
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.797283+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Catch both TimeoutExpired and CalledProcessError — they're siblings
+
+Catch `subprocess.TimeoutExpired` and `subprocess.CalledProcessError` in separate `except` clauses.
+
+Example: `except subprocess.TimeoutExpired: handle_timeout()` followed by `except subprocess.CalledProcessError: handle_failure()`.
+
+**Why:** `TimeoutExpired` is not a subclass of `CalledProcessError`; a single `except CalledProcessError` silently misses timeouts, letting them propagate unhandled.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0228-issue-synthesis-omitting-await-on-async-calls-silently-returns-a-c.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0228-issue-synthesis-omitting-await-on-async-calls-silently-returns-a-c.md
@@ -1,0 +1,18 @@
+---
+id: 0228
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.797675+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Omitting `await` on async calls silently returns a coroutine
+
+Always `await` async method calls; storing an unawaited coroutine silently never executes its body.
+
+Example: `result = fetch_data()` stores a `Coroutine` object; `result = await fetch_data()` executes it.
+
+**Why:** Unawaited coroutines silently no-op; Pyright only catches them at `make typecheck` time when call sites have annotations.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0229-issue-synthesis-store-asyncio-create-task-results-unreferenced-tas.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0229-issue-synthesis-store-asyncio-create-task-results-unreferenced-tas.md
@@ -1,0 +1,18 @@
+---
+id: 0229
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.798063+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Store `asyncio.create_task()` results — unreferenced tasks are GC'd
+
+Assign every `asyncio.create_task()` result to a set and add a done callback for error logging.
+
+Example: `self._tasks.add(t := asyncio.create_task(work())); t.add_done_callback(self._tasks.discard)`.
+
+**Why:** Tasks without a live reference are garbage-collected mid-execution, silently dropping their work and exceptions with no observable signal.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0230-issue-synthesis-new-pydantic-fields-must-have-defaults-for-existin.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0230-issue-synthesis-new-pydantic-fields-must-have-defaults-for-existin.md
@@ -1,0 +1,20 @@
+---
+id: 0230
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.798446+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# New Pydantic fields must have defaults for existing state compat
+
+Add new fields to Pydantic models as `field: Type = default_value` — never as required fields — so existing serialized state files continue to deserialize.
+
+Example: `retry_count: int = 0` allows old state JSONs that lack the key to load without error.
+
+**Why:** A required field with no default causes `ValidationError` on every existing persisted object, breaking recovery from saved state on the first restart after deploy.
+
+See also: gotchas — Use `TypedDict(total=False)` for backward-compatible payloads.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0231-issue-synthesis-use-atomic-write-instead-of-path-write-text-for-js.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0231-issue-synthesis-use-atomic-write-instead-of-path-write-text-for-js.md
@@ -1,0 +1,18 @@
+---
+id: 0231
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.798834+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Use `atomic_write()` instead of `Path.write_text()` for JSON state
+
+Write JSON state files via `file_util.atomic_write()`, not `Path.write_text()`.
+
+Example: `atomic_write(state_path, json_str)` writes to a `.tmp` sibling then renames atomically — a crash mid-write leaves the original intact.
+
+**Why:** `Path.write_text()` truncates before writing; a crash mid-operation produces a zero-byte or partial JSON that fails to parse on restart, corrupting persisted state.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0232-issue-synthesis-use-typeddict-total-false-for-backward-compatible-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0232-issue-synthesis-use-typeddict-total-false-for-backward-compatible-.md
@@ -1,0 +1,20 @@
+---
+id: 0232
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.799231+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Use `TypedDict(total=False)` for backward-compatible payloads
+
+Define event payload TypedDicts with `total=False` so all fields are optional, allowing old producers and new consumers to interoperate.
+
+Example: `class MergePayload(TypedDict, total=False): pr_number: int; labels: list[str]`.
+
+**Why:** A `total=True` TypedDict requires all fields; adding a new field breaks any existing producer that doesn't include it, preventing rolling deployments.
+
+See also: gotchas — New Pydantic fields must have defaults for existing state compat.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0233-issue-synthesis-new-hydraflowconfig-label-fields-must-be-optional-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0233-issue-synthesis-new-hydraflowconfig-label-fields-must-be-optional-.md
@@ -1,0 +1,18 @@
+---
+id: 0233
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.799618+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# New HydraFlowConfig label fields must be optional in ConfigFactory
+
+When adding a `list[str]` label field to `HydraFlowConfig`, add it as an optional `ConfigFactory.create()` parameter with a sensible default.
+
+Example: omitting the parameter causes `TypeError: create() got an unexpected keyword argument` in every test fixture that constructs a config.
+
+**Why:** `ConfigFactory.create()` is called across the entire test suite; missing parameters break all tests that construct a config without the new field.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0234-issue-synthesis-reverse-state-transitions-on-non-fatal-exceptions-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0234-issue-synthesis-reverse-state-transitions-on-non-fatal-exceptions-.md
@@ -1,0 +1,18 @@
+---
+id: 0234
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.800018+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Reverse state transitions on non-fatal exceptions to avoid stuck
+
+Wrap label-swap + operation + cleanup in a try/except that reverses the transition on non-fatal errors.
+
+Example: if a label is swapped `plan → implement` but the API call fails, swap it back to `plan` before re-raising.
+
+**Why:** An exception after a successful state transition but before cleanup leaves issues stuck in intermediate states with no automated recovery path.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0235-issue-synthesis-use-same-id-extraction-logic-everywhere-files-are-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0235-issue-synthesis-use-same-id-extraction-logic-everywhere-files-are-.md
@@ -1,0 +1,18 @@
+---
+id: 0235
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.800422+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Use same ID extraction logic everywhere files are keyed by issue
+
+Define ID prefix lengths as named constants and centralize extraction so every site that keys files by issue uses identical logic.
+
+Example: define `DISCOVER_PREFIX_LEN = 9`; use it in both the writer and the reader rather than hardcoding `fname[9:]` in each.
+
+**Why:** Inconsistent ID logic causes silent lookup failures — a plan is written under key A but read back under key B, producing phantom missing plans.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0236-issue-synthesis-join-factory-pipeline-metrics-by-issue-number-not-.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0236-issue-synthesis-join-factory-pipeline-metrics-by-issue-number-not-.md
@@ -1,0 +1,18 @@
+---
+id: 0236
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.800828+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Join factory pipeline metrics by issue_number, not pr_number
+
+When correlating factory metrics or reviews across pipeline tables, join on `issue_number` rather than `pr_number`.
+
+Example: a PR can be closed and recreated with a new number; `issue_number` is stable across the full lifecycle.
+
+**Why:** `pr_number` changes when PRs are recycled; joining on it silently drops or duplicates records for any issue where the PR was recreated.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0237-issue-synthesis-test-pipeline-stage-ordering-not-just-status-after.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0237-issue-synthesis-test-pipeline-stage-ordering-not-just-status-after.md
@@ -1,0 +1,18 @@
+---
+id: 0237
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.801267+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Test pipeline stage ordering, not just status, after inserting stage
+
+After inserting a new stage into `PIPELINE_STAGES`, assert both that the stage's status value is correct and that its array index is correct.
+
+Example: inserting a stage at index 2 shifts all downstream indices; a test checking only `status == 'active'` passes while skip-detection silently breaks.
+
+**Why:** Index-based progression logic produces incorrect skip decisions when stages are reordered, with no immediate test failure.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0238-issue-synthesis-filter-evicted-memories-on-both-content-prefix-and.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0238-issue-synthesis-filter-evicted-memories-on-both-content-prefix-and.md
@@ -1,0 +1,18 @@
+---
+id: 0238
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.801683+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Filter evicted memories on both content prefix AND metadata status
+
+Apply dual filters when loading recalled memories: check both the `[EVICTED]` content prefix and `status: evicted` in metadata before injecting into prompts.
+
+Example: `if mem.content.startswith('[EVICTED]') or mem.metadata.get('status') == 'evicted': skip`.
+
+**Why:** A single filter has a failure path; if one guard is missing or malformed, a tombstone leaks into agent prompts and produces confusing or incorrect agent behavior.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0239-issue-synthesis-new-automated-skills-must-start-with-blocking-fals.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0239-issue-synthesis-new-automated-skills-must-start-with-blocking-fals.md
@@ -1,0 +1,18 @@
+---
+id: 0239
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.802125+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# New automated skills must start with blocking=False until stable
+
+Register new dynamic skills with `blocking=False` and graduate to `blocking=True` only after ≥20 runs at ≥95% success rate.
+
+Example: a new lint-skill marked `blocking=True` on day one fails builds on edge cases the author didn't anticipate.
+
+**Why:** Unproven blocking skills immediately break CI on legitimate code; graduated promotion ensures checks are stable before they can gate merges.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0240-issue-synthesis-validate-parsers-against-realistic-multi-paragraph.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0240-issue-synthesis-validate-parsers-against-realistic-multi-paragraph.md
@@ -1,0 +1,20 @@
+---
+id: 0240
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.802534+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Validate parsers against realistic multi-paragraph agent output
+
+Write parser tests against realistic multi-paragraph transcripts — prose interspersed with structured markers — not bare marker strings.
+
+Example: test input should resemble real `claude` CLI output; assert on structured markers, not prose wording.
+
+**Why:** Bare-marker tests pass even when the parser fails on the surrounding prose context present in real output, hiding real format regressions.
+
+See also: gotchas — Log warning on zero-match transcript extraction from non-empty input.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0241-issue-synthesis-log-warning-on-zero-match-transcript-extraction-fr.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0241-issue-synthesis-log-warning-on-zero-match-transcript-extraction-fr.md
@@ -1,0 +1,20 @@
+---
+id: 0241
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.802917+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Log warning on zero-match transcript extraction from non-empty input
+
+When extracting structured data from CLI transcripts, wrap regex in try/except and log a warning on zero matches against non-empty input.
+
+Example: `matches = RE.findall(text); if not matches and text.strip(): logger.warning('parser found 0 matches on non-empty transcript')`.
+
+**Why:** Silent zero-match returns hide format drift between transcript versions; warnings surface parser breakage before it causes downstream data loss.
+
+See also: gotchas — Validate parsers against realistic multi-paragraph agent output.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0242-issue-synthesis-use-portable-shell-commands-in-alpine-containers-p.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0242-issue-synthesis-use-portable-shell-commands-in-alpine-containers-p.md
@@ -1,0 +1,18 @@
+---
+id: 0242
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.803314+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Use portable shell commands in Alpine containers — Python is absent
+
+In Alpine-based Docker containers, avoid Python and non-standard utilities. Use portable POSIX commands for memory/CPU operations.
+
+Example: `dd if=/dev/zero bs=1M count=32 of=/dev/null` instead of a Python `bytearray` allocation.
+
+**Why:** Alpine's minimal tooling excludes Python and many GNU utilities; scripts that rely on them fail with `command not found` in constrained CI environments.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0243-issue-synthesis-separate-silent-with-result-events-from-purely-sil.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0243-issue-synthesis-separate-silent-with-result-events-from-purely-sil.md
@@ -1,0 +1,18 @@
+---
+id: 0243
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.803707+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Separate silent-with-result events from purely silent in dispatch
+
+In event dispatch tables, distinguish events that produce no display output but set a result value from events that are truly silent.
+
+Example: check `_SILENT_WITH_RESULT` before `_SILENT_EVENTS` so result-setting events are routed correctly.
+
+**Why:** Treating silent-with-result events as purely silent discards their return values, causing downstream state to silently receive `None` instead of the real result.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0244-issue-synthesis-create-a-specialized-method-rather-than-overloadin.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0244-issue-synthesis-create-a-specialized-method-rather-than-overloadin.md
@@ -1,0 +1,18 @@
+---
+id: 0244
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.804109+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Create a specialized method rather than overloading a general one
+
+When a general method returns insufficient data for a specific use case, create a separate focused method rather than adding optional parameters.
+
+Example: `list_issues_by_label()` returns basic metadata; `get_issue_updated_at()` handles timestamps in a separate call.
+
+**Why:** Overloading general methods couples unrelated concerns and complicates callers that need only one piece of data.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0245-issue-synthesis-ruff-strips-unused-imports-mid-tdd-cycle.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0245-issue-synthesis-ruff-strips-unused-imports-mid-tdd-cycle.md
@@ -1,0 +1,20 @@
+---
+id: 0245
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.804516+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Ruff strips unused imports mid-TDD cycle
+
+During TDD, write the test body (which uses the new symbol) before adding its import — or use a function-local import inside the test body.
+
+Example: add `from scripts.audit import score_rule` only after `score_rule` appears in the test function body.
+
+**Why:** Pre-commit `ruff --fix` removes imports not yet referenced on the first save, producing `NameError` on the second save and breaking the TDD red-phase.
+
+See also: gotchas — Grep for runtime references before removing an import.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0246-issue-synthesis-verify-implementation-files-are-in-the-diff-before.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0246-issue-synthesis-verify-implementation-files-are-in-the-diff-before.md
@@ -1,0 +1,18 @@
+---
+id: 0246
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.804920+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Verify implementation files are in the diff before merging
+
+Before merging, confirm the target source file appears in `git diff --name-only origin/main`.
+
+Example: PR closes #7644 but `git diff --name-only` shows only `docs/` and `tests/` — `src/makefile_scaffold.py` has 0 changes.
+
+**Why:** Tests can pass against stubs or unchanged code; a green CI with no implementation changes ships dead-end work that silently does nothing.

--- a/repo_wiki/T-rav/hydraflow/gotchas/0247-issue-synthesis-coverage-delta-gate-is-asymmetric-gaps-block-clean.md
+++ b/repo_wiki/T-rav/hydraflow/gotchas/0247-issue-synthesis-coverage-delta-gate-is-asymmetric-gaps-block-clean.md
@@ -1,0 +1,18 @@
+---
+id: 0247
+topic: gotchas
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:45:05.805324+00:00
+status: active
+corroborations: 1
+supersedes: 0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213
+---
+
+# Coverage-delta gate is asymmetric: gaps block, clean defers to LLM
+
+The coverage-delta gate overrides LLM verdict only in one direction: uncovered changed lines force FAIL; clean coverage does NOT override an LLM RETRY or FAIL.
+
+Example: Uncovered lines found → FAIL (override). Clean coverage + LLM RETRY → RETRY (defer to LLM).
+
+**Why:** Symmetric override would allow a coverage pass to rescue an LLM RETRY, defeating the purpose of independent verification; the gate is a one-way ratchet against self-grading.

--- a/repo_wiki/T-rav/hydraflow/patterns/0218-issue-synthesis-use-optional-fields-with-defaults-for-backward-com.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0218-issue-synthesis-use-optional-fields-with-defaults-for-backward-com.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.217118+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Use optional fields with defaults for backward-compatible schemas

--- a/repo_wiki/T-rav/hydraflow/patterns/0219-issue-synthesis-distinguish-bare-str-from-str-none-before-narrowin.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0219-issue-synthesis-distinguish-bare-str-from-str-none-before-narrowin.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.217544+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Distinguish bare `str` from `str | None` before narrowing types

--- a/repo_wiki/T-rav/hydraflow/patterns/0220-issue-synthesis-use-strenum-coercion-to-auto-convert-stored-string.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0220-issue-synthesis-use-strenum-coercion-to-auto-convert-stored-string.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.218073+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Use StrEnum coercion to auto-convert stored string values

--- a/repo_wiki/T-rav/hydraflow/patterns/0221-issue-synthesis-define-canonical-constants-for-label-lists-as-sing.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0221-issue-synthesis-define-canonical-constants-for-label-lists-as-sing.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.218467+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Define canonical constants for label lists as single source of truth

--- a/repo_wiki/T-rav/hydraflow/patterns/0222-issue-synthesis-use-metadata-tags-instead-of-enum-variants-for-cat.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0222-issue-synthesis-use-metadata-tags-instead-of-enum-variants-for-cat.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.218827+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Use metadata tags instead of enum variants for categorization

--- a/repo_wiki/T-rav/hydraflow/patterns/0223-issue-synthesis-grep-all-call-sites-before-changing-a-function-sig.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0223-issue-synthesis-grep-all-call-sites-before-changing-a-function-sig.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.219185+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Grep all call sites before changing a function signature

--- a/repo_wiki/T-rav/hydraflow/patterns/0224-issue-synthesis-update-all-callers-atomically-when-a-return-type-c.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0224-issue-synthesis-update-all-callers-atomically-when-a-return-type-c.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.219698+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Update all callers atomically when a return type changes

--- a/repo_wiki/T-rav/hydraflow/patterns/0225-issue-synthesis-preserve-public-api-during-extraction-via-delegati.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0225-issue-synthesis-preserve-public-api-during-extraction-via-delegati.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.220070+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Preserve public API during extraction via delegation stubs

--- a/repo_wiki/T-rav/hydraflow/patterns/0226-issue-synthesis-extract-pure-transform-functions-before-moving-cod.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0226-issue-synthesis-extract-pure-transform-functions-before-moving-cod.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.220449+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Extract pure transform functions before moving code to classes

--- a/repo_wiki/T-rav/hydraflow/patterns/0227-issue-synthesis-preserve-per-concern-try-except-blocks-during-refa.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0227-issue-synthesis-preserve-per-concern-try-except-blocks-during-refa.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.220834+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Preserve per-concern try/except blocks during refactoring

--- a/repo_wiki/T-rav/hydraflow/patterns/0228-issue-synthesis-extract-duplicated-jsonl-reading-logic-to-a-shared.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0228-issue-synthesis-extract-duplicated-jsonl-reading-logic-to-a-shared.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.221191+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Extract duplicated JSONL-reading logic to a shared helper

--- a/repo_wiki/T-rav/hydraflow/patterns/0229-issue-synthesis-mock-at-the-definition-site-not-the-import-site.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0229-issue-synthesis-mock-at-the-definition-site-not-the-import-site.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.221556+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Mock at the definition site, not the import site

--- a/repo_wiki/T-rav/hydraflow/patterns/0230-issue-synthesis-retarget-mock-patches-to-the-new-location-before-m.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0230-issue-synthesis-retarget-mock-patches-to-the-new-location-before-m.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.221945+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Retarget mock patches to the new location before moving a method

--- a/repo_wiki/T-rav/hydraflow/patterns/0231-issue-synthesis-reference-function-names-not-line-numbers-in-gener.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0231-issue-synthesis-reference-function-names-not-line-numbers-in-gener.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.222312+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Reference function names, not line numbers, in generated tests

--- a/repo_wiki/T-rav/hydraflow/patterns/0232-issue-synthesis-use-meta-tests-to-enforce-anti-pattern-absence-in-.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0232-issue-synthesis-use-meta-tests-to-enforce-anti-pattern-absence-in-.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.222664+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Use meta-tests to enforce anti-pattern absence in the test suite

--- a/repo_wiki/T-rav/hydraflow/patterns/0233-issue-synthesis-use-threading-lock-for-thread-pool-code-asyncio-lo.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0233-issue-synthesis-use-threading-lock-for-thread-pool-code-asyncio-lo.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.223013+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Use `threading.Lock` for thread-pool code; `asyncio.Lock` for coroutines

--- a/repo_wiki/T-rav/hydraflow/patterns/0234-issue-synthesis-extract-unlocked-helpers-to-prevent-re-entrant-loc.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0234-issue-synthesis-extract-unlocked-helpers-to-prevent-re-entrant-loc.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.223360+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Extract `_unlocked()` helpers to prevent re-entrant lock attempts

--- a/repo_wiki/T-rav/hydraflow/patterns/0235-issue-synthesis-use-file-util-append-jsonl-for-crash-safe-jsonl-ap.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0235-issue-synthesis-use-file-util-append-jsonl-for-crash-safe-jsonl-ap.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.223709+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Use `file_util.append_jsonl()` for crash-safe JSONL appends

--- a/repo_wiki/T-rav/hydraflow/patterns/0236-issue-synthesis-use-file-util-atomic-write-for-critical-state-file.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0236-issue-synthesis-use-file-util-atomic-write-for-critical-state-file.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.224056+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Use `file_util.atomic_write()` for critical state file updates

--- a/repo_wiki/T-rav/hydraflow/patterns/0237-issue-synthesis-use-claim-then-merge-for-async-queue-processing.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0237-issue-synthesis-use-claim-then-merge-for-async-queue-processing.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.224418+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Use claim-then-merge for async queue processing

--- a/repo_wiki/T-rav/hydraflow/patterns/0238-issue-synthesis-set-and-clear-trace-context-in-a-single-try-finall.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0238-issue-synthesis-set-and-clear-trace-context-in-a-single-try-finall.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.224771+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Set and clear trace context in a single try/finally block

--- a/repo_wiki/T-rav/hydraflow/patterns/0239-issue-synthesis-keep-event-publishing-coupled-with-the-condition-t.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0239-issue-synthesis-keep-event-publishing-coupled-with-the-condition-t.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.225134+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Keep event publishing coupled with the condition that gates it

--- a/repo_wiki/T-rav/hydraflow/patterns/0240-issue-synthesis-preserve-exact-retry-counter-state-during-dispatch.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0240-issue-synthesis-preserve-exact-retry-counter-state-during-dispatch.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.225489+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Preserve exact retry counter state during dispatcher refactoring

--- a/repo_wiki/T-rav/hydraflow/patterns/0241-issue-synthesis-dry-run-mode-must-not-emit-state-changing-events.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0241-issue-synthesis-dry-run-mode-must-not-emit-state-changing-events.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.225857+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Dry-run mode must not emit state-changing events

--- a/repo_wiki/T-rav/hydraflow/patterns/0242-issue-synthesis-maintain-immutable-return-contract-for-parse-tuple.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0242-issue-synthesis-maintain-immutable-return-contract-for-parse-tuple.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.226253+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Maintain immutable return contract for `parse()` tuples

--- a/repo_wiki/T-rav/hydraflow/patterns/0243-issue-synthesis-define-stage-mappings-before-skip-detection.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0243-issue-synthesis-define-stage-mappings-before-skip-detection.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.226685+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Define stage mappings before skip detection

--- a/repo_wiki/T-rav/hydraflow/patterns/0244-issue-synthesis-pre-allocate-memory-budget-upfront-before-prompt-a.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0244-issue-synthesis-pre-allocate-memory-budget-upfront-before-prompt-a.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.227054+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Pre-allocate memory budget upfront before prompt assembly

--- a/repo_wiki/T-rav/hydraflow/patterns/0245-issue-synthesis-use-a-two-round-allocator-for-memory-budgets.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0245-issue-synthesis-use-a-two-round-allocator-for-memory-budgets.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.227415+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Use a two-round allocator for memory budgets

--- a/repo_wiki/T-rav/hydraflow/patterns/0246-issue-synthesis-deduct-wiki-budget-from-memory-surplus-before-redi.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0246-issue-synthesis-deduct-wiki-budget-from-memory-surplus-before-redi.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.227773+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Deduct wiki budget from memory surplus before redistributing

--- a/repo_wiki/T-rav/hydraflow/patterns/0247-issue-synthesis-lazy-load-memory-context-on-explicit-user-action.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0247-issue-synthesis-lazy-load-memory-context-on-explicit-user-action.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.228135+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Lazy-load memory context on explicit user action

--- a/repo_wiki/T-rav/hydraflow/patterns/0248-issue-synthesis-use-sha-256-truncated-to-16-chars-for-memory-dedup.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0248-issue-synthesis-use-sha-256-truncated-to-16-chars-for-memory-dedup.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.228500+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Use SHA-256 truncated to 16 chars for memory dedup keys

--- a/repo_wiki/T-rav/hydraflow/patterns/0249-issue-synthesis-use-asymmetric-word-set-overlap-for-memory-dedupli.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0249-issue-synthesis-use-asymmetric-word-set-overlap-for-memory-dedupli.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.228898+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Use asymmetric word-set overlap for memory deduplication

--- a/repo_wiki/T-rav/hydraflow/patterns/0250-issue-synthesis-batch-load-scoring-data-once-per-eviction-operatio.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0250-issue-synthesis-batch-load-scoring-data-once-per-eviction-operatio.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.229293+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Batch-load scoring data once per eviction operation

--- a/repo_wiki/T-rav/hydraflow/patterns/0251-issue-synthesis-use-true-not-is-true-for-retain-metadata-booleans.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0251-issue-synthesis-use-true-not-is-true-for-retain-metadata-booleans.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.229731+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Use `== "true"`, not `is True` for `retain()` metadata booleans

--- a/repo_wiki/T-rav/hydraflow/patterns/0252-issue-synthesis-memory-contradiction-resolution-provenance-wins-ov.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0252-issue-synthesis-memory-contradiction-resolution-provenance-wins-ov.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.230151+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Memory contradiction resolution: provenance wins over recency

--- a/repo_wiki/T-rav/hydraflow/patterns/0253-issue-synthesis-atomically-update-scores-and-items-files-during-ev.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0253-issue-synthesis-atomically-update-scores-and-items-files-during-ev.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.230555+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Atomically update scores and items files during eviction

--- a/repo_wiki/T-rav/hydraflow/patterns/0254-issue-synthesis-guard-close-with-a-closed-flag-to-make-it-idempote.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0254-issue-synthesis-guard-close-with-a-closed-flag-to-make-it-idempote.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.230930+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Guard `close()` with a `_closed` flag to make it idempotent

--- a/repo_wiki/T-rav/hydraflow/patterns/0255-issue-synthesis-memory-staleness-detection-must-emit-events-not-mu.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0255-issue-synthesis-memory-staleness-detection-must-emit-events-not-mu.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.231306+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Memory staleness detection must emit events, not mutate state

--- a/repo_wiki/T-rav/hydraflow/patterns/0256-issue-synthesis-adr-files-without-readme-entries-are-invisible-to-.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0256-issue-synthesis-adr-files-without-readme-entries-are-invisible-to-.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.231722+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # ADR files without README entries are invisible to tooling

--- a/repo_wiki/T-rav/hydraflow/patterns/0257-issue-synthesis-preserve-the-hf-namespace-prefix-when-renaming-ski.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0257-issue-synthesis-preserve-the-hf-namespace-prefix-when-renaming-ski.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.232160+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Preserve the `hf.` namespace prefix when renaming skill files

--- a/repo_wiki/T-rav/hydraflow/patterns/0258-issue-synthesis-keep-skill-prompts-in-sync-across-all-four-backend.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0258-issue-synthesis-keep-skill-prompts-in-sync-across-all-four-backend.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.232583+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Keep skill prompts in sync across all four backend locations

--- a/repo_wiki/T-rav/hydraflow/patterns/0259-issue-synthesis-avoid-in-place-diff-truncation-for-non-llm-consume.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0259-issue-synthesis-avoid-in-place-diff-truncation-for-non-llm-consume.md
@@ -4,9 +4,10 @@ topic: patterns
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:45:28.232977+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0176,0177,0178,0179,0180,0181,0182,0183,0184,0185,0186,0187,0188,0189,0190,0191,0192,0193,0194,0195,0196,0197,0198,0199,0200,0201,0202,0203,0204,0205,0206,0207,0208,0209,0210,0211,0212,0213,0214,0215,0216,0217
+superseded_by: 0260
 ---
 
 # Avoid in-place diff truncation for non-LLM consumers

--- a/repo_wiki/T-rav/hydraflow/patterns/0260-issue-synthesis-use-optional-fields-with-defaults-for-backward-com.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0260-issue-synthesis-use-optional-fields-with-defaults-for-backward-com.md
@@ -1,0 +1,18 @@
+---
+id: 0260
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.707007+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Use optional fields with defaults for backward-compatible schemas
+
+New Pydantic fields must be optional with sensible defaults so existing state.json files load without migration validators.
+
+Example: `field: str = "default"` or `field: str | None = None`; read with `.get("scope", "repo")`.
+
+**Why:** Pydantic v2 auto-coerces raw dicts from state.json into typed models — no migration step exists, so non-optional new fields crash on load.

--- a/repo_wiki/T-rav/hydraflow/patterns/0261-issue-synthesis-distinguish-bare-str-from-str-none-before-narrowin.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0261-issue-synthesis-distinguish-bare-str-from-str-none-before-narrowin.md
@@ -1,0 +1,18 @@
+---
+id: 0261
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.707672+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Distinguish bare `str` from `str | None` before narrowing types
+
+Narrowing a bare `str` field to a StrEnum is safe when all stored values conform, but narrowing `str | None` requires union narrowing, not direct replacement.
+
+Example: Grep all state.json consumers and call sites exhaustively before narrowing; treat union fields separately.
+
+**Why:** Narrowing a union type as if it were a bare type causes `ValidationError` on load for any stored `None` values.

--- a/repo_wiki/T-rav/hydraflow/patterns/0262-issue-synthesis-use-strenum-coercion-to-auto-convert-stored-string.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0262-issue-synthesis-use-strenum-coercion-to-auto-convert-stored-string.md
@@ -1,0 +1,18 @@
+---
+id: 0262
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.708235+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Use StrEnum coercion to auto-convert stored string values
+
+Declare Pydantic fields as StrEnum when values already conform, so Pydantic v2 auto-coerces stored strings at load time.
+
+Example: `class Phase(StrEnum): READY = "hydraflow-ready"` — field `phase: Phase` coerces `"hydraflow-ready"` from state.json automatically.
+
+**Why:** Manual `Phase(raw)` coercions at every read site diverge when new read paths are added; StrEnum coercion centralises conversion.

--- a/repo_wiki/T-rav/hydraflow/patterns/0263-issue-synthesis-define-canonical-constants-for-label-lists-as-sing.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0263-issue-synthesis-define-canonical-constants-for-label-lists-as-sing.md
@@ -1,0 +1,18 @@
+---
+id: 0263
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.708648+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Define canonical constants for label lists as single source of truth
+
+Establish a canonical constant (e.g., `ALL_LIFECYCLE_LABEL_FIELDS`) and derive every label list from it; never duplicate the list inline.
+
+Example: Reset code, validators, and display logic all reference `ALL_LIFECYCLE_LABEL_FIELDS` — no magic strings.
+
+**Why:** Duplicated label lists diverge silently; a canonical constant makes omissions a grep-findable gap, not a runtime miss.

--- a/repo_wiki/T-rav/hydraflow/patterns/0264-issue-synthesis-use-metadata-tags-instead-of-enum-variants-for-cat.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0264-issue-synthesis-use-metadata-tags-instead-of-enum-variants-for-cat.md
@@ -1,0 +1,18 @@
+---
+id: 0264
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.709047+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Use metadata tags instead of enum variants for categorization
+
+Tag items with metadata (e.g., `{"source": "adr_council"}`) rather than adding new enum variants for each category.
+
+Example: `retain(bank=Bank.LEARNINGS, metadata={"source": "adr_council"})` — no new enum variant needed.
+
+**Why:** Enum variants require syncing type checks, prompts, and display order across the codebase; a metadata tag adds a category with no schema change.

--- a/repo_wiki/T-rav/hydraflow/patterns/0265-issue-synthesis-grep-all-call-sites-before-changing-a-function-sig.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0265-issue-synthesis-grep-all-call-sites-before-changing-a-function-sig.md
@@ -1,0 +1,18 @@
+---
+id: 0265
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.709465+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Grep all call sites before changing a function signature
+
+Run `git grep <function_name>` before modifying any signature; for public functions, verify zero remaining unpatched matches after the change.
+
+Example: `git grep 'load_state'` before changing its return type — update every caller in the same commit.
+
+**Why:** Missing even one call site causes `TypeError` at runtime; exhaustive grep audit is the only way to confirm full coverage.

--- a/repo_wiki/T-rav/hydraflow/patterns/0266-issue-synthesis-update-all-callers-atomically-when-a-return-type-c.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0266-issue-synthesis-update-all-callers-atomically-when-a-return-type-c.md
@@ -1,0 +1,18 @@
+---
+id: 0266
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.709906+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Update all callers atomically when a return type changes
+
+When a function's return type changes, update every caller in a single commit — never in separate PRs.
+
+Example: Change `parse()` return type and grep + update all `result[0]` / `result[1]` unpack sites before committing.
+
+**Why:** A partially-migrated codebase compiles but crashes at runtime on unpatched callers.

--- a/repo_wiki/T-rav/hydraflow/patterns/0267-issue-synthesis-preserve-public-api-during-extraction-via-delegati.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0267-issue-synthesis-preserve-public-api-during-extraction-via-delegati.md
@@ -1,0 +1,18 @@
+---
+id: 0267
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.710318+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Preserve public API during extraction via delegation stubs
+
+When extracting code that tests or external callers depend on, keep the original method as a thin stub delegating to the new location.
+
+Example: Leave `Client.old_method(self, x)` calling `new_module.old_method(x)` after extraction.
+
+**Why:** Removing public/semi-public methods during refactoring breaks callers that aren't visible in local grep (e.g., dynamically assembled call sites or test mocks).

--- a/repo_wiki/T-rav/hydraflow/patterns/0268-issue-synthesis-extract-pure-transform-functions-before-moving-cod.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0268-issue-synthesis-extract-pure-transform-functions-before-moving-cod.md
@@ -1,0 +1,18 @@
+---
+id: 0268
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.710720+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Extract pure transform functions before moving code to classes
+
+Identify pure functions (no mutable closure state, no side effects) and extract them to module-level first; only then move to a class if ownership is clear.
+
+Example: Extract `_format_label(name)` before creating `LabelFormatter` — the extracted form is independently testable.
+
+**Why:** Pure functions have the smallest blast radius and validate the extraction boundary before higher-risk class restructuring.

--- a/repo_wiki/T-rav/hydraflow/patterns/0269-issue-synthesis-preserve-per-concern-try-except-blocks-during-refa.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0269-issue-synthesis-preserve-per-concern-try-except-blocks-during-refa.md
@@ -1,0 +1,18 @@
+---
+id: 0269
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.711121+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Preserve per-concern try/except blocks during refactoring
+
+Do not merge or widen separate try/except blocks that each guard a specific concern — keep them as-is when extracting surrounding code.
+
+Example: If `fetch_labels()` and `post_comment()` each have their own try/except, extracted helpers must not share a single outer handler.
+
+**Why:** Merging exception scopes lets a failure in one concern silently suppress or skip a different concern.

--- a/repo_wiki/T-rav/hydraflow/patterns/0270-issue-synthesis-extract-duplicated-jsonl-reading-logic-to-a-shared.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0270-issue-synthesis-extract-duplicated-jsonl-reading-logic-to-a-shared.md
@@ -1,0 +1,18 @@
+---
+id: 0270
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.711520+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Extract duplicated JSONL-reading logic to a shared helper
+
+Shared JSONL-reading logic must be extracted to a `_load_jsonl(path, label)` helper rather than duplicated inline.
+
+Example: `records = _load_jsonl(path, "events")` — one implementation, multiple callers.
+
+**Why:** Inline duplication causes silent divergence when one copy gets a bug fix (e.g., empty-file guard) that the other copies miss.

--- a/repo_wiki/T-rav/hydraflow/patterns/0271-issue-synthesis-mock-at-the-definition-site-not-the-import-site.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0271-issue-synthesis-mock-at-the-definition-site-not-the-import-site.md
@@ -1,0 +1,18 @@
+---
+id: 0271
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.711939+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Mock at the definition site, not the import site
+
+Patch `hindsight.tombstone_safe`, not `module_under_test.tombstone_safe`; combine with deferred imports inside test methods.
+
+Example: `@patch('hindsight.tombstone_safe')` not `@patch('mymodule.tombstone_safe')`.
+
+**Why:** Import-site patches fail when the import is deferred or when optional dependencies are conditionally loaded — definition-site patches intercept regardless of import order.

--- a/repo_wiki/T-rav/hydraflow/patterns/0272-issue-synthesis-retarget-mock-patches-to-the-new-location-before-m.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0272-issue-synthesis-retarget-mock-patches-to-the-new-location-before-m.md
@@ -1,0 +1,18 @@
+---
+id: 0272
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.712357+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Retarget mock patches to the new location before moving a method
+
+Before moving a method to a new module, update all `@patch` decorators in tests to point to the destination path, then move the implementation.
+
+Example: Change `@patch('old.module.Method')` → `@patch('new.module.Method')` before the move commit.
+
+**Why:** Moving a method without updating patches leaves tests patching a now-unused import, so the live code runs unpatched and the test silently stops covering the real path.

--- a/repo_wiki/T-rav/hydraflow/patterns/0273-issue-synthesis-reference-function-names-not-line-numbers-in-gener.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0273-issue-synthesis-reference-function-names-not-line-numbers-in-gener.md
@@ -1,0 +1,18 @@
+---
+id: 0273
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.712757+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Reference function names, not line numbers, in generated tests
+
+Test skeletons, comments, and generated assertions must use exact function/class names for stability across refactors.
+
+Example: `# tests path through calculate_drift()` not `# tests line 42 in drift.py`.
+
+**Why:** Line numbers shift on every edit, making generated references immediately stale and misleading.

--- a/repo_wiki/T-rav/hydraflow/patterns/0274-issue-synthesis-use-meta-tests-to-enforce-anti-pattern-absence-in-.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0274-issue-synthesis-use-meta-tests-to-enforce-anti-pattern-absence-in-.md
@@ -1,0 +1,18 @@
+---
+id: 0274
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.713159+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Use meta-tests to enforce anti-pattern absence in the test suite
+
+Write meta-tests that scan `tests/test_*.py` for forbidden patterns (e.g., `sys.path.insert`, "Should..." docstrings, AAA comments) and fail CI if any are found.
+
+Example: `assert not any('sys.path.insert' in line for line in test_files)` as a standalone test.
+
+**Why:** Manual review misses anti-patterns introduced across hundreds of test files; a meta-test turns the check into a permanent CI gate.

--- a/repo_wiki/T-rav/hydraflow/patterns/0275-issue-synthesis-use-threading-lock-for-thread-pool-code-asyncio-lo.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0275-issue-synthesis-use-threading-lock-for-thread-pool-code-asyncio-lo.md
@@ -1,0 +1,18 @@
+---
+id: 0275
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.713562+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Use `threading.Lock` for thread-pool code; `asyncio.Lock` for coroutines
+
+When code runs via `asyncio.to_thread()` or is called from both sync and async contexts, use `threading.Lock`. Use `asyncio.Lock` only for coordinating pure coroutines.
+
+Example: `self._lock = threading.Lock()` for a cache shared between thread-pool workers.
+
+**Why:** `asyncio.Lock` is not thread-safe — acquiring it from a thread pool raises or silently corrupts state.

--- a/repo_wiki/T-rav/hydraflow/patterns/0276-issue-synthesis-extract-unlocked-helpers-to-prevent-re-entrant-loc.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0276-issue-synthesis-extract-unlocked-helpers-to-prevent-re-entrant-loc.md
@@ -1,0 +1,18 @@
+---
+id: 0276
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.713975+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Extract `_unlocked()` helpers to prevent re-entrant lock attempts
+
+When a lock-holding method needs to call another method that also acquires the same lock, extract an `_unlocked()` variant and call that from both.
+
+Example: `def update(self): with self._lock: self._update_unlocked()` — `batch_update` calls `_update_unlocked()` too.
+
+**Why:** Re-entrant `threading.Lock` acquisition deadlocks; re-entrant `asyncio.Lock` raises — `_unlocked()` variants eliminate both failure modes.

--- a/repo_wiki/T-rav/hydraflow/patterns/0277-issue-synthesis-use-file-util-append-jsonl-for-crash-safe-jsonl-ap.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0277-issue-synthesis-use-file-util-append-jsonl-for-crash-safe-jsonl-ap.md
@@ -1,0 +1,18 @@
+---
+id: 0277
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.714380+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Use `file_util.append_jsonl()` for crash-safe JSONL appends
+
+Wrap JSONL appends in `file_util.append_jsonl()`, which calls `flush()` + `os.fsync()` inside a `file_lock()`.
+
+Example: `file_util.append_jsonl(path, record)` — not `with open(path, 'a') as f: f.write(...)`.
+
+**Why:** Bare `open(..., 'a')` without fsync loses the last record on crash; the lock prevents interleaved writes from concurrent processes.

--- a/repo_wiki/T-rav/hydraflow/patterns/0278-issue-synthesis-use-file-util-atomic-write-for-critical-state-file.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0278-issue-synthesis-use-file-util-atomic-write-for-critical-state-file.md
@@ -1,0 +1,18 @@
+---
+id: 0278
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.714782+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Use `file_util.atomic_write()` for critical state file updates
+
+Write critical state via `file_util.atomic_write()`, which writes to a temp file then calls `os.replace()` atomically.
+
+Example: `file_util.atomic_write(state_path, json.dumps(state))` — not `open(path, 'w').write(...)`.
+
+**Why:** A crash mid-write with `open(..., 'w')` truncates the file, producing an empty or partial state that cannot be loaded.

--- a/repo_wiki/T-rav/hydraflow/patterns/0279-issue-synthesis-use-claim-then-merge-for-async-queue-processing.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0279-issue-synthesis-use-claim-then-merge-for-async-queue-processing.md
@@ -1,0 +1,18 @@
+---
+id: 0279
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.715196+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Use claim-then-merge for async queue processing
+
+Atomically claim queue items (clear/load under lock), release lock, perform async work, re-acquire lock, reload new items, merge, then atomically write.
+
+Example: `with lock: batch = queue.copy(); queue.clear()` → async work → `with lock: queue.update(new); queue.update(results); write(queue)`.
+
+**Why:** Releasing the lock during async work avoids deadlock, but re-acquiring before write prevents entries appended during the async gap from being lost.

--- a/repo_wiki/T-rav/hydraflow/patterns/0280-issue-synthesis-set-and-clear-trace-context-in-a-single-try-finall.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0280-issue-synthesis-set-and-clear-trace-context-in-a-single-try-finall.md
@@ -1,0 +1,18 @@
+---
+id: 0280
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.715627+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Set and clear trace context in a single try/finally block
+
+Set/clear or begin/end pairs for tracing context MUST execute within a single try/finally — never split across separate methods.
+
+Example: `token = ctx.set(val); try: ... finally: ctx.reset(token)` — both in one scope.
+
+**Why:** Splitting the set/clear across call boundaries leaks trace state across issues or loop iterations, corrupting span attribution.

--- a/repo_wiki/T-rav/hydraflow/patterns/0281-issue-synthesis-keep-event-publishing-coupled-with-the-condition-t.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0281-issue-synthesis-keep-event-publishing-coupled-with-the-condition-t.md
@@ -1,0 +1,18 @@
+---
+id: 0281
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.716033+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Keep event publishing coupled with the condition that gates it
+
+The `if should_alert:` check and `event_bus.publish(ALERT)` must live in the same method body — never separated into different methods.
+
+Example: Inline both in `_check_and_notify()` rather than calling `_check()` then `_publish()`.
+
+**Why:** Separating them creates code paths where the gate is checked but the event isn't fired (or vice versa), breaking observability silently.

--- a/repo_wiki/T-rav/hydraflow/patterns/0282-issue-synthesis-preserve-exact-retry-counter-state-during-dispatch.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0282-issue-synthesis-preserve-exact-retry-counter-state-during-dispatch.md
@@ -1,0 +1,18 @@
+---
+id: 0282
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.716467+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Preserve exact retry counter state during dispatcher refactoring
+
+When refactoring state machine dispatchers, carry over retry counters and escalation conditions exactly — do not reset or re-derive them.
+
+Example: Copy `issue.attempt_count` and `issue.escalation_triggered` into the refactored handler without modification.
+
+**Why:** Dropping retry state silently resets attempt budgets, allowing previously-exhausted issues to cycle again or miss escalation thresholds.

--- a/repo_wiki/T-rav/hydraflow/patterns/0283-issue-synthesis-dry-run-mode-must-not-emit-state-changing-events.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0283-issue-synthesis-dry-run-mode-must-not-emit-state-changing-events.md
@@ -1,0 +1,18 @@
+---
+id: 0283
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.716880+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Dry-run mode must not emit state-changing events
+
+Gate every side-effecting event bus publish behind `if not self.dry_run:` to ensure dry-run has no observable side effects.
+
+Example: `if not self.dry_run: self.event_bus.publish(TRIAGE_ROUTING, ...)` — not emitted during dry-run.
+
+**Why:** An emitted event in dry-run triggers downstream label mutations and state transitions, making dry-run non-idempotent.

--- a/repo_wiki/T-rav/hydraflow/patterns/0284-issue-synthesis-maintain-immutable-return-contract-for-parse-tuple.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0284-issue-synthesis-maintain-immutable-return-contract-for-parse-tuple.md
@@ -1,0 +1,18 @@
+---
+id: 0284
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.717303+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Maintain immutable return contract for `parse()` tuples
+
+Phase result `parse()` must always return `tuple[str, str | None]`; refactors that widen or change this shape break all callers.
+
+Example: Return `("approved", None)` or `("rejected", "reason")` — never a plain `str` or `dict`.
+
+**Why:** Callers destructure the tuple positionally; a shape change produces `TypeError` or silent data corruption at the unpack site.

--- a/repo_wiki/T-rav/hydraflow/patterns/0285-issue-synthesis-define-stage-mappings-before-skip-detection.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0285-issue-synthesis-define-stage-mappings-before-skip-detection.md
@@ -1,0 +1,18 @@
+---
+id: 0285
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.717712+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Define stage mappings before skip detection
+
+Implement event/worker-to-stage mappings together with skip detection logic — never add a mapping after skip detection is wired.
+
+Example: Define `EVENT_TO_STAGE = {...}` and `SOURCE_TO_STAGE = {...}` before the `if event in skip_set: return` guard.
+
+**Why:** Mappings added after the early-return guard are never evaluated, making the new stage silently unreachable.

--- a/repo_wiki/T-rav/hydraflow/patterns/0286-issue-synthesis-pre-allocate-memory-budget-upfront-before-prompt-a.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0286-issue-synthesis-pre-allocate-memory-budget-upfront-before-prompt-a.md
@@ -1,0 +1,18 @@
+---
+id: 0286
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.718130+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Pre-allocate memory budget upfront before prompt assembly
+
+Call `get_allocation()` and consume all budget caps before starting `_inject_memory()` — post-hoc surplus reclamation is not possible.
+
+Example: Allocate wiki budget first, deduct from surplus, then distribute remaining memory budget proportionally.
+
+**Why:** Prompt assembly is streaming; once a section is written, its token budget cannot be reclaimed for a different section.

--- a/repo_wiki/T-rav/hydraflow/patterns/0287-issue-synthesis-use-a-two-round-allocator-for-memory-budgets.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0287-issue-synthesis-use-a-two-round-allocator-for-memory-budgets.md
@@ -1,0 +1,18 @@
+---
+id: 0287
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.718547+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Use a two-round allocator for memory budgets
+
+Round one gives each memory section its minimum budget; round two distributes the remainder proportionally by `_DEFAULT_PRIORITIES` label.
+
+Example: `min_alloc = {k: MINIMUMS[k] for k in sections}; surplus = total - sum(min_alloc.values()); prop += surplus * weights`.
+
+**Why:** A single-round proportional allocator can starve low-priority sections below their functional minimum, breaking prompt structure.

--- a/repo_wiki/T-rav/hydraflow/patterns/0288-issue-synthesis-deduct-wiki-budget-from-memory-surplus-before-redi.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0288-issue-synthesis-deduct-wiki-budget-from-memory-surplus-before-redi.md
@@ -1,0 +1,18 @@
+---
+id: 0288
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.718955+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Deduct wiki budget from memory surplus before redistributing
+
+Compute the wiki budget (`max_repo_wiki_chars`) and subtract it from the memory surplus BEFORE distributing the remainder proportionally across memory sections.
+
+Example: `surplus -= wiki_budget; memory_alloc = distribute(surplus, weights)`.
+
+**Why:** Not deducting first causes memory sections to over-allocate, then the wiki gets truncated when both compete for the same token pool.

--- a/repo_wiki/T-rav/hydraflow/patterns/0289-issue-synthesis-lazy-load-memory-context-on-explicit-user-action.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0289-issue-synthesis-lazy-load-memory-context-on-explicit-user-action.md
@@ -1,0 +1,18 @@
+---
+id: 0289
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.719384+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Lazy-load memory context on explicit user action
+
+Fetch memory context only when the user expands a section — not when the HITL list view renders.
+
+Example: Expand button triggers `fetchMemoryContext(issueId)` — the list view fires no memory API calls.
+
+**Why:** Pre-fetching on render causes N+1 API calls on every HITL list load, amplified by the number of open issues.

--- a/repo_wiki/T-rav/hydraflow/patterns/0290-issue-synthesis-use-sha-256-truncated-to-16-chars-for-memory-dedup.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0290-issue-synthesis-use-sha-256-truncated-to-16-chars-for-memory-dedup.md
@@ -1,0 +1,18 @@
+---
+id: 0290
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.719801+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Use SHA-256 truncated to 16 chars for memory dedup keys
+
+Compute dedup keys and recall-hit tracking via `SHA-256(content)[:16]`.
+
+Example: `key = hashlib.sha256(item['text'].encode()).hexdigest()[:16]`.
+
+**Why:** Consistent hashing ensures the same content maps to the same key across process restarts; truncation keeps keys human-scannable in logs.

--- a/repo_wiki/T-rav/hydraflow/patterns/0291-issue-synthesis-use-asymmetric-word-set-overlap-for-memory-dedupli.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0291-issue-synthesis-use-asymmetric-word-set-overlap-for-memory-dedupli.md
@@ -1,0 +1,18 @@
+---
+id: 0291
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.720214+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Use asymmetric word-set overlap for memory deduplication
+
+Compute dedup similarity as `len(words & existing) / max(len(words), 1)` with a configurable threshold (default 0.85).
+
+Example: New item with 10 words sharing 9 with an existing item → score 0.9 → suppress.
+
+**Why:** Symmetric Jaccard penalises short additions to long entries; asymmetric overlap correctly identifies content that's mostly a subset of existing memory.

--- a/repo_wiki/T-rav/hydraflow/patterns/0292-issue-synthesis-batch-load-scoring-data-once-per-eviction-operatio.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0292-issue-synthesis-batch-load-scoring-data-once-per-eviction-operatio.md
@@ -1,0 +1,18 @@
+---
+id: 0292
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.720672+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Batch-load scoring data once per eviction operation
+
+Call `MemoryScorer.load_item_scores()` once per eviction pass and reuse the result across all items.
+
+Example: `scores = scorer.load_item_scores(); for item in items: rank(item, scores)`.
+
+**Why:** Per-item score loading reads the same file N times; batch loading makes eviction O(1) in I/O regardless of corpus size.

--- a/repo_wiki/T-rav/hydraflow/patterns/0293-issue-synthesis-use-true-not-is-true-for-retain-metadata-booleans.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0293-issue-synthesis-use-true-not-is-true-for-retain-metadata-booleans.md
@@ -1,0 +1,18 @@
+---
+id: 0293
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.721116+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Use `== "true"`, not `is True` for `retain()` metadata booleans
+
+`HindsightClient.retain()` calls `str(v)` on all metadata values; boolean `True` becomes string `"true"`.
+
+Example: `metadata={"warning": "true"}` not `{"warning": True}`; check with `metadata.get("warning") == "true"`.
+
+**Why:** `metadata.get("warning") is True` always returns `False` after coercion, silently disabling warning-based filtering.

--- a/repo_wiki/T-rav/hydraflow/patterns/0294-issue-synthesis-memory-contradiction-resolution-provenance-wins-ov.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0294-issue-synthesis-memory-contradiction-resolution-provenance-wins-ov.md
@@ -1,0 +1,18 @@
+---
+id: 0294
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.721598+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Memory contradiction resolution: provenance wins over recency
+
+When two memory items contradict, human-sourced wins over agent-sourced regardless of timestamp; among equal provenance, newer wins.
+
+Example: A human-written learning from 2024 beats an agent-written one from 2025.
+
+**Why:** Agent-sourced items can encode hallucinations; provenance-first resolution ensures human corrections are never overwritten by automated entries.

--- a/repo_wiki/T-rav/hydraflow/patterns/0295-issue-synthesis-atomically-update-scores-and-items-files-during-ev.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0295-issue-synthesis-atomically-update-scores-and-items-files-during-ev.md
@@ -1,0 +1,18 @@
+---
+id: 0295
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.722050+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Atomically update scores and items files during eviction
+
+An eviction operation must write `item_scores.json` and `items.jsonl` together within the same lock scope — never update one without the other.
+
+Example: `atomic_write(scores_path, ...)` then `atomic_write(items_path, ...)` under a single lock acquire.
+
+**Why:** A partial update leaves scores referencing evicted items (or items with stale scores), corrupting ranking on the next eviction pass.

--- a/repo_wiki/T-rav/hydraflow/patterns/0296-issue-synthesis-guard-close-with-a-closed-flag-to-make-it-idempote.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0296-issue-synthesis-guard-close-with-a-closed-flag-to-make-it-idempote.md
@@ -1,0 +1,18 @@
+---
+id: 0296
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.722501+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Guard `close()` with a `_closed` flag to make it idempotent
+
+All cleanup methods must check and set a `_closed` flag as their first step.
+
+Example: `def close(self): if self._closed: return; self._closed = True; await self._resource.aclose()`.
+
+**Why:** Double-close on an async resource (e.g., HTTP session) raises; idempotent close makes teardown order-independent in test fixtures.

--- a/repo_wiki/T-rav/hydraflow/patterns/0297-issue-synthesis-memory-staleness-detection-must-emit-events-not-mu.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0297-issue-synthesis-memory-staleness-detection-must-emit-events-not-mu.md
@@ -1,0 +1,18 @@
+---
+id: 0297
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.722927+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Memory staleness detection must emit events, not mutate state
+
+Staleness detection must emit events or log warnings rather than silently deleting or modifying stale entries.
+
+Example: `event_bus.publish(STALE_MEMORY, item_id=item.id, age_days=age)` instead of `self._items.pop(item.id)`.
+
+**Why:** Silent mutation removes the operator's ability to review or override staleness decisions; events keep the action reversible.

--- a/repo_wiki/T-rav/hydraflow/patterns/0298-issue-synthesis-adr-files-without-readme-entries-are-invisible-to-.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0298-issue-synthesis-adr-files-without-readme-entries-are-invisible-to-.md
@@ -1,0 +1,18 @@
+---
+id: 0298
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.723404+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# ADR files without README entries are invisible to tooling
+
+Every ADR file in `docs/adr/` must have a corresponding row in `docs/adr/README.md` to be canonically referenceable.
+
+Example: Adding `docs/adr/0055-new-decision.md` requires a matching `| 0055 | New Decision | Accepted |` row in README.
+
+**Why:** `scan_adr_directory()` builds its index from README rows; a file without a row is silently skipped by drift detection and cross-reference tooling.

--- a/repo_wiki/T-rav/hydraflow/patterns/0299-issue-synthesis-preserve-the-hf-namespace-prefix-when-renaming-ski.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0299-issue-synthesis-preserve-the-hf-namespace-prefix-when-renaming-ski.md
@@ -1,0 +1,18 @@
+---
+id: 0299
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.723873+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Preserve the `hf.` namespace prefix when renaming skill files
+
+When renaming fixture or command files, keep the `hf.` or `hf-` prefix intact.
+
+Example: Rename `hf.audit-code.md` → `hf.audit-contracts.md`, not `audit-contracts.md`.
+
+**Why:** Skill lookup strips the prefix at registration; dropping it makes the skill unreachable via `/hf.audit-contracts` and breaks namespace consistency.

--- a/repo_wiki/T-rav/hydraflow/patterns/0300-issue-synthesis-keep-skill-prompts-in-sync-across-all-four-backend.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0300-issue-synthesis-keep-skill-prompts-in-sync-across-all-four-backend.md
@@ -1,0 +1,18 @@
+---
+id: 0300
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.724311+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Keep skill prompts in sync across all four backend locations
+
+Skill prompt text lives in `src/`, `.claude/commands/`, `.pi/skills/`, and `.codex/skills/` — update all four locations when changing a prompt.
+
+Example: Editing `.claude/commands/hf.diff-sanity.md` requires mirroring the change to the other three locations.
+
+**Why:** Missed updates cause the same skill to behave differently depending on which backend routes the request, producing inconsistent LLM behavior.

--- a/repo_wiki/T-rav/hydraflow/patterns/0301-issue-synthesis-avoid-in-place-diff-truncation-for-non-llm-consume.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0301-issue-synthesis-avoid-in-place-diff-truncation-for-non-llm-consume.md
@@ -1,0 +1,18 @@
+---
+id: 0301
+topic: patterns
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:42:57.724739+00:00
+status: active
+corroborations: 1
+supersedes: 0218,0219,0220,0221,0222,0223,0224,0225,0226,0227,0228,0229,0230,0231,0232,0233,0234,0235,0236,0237,0238,0239,0240,0241,0242,0243,0244,0245,0246,0247,0248,0249,0250,0251,0252,0253,0254,0255,0256,0257,0258,0259
+---
+
+# Avoid in-place diff truncation for non-LLM consumers
+
+When a diff is truncated for an LLM prompt, rebind to a separate name rather than mutating the original variable.
+
+Example: `prompt_diff = diff[:max_diff] + "[truncated]"` instead of reassigning `diff`, so the full `diff` is still available for structural consumers.
+
+**Why:** In-place truncation causes coverage mapping to silently under-report changed lines in the tail of large diffs, making the gate fail-open on the diffs most likely to need it.

--- a/repo_wiki/T-rav/hydraflow/testing/0373-issue-synthesis-mock-at-definition-site-not-at-usage-site.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0373-issue-synthesis-mock-at-definition-site-not-at-usage-site.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.715837+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Mock at definition site, not at usage site

--- a/repo_wiki/T-rav/hydraflow/testing/0374-issue-synthesis-mark-integration-tests-only-for-real-external-deps.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0374-issue-synthesis-mark-integration-tests-only-for-real-external-deps.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.717454+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Mark integration tests only for real external deps

--- a/repo_wiki/T-rav/hydraflow/testing/0375-issue-synthesis-await-asyncio-sleep-0-after-create-task-before-ass.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0375-issue-synthesis-await-asyncio-sleep-0-after-create-task-before-ass.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.718835+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Await asyncio.sleep(0) after create_task() before asserting

--- a/repo_wiki/T-rav/hydraflow/testing/0376-issue-synthesis-reset-global-state-in-both-setup-and-teardown.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0376-issue-synthesis-reset-global-state-in-both-setup-and-teardown.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.720009+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Reset global state in both setup and teardown

--- a/repo_wiki/T-rav/hydraflow/testing/0377-issue-synthesis-use-tmp-path-with-configfactory-for-file-based-tes.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0377-issue-synthesis-use-tmp-path-with-configfactory-for-file-based-tes.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.721475+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Use tmp_path with ConfigFactory for file-based test I/O

--- a/repo_wiki/T-rav/hydraflow/testing/0378-issue-synthesis-caplog-assertions-must-name-the-exact-logger.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0378-issue-synthesis-caplog-assertions-must-name-the-exact-logger.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.722431+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Caplog assertions must name the exact logger

--- a/repo_wiki/T-rav/hydraflow/testing/0379-issue-synthesis-test-protocols-with-isinstance-and-hasattr.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0379-issue-synthesis-test-protocols-with-isinstance-and-hasattr.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.723682+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Test protocols with isinstance and hasattr

--- a/repo_wiki/T-rav/hydraflow/testing/0380-issue-synthesis-facade-tests-must-cover-routing-error-and-delegati.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0380-issue-synthesis-facade-tests-must-cover-routing-error-and-delegati.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.725555+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Facade tests must cover routing, error, and delegation

--- a/repo_wiki/T-rav/hydraflow/testing/0381-issue-synthesis-use-playwright-not-testclient-for-js-rendered-attr.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0381-issue-synthesis-use-playwright-not-testclient-for-js-rendered-attr.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.727322+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Use Playwright, not TestClient, for JS-rendered attrs

--- a/repo_wiki/T-rav/hydraflow/testing/0382-issue-synthesis-subprocess-cli-test-stubs-log-to-jsonl.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0382-issue-synthesis-subprocess-cli-test-stubs-log-to-jsonl.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.728508+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Subprocess CLI test stubs: log to JSONL

--- a/repo_wiki/T-rav/hydraflow/testing/0383-issue-synthesis-mock-only-execute-in-phase-runner-integration-test.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0383-issue-synthesis-mock-only-execute-in-phase-runner-integration-test.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.729353+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Mock only _execute() in phase-runner integration tests

--- a/repo_wiki/T-rav/hydraflow/testing/0384-issue-synthesis-use-word-boundary-matching-in-coverage-checks.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0384-issue-synthesis-use-word-boundary-matching-in-coverage-checks.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.730308+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Use word-boundary matching in coverage checks

--- a/repo_wiki/T-rav/hydraflow/testing/0385-issue-synthesis-enforce-50-30-line-limits-on-handlers-and-wiring.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0385-issue-synthesis-enforce-50-30-line-limits-on-handlers-and-wiring.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.731250+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Enforce 50/30-line limits on handlers and wiring

--- a/repo_wiki/T-rav/hydraflow/testing/0386-issue-synthesis-assert-relative-event-ordering-not-absolute-ids.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0386-issue-synthesis-assert-relative-event-ordering-not-absolute-ids.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.732038+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Assert relative event ordering, not absolute IDs

--- a/repo_wiki/T-rav/hydraflow/testing/0387-issue-synthesis-add-structural-tests-before-property-based-tests.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0387-issue-synthesis-add-structural-tests-before-property-based-tests.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.732806+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Add structural tests before property-based tests

--- a/repo_wiki/T-rav/hydraflow/testing/0388-issue-synthesis-sync-test-label-constants-with-production-definiti.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0388-issue-synthesis-sync-test-label-constants-with-production-definiti.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.733589+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Sync test label constants with production definitions

--- a/repo_wiki/T-rav/hydraflow/testing/0389-issue-synthesis-update-4-places-on-pydantic-typeddict-field-change.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0389-issue-synthesis-update-4-places-on-pydantic-typeddict-field-change.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.734295+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Update 4 places on Pydantic/TypedDict field changes

--- a/repo_wiki/T-rav/hydraflow/testing/0390-issue-synthesis-feature-toggles-need-config-field-and-overrides.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0390-issue-synthesis-feature-toggles-need-config-field-and-overrides.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.735109+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Feature toggles need config field and overrides

--- a/repo_wiki/T-rav/hydraflow/testing/0391-issue-synthesis-dict-to-typeddict-migrations-require-no-new-tests.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0391-issue-synthesis-dict-to-typeddict-migrations-require-no-new-tests.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.735872+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # dict-to-TypedDict migrations require no new tests

--- a/repo_wiki/T-rav/hydraflow/testing/0392-issue-synthesis-concurrent-jsonl-appends-assert-exact-counts.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0392-issue-synthesis-concurrent-jsonl-appends-assert-exact-counts.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.736713+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Concurrent JSONL appends: assert exact counts

--- a/repo_wiki/T-rav/hydraflow/testing/0393-issue-synthesis-keep-memory-bank-keys-consistent-across-dedup.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0393-issue-synthesis-keep-memory-bank-keys-consistent-across-dedup.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.737778+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Keep memory bank keys consistent across dedup

--- a/repo_wiki/T-rav/hydraflow/testing/0394-issue-synthesis-validate-skill-markers-across-all-4-backend-copies.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0394-issue-synthesis-validate-skill-markers-across-all-4-backend-copies.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.738834+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Validate skill markers across all 4 backend copies

--- a/repo_wiki/T-rav/hydraflow/testing/0395-issue-synthesis-generate-adr-derived-tests-as-skipped-skeletons.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0395-issue-synthesis-generate-adr-derived-tests-as-skipped-skeletons.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.739830+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Generate ADR-derived tests as skipped skeletons

--- a/repo_wiki/T-rav/hydraflow/testing/0396-issue-synthesis-adr-pre-validator-enforce-required-sections.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0396-issue-synthesis-adr-pre-validator-enforce-required-sections.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.741048+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # ADR pre-validator: enforce required sections

--- a/repo_wiki/T-rav/hydraflow/testing/0397-issue-synthesis-never-import-private-helpers-at-module-level.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0397-issue-synthesis-never-import-private-helpers-at-module-level.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.742430+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Never import private helpers at module level

--- a/repo_wiki/T-rav/hydraflow/testing/0398-issue-synthesis-pin-function-signatures-before-writing-callers.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0398-issue-synthesis-pin-function-signatures-before-writing-callers.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.743296+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Pin function signatures before writing callers

--- a/repo_wiki/T-rav/hydraflow/testing/0399-issue-synthesis-validate-sys-modules-cleanup-with-multiple-seeds.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0399-issue-synthesis-validate-sys-modules-cleanup-with-multiple-seeds.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.744041+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Validate sys.modules cleanup with multiple seeds

--- a/repo_wiki/T-rav/hydraflow/testing/0400-issue-synthesis-skip-broken-tests-with-an-issue-reference.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0400-issue-synthesis-skip-broken-tests-with-an-issue-reference.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.745072+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Skip broken tests with an issue reference

--- a/repo_wiki/T-rav/hydraflow/testing/0401-issue-synthesis-use-is-to-verify-shared-runner-instance.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0401-issue-synthesis-use-is-to-verify-shared-runner-instance.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.746324+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Use `is` to verify shared runner instance

--- a/repo_wiki/T-rav/hydraflow/testing/0402-issue-synthesis-memory-dedup-higher-priority-bank-wins-on-collisio.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0402-issue-synthesis-memory-dedup-higher-priority-bank-wins-on-collisio.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.747401+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Memory dedup: higher-priority bank wins on collision

--- a/repo_wiki/T-rav/hydraflow/testing/0403-issue-synthesis-hoist-deterministic-gates-outside-llm-retry-loops.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0403-issue-synthesis-hoist-deterministic-gates-outside-llm-retry-loops.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.748295+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Hoist deterministic gates outside LLM retry loops

--- a/repo_wiki/T-rav/hydraflow/testing/0404-issue-synthesis-use-public-fakegithub-api-in-scenario-tests.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0404-issue-synthesis-use-public-fakegithub-api-in-scenario-tests.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.749470+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Use public FakeGitHub API in scenario tests

--- a/repo_wiki/T-rav/hydraflow/testing/0405-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0405-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.750523+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Test async context managers in three standard scenarios

--- a/repo_wiki/T-rav/hydraflow/testing/0406-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0406-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.751806+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Test direct-swap labels via swap_pipeline_labels()

--- a/repo_wiki/T-rav/hydraflow/testing/0407-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0407-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.752530+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Allow ±3 line drift in AST-based structure assertions

--- a/repo_wiki/T-rav/hydraflow/testing/0408-issue-synthesis-existing-tests-cover-private-method-extractions.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0408-issue-synthesis-existing-tests-cover-private-method-extractions.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.753303+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Existing tests cover private-method extractions

--- a/repo_wiki/T-rav/hydraflow/testing/0409-issue-synthesis-assert-numeric-values-in-sentry-breadcrumbs.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0409-issue-synthesis-assert-numeric-values-in-sentry-breadcrumbs.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.754232+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Assert numeric values in Sentry breadcrumbs

--- a/repo_wiki/T-rav/hydraflow/testing/0410-issue-synthesis-test-pydantic-literal-constraints-valid-and-invali.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0410-issue-synthesis-test-pydantic-literal-constraints-valid-and-invali.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.756593+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Test Pydantic Literal constraints: valid and invalid

--- a/repo_wiki/T-rav/hydraflow/testing/0411-issue-synthesis-verify-fatal-exception-propagation-through-loops.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0411-issue-synthesis-verify-fatal-exception-propagation-through-loops.md
@@ -4,9 +4,10 @@ topic: testing
 source_issue: synthesis
 source_phase: synthesis
 created_at: 2026-07-19T01:49:52.758123+00:00
-status: active
+status: superseded
 corroborations: 1
 supersedes: 0334,0335,0336,0337,0338,0339,0340,0341,0342,0343,0344,0345,0346,0347,0348,0349,0350,0351,0352,0353,0354,0355,0356,0357,0358,0359,0360,0361,0362,0363,0364,0365,0366,0367,0368,0369,0370,0371,0372
+superseded_by: 0412
 ---
 
 # Verify fatal exception propagation through loops

--- a/repo_wiki/T-rav/hydraflow/testing/0412-issue-synthesis-mock-at-definition-site-not-at-usage-site.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0412-issue-synthesis-mock-at-definition-site-not-at-usage-site.md
@@ -1,0 +1,18 @@
+---
+id: 0412
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.844289+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Mock at definition site, not at usage site
+
+Patch symbols at the module where they are defined, not where they are imported.
+
+Example: Good: `patch('src.foo._cache')`. Bad: `patch('src.consumer._cache')`. For optional deps: `patch.dict("sys.modules", {"sentry_sdk": mock_sdk})`.
+
+**Why:** Usage-site patches intercept only one import; other callers see the real object, producing inconsistent test behavior.

--- a/repo_wiki/T-rav/hydraflow/testing/0413-issue-synthesis-mark-integration-tests-only-for-real-external-deps.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0413-issue-synthesis-mark-integration-tests-only-for-real-external-deps.md
@@ -1,0 +1,18 @@
+---
+id: 0413
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.844986+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Mark integration tests only for real external deps
+
+Apply `@pytest.mark.integration` only when a test exercises Docker, network, filesystem, real worktrees, or live services — not when all deps are mocked.
+
+Example: Use `pytest.mark.skipif(shutil.which("tool") is None, ...)` for optional CLI tools instead of marking as integration.
+
+**Why:** Over-marking slows the fast suite and blurs the unit/integration boundary, making targeted test runs unreliable.

--- a/repo_wiki/T-rav/hydraflow/testing/0414-issue-synthesis-await-asyncio-sleep-0-after-create-task-before-ass.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0414-issue-synthesis-await-asyncio-sleep-0-after-create-task-before-ass.md
@@ -1,0 +1,18 @@
+---
+id: 0414
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.845673+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Await asyncio.sleep(0) after create_task() before asserting
+
+After triggering a fire-and-forget task, yield one event loop tick before asserting.
+
+Example: `task = asyncio.create_task(fn()); await asyncio.sleep(0); mock.assert_called_once()`
+
+**Why:** Without yielding, the scheduled task has not run yet; assertions fire on stale state and produce false negatives.

--- a/repo_wiki/T-rav/hydraflow/testing/0415-issue-synthesis-reset-global-state-in-both-setup-and-teardown.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0415-issue-synthesis-reset-global-state-in-both-setup-and-teardown.md
@@ -1,0 +1,18 @@
+---
+id: 0415
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.846346+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Reset global state in both setup and teardown
+
+Fixtures that touch shared singletons must reset them at fixture start and at teardown.
+
+Example: Use an autouse conftest fixture to ensure `module._rate_limit_until = 0` runs before and after every test.
+
+**Why:** Stale state from a prior test leaks into later tests, causing order-dependent flakiness invisible in isolation.

--- a/repo_wiki/T-rav/hydraflow/testing/0416-issue-synthesis-use-tmp-path-with-configfactory-for-file-based-tes.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0416-issue-synthesis-use-tmp-path-with-configfactory-for-file-based-tes.md
@@ -1,0 +1,18 @@
+---
+id: 0416
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.847031+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Use tmp_path with ConfigFactory for file-based test I/O
+
+All tests that read or write files must use pytest's `tmp_path` combined with `ConfigFactory.create(base_path=tmp_path)`, never writing to real project paths.
+
+Example: `def test_something(tmp_path): config = ConfigFactory.create(base_path=tmp_path)`
+
+**Why:** Writing to project paths pollutes the working tree and causes cross-test interference, especially under parallel execution.

--- a/repo_wiki/T-rav/hydraflow/testing/0417-issue-synthesis-caplog-assertions-must-name-the-exact-logger.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0417-issue-synthesis-caplog-assertions-must-name-the-exact-logger.md
@@ -1,0 +1,18 @@
+---
+id: 0417
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.847713+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Caplog assertions must name the exact logger
+
+Always pass the exact logger name to `caplog.at_level()` and clear caplog before the action under test.
+
+Example: `with caplog.at_level(logging.WARNING, logger='src.module.name'): trigger_action()`. Assert on message substrings specific to the logged values.
+
+**Why:** Without the logger filter, caplog captures all loggers and assertions may match unrelated log lines, producing false positives.

--- a/repo_wiki/T-rav/hydraflow/testing/0418-issue-synthesis-test-protocols-with-isinstance-and-hasattr.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0418-issue-synthesis-test-protocols-with-isinstance-and-hasattr.md
@@ -1,0 +1,18 @@
+---
+id: 0418
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.848373+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Test protocols with isinstance and hasattr
+
+Use two complementary checks: `isinstance(obj, Protocol)` with `@runtime_checkable`, and `hasattr(obj, 'method_name')` for each protocol method.
+
+Example: Add `inspect.signature()` comparison to catch parameter drift. Parametrize tests over all protocol methods so failures are specific.
+
+**Why:** `isinstance` alone misses methods added at runtime; `hasattr` alone skips type-contract enforcement.

--- a/repo_wiki/T-rav/hydraflow/testing/0419-issue-synthesis-facade-tests-must-cover-routing-error-and-delegati.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0419-issue-synthesis-facade-tests-must-cover-routing-error-and-delegati.md
@@ -1,0 +1,18 @@
+---
+id: 0419
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.849035+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Facade tests must cover routing, error, and delegation
+
+When testing a facade's `__getattr__`, verify four cases: correct method routing, nonexistent method raises `AttributeError`, protocol delegation, and backward compat.
+
+Example: Assert sub-components receive mutable shared-state references, not copies, to verify true delegation.
+
+**Why:** Missing any case allows silent routing failures to ship undetected.

--- a/repo_wiki/T-rav/hydraflow/testing/0420-issue-synthesis-use-playwright-not-testclient-for-js-rendered-attr.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0420-issue-synthesis-use-playwright-not-testclient-for-js-rendered-attr.md
@@ -1,0 +1,18 @@
+---
+id: 0420
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.849717+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Use Playwright, not TestClient, for JS-rendered attrs
+
+Use Playwright for JS-rendered attributes like `aria-labelledby`, as server-side `TestClient` only sees the initial HTML shell.
+
+Example: Delete dead server-side tests that assert JS-rendered HTML; replace with Playwright-based browser tests.
+
+**Why:** TestClient tests for client-rendered attributes always pass vacuously, giving false confidence about real rendering behavior.

--- a/repo_wiki/T-rav/hydraflow/testing/0421-issue-synthesis-subprocess-cli-test-stubs-log-to-jsonl.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0421-issue-synthesis-subprocess-cli-test-stubs-log-to-jsonl.md
@@ -1,0 +1,18 @@
+---
+id: 0421
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.850389+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Subprocess CLI test stubs: log to JSONL
+
+Replace real CLI dependencies in tests with a small Python script that accepts the same arguments, writes each invocation to a JSONL file, and exits 0.
+
+Example: `subprocess_runner = ['python3', 'fake_gh.py']`. Assert behavior by parsing the JSONL log: `json.loads(log_path.read_text())`.
+
+**Why:** Real subprocess boundaries catch shell-quoting, PATH resolution, and argument-passing bugs that mock-based patches cannot detect.

--- a/repo_wiki/T-rav/hydraflow/testing/0422-issue-synthesis-mock-only-execute-in-phase-runner-integration-test.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0422-issue-synthesis-mock-only-execute-in-phase-runner-integration-test.md
@@ -1,0 +1,18 @@
+---
+id: 0422
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.851078+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Mock only _execute() in phase-runner integration tests
+
+In phase-runner integration tests, wire real `StateTracker`, `EventBus`, and `VerificationJudge`. Mock only the `_execute()` subprocess boundary with configurable transcript strings.
+
+Example: Validate state via `StateTracker` APIs and `EventBus.get_history()`, not mock call assertions.
+
+**Why:** Fully-mocked runners hide parser mismatches between test transcripts and real output formats that only real parsers would catch.

--- a/repo_wiki/T-rav/hydraflow/testing/0423-issue-synthesis-use-word-boundary-matching-in-coverage-checks.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0423-issue-synthesis-use-word-boundary-matching-in-coverage-checks.md
@@ -1,0 +1,18 @@
+---
+id: 0423
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.851742+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Use word-boundary matching in coverage checks
+
+When asserting that a name appears in coverage output, use full-name or word-boundary matching.
+
+Example: Bad: `'Foo' in text` — also matches `FooBar`. Good: `re.search(r'\bFoo\b', text)` or full-name match.
+
+**Why:** Short-name collisions silently mark unrelated targets as covered, hiding real gaps in coverage.

--- a/repo_wiki/T-rav/hydraflow/testing/0424-issue-synthesis-enforce-50-30-line-limits-on-handlers-and-wiring.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0424-issue-synthesis-enforce-50-30-line-limits-on-handlers-and-wiring.md
@@ -1,0 +1,18 @@
+---
+id: 0424
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.852419+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Enforce 50/30-line limits on handlers and wiring
+
+Keep handler functions to ≤ 50 lines and registration wiring to ≤ 30 lines. Extract nested closures into instance methods to hold nesting to ≤ 3 levels.
+
+Example: Enforce via AST-based tests with ±3 line tolerance. See also: testing — Allow ±3 line drift in AST-based structure assertions.
+
+**Why:** Functions exceeding these limits are difficult to test in isolation; deeply nested closures cannot be mocked independently.

--- a/repo_wiki/T-rav/hydraflow/testing/0425-issue-synthesis-assert-relative-event-ordering-not-absolute-ids.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0425-issue-synthesis-assert-relative-event-ordering-not-absolute-ids.md
@@ -1,0 +1,18 @@
+---
+id: 0425
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.853089+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Assert relative event ordering, not absolute IDs
+
+Tests must never assert on absolute event counter values — only on relative ordering and uniqueness within a single test run.
+
+Example: Good: `assert event_a.id < event_b.id`. Bad: `assert event_a.id == 1`.
+
+**Why:** Global counters are shared across all test instances; absolute ID assertions are order-dependent and flaky under parallel execution.

--- a/repo_wiki/T-rav/hydraflow/testing/0426-issue-synthesis-add-structural-tests-before-property-based-tests.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0426-issue-synthesis-add-structural-tests-before-property-based-tests.md
@@ -1,0 +1,18 @@
+---
+id: 0426
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.853771+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Add structural tests before property-based tests
+
+Before running property-based tests on a transition graph, add structural tests: every target is a valid stage, every stage has a transition entry, and no dangling references exist.
+
+Example: `assert set(VALID_TRANSITIONS.keys()) == VALID_STAGES`
+
+**Why:** Property-based tests discover transition paths but silently skip unreachable states caused by structural gaps in the graph definition.

--- a/repo_wiki/T-rav/hydraflow/testing/0427-issue-synthesis-sync-test-label-constants-with-production-definiti.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0427-issue-synthesis-sync-test-label-constants-with-production-definiti.md
@@ -1,0 +1,18 @@
+---
+id: 0427
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.854464+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Sync test label constants with production definitions
+
+Keep test constants (`ALL_PIPELINE_LABELS`, `VALID_STAGES`, `VALID_TRANSITIONS`) synchronized with production definitions. Add a sync test asserting set equality.
+
+Example: `assert set(VALID_TRANSITIONS.keys()) == VALID_STAGES`. Test both `EVENT_TYPE_TO_STAGE` and `SOURCE_TO_STAGE` independently. See also: testing — Test direct-swap labels via swap_pipeline_labels().
+
+**Why:** Stale test constants let new label additions pass CI without being exercised by the test suite.

--- a/repo_wiki/T-rav/hydraflow/testing/0428-issue-synthesis-update-4-places-on-pydantic-typeddict-field-change.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0428-issue-synthesis-update-4-places-on-pydantic-typeddict-field-change.md
@@ -1,0 +1,18 @@
+---
+id: 0428
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.855136+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Update 4 places on Pydantic/TypedDict field changes
+
+When adding or removing fields, update: (1) model definition, (2) test factory defaults, (3) field-presence assertions, (4) serialization round-trip tests.
+
+Example: Grep for the model name: `grep -r "ModelName" tests/`. For `NotRequired` fields, update exact-match assertions but not missing-key assertions. See also: testing — dict-to-TypedDict migrations require no new tests.
+
+**Why:** Missing any location leaves tests that silently ignore the new field, giving false coverage confidence.

--- a/repo_wiki/T-rav/hydraflow/testing/0429-issue-synthesis-feature-toggles-need-config-field-and-overrides.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0429-issue-synthesis-feature-toggles-need-config-field-and-overrides.md
@@ -1,0 +1,18 @@
+---
+id: 0429
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.855812+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Feature toggles need config field and overrides
+
+Every toggle requires both a field in `src/config.py` AND an entry in `_ENV_INT_OVERRIDES`. Test both the default value and the env-var override path.
+
+Example: The `_ENV_INT_OVERRIDES` tuple default must equal the Field default or the override silently stops applying. See also: architecture-state-persistence — `_ENV_INT_OVERRIDES` default sync.
+
+**Why:** Without the overrides entry, the env-var has no effect; the toggle appears configurable at runtime but is not.

--- a/repo_wiki/T-rav/hydraflow/testing/0430-issue-synthesis-dict-to-typeddict-migrations-require-no-new-tests.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0430-issue-synthesis-dict-to-typeddict-migrations-require-no-new-tests.md
@@ -1,0 +1,18 @@
+---
+id: 0430
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.856480+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# dict-to-TypedDict migrations require no new tests
+
+Migrating `dict[str, Any]` return types to TypedDicts requires no additional tests; the change is purely static.
+
+Example: TypedDicts are plain dicts at runtime, so existing assertions continue to work identically. Verify via `make quality-lite` and `make test`. See also: testing — Update 4 places on Pydantic/TypedDict field changes.
+
+**Why:** Adding tests for a purely static type change wastes effort and can introduce false precision assumptions about runtime structure.

--- a/repo_wiki/T-rav/hydraflow/testing/0431-issue-synthesis-concurrent-jsonl-appends-assert-exact-counts.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0431-issue-synthesis-concurrent-jsonl-appends-assert-exact-counts.md
@@ -1,0 +1,18 @@
+---
+id: 0431
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.857115+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Concurrent JSONL appends: assert exact counts
+
+Test concurrent file operations with a fixed thread count and deterministic iteration count, then assert on exact line counts.
+
+Example: `# 10 threads × 20 events = 200 total` followed by `assert len(lines) == 200`.
+
+**Why:** Timing-based assertions are flaky; deterministic event counts make failures reproducible.

--- a/repo_wiki/T-rav/hydraflow/testing/0432-issue-synthesis-keep-memory-bank-keys-consistent-across-dedup.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0432-issue-synthesis-keep-memory-bank-keys-consistent-across-dedup.md
@@ -1,0 +1,18 @@
+---
+id: 0432
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.857742+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Keep memory bank keys consistent across dedup
+
+Use identical string keys (`'review_insights'`, not `'review-insights'`) in both deduplication priority maps and bank-assembly pipelines.
+
+Example: Fallback recall functions must try multiple field names (`learning`, `text`, `content`, `display_text`) when extracting text payload from different bank record formats.
+
+**Why:** Mismatched keys cause entire banks to be silently skipped during validation, producing gaps that look like passing coverage.

--- a/repo_wiki/T-rav/hydraflow/testing/0433-issue-synthesis-validate-skill-markers-across-all-4-backend-copies.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0433-issue-synthesis-validate-skill-markers-across-all-4-backend-copies.md
@@ -1,0 +1,18 @@
+---
+id: 0433
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.858392+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Validate skill markers across all 4 backend copies
+
+Validate marker presence via substring search across `.claude/commands/`, `.pi/skills/`, `.codex/skills/`, and `src/*.py`.
+
+Example: Use a manual `SKILL_MARKERS` mapping, not regex introspection. A single skill addition or removal requires updating 3+ test files.
+
+**Why:** Updating fewer than 4 copies silently diverges behavior across execution environments with no test failure to signal the gap.

--- a/repo_wiki/T-rav/hydraflow/testing/0434-issue-synthesis-generate-adr-derived-tests-as-skipped-skeletons.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0434-issue-synthesis-generate-adr-derived-tests-as-skipped-skeletons.md
@@ -1,0 +1,18 @@
+---
+id: 0434
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.859039+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Generate ADR-derived tests as skipped skeletons
+
+Extract baseline invariants (uniqueness, usage, negative, coverage) from an ADR's Decision section and generate each test as a skipped skeleton.
+
+Example: `@pytest.mark.skip(reason='skeleton: requires human review')`
+
+**Why:** Auto-generating non-skipped tests from ambiguous ADR language creates brittle tests that break on legitimate wording updates.

--- a/repo_wiki/T-rav/hydraflow/testing/0435-issue-synthesis-adr-pre-validator-enforce-required-sections.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0435-issue-synthesis-adr-pre-validator-enforce-required-sections.md
@@ -1,0 +1,18 @@
+---
+id: 0435
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.859707+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# ADR pre-validator: enforce required sections
+
+All ADRs must pass `tests/test_adr_pre_validator.py`, enforcing required sections (Status, Context, Decision, Consequences) and valid status values.
+
+Example: See also: architecture — ADR number collision and README guards.
+
+**Why:** Missing sections or invalid status values make ADRs non-machine-readable, breaking automated drift detection and the ADR README completeness guard.

--- a/repo_wiki/T-rav/hydraflow/testing/0436-issue-synthesis-never-import-private-helpers-at-module-level.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0436-issue-synthesis-never-import-private-helpers-at-module-level.md
@@ -1,0 +1,18 @@
+---
+id: 0436
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.860390+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Never import private helpers at module level
+
+Import private or internal functions (`_foo`) inside the test function or a `pytest.fixture`, never at module top level.
+
+Example: `def test_check_prereq(): from src.makefile_scaffold import _check_prereq_deps`
+
+**Why:** A module-level `ImportError` prevents pytest from collecting the file, silently destroying all passing tests in that module.

--- a/repo_wiki/T-rav/hydraflow/testing/0437-issue-synthesis-pin-function-signatures-before-writing-callers.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0437-issue-synthesis-pin-function-signatures-before-writing-callers.md
@@ -1,0 +1,18 @@
+---
+id: 0437
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.861090+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Pin function signatures before writing callers
+
+Decide the authoritative signature (argument order, return tuple shape) in the source file first; then write docs and tests to match.
+
+Example: 1. Write the function stub. 2. Copy its exact signature into the docstring. 3. Write the test.
+
+**Why:** When docs and tests are authored before implementation, signature drift goes undetected until runtime, and both artifacts may be wrong.

--- a/repo_wiki/T-rav/hydraflow/testing/0438-issue-synthesis-validate-sys-modules-cleanup-with-multiple-seeds.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0438-issue-synthesis-validate-sys-modules-cleanup-with-multiple-seeds.md
@@ -1,0 +1,18 @@
+---
+id: 0438
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.861862+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Validate sys.modules cleanup with multiple seeds
+
+Run `pytest --randomly-seed=<N>` with at least two different seeds to confirm that module-level import side effects do not leak between tests.
+
+Example: Execute the test suite with `--randomly-seed=1` and `--randomly-seed=42` to verify isolation.
+
+**Why:** Cleanup failures only surface under specific test orderings; a single seed may never trigger the problematic sequence.

--- a/repo_wiki/T-rav/hydraflow/testing/0439-issue-synthesis-skip-broken-tests-with-an-issue-reference.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0439-issue-synthesis-skip-broken-tests-with-an-issue-reference.md
@@ -1,0 +1,18 @@
+---
+id: 0439
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.862588+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Skip broken tests with an issue reference
+
+Mark broken tests with a referenced issue, never a bare skip. Remove the skip immediately after the issue is resolved.
+
+Example: `@pytest.mark.skip(reason="documenting bug: #1234")`
+
+**Why:** Without an issue reference, skipped tests become permanent dead weight with no path to removal or triage.

--- a/repo_wiki/T-rav/hydraflow/testing/0440-issue-synthesis-use-is-to-verify-shared-runner-instance.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0440-issue-synthesis-use-is-to-verify-shared-runner-instance.md
@@ -1,0 +1,18 @@
+---
+id: 0440
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.863390+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Use `is` to verify shared runner instance
+
+Assert that two components share the same subprocess runner with `is`, not `==`.
+
+Example: `assert component_a.runner is component_b.runner`
+
+**Why:** `==` may pass even when different instances are created; `is` verifies the exact object reference required by the single-runner design contract.

--- a/repo_wiki/T-rav/hydraflow/testing/0441-issue-synthesis-memory-dedup-higher-priority-bank-wins-on-collisio.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0441-issue-synthesis-memory-dedup-higher-priority-bank-wins-on-collisio.md
@@ -1,0 +1,18 @@
+---
+id: 0441
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.864112+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Memory dedup: higher-priority bank wins on collision
+
+When two near-duplicate items collide, the higher-priority bank's item survives.
+
+Example: Priority order: LEARNINGS (5) > TROUBLESHOOTING (4) > RETROSPECTIVES (3) > REVIEW_INSIGHTS (2) > HARNESS_INSIGHTS (1). Test collision behavior explicitly.
+
+**Why:** Without priority enforcement, a lower-quality retrospective can silently overwrite a load-bearing learning entry.

--- a/repo_wiki/T-rav/hydraflow/testing/0442-issue-synthesis-hoist-deterministic-gates-outside-llm-retry-loops.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0442-issue-synthesis-hoist-deterministic-gates-outside-llm-retry-loops.md
@@ -1,0 +1,18 @@
+---
+id: 0442
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.864836+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Hoist deterministic gates outside LLM retry loops
+
+Run subprocess-based validation (coverage, linting) once after the loop exits, not inside each retry iteration.
+
+Example: `result = run_llm_loop(...); if result == PASS: _run_coverage_delta_check(diff)`
+
+**Why:** Placing an expensive deterministic check inside the retry loop multiplies wall-clock cost by `max_attempts` without any additional signal.

--- a/repo_wiki/T-rav/hydraflow/testing/0443-issue-synthesis-use-public-fakegithub-api-in-scenario-tests.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0443-issue-synthesis-use-public-fakegithub-api-in-scenario-tests.md
@@ -1,0 +1,18 @@
+---
+id: 0443
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.865547+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Use public FakeGitHub API in scenario tests
+
+Always use the public API to mutate `FakeGitHub` state in scenario tests; never write to private attributes directly.
+
+Example: Bad: `world.github._issues[901].state = "closed"`. Good: `await world.github.close_issue(901)`
+
+**Why:** If `FakeIssue` internals change, direct attribute writes silently remain valid Python while the fake's behavior drifts — the public API is the compatibility boundary.

--- a/repo_wiki/T-rav/hydraflow/testing/0444-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0444-issue-synthesis-test-async-context-managers-in-three-standard-scen.md
@@ -1,0 +1,18 @@
+---
+id: 0444
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.866259+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Test async context managers in three standard scenarios
+
+Cover async context managers with three scenarios: (1) idempotent close — calling `close()` twice is safe; (2) `__aexit__` triggers `close()` exactly once; (3) `__aenter__` returns `self`.
+
+Example: `async with resource as r: assert r is resource`
+
+**Why:** Missing any scenario leaves an incomplete behavioral contract, hiding bugs in external-connection or file-handle management.

--- a/repo_wiki/T-rav/hydraflow/testing/0445-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0445-issue-synthesis-test-direct-swap-labels-via-swap-pipeline-labels.md
@@ -1,0 +1,18 @@
+---
+id: 0445
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.867022+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Test direct-swap labels via swap_pipeline_labels()
+
+Labels set via atomic swap (`hitl-active`, `fixed`) bypass the transition graph and are applied by `swap_pipeline_labels()` — test them on that call path.
+
+Example: Do not test swap labels through `VALID_TRANSITIONS`. See also: testing — Sync test label constants with production definitions.
+
+**Why:** Testing swap labels through the transition graph masks missing coverage; they have no transition entry by design.

--- a/repo_wiki/T-rav/hydraflow/testing/0446-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0446-issue-synthesis-allow-3-line-drift-in-ast-based-structure-assertio.md
@@ -1,0 +1,18 @@
+---
+id: 0446
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.867759+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Allow ±3 line drift in AST-based structure assertions
+
+For tests that verify code structure by parsing source ASTs (e.g., checking function length), allow ±3 line tolerance.
+
+Example: Assert `len(func.body) <= 53` rather than `<= 50` to account for blank lines and decorator variations. See also: testing — Enforce 50/30-line limits on handlers and wiring.
+
+**Why:** Exact line-count assertions redden CI on whitespace-only diffs, creating maintenance noise without improving correctness.

--- a/repo_wiki/T-rav/hydraflow/testing/0447-issue-synthesis-existing-tests-cover-private-method-extractions.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0447-issue-synthesis-existing-tests-cover-private-method-extractions.md
@@ -1,0 +1,18 @@
+---
+id: 0447
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.868486+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Existing tests cover private-method extractions
+
+When extracting a private method from a public one with an unchanged public API, the existing test suite provides full coverage — no new tests are needed for the extraction itself.
+
+Example: When extracting prompt-building methods, run prompt-assertion tests in isolation immediately after extraction to verify parity.
+
+**Why:** Adding duplicate tests for unchanged behavior inflates the suite; the real regression risk is behavioral, which existing tests already guard.

--- a/repo_wiki/T-rav/hydraflow/testing/0448-issue-synthesis-assert-numeric-values-in-sentry-breadcrumbs.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0448-issue-synthesis-assert-numeric-values-in-sentry-breadcrumbs.md
@@ -1,0 +1,18 @@
+---
+id: 0448
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.869188+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Assert numeric values in Sentry breadcrumbs
+
+When testing Sentry integration, assert actual numeric values in breadcrumbs and metrics, not just that a key exists.
+
+Example: `assert breadcrumb['data']['latency_ms'] == 42`
+
+**Why:** Key-presence assertions pass even when values are wrong or zero; numeric value assertions catch metric miscalculation bugs that presence checks miss entirely.

--- a/repo_wiki/T-rav/hydraflow/testing/0449-issue-synthesis-test-pydantic-literal-constraints-valid-and-invali.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0449-issue-synthesis-test-pydantic-literal-constraints-valid-and-invali.md
@@ -1,0 +1,18 @@
+---
+id: 0449
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.869910+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Test Pydantic Literal constraints: valid and invalid
+
+When adding `Literal` constraints to Pydantic fields, test both valid and invalid values — verify valid values are accepted and invalid values raise `ValidationError`.
+
+Example: For `status: Literal['open', 'closed']`, test `status='open'` passes and `status='unknown'` raises.
+
+**Why:** Literal constraints are invisible at runtime if only valid values are tested; invalid-value tests confirm the constraint is actually enforced.

--- a/repo_wiki/T-rav/hydraflow/testing/0450-issue-synthesis-verify-fatal-exception-propagation-through-loops.md
+++ b/repo_wiki/T-rav/hydraflow/testing/0450-issue-synthesis-verify-fatal-exception-propagation-through-loops.md
@@ -1,0 +1,18 @@
+---
+id: 0450
+topic: testing
+source_issue: synthesis
+source_phase: synthesis
+created_at: 2026-07-19T02:46:15.870661+00:00
+status: active
+corroborations: 1
+supersedes: 0373,0374,0375,0376,0377,0378,0379,0380,0381,0382,0383,0384,0385,0386,0387,0388,0389,0390,0391,0392,0393,0394,0395,0396,0397,0398,0399,0400,0401,0402,0403,0404,0405,0406,0407,0408,0409,0410,0411
+---
+
+# Verify fatal exception propagation through loops
+
+Test that fatal exceptions propagate through multi-phase loops by mocking internal methods to raise specific exception types, then asserting the exception reaches the caller.
+
+Example: `mock._execute.side_effect = FatalError(); with pytest.raises(FatalError): await loop.run_once()`
+
+**Why:** Broad `except Exception` blocks in loop runners silently swallow fatal exceptions, making multi-phase loops appear to succeed when they have failed.

--- a/src/triage.py
+++ b/src/triage.py
@@ -442,14 +442,16 @@ or for a claim that is demonstrably false / already implemented (the described p
                 )
             return result
 
-        # Fallback: could not parse LLM response.  Rather than escalating
-        # to HITL (which is for genuinely bad issues, not infra failures),
-        # default to passing the issue through.  The triage prompt says
-        # "default to passing issues through" — a parse failure is an
-        # infrastructure problem, not an issue quality problem.
+        # Fallback (#9798): could not parse the LLM response. A parse failure
+        # is an INFRASTRUCTURE problem, and the established contract for
+        # infra failures (see the empty-response check above and the
+        # ``except RuntimeError: raise`` in ``evaluate``) is to propagate so
+        # the issue STAYS IN THE TRIAGE QUEUE for retry. The old behavior —
+        # defaulting to ready=True — rubber-stamped ~131 issues straight past
+        # the gate, making triage a no-op exactly when the parser broke.
         logger.warning(
-            "Issue #%d triage — could not parse LLM response, defaulting to "
-            "ready=True. Transcript snippet: %.200s",
+            "Issue #%d triage — could not parse LLM response; keeping the "
+            "issue queued for retry. Transcript snippet: %.200s",
             issue.id,
             transcript.strip(),
         )
@@ -460,16 +462,9 @@ or for a claim that is demonstrably false / already implemented (the described p
                 level="warning",
                 issue_id=issue.id,
             )
-        return TriageResult(
-            issue_number=issue.id,
-            ready=True,
-            reasons=["Triage parse failed — defaulting to ready"],
-            enrichment=(
-                "## Triage Note\n\n"
-                "Triage evaluation could not parse the LLM response. "
-                "This issue was passed through to planning by default. "
-                "The planner should validate sufficient context."
-            ),
+        raise RuntimeError(
+            "triage verdict unparseable — LLM response contained no "
+            "recognizable JSON verdict (issue stays queued for retry)"
         )
 
     @staticmethod
@@ -554,9 +549,61 @@ or for a claim that is demonstrably false / already implemented (the described p
         2. Extract JSON from markdown code fences
         3. Regex to find a JSON object with ``"ready"`` key
         """
-        # Pre-process: strip Claude Code system/init lines
-        transcript = TriageRunner._strip_system_lines(transcript)
+        # Strategy 0 (#9798): the transcript may be RAW stream-json — one
+        # frame per line, with the verdict escaped INSIDE a ``result`` frame
+        # (``{"type":"result","result":"{\"ready\":...}"}``) or an assistant
+        # content block. None of the text strategies below can see escaped
+        # JSON (the regex looks for an unescaped "ready" key), which is how
+        # ~131 real verdicts fell through to the old rubber-stamp fallback.
+        # Extract the embedded text first and give the strategies real input.
+        stream_text = TriageRunner._extract_stream_json_text(transcript)
+        if stream_text:
+            extracted = TriageRunner._parse_json_strategies(stream_text, issue_number)
+            if extracted is not None:
+                return extracted
 
+        # Pre-process: strip Claude Code system/init lines, then run the
+        # text-level strategies on what remains.
+        transcript = TriageRunner._strip_system_lines(transcript)
+        return TriageRunner._parse_json_strategies(transcript, issue_number)
+
+    @staticmethod
+    def _extract_stream_json_text(transcript: str) -> str | None:
+        """Pull human/verdict text out of a stream-json transcript.
+
+        Collects ``result`` payloads and assistant message text blocks from
+        per-line JSON frames. Returns None when no frame parses (plain-text
+        transcripts fall through to the direct strategies unchanged).
+        """
+        chunks: list[str] = []
+        saw_frame = False
+        for raw_line in transcript.splitlines():
+            candidate = raw_line.strip()
+            if not candidate.startswith("{"):
+                continue
+            try:
+                frame = json.loads(candidate)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if not isinstance(frame, dict):
+                continue
+            saw_frame = True
+            if isinstance(frame.get("result"), str):
+                chunks.append(frame["result"])
+            message = frame.get("message")
+            if isinstance(message, dict):
+                for block in message.get("content") or []:
+                    if isinstance(block, dict) and isinstance(block.get("text"), str):
+                        chunks.append(block["text"])
+        if not saw_frame or not chunks:
+            return None
+        return "\n".join(chunks)
+
+    @staticmethod
+    def _parse_json_strategies(
+        transcript: str, issue_number: int
+    ) -> TriageResult | None:
+        """The original three text-level parse strategies."""
         # Strategy 1: direct parse
         try:
             data = json.loads(transcript.strip())

--- a/tests/regressions/test_issue_9798_triage_fail_closed.py
+++ b/tests/regressions/test_issue_9798_triage_fail_closed.py
@@ -1,0 +1,78 @@
+"""Regression: triage rubber-stamped unparseable verdicts as ready=True (#9798).
+
+~131 occurrences of "could not parse LLM response, defaulting to ready=True"
+made the triage gate a no-op: the parser was handed RAW stream-json frames
+whose verdict is ESCAPED inside a ``result`` payload
+(``{"type":"result","result":"{\\"ready\\":...}"}``), which none of the
+text-level strategies could see, and the fallback then passed the issue
+through unevaluated.
+
+Pins:
+1. Stream-json transcripts parse — via the ``result`` frame and via
+   assistant content blocks — including a ready=false verdict (proof of
+   real evaluation, not pass-through).
+2. A genuinely unparseable transcript raises RuntimeError (the established
+   infra-failure contract: issue stays queued for retry) instead of
+   returning ready=True.
+"""
+
+from __future__ import annotations
+
+import json
+
+from triage import TriageRunner
+
+
+def _stream_result_frame(verdict: dict) -> str:
+    init = json.dumps(
+        {"type": "system", "subtype": "init", "cwd": "/w", "tools": ["Bash"]}
+    )
+    result = json.dumps({"type": "result", "result": json.dumps(verdict)})
+    return f"{init}\n{result}"
+
+
+def test_verdict_escaped_in_result_frame_parses_ready_false() -> None:
+    transcript = _stream_result_frame(
+        {"ready": False, "reasons": ["needs acceptance criteria"]}
+    )
+
+    result = TriageRunner._parse_verdict(transcript, 42)
+
+    assert result is not None
+    assert result.ready is False
+    assert result.reasons == ["needs acceptance criteria"]
+
+
+def test_verdict_in_assistant_content_block_parses() -> None:
+    frame = json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": '{"ready": true, "reasons": []}',
+                    }
+                ]
+            },
+        }
+    )
+    transcript = f'{{"type":"system","subtype":"init"}}\n{frame}'
+
+    result = TriageRunner._parse_verdict(transcript, 42)
+
+    assert result is not None
+    assert result.ready is True
+
+
+def test_plain_text_transcripts_still_parse_unchanged() -> None:
+    result = TriageRunner._parse_verdict('{"ready": false, "reasons": ["x"]}', 7)
+
+    assert result is not None
+    assert result.ready is False
+
+
+def test_stream_json_with_no_verdict_still_returns_none() -> None:
+    transcript = _stream_result_frame({"no_verdict_here": 1})
+
+    assert TriageRunner._parse_verdict(transcript, 7) is None

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -183,11 +183,11 @@ class TestLLMEvaluation:
         stdout = f"{assistant_event}\n{result_event}"
         mock_runner.create_streaming_process = make_streaming_proc(stdout=stdout)
 
-        result = await runner.evaluate(issue)
-        # Parse failures now default to ready=True (pass through to planner)
-        # rather than escalating to HITL — the issue isn't bad, the parse is.
-        assert result.ready is True
-        assert any("parse" in r.lower() for r in result.reasons)
+        # Parse failures are infrastructure errors (#9798): they propagate as
+        # RuntimeError so the issue STAYS QUEUED for retry — the old
+        # ready=True default rubber-stamped ~131 issues past the gate.
+        with pytest.raises(RuntimeError, match="unparseable"):
+            await runner.evaluate(issue)
 
     @pytest.mark.asyncio
     async def test_llm_process_failure_propagates(
@@ -876,8 +876,10 @@ class TestTriageSentryBreadcrumbs:
 
         fake_obs = FakeSentry()
         runner._obs = fake_obs
-        result = await runner.evaluate(issue)
-        assert result.ready is True  # Parse failures default to ready
+        # Parse failures now raise (#9798 — issue stays queued for retry);
+        # the breadcrumb must still land before the raise.
+        with pytest.raises(RuntimeError, match="unparseable"):
+            await runner.evaluate(issue)
         parse_bcs = [
             b for b in fake_obs.breadcrumbs if b["category"] == "triage.parse_failed"
         ]


### PR DESCRIPTION
## Problem (#9798)

Triage logged `could not parse LLM response, defaulting to ready=True` **~131 times** — the gate was rubber-stamping every issue it failed to parse (P1; also the source of useless 'Triage Note: passed through by default' comments on e.g. #9796).

## Root causes + fix

1. **Verdicts arrive as raw stream-json** with the payload ESCAPED inside a `result` frame or an assistant content block. `_strip_system_lines` extracted `result` strings but DISCARDED assistant frames wholesale, and no text strategy can see escaped JSON. New **Strategy 0** extracts result payloads + assistant text blocks from the raw transcript before any stripping, then runs the existing strategies on the extracted text.
2. **The unparseable fallback returned ready=True.** It now raises RuntimeError — the established infra-failure contract (matching the empty-response check and `evaluate`'s `except RuntimeError: raise`): the issue **stays in the triage queue for retry** instead of skipping the gate. The parse-failed breadcrumb still lands before the raise.

## Tests

- `tests/regressions/test_issue_9798_triage_fail_closed.py`: escaped-result-frame verdict parses (ready=false — proof of real evaluation), assistant-content-block verdict parses, plain-text path unchanged, no-verdict stream still None.
- Updated the two tests that pinned the old rubber-stamp (evaluate now raises; breadcrumb assertion retained).
- Full `make quality` green (exit 0).

Closes #9798

🤖 Generated with [Claude Code](https://claude.com/claude-code)