### PR TITLE
fix(adr-xref): merge cited modules per ADR number + warn on duplicates (#9505, #9465)

### DIFF
--- a/src/arch/extractors/adr_xref.py
+++ b/src/arch/extractors/adr_xref.py
@@ -8,10 +8,14 @@ The reverse `module -> [ADRs]` index is computed by the generator.
 
 from __future__ import annotations
 
+import logging
 import re
+from collections import defaultdict
 from pathlib import Path
 
 from arch._models import ADRRef, ADRRefIndex
+
+logger = logging.getLogger(__name__)
 
 _ADR_FILE_RE = re.compile(r"^(\d{4})-.+\.md$")
 # Match "src/foo/bar.py", "src/foo/bar.py:Class", "src/foo/bar.py:func_name"
@@ -26,14 +30,34 @@ def _module_from_path_ref(s: str) -> str:
 
 def extract_adr_refs(adr_dir: Path) -> ADRRefIndex:
     adr_dir = Path(adr_dir).resolve()
-    refs: list[ADRRef] = []
+    # Accumulate the UNION of cited modules per adr_id. Two files can claim the
+    # same ADR number (the #9406 collisions); merging here keeps every file's
+    # citations instead of letting a dict-keyed downstream consumer silently
+    # drop one (issues #9505 / #9465).
+    modules_by_id: dict[str, set[str]] = defaultdict(set)
+    files_by_id: dict[str, list[str]] = defaultdict(list)
     for md in sorted(adr_dir.glob("*.md")):
         m = _ADR_FILE_RE.match(md.name)
         if not m:
             continue
         adr_id = f"ADR-{m.group(1)}"
         text = md.read_text()
-        modules = sorted({_module_from_path_ref(s) for s in _PATH_REF_RE.findall(text)})
-        refs.append(ADRRef(adr_id=adr_id, cited_modules=modules))
-    refs.sort(key=lambda r: r.adr_id)
+        modules_by_id[adr_id].update(
+            _module_from_path_ref(s) for s in _PATH_REF_RE.findall(text)
+        )
+        files_by_id[adr_id].append(md.name)
+    for adr_id, names in files_by_id.items():
+        if len(names) > 1:
+            logger.warning(
+                "Duplicate ADR number %s claimed by %d files: %s. Merging their "
+                "cited modules; dict-keyed callers would otherwise drop one — "
+                "renumber the later-authored file (issue #9505 / #9465 / #9406).",
+                adr_id,
+                len(names),
+                ", ".join(sorted(names)),
+            )
+    refs = [
+        ADRRef(adr_id=adr_id, cited_modules=sorted(modules_by_id[adr_id]))
+        for adr_id in sorted(modules_by_id)
+    ]
     return ADRRefIndex(adr_to_modules=refs)

--- a/tests/regressions/test_issue_9505.py
+++ b/tests/regressions/test_issue_9505.py
@@ -1,0 +1,87 @@
+"""Regression test for issues #9505 + #9465.
+
+Bug: ``arch.extractors.adr_xref.extract_adr_refs`` appended one ``ADRRef`` per
+ADR *file* with no merge. Two files sharing an ADR number (the #9406-style
+collisions) therefore produced two ``ADRRef`` rows with the same ``adr_id``.
+Every downstream consumer keys by ``adr_id`` (``{r.adr_id: r ...}`` and the
+``adr_cross_reference`` generator's reverse-index build), so one file's
+``cited_modules`` was silently dropped — the last row keyed wins.
+
+Separately (#9465), unlike ``adr_index.scan_adr_directory``, the extractor
+emitted *no* WARNING when it observed a duplicate ADR number, leaving the
+collision invisible on the runtime path (mirrors the #9457 caplog pattern).
+
+These tests assert the CORRECT (post-fix) invariant:
+  * exactly ONE ``ADRRef`` per ``adr_id``, whose ``cited_modules`` is the
+    de-duplicated UNION of every file claiming that number, and
+  * a WARNING naming the colliding number is emitted.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from arch.extractors.adr_xref import extract_adr_refs
+
+
+def _write_adr(adr_dir: Path, number: int, slug: str, body: str) -> Path:
+    """Write an ADR file. ``slug`` keeps filenames distinct so two files can
+    legitimately claim the same ADR ``number``."""
+    p = adr_dir / f"{number:04d}-{slug}.md"
+    p.write_text(f"# ADR-{number:04d}: {slug}\n\n{body}\n")
+    return p
+
+
+def test_duplicate_adr_number_merges_cited_modules_and_warns(tmp_path, caplog) -> None:
+    # Two distinct files both claim ADR-0099, citing different src modules with
+    # one module (src/shared.py) cited by BOTH — the union must de-dupe it.
+    _write_adr(
+        tmp_path,
+        99,
+        "first-decision",
+        "See src/foo.py and src/shared.py:helper for details.",
+    )
+    _write_adr(
+        tmp_path,
+        99,
+        "second-decision",
+        "Also relies on src/bar.py:Bar and src/shared.py.",
+    )
+    _write_adr(tmp_path, 7, "unrelated", "Touches src/baz.py only.")
+
+    with caplog.at_level(logging.WARNING):
+        idx = extract_adr_refs(tmp_path)
+
+    # Exactly ONE ADRRef per adr_id — the collision is merged, not duplicated.
+    ids = [r.adr_id for r in idx.adr_to_modules]
+    assert ids.count("ADR-0099") == 1, (
+        f"Expected a single merged ADRRef for ADR-0099; got rows: {ids}"
+    )
+
+    by_id = {r.adr_id: r for r in idx.adr_to_modules}
+
+    # cited_modules is the de-duplicated UNION of both files, sorted.
+    assert by_id["ADR-0099"].cited_modules == [
+        "src.bar",
+        "src.foo",
+        "src.shared",
+    ], (
+        "ADR-0099 must union both files' citations (shared module deduped); "
+        f"got: {by_id['ADR-0099'].cited_modules}"
+    )
+
+    # The non-colliding ADR is unaffected.
+    assert by_id["ADR-0007"].cited_modules == ["src.baz"]
+
+    # #9465: a WARNING naming the colliding number MUST be emitted.
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings, (
+        "extract_adr_refs observed two files sharing ADR number 0099 but emitted "
+        "no WARNING — duplicate ADR numbers stay invisible on the runtime path "
+        "(mirror scan_adr_directory per #9457/#9465)."
+    )
+    assert any("99" in r.getMessage() for r in warnings), (
+        "Expected a WARNING mentioning the duplicated ADR number 99; got: "
+        f"{[r.getMessage() for r in warnings]}"
+    )


### PR DESCRIPTION
## Summary

Fixes #9505 and #9465 (same function, `src/arch/extractors/adr_xref.py::extract_adr_refs`).

**Bug (#9505):** `extract_adr_refs` appended one `ADRRef` per ADR *file* with no merge. When two ADR files share an ADR number (the #9406-style collisions), this produced two `ADRRef` rows with the same `adr_id`. Every downstream consumer keys by `adr_id` — the architecture test's `{r.adr_id: r ...}` and the `adr_cross_reference` generator's reverse-index build — so one file's `cited_modules` was silently dropped (last row keyed wins).

**Bug (#9465):** Unlike `adr_index.scan_adr_directory`, the extractor emitted *no* WARNING on a duplicate ADR number, leaving collisions invisible on the runtime path.

## Fix (~small)

- Accumulate cited modules into a `dict[str, set[str]]` keyed by `adr_id` (union + dedupe).
- Emit exactly ONE `ADRRef` per `adr_id` with `sorted(modules)`.
- `logger.warning(...)` when an `adr_id` is claimed by >1 file, mirroring `scan_adr_directory`'s message so collisions surface in logs / Sentry immediately.

## Tests (TDD)

- New regression `tests/regressions/test_issue_9505.py`: two files sharing ADR-0099 (one shared module cited by both) → asserts a single merged `ADRRef` whose `cited_modules` is the de-duplicated UNION, and a WARNING naming the colliding number.
- Written RED first (2 duplicate `ADR-0099` rows), GREEN after fix.
- Confirmed green: `test_issue_9505.py`, `test_issue_9457.py` (mirrored caplog pattern), `tests/architecture/test_extractor_adr_xref.py` — 5 passed.
- `ruff check` + `ruff format --check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)