### PR TITLE
ci(security): least-privilege permissions for arch-regen.yml (code-scanning #103)

### DIFF
--- a/.github/workflows/arch-regen.yml
+++ b/.github/workflows/arch-regen.yml
@@ -17,6 +17,12 @@ on:
       - 'tests/scenarios/fakes/**'
       - 'tests/architecture/**'
 
+# Least-privilege GITHUB_TOKEN (code-scanning alert #103): this workflow only
+# reads the checkout to run drift checks — it never pushes, comments, or opens
+# PRs — so read-only contents access is sufficient.
+permissions:
+  contents: read
+
 jobs:
   arch-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes code-scanning alert **#103** (`actions/missing-workflow-permissions`). arch-regen.yml had no `permissions:` block; its `arch-check` job is read-only (drift checks — no push/comment/PR), so `permissions: {contents: read}` is the correct minimal grant. Resolves the 3rd of the 3 open medium security alerts (the other two, Dependabot #28/#29, are handled by #9958 lowering the SecurityPatchLoop threshold to medium).

🤖 Generated with [Claude Code](https://claude.com/claude-code)