### PR TITLE
fix(adr-validator): verify dotted method-level source citations (#9574)

### DIFF
--- a/src/adr_pre_validator.py
+++ b/src/adr_pre_validator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -71,15 +72,68 @@ _ADR_PAREN_TITLE_RE = re.compile(r"ADR[- ]\d{4}\s*\(([^()]*(?:\([^()]*\)[^()]*)*
 # titles that contain dots (e.g. "Pi.dev" in ADR-0004's title).
 _ADR_EMDASH_TITLE_RE = re.compile(r"ADR[- ]\d{4}\s*—\s*(.+?)(?:\.\s|,|;|$)")
 
-# Matches source file + symbol citations like `src/config.py:_resolve_paths` or
-# `src/config.py:HydraFlowConfig`.  Group 1 = file path, Group 2 = symbol name.
-# Symbol must start with a letter or underscore (not a digit) to exclude line numbers.
-_SOURCE_SYMBOL_RE = re.compile(r"`(src/[^`:\s]+\.py):([A-Za-z_]\w*)`")
+# Matches source file + symbol citations like `src/config.py:_resolve_paths`,
+# `src/config.py:HydraFlowConfig`, or dotted method-level citations such as
+# `src/config.py:HydraFlowConfig.base_branch`.
+# Group 1 = file path, Group 2 = (possibly dotted) symbol name.
+# Symbol must start with a letter or underscore (not a digit) to exclude line
+# numbers.  The dotted extension is a strict superset: a single-segment symbol
+# still matches byte-for-byte identically.
+_SOURCE_SYMBOL_RE = re.compile(
+    r"`(src/[^`:\s]+\.py):([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)`"
+)
 
 # Matches inline line-number citations in the `src/file.py:DIGITS` format.
 # These are a variant of volatile line citations that embed the number in the
 # symbol position of a source reference.  Group 1 = file path, Group 2 = digits.
 _INLINE_LINE_NUM_RE = re.compile(r"`(src/[^`:\s]+\.py):(\d[\d,]*)`")
+
+# AST node types that introduce a named definition we can resolve a dotted
+# source citation against (e.g. a class, a function, or an async function).
+_NAMED_DEF_NODES = (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+
+
+def _find_named_def(
+    body: list[ast.stmt], name: str
+) -> ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef | None:
+    """Return the class/function/async-function named *name* directly in *body*.
+
+    Only DIRECT members of *body* are considered — this deliberately does not
+    recurse, so each segment of a dotted citation must be a direct child of the
+    previous one.  Returns None when no matching definition is present.
+    """
+    for node in body:
+        if isinstance(node, _NAMED_DEF_NODES) and node.name == name:
+            return node
+    return None
+
+
+def _resolve_dotted_symbol(source: str, dotted: str) -> bool | None:
+    """Resolve a dotted symbol path (e.g. ``Class.method``) against *source*.
+
+    Walks the AST segment-by-segment, confirming each segment is a class or
+    (async) function defined directly inside the previous segment's body.
+
+    Returns:
+        True  — every segment resolved (the symbol exists).
+        False — the source parsed but a segment could not be resolved
+                (a substantiated phantom — safe to flag).
+        None  — the source could not be parsed; the citation cannot be
+                substantiated either way, so the caller must skip it and
+                never flag it.
+    """
+    try:
+        tree = ast.parse(source)
+    except (SyntaxError, ValueError):
+        return None
+
+    body: list[ast.stmt] = tree.body
+    for segment in dotted.split("."):
+        node = _find_named_def(body, segment)
+        if node is None:
+            return False
+        body = node.body
+    return True
 
 
 class ADRPreValidator:
@@ -544,6 +598,26 @@ class ADRPreValidator:
             source = file_cache[file_path]
             if source is None:
                 # File doesn't exist or is unreadable — skip silently
+                continue
+
+            if "." in symbol:
+                # Dotted method-level citation (e.g. `Class.method`): resolve it
+                # structurally via the AST, confirming each segment is a direct
+                # member of the previous.  None means the source could not be
+                # parsed — never flag what can't be substantiated.
+                resolved = _resolve_dotted_symbol(source, symbol)
+                if resolved is False:
+                    result.issues.append(
+                        ADRValidationIssue(
+                            code="phantom_source_symbol",
+                            message=(
+                                f"`{file_path}:{symbol}` is cited but "
+                                f"`{symbol}` does not resolve to a class or "
+                                f"function in `{file_path}`"
+                            ),
+                            fixable=False,
+                        )
+                    )
                 continue
 
             # Match both top-level and indented definitions (class methods, async defs)

--- a/tests/regressions/test_issue_9574.py
+++ b/tests/regressions/test_issue_9574.py
@@ -1,0 +1,85 @@
+"""Regression test for issue #9574.
+
+Bug: ``ADRPreValidator._check_source_function_refs`` only verified
+single-segment source symbols.  ``_SOURCE_SYMBOL_RE`` captured only
+``[A-Za-z_]\\w*`` in the symbol position, so a dotted method-level citation
+like ``src/foo.py:Class.method`` matched NOTHING and was silently skipped.
+A citation naming a nonexistent method therefore passed validation.
+
+Expected behaviour after fix:
+  - A dotted citation naming a REAL class but a NONEXISTENT method
+    (``src/adr_pre_validator.py:ADRPreValidator.typo_method``) is flagged
+    as ``phantom_source_symbol``.
+  - A dotted citation naming a REAL class AND a REAL method
+    (``src/adr_pre_validator.py:ADRPreValidator.validate``) is NOT flagged.
+
+The first assertion is RED against the current (buggy) code: the dotted
+citation is skipped entirely, so no phantom_source_symbol issue is raised.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+from adr_pre_validator import ADRPreValidator
+
+
+def _valid_adr(*, context: str) -> str:
+    return f"""# ADR-0001: Test ADR
+
+**Status:** Proposed
+
+## Context
+
+{context}
+
+## Decision
+
+We decided to do the thing.
+
+## Consequences
+
+Some consequences.
+"""
+
+
+@pytest.fixture
+def validator() -> ADRPreValidator:
+    return ADRPreValidator()
+
+
+class TestIssue9574DottedSourceCitations:
+    def test_dotted_citation_to_nonexistent_method_is_flagged(
+        self, validator: ADRPreValidator
+    ) -> None:
+        """A real class with a typo'd method name is flagged as a phantom symbol."""
+        content = _valid_adr(
+            context=(
+                "See `src/adr_pre_validator.py:ADRPreValidator.typo_method` "
+                "for details."
+            )
+        )
+        result = validator.validate(content, repo_root=_REPO_ROOT)
+        codes = [i.code for i in result.issues]
+        assert "phantom_source_symbol" in codes
+        issue = next(i for i in result.issues if i.code == "phantom_source_symbol")
+        assert "typo_method" in issue.message
+
+    def test_dotted_citation_to_real_method_is_not_flagged(
+        self, validator: ADRPreValidator
+    ) -> None:
+        """A real class with a real method is NOT flagged (no false positive)."""
+        content = _valid_adr(
+            context=(
+                "See `src/adr_pre_validator.py:ADRPreValidator.validate` for details."
+            )
+        )
+        result = validator.validate(content, repo_root=_REPO_ROOT)
+        codes = [i.code for i in result.issues]
+        assert "phantom_source_symbol" not in codes


### PR DESCRIPTION
## Summary

Fixes #9574.

`ADRPreValidator._check_source_function_refs` only verified single-segment source symbols. `_SOURCE_SYMBOL_RE` captured only `[A-Za-z_]\w*` in the symbol position, so a dotted method-level citation like `` `src/foo.py:Class.method` `` matched **nothing** and was silently skipped — a citation naming a nonexistent method passed validation.

## Changes

- **Widen `_SOURCE_SYMBOL_RE`** symbol group to `[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*`. Strict superset — single-segment behavior is byte-for-byte unchanged. This also brings it in sync with the already-dotted-aware `adr_index._SOURCE_FILE_CITATION_RE` (whose comment already claimed the two were shared).
- **Add module-private `_find_named_def(body, name)` and `_resolve_dotted_symbol(source, dotted)`** that AST-walk `ClassDef`/`FunctionDef`/`AsyncFunctionDef` bodies segment-by-segment, confirming each segment is a **direct** member of the previous.
- **Branch on `'.' in symbol`** in `_check_source_function_refs`, before the existing single-segment regex path (dotted -> resolver; single-segment -> unchanged).
- **On `ast.parse` SyntaxError/ValueError, skip** — never flag what can't be substantiated. `_resolve_dotted_symbol` returns `None` (skip) on parse failure, `False` (flag) on a substantiated absence, `True` when resolved.

## Testing (TDD)

- `tests/regressions/test_issue_9574.py` written first (RED): a dotted citation to a real class + typo'd method (`ADRPreValidator.typo_method`) is flagged as `phantom_source_symbol`; a real class + real method (`ADRPreValidator.validate`) is **not** flagged.
- Regression test now GREEN; full `tests/test_adr_pre_validator.py` (120 tests) passes.
- `ruff check`, `ruff format --check`, and `pyright` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)