### PR TITLE
fix(adr): repoint rotted src citations + add citation-existence ratchet

### DIFF
--- a/docs/adr/0003-git-worktrees-for-isolation.md
+++ b/docs/adr/0003-git-worktrees-for-isolation.md
@@ -59,7 +59,7 @@ Default is a sibling directory to the repo root (e.g., `../hydraflow-worktrees/`
 
 ## Related
 
-- `src/worktree.py:WorktreeManager` — full lifecycle implementation
+- `src/workspace.py:WorkspaceManager` — full lifecycle implementation
 - `src/ports.py:WorkspacePort` — formal interface
 - `CLAUDE.md` — "Always implement issue work on a dedicated git worktree branch"
 - ADR-0001 (Five Concurrent Async Loops) for the concurrency model that makes parallel worktrees necessary

--- a/docs/adr/0006-repo-runtime-isolation.md
+++ b/docs/adr/0006-repo-runtime-isolation.md
@@ -64,5 +64,5 @@ Key elements:
 - Superseded by: ADR-0009 (Multi-Repo Process-Per-Repo Model)
 - Source memory: #1615
 - Implementation: #1467
-- `src/orchestrator.py`, `src/state.py`, `src/issue_store.py`, `src/events.py`
-- `src/hf_cli/supervisor_service.py`
+- `src/orchestrator.py`, `src/state/__init__.py`, `src/issue_store.py`, `src/events.py`
+- Repo lifecycle now lives in `src/repo_runtime.py` (RepoRuntime) under one `server:main` process (the old `hf_cli/supervisor_service.py` TCP supervisor layer was removed).

--- a/docs/adr/0007-dashboard-api-multi-repo-scoping.md
+++ b/docs/adr/0007-dashboard-api-multi-repo-scoping.md
@@ -12,10 +12,13 @@ all endpoints are defined inside `create_router()` and share `config`, `state`,
 `event_bus`, and `orchestrator` via closure variables. This design assumes a
 single repo context per dashboard instance.
 
-The supervisor layer (`supervisor_service.py`, `supervisor_client.py`,
-`supervisor_state.py`) already manages multi-repo lifecycle via a TCP protocol
-with actions: `ping`, `list_repos`, `add_repo`, `remove_repo`. Each repo gets
-its own subprocess with its own dashboard port.
+Multi-repo lifecycle is managed by `src/repo_runtime.py` (RepoRuntime /
+RepoRuntimeRegistry) inside a single `server:main` process; repos are
+started/stopped through the dashboard control routes rather than a separate
+subprocess per repo. (Historically this was a TCP supervisor layer —
+`supervisor_service.py` / `supervisor_client.py` — that spawned one subprocess
+per repo with its own dashboard port; that layer has since been removed. The
+API-scoping decision below is unchanged by that refactor.)
 
 The UI context (`HydraFlowContext.jsx`) already tracks `supervisedRepos` and
 exposes `addRepoShortcut` / `removeRepoShortcut`. Sessions support repo
@@ -77,7 +80,7 @@ Extend the dashboard API to support multi-repo scoping through two mechanisms:
 - Source memory: #1617
 - Implementation: #1468
 - `src/dashboard_routes/_routes.py:create_router`, `src/dashboard.py`
-- `src/hf_cli/supervisor_service.py`, `src/hf_cli/supervisor_client.py`
+- `src/repo_runtime.py:RepoRuntime`, `src/dashboard_routes/_state_routes.py` — per-repo start/stop/status control routes (replaced the removed supervisor TCP layer)
 - `src/ui/src/context/HydraFlowContext.jsx`
 - ADR-0006 (RepoRuntime Isolation Architecture)
 ## Council Amendment Notes

--- a/docs/adr/0008-multi-repo-dashboard-architecture.md
+++ b/docs/adr/0008-multi-repo-dashboard-architecture.md
@@ -76,8 +76,8 @@ Adopt a **supervisor-proxied aggregation model** for the multi-repo dashboard:
 
 - Source memory: #1619
 - Implementation: #1469
-- `src/hf_cli/supervisor_service.py` (`_start_repo`, `RUNNERS`)
-- `src/dashboard.py`, `src/dashboard_routes.py`
+- `src/repo_runtime.py:RepoRuntimeRegistry` — repo start/stop lifecycle (the old `hf_cli/supervisor_service.py` TCP supervisor with `_start_repo` / `RUNNERS` was removed)
+- `src/dashboard.py`, `src/dashboard_routes/_routes.py:create_router`
 - `src/ui/src/context/HydraFlowContext.jsx`
 - ADR-0006 (RepoRuntime Isolation Architecture)
 - ADR-0007 (Dashboard API Architecture for Multi-Repo Scoping)

--- a/docs/adr/0010-worktree-and-path-isolation.md
+++ b/docs/adr/0010-worktree-and-path-isolation.md
@@ -120,6 +120,6 @@ artifacts:
   `log_dir`, `plans_dir`, and `memory_dir` as mandated by this ADR.
 - `src/config.py:HydraFlowConfig` — `worktree_path_for_issue`, `log_dir`, `plans_dir`, `memory_dir` properties
 - `src/config.py:_resolve_base_paths`, `src/config.py:_resolve_repo_scoped_paths` — config resolution phases
-- `src/worktree.py:WorktreeManager` — worktree lifecycle and cleanup
+- `src/workspace.py:WorkspaceManager` — worktree lifecycle and cleanup
 - `src/docker_runner.py:DockerRunner._build_mounts` — container mount strategy
 - `src/metrics_manager.py:get_metrics_cache_dir` — repo-slug scoping reference

--- a/docs/adr/0012-epic-merge-coordination-architecture.md
+++ b/docs/adr/0012-epic-merge-coordination-architecture.md
@@ -184,5 +184,5 @@ an epic body directive parsed during registration.
 - `src/post_merge_handler.py` (`handle_approved`, `_should_defer_merge` — merge interception)
 - `src/epic.py` (`EpicManager.on_child_approved`, `_handle_bundled_ready`, `_handle_ordered_ready`, `_get_merge_order`)
 - `src/models.py` (`EpicState` — model to extend)
-- `src/review_phase.py:_handle_approved_merge` — review-to-merge flow
+- `src/review_phase/_phase.py:_handle_approved_merge` — review-to-merge flow
 - `src/epic_monitor_loop.py` (stale epic detection — relevant for held bundles)

--- a/docs/adr/0013-screenshot-capture-pipeline.md
+++ b/docs/adr/0013-screenshot-capture-pipeline.md
@@ -136,8 +136,8 @@ images are filtered out, and the DOM sanitizer strips external resources).
 - ADR issue: #1704
 - `src/ui/src/components/Header.jsx` (capture + three-tier fallback)
 - `src/ui/src/components/ReportIssueModal.jsx` (annotation + base64 conversion)
-- `src/dashboard_routes.py` (`POST /api/report` endpoint)
+- `src/dashboard_routes/_reports_routes.py:submit_report` (`POST /api/report` endpoint)
 - `src/models.py` (`PendingReport`, `ReportIssueRequest`, `ReportIssueResponse`)
-- `src/state.py` (`enqueue_report`, `dequeue_report`)
+- `src/state/_report.py` (`enqueue_report`, `dequeue_report`)
 - `src/report_issue_loop.py` (`ReportIssueLoop` background worker)
 - `src/pr_manager.py` (`upload_screenshot_gist` method)

--- a/docs/adr/0014-session-counter-forward-progression-semantics.md
+++ b/docs/adr/0014-session-counter-forward-progression-semantics.md
@@ -106,10 +106,10 @@ Adopt **forward-progression-only** as the canonical semantics for all
 - Source memory: #1697
 - Implementation: PR #1689, issue #1542
 - `src/models.py:SessionCounters` — counter model definition
-- `src/state.py:StateTracker.increment_session_counter` — increment logic
+- `src/state/_session.py:SessionStateMixin.increment_session_counter` — increment logic
 - `src/triage_phase.py:_triage_single` — triaged counter (forward-progression)
 - `src/plan_phase.py:_handle_already_satisfied`, `src/plan_phase.py:_handle_plan_success` — planned counter (forward-progression)
 - `src/implement_phase.py:_handle_implementation_result` — implemented counter (forward-progression)
-- `src/review_phase.py:_record_review_outcome` — reviewed counter (guarded on APPROVE)
+- `src/review_phase/_phase.py:_record_review_outcome` — reviewed counter (guarded on APPROVE)
 - `src/post_merge_handler.py:handle_approved` — merged counter (forward-progression)
 - `src/orchestrator.py:build_pipeline_stats` — session_counter_map (stage-to-field mapping)

--- a/docs/adr/0015-protocol-callback-gate-pattern.md
+++ b/docs/adr/0015-protocol-callback-gate-pattern.md
@@ -141,6 +141,6 @@ exception in spirit: pragmatic co-location where the type has a narrow scope.
 - Issue: #1746
 - `src/models.py` — `CiGateFn`, `VisualGateFn`, `MergeConflictFixFn`, `EscalateFn`, `PublishFn`, `VisualValidationDecision`
 - `src/post_merge_handler.py` — `handle_approved()` callback injection
-- `src/review_phase.py:check_visual_gate`, `src/review_phase.py:_fetch_code_scanning_alerts`
+- `src/review_phase/_phase.py:check_visual_gate`, `src/review_phase/_phase.py:_fetch_code_scanning_alerts`
 - `src/visual_validation.py` — `compute_visual_validation()`
 - `src/escalation_gate.py` — `should_escalate_debug()`

--- a/docs/adr/0017-auto-decompose-triage-counter-exclusion.md
+++ b/docs/adr/0017-auto-decompose-triage-counter-exclusion.md
@@ -99,6 +99,6 @@ is **intentional and should remain as-is**. The rationale:
 - Source memory: #1729
 - Original implementation: PR #1689 (issue #1542)
 - `src/triage_phase.py` — `_maybe_decompose()`, `triage_issues()`
-- `src/state.py` — `StateTracker.increment_session_counter()`,
+- `src/state/__init__.py:StateTracker` — `StateTracker.increment_session_counter()`,
   `StateTracker.mark_issue()`
 - ADR-0001 (Five concurrent async loops — triage is loop 1)

--- a/docs/adr/0019-background-task-delegation-abstraction-layer.md
+++ b/docs/adr/0019-background-task-delegation-abstraction-layer.md
@@ -119,4 +119,4 @@ Adopt the following rules for background-task delegation in HydraFlow workers:
 - `src/epic.py` — `EpicManager.release_epic`, `EpicChecker.check_and_close_epics`, `EpicManager.on_child_completed`
 - `src/post_merge_handler.py` — `PostMergeHandler._handle_merge` (delegation call-site)
 - `src/issue_fetcher.py` — collaborator cache TTL pattern
-- `src/dashboard_routes.py` — `release_epic` API entry-point
+- `src/dashboard_routes/_epic_routes.py:trigger_epic_release` — `release_epic` API entry-point

--- a/docs/adr/0024-implementation-retry-recovery-architecture.md
+++ b/docs/adr/0024-implementation-retry-recovery-architecture.md
@@ -75,7 +75,7 @@ by whether review feedback is present.
 
 - The retry recovery changes are scoped to the implement phase
   (`src/implement_phase.py:ImplementPhase`) and its interaction with
-  `src/state.py:StateTracker` and `src/agent.py:AgentRunner`.
+  `src/state/__init__.py:StateTracker` and `src/agent.py:AgentRunner`.
 - The review phase's own retry/escalation logic remains unchanged.
 - The `max_issue_attempts` cap continues to serve as the upper bound for all
   retry paths, preventing infinite retry loops.
@@ -130,4 +130,4 @@ by whether review feedback is present.
 
 - Source memory: [#2258 — Implementation retry recovery architecture](https://github.com/T-rav/hydra/issues/2258)
 - Implementing issue: [#2264](https://github.com/T-rav/hydra/issues/2264)
-- Key files: `src/implement_phase.py:ImplementPhase`, `src/state.py:StateTracker`, `src/agent.py:AgentRunner`
+- Key files: `src/implement_phase.py:ImplementPhase`, `src/state/__init__.py:StateTracker`, `src/agent.py:AgentRunner`

--- a/docs/adr/0031-product-track-architecture.md
+++ b/docs/adr/0031-product-track-architecture.md
@@ -201,7 +201,7 @@ as all other pipeline labels.
   engineering)
 - `src/ui/src/constants.js:PRODUCT_TRACK_KEYS` — product track stage set
 - `src/plan_phase.py:_is_product_track_issue` — decomposition enforcement
-- `src/review_phase.py:_is_product_track_pr` — spec-match verification
+- `src/review_phase/_phase.py:_is_product_track_pr` — spec-match verification
 - `src/models.py:TriageResult` — clarity_score and needs_discovery fields
 - `src/models.py:DiscoverResult` — research brief output model
 - `src/models.py:ShapeConversation` — conversation state model

--- a/docs/adr/0036-cli-argparse-config-builder-pattern.md
+++ b/docs/adr/0036-cli-argparse-config-builder-pattern.md
@@ -1,9 +1,15 @@
 # ADR-0036: CLI Architecture — argparse with Config Builder Pattern
 
-**Status:** Accepted
+**Status:** Superseded
 **Enforcement:** manual
-**Enforced by:** Code review of `src/cli.py:build_config()` and `src/hf_cli/__main__.py` dispatch wiring during PR review of CLI/config changes.
+**Enforced by:** n/a (decision reverted — CLI removed)
 **Date:** 2026-03-08
+
+> **Superseded 2026-07:** The argparse CLI was removed entirely — there is no
+> `cli.py`, no `build_config()`, and no `hf_cli/` package. The console
+> entrypoint is now `hydraflow = server:main` (see `pyproject.toml`), and
+> runtime control moved to the dashboard `/api/control/*` routes. This decision
+> was reverted rather than replaced; there is no successor ADR.
 
 ## Context
 
@@ -31,7 +37,7 @@ all CLI operations (clean, prep, scaffold, labels, audit).
 ## Decision
 
 Use **argparse** (Python standard library) as the CLI framework, paired with a
-**config builder pattern** implemented in `build_config()` (`src/cli.py`).
+**config builder pattern** implemented in `build_config()` (`cli.py`, since removed).
 
 ### Framework: argparse over Click
 
@@ -107,8 +113,8 @@ without requiring a shared CLI framework.
 ## Related
 
 - Source memory: Issue #2268
-- `src/cli.py` — `build_config()`, `parse_args()`, `main()`
-- `src/hf_cli/__main__.py` — Two-layer CLI dispatcher
+- `cli.py` (removed) — `build_config()`, `parse_args()`, `main()`
+- `hf_cli/__main__.py` (removed) — Two-layer CLI dispatcher
 - `src/config.py` — `HydraFlowConfig` Pydantic model
 - ADR-0004 (agent cli as runtime) — related but distinct: that ADR covers
   agent invocation via CLI subprocesses, this ADR covers HydraFlow's own CLI

--- a/docs/adr/0038-multi-repo-architecture-wiring-pattern.md
+++ b/docs/adr/0038-multi-repo-architecture-wiring-pattern.md
@@ -9,7 +9,7 @@
 HydraFlow's multi-repo support relies on `RepoRuntime` (bundles config, event bus,
 state tracker, and orchestrator per repository) and `RepoRuntimeRegistry` (manages
 multiple `RepoRuntime` instances by slug). Both abstractions exist in
-`src/repo_runtime.py` and the dashboard routes in `src/dashboard_routes.py` already
+`src/repo_runtime.py` and the dashboard routes in `src/dashboard_routes/_routes.py` already
 accept an optional `registry` parameter with a `_resolve_runtime()` fallback that
 transparently supports single-repo and multi-repo modes.
 
@@ -118,4 +118,4 @@ across the multi-repo deployment. They serve different architectural layers:
 - `src/repo_runtime.py` — `RepoRuntime` and `RepoRuntimeRegistry`
 - `src/server.py` — `_run_with_dashboard()` and `_run_headless()` startup paths
 - `src/dashboard.py` — `HydraFlowDashboard` (already accepts `registry` parameter)
-- `src/dashboard_routes.py` — `create_router()` and `_resolve_runtime()`
+- `src/dashboard_routes/_routes.py:create_router` — `create_router()` and `_resolve_runtime()`

--- a/docs/adr/0043-dynamic-plugin-skill-loading.md
+++ b/docs/adr/0043-dynamic-plugin-skill-loading.md
@@ -25,7 +25,7 @@ In practice the system leaks value in three ways:
 
 Do three things together, in one PR:
 
-1. **Install at boot.** `_check_plugins` in `src/preflight.py` shells out to `claude plugin install <name>@<marketplace> --scope user` for each missing Tier‑1 (and language-matched Tier‑2) plugin, then re-verifies. Still FAILs — but only if the install itself fails. Toggleable via `auto_install_plugins: bool = True`.
+1. **Install at boot.** `_check_plugins` in `src/preflight/__init__.py` shells out to `claude plugin install <name>@<marketplace> --scope user` for each missing Tier‑1 (and language-matched Tier‑2) plugin, then re-verifies. Still FAILs — but only if the install itself fails. Toggleable via `auto_install_plugins: bool = True`.
 2. **Rewrite the preamble.** `format_plugin_skills_for_prompt` emits a condensed version of `using-superpowers`: "even at 1% confidence you MUST invoke", process-first priority, a short red-flag reminder. Descriptions still come verbatim from `SKILL.md` frontmatter.
 3. **Per-phase whitelist.** A new `phase_skills: dict[str, list[str]]` config field maps each factory phase (`triage`, `discover`, `shape`, `planner`, `agent`, `reviewer`) to a curated set of qualified skill names. Each runner filters discovery through its whitelist before formatting.
 

--- a/docs/adr/0046-meta-observability-bounded-recursion.md
+++ b/docs/adr/0046-meta-observability-bounded-recursion.md
@@ -5,7 +5,7 @@
 - **Supersedes:** none
 - **Superseded by:** none
 - **Related:** [ADR-0045](0045-trust-architecture-hardening.md) (establishes the trust fleet that this ADR supervises)
-- **Enforced by:** `src/trust_fleet_sanity_loop.py::TrustFleetSanityLoop` (the meta-observer); `src/health_monitor_loop.py::_check_sanity_loop_staleness` (the dead-man-switch watching the meta-observer); `tests/test_health_monitor_sanity_stall.py` (runtime enforcement test).
+- **Enforced by:** `src/trust_fleet_sanity_loop.py:TrustFleetSanityLoop` (the meta-observer); `src/health_monitor_loop.py:_check_sanity_loop_staleness` (the dead-man-switch watching the meta-observer); `tests/test_health_monitor_sanity_stall.py` (runtime enforcement test).
 
 ## Context
 

--- a/docs/adr/0059-advisor-pattern-self-repairing-review.md
+++ b/docs/adr/0059-advisor-pattern-self-repairing-review.md
@@ -52,7 +52,7 @@ favour of the single-source-of-truth `post_verify_authority`):
    - Per-role: `HYDRAFLOW_REVIEW_PREFLIGHT_ENABLED`, `HYDRAFLOW_REVIEW_MIDFLIGHT_ENABLED`, `HYDRAFLOW_REVIEW_POSTVERIFY_ENABLED`
    - Per-surface: `HYDRAFLOW_<SURFACE>_ADVISOR_ENABLED`
    Kill-switch state is resolved **once per review at start**; mid-review flips do not take effect (consistent with [ADR-0049](0049-trust-loop-kill-switch-convention.md)'s tick-boundary semantics, adapted to per-review boundaries here).
-3. **Self-modification guard** (T29) — when a diff modifies `src/review_advisor.py` or `src/review_phase.py`, post-verify authority is **forced to `veto`** regardless of surface config. Prevents the advisor from approving changes to itself in `wiki_ingest` (advisory) mode.
+3. **Self-modification guard** (T29) — when a diff modifies `src/review_advisor.py` or `src/review_phase/_phase.py`, post-verify authority is **forced to `veto`** regardless of surface config. Prevents the advisor from approving changes to itself in `wiki_ingest` (advisory) mode.
 4. **Failure-soft contract** — advisor crashes / parse errors degrade per-role:
    - Pre-flight failure → `None` (executor proceeds without plan).
    - Mid-flight failure → executor proceeds with own judgment.
@@ -91,9 +91,9 @@ Nine OTel metrics (all surface-tagged), wired via [ADR-0055](0055-otel-honeycomb
 
 **Negative:**
 
-- Adds ~3500 lines of code + tests across `src/review_advisor.py`, `src/review_phase.py`, `src/reviewer.py`, `src/mockworld/fakes/fake_llm.py`, and `tests/`.
+- Adds ~3500 lines of code + tests across `src/review_advisor.py`, `src/review_phase/_phase.py`, `src/reviewer.py`, `src/mockworld/fakes/fake_llm.py`, and `tests/`.
 - Each advisor invocation is a Claude Code subagent dispatch — measurable latency and cost. Mitigated by per-surface tiering and conditional pre-flight (composite trigger skips trivial PRs).
-- `src/review_phase.py` grew to ~3700 lines. Phase 5+ should consider extraction (per cumulative review M2, see *When to supersede* below).
+- `src/review_phase/_phase.py` grew to ~3700 lines. Phase 5+ should consider extraction (per cumulative review M2, see *When to supersede* below).
 
 **Risks:**
 
@@ -114,13 +114,13 @@ Nine OTel metrics (all surface-tagged), wired via [ADR-0055](0055-otel-honeycomb
 
 - If a future feature replaces the advisor pattern (e.g. a unified executor with built-in second-opinion reasoning), supersede with rationale.
 - If empirical KPIs after staging soak deviate significantly from the targets in §Telemetry, supersede with the new tuning + fresh KPI bands.
-- If the helper duplication cleanup (Phase 5 cumulative review M1+M2 — extract a `_run_post_verify_for_surface` skeleton from the per-surface wiring in `src/review_phase.py`) materially changes the wiring shape, supersede.
+- If the helper duplication cleanup (Phase 5 cumulative review M1+M2 — extract a `_run_post_verify_for_surface` skeleton from the per-surface wiring in `src/review_phase/_phase.py`) materially changes the wiring shape, supersede.
 - If the runtime gains literal shared-session subagent semantics (Claude Code roadmap), revisit the artifact-based sharing decision and supersede if the literal shape becomes preferable.
 
 ## Source-file citations
 
 - `src/review_advisor.py` — schemas, env helpers, advisor classes, `_SURFACE_DEFAULTS`, telemetry.
-- `src/review_phase.py` — wiring across 5 surfaces, retry loop, runner adapter, self-modification guard.
+- `src/review_phase/_phase.py` — wiring across 5 surfaces, retry loop, runner adapter, self-modification guard.
 - `src/reviewer.py` — executor prompt threading (pre-flight plan injection).
 - `src/mockworld/fakes/fake_llm.py` — `_FakeAdvisorRunner` for scenario testing.
 - `.claude/agents/hydraflow-review-advisor.md` — Opus subagent definition.

--- a/docs/adr/0071-route-back-counter-port.md
+++ b/docs/adr/0071-route-back-counter-port.md
@@ -35,5 +35,5 @@ Production wiring passes `StateTracker`. Tests pass a small in-memory dict imple
 ## Related
 
 - `src/route_back.py:RouteBackCounterPort`, `src/route_back.py:RouteBackCoordinator`
-- `src/state.py:StateTracker` — production implementation
+- `src/state/__init__.py:StateTracker` — production implementation
 - `tests/test_route_back.py` — enforces the rollback invariant

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,51 +1,51 @@
 {
-  "regenerated_at": "2026-07-19T00:50:19.871969+00:00",
-  "commit_sha": "0e40eb72bd8431c00551e098ca9511d70ce3b300",
+  "regenerated_at": "2026-07-19T04:18:01.263076+00:00",
+  "commit_sha": "6fcd40c940e9a5eafd15ddc248283536976411a8",
   "artifacts": {
     "loops.md": {
-      "source_sha": "0e40eb72bd8431c00551e098ca9511d70ce3b300"
+      "source_sha": "6fcd40c940e9a5eafd15ddc248283536976411a8"
     },
     "ports.md": {
-      "source_sha": "0e40eb72bd8431c00551e098ca9511d70ce3b300"
+      "source_sha": "6fcd40c940e9a5eafd15ddc248283536976411a8"
     },
     "labels.md": {
-      "source_sha": "0e40eb72bd8431c00551e098ca9511d70ce3b300"
+      "source_sha": "6fcd40c940e9a5eafd15ddc248283536976411a8"
     },
     "modules.md": {
-      "source_sha": "0e40eb72bd8431c00551e098ca9511d70ce3b300"
+      "source_sha": "6fcd40c940e9a5eafd15ddc248283536976411a8"
     },
     "events.md": {
-      "source_sha": "0e40eb72bd8431c00551e098ca9511d70ce3b300"
+      "source_sha": "6fcd40c940e9a5eafd15ddc248283536976411a8"
     },
     "adr_xref.md": {
-      "source_sha": "0e40eb72bd8431c00551e098ca9511d70ce3b300"
+      "source_sha": "6fcd40c940e9a5eafd15ddc248283536976411a8"
     },
     "mockworld.md": {
-      "source_sha": "0e40eb72bd8431c00551e098ca9511d70ce3b300"
+      "source_sha": "6fcd40c940e9a5eafd15ddc248283536976411a8"
     },
     "changelog.md": {
-      "source_sha": "0e40eb72bd8431c00551e098ca9511d70ce3b300"
+      "source_sha": "6fcd40c940e9a5eafd15ddc248283536976411a8"
     },
     "coverage_matrix.md": {
-      "source_sha": "0e40eb72bd8431c00551e098ca9511d70ce3b300"
+      "source_sha": "6fcd40c940e9a5eafd15ddc248283536976411a8"
     },
     "adr-conformance.md": {
-      "source_sha": "0e40eb72bd8431c00551e098ca9511d70ce3b300"
+      "source_sha": "6fcd40c940e9a5eafd15ddc248283536976411a8"
     },
     "ai_system_inventory.md": {
-      "source_sha": "0e40eb72bd8431c00551e098ca9511d70ce3b300"
+      "source_sha": "6fcd40c940e9a5eafd15ddc248283536976411a8"
     },
     "traceability_matrix.md": {
-      "source_sha": "0e40eb72bd8431c00551e098ca9511d70ce3b300"
+      "source_sha": "6fcd40c940e9a5eafd15ddc248283536976411a8"
     },
     "functional_areas.md": {
-      "source_sha": "0e40eb72bd8431c00551e098ca9511d70ce3b300"
+      "source_sha": "6fcd40c940e9a5eafd15ddc248283536976411a8"
     },
     "ubiquitous-language.md": {
-      "source_sha": "0e40eb72bd8431c00551e098ca9511d70ce3b300"
+      "source_sha": "6fcd40c940e9a5eafd15ddc248283536976411a8"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "0e40eb72bd8431c00551e098ca9511d70ce3b300"
+      "source_sha": "6fcd40c940e9a5eafd15ddc248283536976411a8"
     }
   }
 }

--- a/docs/arch/generated/adr-conformance.md
+++ b/docs/arch/generated/adr-conformance.md
@@ -38,7 +38,6 @@ Static structural map of ADR enforcement, derived purely from parsing Accepted A
 | ADR-0032 | enforced | `pytest:tests/test_repo_wiki.py`, `pytest:tests/test_repo_wiki_store_git.py`, `pytest:tests/test_repo_wiki_ingest.py`, `pytest:tests/test_wiki_drift_detector.py`, `pytest:tests/test_wiki_drift_symbols.py`, `pytest:tests/test_wiki_semantic_drift.py`, `pytest:tests/test_repo_wiki_temporal.py`, `pytest:tests/test_wiki_corroboration.py` |
 | ADR-0034 | enforced | `pytest:tests/test_state_machine.py` |
 | ADR-0035 | manual | `Code review checklist item (Decision §3) applied during PR review of any change touching toggle-gated logic; see also 'docs/wiki/testing.md'.` |
-| ADR-0036 | manual | `Code review of 'src/cli.py:build_config()' and 'src/hf_cli/__main__.py' dispatch wiring during PR review of CLI/config changes.` |
 | ADR-0037 | enforced | `pytest:tests/test_adr_pre_validator.py` |
 | ADR-0041 | enforced | `pytest:tests/test_issue_cache.py`, `pytest:tests/test_precondition_gate.py` |
 | ADR-0042 | manual | `branch-protection ruleset review per docs/standards/branch_protection` |
@@ -86,7 +85,6 @@ Static structural map of ADR enforcement, derived purely from parsing Accepted A
 | `'superpowers:subagent-driven-development' workflow (per-task reviews), this ADR (process documentation), 'superpowers:requesting-code-review' (which dispatches the 'code-reviewer' agent) skill (the fresh-eyes reviewer) — a process convention, not a runnable check.` | ADR-0051 |
 | `Code review checklist (see "Review checklist addition" below) — reviewers verify every test-local class is instantiated or referenced; no automated CI check exists (see "Scope boundaries").` | ADR-0023 |
 | `Code review checklist item (Decision §3) applied during PR review of any change touching toggle-gated logic; see also 'docs/wiki/testing.md'.` | ADR-0035 |
-| `Code review of 'src/cli.py:build_config()' and 'src/hf_cli/__main__.py' dispatch wiring during PR review of CLI/config changes.` | ADR-0036 |
 | `Process check — 'grep -rn 'code_grooming\|CodeGrooming' src/ tests/ docs/' must return no live references; only this ADR and the historical date-stamped snapshot in 'docs/arch/area_review_caretaking_2026-05-12.md' are allowed to mention the removed loop. Closes #8984.` | ADR-0065 |
 | `Process guardrail — reviewed at PR time via the process-per-repo model's operational invariants (one 'cli.py' subprocess per repo slug, no shared mutable state); no automated test asserts subprocess isolation directly.` | ADR-0009 |
 | `Review checklist — reviewers verify symmetric field-assertion coverage (all three legs per method) by searching for the field name across test functions for the affected methods (see "Review checklist" under Consequences).` | ADR-0025 |
@@ -197,7 +195,6 @@ Static structural map of ADR enforcement, derived purely from parsing Accepted A
 | ADR-0023 | `Code review checklist (see "Review checklist addition" below) — reviewers verify every test-local class is instantiated or referenced; no automated CI check exists (see "Scope boundaries").` |
 | ADR-0025 | `Review checklist — reviewers verify symmetric field-assertion coverage (all three legs per method) by searching for the field name across test functions for the affected methods (see "Review checklist" under Consequences).` |
 | ADR-0035 | `Code review checklist item (Decision §3) applied during PR review of any change touching toggle-gated logic; see also 'docs/wiki/testing.md'.` |
-| ADR-0036 | `Code review of 'src/cli.py:build_config()' and 'src/hf_cli/__main__.py' dispatch wiring during PR review of CLI/config changes.` |
 | ADR-0042 | `branch-protection ruleset review per docs/standards/branch_protection` |
 | ADR-0051 | `'superpowers:subagent-driven-development' workflow (per-task reviews), this ADR (process documentation), 'superpowers:requesting-code-review' (which dispatches the 'code-reviewer' agent) skill (the fresh-eyes reviewer) — a process convention, not a runnable check.` |
 | ADR-0065 | `Process check — 'grep -rn 'code_grooming\|CodeGrooming' src/ tests/ docs/' must return no live references; only this ADR and the historical date-stamped snapshot in 'docs/arch/area_review_caretaking_2026-05-12.md' are allowed to mention the removed loop. Closes #8984.` |

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -10,49 +10,49 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 |---|---|---|
 | ADR-0001 | — | `pytest:tests/test_orchestrator_loops.py`, `pytest:tests/architecture/test_loop_count_matches_adr0001.py` |
 | ADR-0002 | `src.config`, `src.pr_manager` | `pytest:tests/test_state_machine.py` |
-| ADR-0003 | `src.ports`, `src.worktree` | — |
+| ADR-0003 | `src.ports`, `src.workspace` | — |
 | ADR-0004 | `src.agent_cli`, `src.base_runner` | `pytest:tests/test_agent_cli.py`, `pytest:tests/test_base_runner.py` |
 | ADR-0005 | `src.implement_phase`, `src.pr_manager` | `pytest:tests/test_implement_phase.py` |
-| ADR-0006 | `src.events`, `src.hf_cli.supervisor_service`, `src.issue_store`, `src.orchestrator`, `src.state` | — |
-| ADR-0007 | `src.dashboard`, `src.dashboard_routes._routes`, `src.hf_cli.supervisor_client`, `src.hf_cli.supervisor_service` | `pytest:tests/test_dashboard_routes_repo.py` |
-| ADR-0008 | `src.dashboard`, `src.dashboard_routes`, `src.hf_cli.supervisor_service` | `pytest:tests/test_dashboard_routes_repo.py` |
+| ADR-0006 | `src.events`, `src.issue_store`, `src.orchestrator`, `src.repo_runtime`, `src.state.__init__` | — |
+| ADR-0007 | `src.dashboard`, `src.dashboard_routes._routes`, `src.dashboard_routes._state_routes`, `src.repo_runtime` | `pytest:tests/test_dashboard_routes_repo.py` |
+| ADR-0008 | `src.dashboard`, `src.dashboard_routes._routes`, `src.repo_runtime` | `pytest:tests/test_dashboard_routes_repo.py` |
 | ADR-0009 | `src.config`, `src.orchestrator`, `src.repo_runtime`, `src.workspace` | `Process guardrail — reviewed at PR time via the process-per-repo model's operational invariants (one 'cli.py' subprocess per repo slug, no shared mutable state); no automated test asserts subprocess isolation directly.` |
-| ADR-0010 | `src.config`, `src.docker_runner`, `src.metrics_manager`, `src.worktree` | `pytest:tests/test_integration_worktree.py` |
+| ADR-0010 | `src.config`, `src.docker_runner`, `src.metrics_manager`, `src.workspace` | `pytest:tests/test_integration_worktree.py` |
 | ADR-0011 | `src.epic`, `src.models`, `src.pr_manager` | `pytest:tests/test_epic.py`, `pytest:tests/test_release.py` |
-| ADR-0012 | `src.epic`, `src.epic_monitor_loop`, `src.models`, `src.post_merge_handler`, `src.review_phase` | `pytest:tests/test_epic_merge_coordination.py` |
-| ADR-0013 | `src.dashboard_routes`, `src.models`, `src.pr_manager`, `src.report_issue_loop`, `src.state` | — |
-| ADR-0014 | `src.implement_phase`, `src.models`, `src.orchestrator`, `src.plan_phase`, `src.post_merge_handler`, `src.review_phase`, `src.state`, `src.triage_phase` | `pytest:tests/test_state_machine.py` |
-| ADR-0015 | `src.escalation_gate`, `src.models`, `src.post_merge_handler`, `src.review_phase`, `src.visual_validation` | `pytest:tests/test_review_phase_hooks.py` |
+| ADR-0012 | `src.epic`, `src.epic_monitor_loop`, `src.models`, `src.post_merge_handler`, `src.review_phase._phase` | `pytest:tests/test_epic_merge_coordination.py` |
+| ADR-0013 | `src.dashboard_routes._reports_routes`, `src.models`, `src.pr_manager`, `src.report_issue_loop`, `src.state._report` | — |
+| ADR-0014 | `src.implement_phase`, `src.models`, `src.orchestrator`, `src.plan_phase`, `src.post_merge_handler`, `src.review_phase._phase`, `src.state._session`, `src.triage_phase` | `pytest:tests/test_state_machine.py` |
+| ADR-0015 | `src.escalation_gate`, `src.models`, `src.post_merge_handler`, `src.review_phase._phase`, `src.visual_validation` | `pytest:tests/test_review_phase_hooks.py` |
 | ADR-0016 | `src.models`, `src.post_merge_handler` | `pytest:tests/test_visual_validation.py` |
-| ADR-0017 | `src.state`, `src.triage_phase` | `pytest:tests/test_state_machine.py` |
+| ADR-0017 | `src.state.__init__`, `src.triage_phase` | `pytest:tests/test_state_machine.py` |
 | ADR-0018 | `src.config`, `src.pr_manager`, `src.report_issue_loop`, `src.screenshot_scanner` | `pytest:tests/test_screenshot_scanner.py`, `pytest:tests/test_report_issue_loop.py` |
-| ADR-0019 | `src.dashboard_routes`, `src.epic`, `src.issue_fetcher`, `src.post_merge_handler` | `pytest:tests/test_epic_manager.py`, `pytest:tests/test_post_merge_handler.py` |
+| ADR-0019 | `src.dashboard_routes._epic_routes`, `src.epic`, `src.issue_fetcher`, `src.post_merge_handler` | `pytest:tests/test_epic_manager.py`, `pytest:tests/test_post_merge_handler.py` |
 | ADR-0020 | — | — |
 | ADR-0021 | `src.config`, `src.data_migration`, `src.file_util`, `src.metrics_manager`, `src.state._session` | `pytest:tests/test_state_persistence.py`, `pytest:tests/test_event_persistence.py`, `pytest:tests/test_data_migration_d2.py` |
 | ADR-0022 | `src.config`, `src.issue_store` | `pytest:tests/test_integration_pipeline.py` |
 | ADR-0023 | — | `Code review checklist (see "Review checklist addition" below) — reviewers verify every test-local class is instantiated or referenced; no automated CI check exists (see "Scope boundaries").` |
-| ADR-0024 | `src.agent`, `src.implement_phase`, `src.state` | `pytest:tests/test_implement_phase.py`, `pytest:tests/scenarios/fakes/test_prior_failure_propagation.py` |
+| ADR-0024 | `src.agent`, `src.implement_phase`, `src.state.__init__` | `pytest:tests/test_implement_phase.py`, `pytest:tests/scenarios/fakes/test_prior_failure_propagation.py` |
 | ADR-0025 | `src.models`, `src.reviewer` | `Review checklist — reviewers verify symmetric field-assertion coverage (all three legs per method) by searching for the field name across test functions for the affected methods (see "Review checklist" under Consequences).` |
 | ADR-0027 | `src.agent`, `src.reviewer` | — |
 | ADR-0028 | — | `pytest:tests/test_report_event_flow.py` |
 | ADR-0029 | — | `pytest:tests/test_caretaker_loop_wiring.py` |
 | ADR-0030 | `src.dashboard_routes._routes` | — |
-| ADR-0031 | `src.config`, `src.discover_phase`, `src.discover_runner`, `src.models`, `src.plan_phase`, `src.review_phase`, `src.shape_phase`, `src.shape_runner`, `src.triage_phase` | `pytest:tests/test_discover_phase.py`, `pytest:tests/test_shape_phase.py`, `pytest:tests/test_discover_runner.py`, `pytest:tests/test_shape_runner.py`, `pytest:tests/architecture/test_functional_area_coverage.py` |
+| ADR-0031 | `src.config`, `src.discover_phase`, `src.discover_runner`, `src.models`, `src.plan_phase`, `src.review_phase._phase`, `src.shape_phase`, `src.shape_runner`, `src.triage_phase` | `pytest:tests/test_discover_phase.py`, `pytest:tests/test_shape_phase.py`, `pytest:tests/test_discover_runner.py`, `pytest:tests/test_shape_runner.py`, `pytest:tests/architecture/test_functional_area_coverage.py` |
 | ADR-0032 | `src.base_runner`, `src.repo_wiki`, `src.repo_wiki_loop`, `src.wiki_compiler` | `pytest:tests/test_repo_wiki.py`, `pytest:tests/test_repo_wiki_store_git.py`, `pytest:tests/test_repo_wiki_ingest.py`, `pytest:tests/test_wiki_drift_detector.py`, `pytest:tests/test_wiki_drift_symbols.py`, `pytest:tests/test_wiki_semantic_drift.py`, `pytest:tests/test_repo_wiki_temporal.py`, `pytest:tests/test_wiki_corroboration.py` |
 | ADR-0033 | `src.adr_reviewer`, `src.config` | — |
 | ADR-0034 | `src.adr_reviewer`, `src.config` | `pytest:tests/test_state_machine.py` |
 | ADR-0035 | `src.config` | `Code review checklist item (Decision §3) applied during PR review of any change touching toggle-gated logic; see also 'docs/wiki/testing.md'.` |
-| ADR-0036 | `src.cli`, `src.config`, `src.hf_cli.__main__` | `Code review of 'src/cli.py:build_config()' and 'src/hf_cli/__main__.py' dispatch wiring during PR review of CLI/config changes.` |
+| ADR-0036 | `src.config` | `n/a (decision reverted — CLI removed)` |
 | ADR-0037 | `src.adr_pre_validator`, `src.adr_reviewer`, `src.models` | `pytest:tests/test_adr_pre_validator.py` |
-| ADR-0038 | `src.dashboard`, `src.dashboard_routes`, `src.repo_runtime`, `src.server` | — |
+| ADR-0038 | `src.dashboard`, `src.dashboard_routes._routes`, `src.repo_runtime`, `src.server` | — |
 | ADR-0039 | `src.adr_reviewer`, `src.triage_phase` | — |
 | ADR-0040 | `src.adr_reviewer` | — |
 | ADR-0041 | `src.caching_issue_store`, `src.issue_cache`, `src.issue_store`, `src.precondition_gate`, `src.route_back` | `pytest:tests/test_issue_cache.py`, `pytest:tests/test_precondition_gate.py` |
 | ADR-0042 | — | `branch-protection ruleset review per docs/standards/branch_protection` |
-| ADR-0043 | `src.docker_runner`, `src.preflight` | `pytest:tests/test_preflight_plugins.py`, `pytest:tests/test_phase_skill_filter.py` |
+| ADR-0043 | `src.docker_runner`, `src.preflight.__init__` | `pytest:tests/test_preflight_plugins.py`, `pytest:tests/test_phase_skill_filter.py` |
 | ADR-0044 | `src.orchestrator`, `src.ports` | `scripts/hydraflow_audit/* (structural/behavioural checks), tests/test_planner.py::test_build_prompt_includes_principles_checklist, tests/test_reviewer.py::test_build_review_prompt_includes_hydraflow_principles_checks (prompt-level enforcement in plan + review phases)` |
 | ADR-0045 | `src.config`, `src.contract_refresh_loop`, `src.corpus_learning_loop`, `src.dashboard_routes._cost_rollups`, `src.discover_phase`, `src.discover_runner`, `src.fake_coverage_auditor_loop`, `src.flake_tracker_loop`, `src.health_monitor_loop`, `src.models`, `src.orchestrator`, `src.pr_manager`, `src.principles_audit_loop`, `src.rc_budget_loop`, `src.report_issue_loop`, `src.service_registry`, `src.shape_phase`, `src.shape_runner`, `src.skill_prompt_eval_loop`, `src.staging_bisect_loop`, `src.trust_fleet_sanity_loop`, `src.wiki_rot_detector_loop` | `pytest:tests/test_trust_fleet_sanity_loop.py`, `pytest:tests/test_loop_wiring_completeness.py`, `pytest:tests/test_trust_fleet_anomaly_detectors.py` |
-| ADR-0046 | `src.health_monitor_loop`, `src.trust_fleet_sanity_loop` | `'src/trust_fleet_sanity_loop.py::TrustFleetSanityLoop' (the meta-observer); 'src/health_monitor_loop.py::_check_sanity_loop_staleness' (the dead-man-switch watching the meta-observer); 'tests/test_health_monitor_sanity_stall.py' (runtime enforcement test).` |
+| ADR-0046 | `src.health_monitor_loop`, `src.trust_fleet_sanity_loop` | `'src/trust_fleet_sanity_loop.py:TrustFleetSanityLoop' (the meta-observer); 'src/health_monitor_loop.py:_check_sanity_loop_staleness' (the dead-man-switch watching the meta-observer); 'tests/test_health_monitor_sanity_stall.py' (runtime enforcement test).` |
 | ADR-0047 | `src.contract_diff`, `src.contract_recording`, `src.contract_refresh_loop` | `make:trust-contracts`, `pytest:tests/trust/contracts/test_fake_github_contract.py` |
 | ADR-0048 | `src.staging_bisect_loop` | `'src/staging_bisect_loop.py' (the loop that performs the auto-revert); 'tests/test_staging_bisect_loop.py'; 'tests/scenarios/test_staging_bisect_scenario.py'; 'tests/test_staging_bisect_e2e.py' (three-commit fixture); watchdog in '_check_pending_watchdog'; guardrail in '_check_guardrail_and_maybe_escalate'.` |
 | ADR-0049 | `src.base_background_loop`, `src.bg_worker_manager` | `pytest:tests/test_loop_kill_switch_completeness.py`, `pytest:tests/regressions/test_canonical_killswitch.py` |
@@ -65,7 +65,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | ADR-0056 | `src.adr_drift`, `src.adr_touchpoint_auditor_loop`, `src.state._adr_audit` | `pytest:tests/test_adr_touchpoint_auditor_loop.py` |
 | ADR-0057 | `src.term_pruner_loop`, `src.ubiquitous_language` | `pytest:tests/test_term_pruner_loop.py`, `pytest:tests/architecture/test_term_pruner_wiring.py` |
 | ADR-0058 | `src.edge_proposer_loop`, `src.ubiquitous_language` | `pytest:tests/test_edge_proposer_loop.py`, `pytest:tests/architecture/test_edge_proposer_wiring.py` |
-| ADR-0059 | `src.mockworld.fakes.fake_llm`, `src.review_advisor`, `src.review_phase`, `src.reviewer` | `'tests/test_review_advisor.py' (~100+ unit tests covering all 5 surfaces); 'tests/scenarios/test_pr_review_advisor_*.py' (11 Tier-1 MockWorld scenarios); 'tests/test_review_phase_core.py::TestSelfModificationGuard' (T29 self-modification guard); 'make quality' CI gate.` |
+| ADR-0059 | `src.mockworld.fakes.fake_llm`, `src.review_advisor`, `src.review_phase._phase`, `src.reviewer` | `'tests/test_review_advisor.py' (~100+ unit tests covering all 5 surfaces); 'tests/scenarios/test_pr_review_advisor_*.py' (11 Tier-1 MockWorld scenarios); 'tests/test_review_phase_core.py::TestSelfModificationGuard' (T29 self-modification guard); 'make quality' CI gate.` |
 | ADR-0060 | `src.dashboard_routes._atlas_routes` | `pytest:tests/test_atlas_routes.py` |
 | ADR-0061 | `src.repo_wiki` | `pytest:tests/test_atlas_routes.py` |
 | ADR-0062 | `src.entry_evidence_loop`, `src.term_proposer_llm` | `pytest:tests/test_entry_evidence_loop.py`, `pytest:tests/scenarios/test_entry_evidence_loop_scenario.py` |
@@ -77,7 +77,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | ADR-0068 | `src.ports`, `src.term_proposer_loop`, `src.term_pruner_loop` | `(none) — structural subtype check planned in follow-up` |
 | ADR-0069 | `src.ports`, `src.workspace_gc_loop` | `tests/test_workspace_gc_loop.py` |
 | ADR-0070 | `src.ports`, `src.review_insights` | `(none) — structural subtype check planned for 'tests/test_ports.py' in follow-up` |
-| ADR-0071 | `src.route_back`, `src.state` | `pytest:tests/test_route_back.py` |
+| ADR-0071 | `src.route_back`, `src.state.__init__` | `pytest:tests/test_route_back.py` |
 | ADR-0072 | `src.stale_issue_gc_loop`, `src.stale_issue_loop` | `tests/test_stale_issue_loop.py` |
 | ADR-0073 | `src.run_recorder`, `src.runs_gc_loop` | — |
 | ADR-0074 | `src.retrospective`, `src.retrospective_loop`, `src.retrospective_queue` | — |
@@ -139,7 +139,6 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.branch_protection_audit` | ADR-0082 |
 | `src.branch_protection_auditor_loop` | ADR-0082 |
 | `src.caching_issue_store` | ADR-0041 |
-| `src.cli` | ADR-0036 |
 | `src.code_grooming_loop` | ADR-0065 |
 | `src.complexity_gate` | ADR-0064 |
 | `src.config` | ADR-0002, ADR-0009, ADR-0010, ADR-0018, ADR-0021, ADR-0022, ADR-0031, ADR-0033, ADR-0034, ADR-0035, ADR-0036, ADR-0045, ADR-0050, ADR-0055, ADR-0065, ADR-0084, ADR-0094, ADR-0102, ADR-0103 |
@@ -152,11 +151,13 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.convergence_recording` | ADR-0096, ADR-0102 |
 | `src.corpus_learning_loop` | ADR-0045 |
 | `src.dashboard` | ADR-0007, ADR-0008, ADR-0038 |
-| `src.dashboard_routes` | ADR-0008, ADR-0013, ADR-0019, ADR-0038 |
 | `src.dashboard_routes._atlas_routes` | ADR-0060, ADR-0090 |
 | `src.dashboard_routes._cost_rollups` | ADR-0045 |
 | `src.dashboard_routes._diagnostics_routes` | ADR-0050 |
-| `src.dashboard_routes._routes` | ADR-0007, ADR-0030 |
+| `src.dashboard_routes._epic_routes` | ADR-0019 |
+| `src.dashboard_routes._reports_routes` | ADR-0013 |
+| `src.dashboard_routes._routes` | ADR-0007, ADR-0008, ADR-0030, ADR-0038 |
+| `src.dashboard_routes._state_routes` | ADR-0007 |
 | `src.data_migration` | ADR-0021 |
 | `src.discover_completeness` | ADR-0103 |
 | `src.discover_phase` | ADR-0031, ADR-0045 |
@@ -189,9 +190,6 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.github_cache_loop` | ADR-0076 |
 | `src.harness_insights` | ADR-0099 |
 | `src.health_monitor_loop` | ADR-0045, ADR-0046 |
-| `src.hf_cli.__main__` | ADR-0036 |
-| `src.hf_cli.supervisor_client` | ADR-0007 |
-| `src.hf_cli.supervisor_service` | ADR-0006, ADR-0007, ADR-0008 |
 | `src.hitl_runner` | ADR-0103 |
 | `src.human_steering` | ADR-0103 |
 | `src.human_steering_loop` | ADR-0103 |
@@ -223,7 +221,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.pr_unsticker` | ADR-0077 |
 | `src.pr_unsticker_loop` | ADR-0077 |
 | `src.precondition_gate` | ADR-0041 |
-| `src.preflight` | ADR-0043 |
+| `src.preflight.__init__` | ADR-0043 |
 | `src.preflight.agent` | ADR-0050, ADR-0084 |
 | `src.preflight.audit` | ADR-0050 |
 | `src.preflight.auto_agent_runner` | ADR-0050 |
@@ -236,7 +234,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.prompt_builder` | ADR-0087 |
 | `src.prompt_template` | ADR-0087 |
 | `src.rc_budget_loop` | ADR-0045 |
-| `src.repo_runtime` | ADR-0009, ADR-0038 |
+| `src.repo_runtime` | ADR-0006, ADR-0007, ADR-0008, ADR-0009, ADR-0038 |
 | `src.repo_wiki` | ADR-0032, ADR-0053, ADR-0061 |
 | `src.repo_wiki_loop` | ADR-0032, ADR-0053 |
 | `src.report_issue_loop` | ADR-0013, ADR-0018, ADR-0045 |
@@ -245,8 +243,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.retrospective_queue` | ADR-0074 |
 | `src.review_advisor` | ADR-0059, ADR-0094, ADR-0095, ADR-0099, ADR-0103 |
 | `src.review_insights` | ADR-0070 |
-| `src.review_phase` | ADR-0012, ADR-0014, ADR-0015, ADR-0031, ADR-0059 |
-| `src.review_phase._phase` | ADR-0063, ADR-0094, ADR-0095, ADR-0102 |
+| `src.review_phase._phase` | ADR-0012, ADR-0014, ADR-0015, ADR-0031, ADR-0059, ADR-0063, ADR-0094, ADR-0095, ADR-0102 |
 | `src.reviewer` | ADR-0025, ADR-0027, ADR-0059, ADR-0103 |
 | `src.route_back` | ADR-0041, ADR-0071 |
 | `src.run_recorder` | ADR-0073 |
@@ -268,12 +265,13 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.staging_bisect_loop` | ADR-0045, ADR-0048 |
 | `src.stale_issue_gc_loop` | ADR-0072 |
 | `src.stale_issue_loop` | ADR-0072 |
-| `src.state` | ADR-0006, ADR-0013, ADR-0014, ADR-0017, ADR-0024, ADR-0071 |
+| `src.state.__init__` | ADR-0006, ADR-0017, ADR-0024, ADR-0071 |
 | `src.state._adr_audit` | ADR-0056 |
 | `src.state._auto_agent` | ADR-0050, ADR-0097 |
 | `src.state._convergence` | ADR-0094, ADR-0097, ADR-0098 |
+| `src.state._report` | ADR-0013 |
 | `src.state._sandbox_failure_fixer` | ADR-0097 |
-| `src.state._session` | ADR-0021 |
+| `src.state._session` | ADR-0014, ADR-0021 |
 | `src.telemetry.__init__` | ADR-0055 |
 | `src.telemetry.otel` | ADR-0055 |
 | `src.telemetry.slugs` | ADR-0055 |
@@ -291,8 +289,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.wiki_carryover` | ADR-0064 |
 | `src.wiki_compiler` | ADR-0032 |
 | `src.wiki_rot_detector_loop` | ADR-0045 |
-| `src.workspace` | ADR-0009, ADR-0055 |
+| `src.workspace` | ADR-0003, ADR-0009, ADR-0010, ADR-0055 |
 | `src.workspace_gc_loop` | ADR-0069 |
-| `src.worktree` | ADR-0003, ADR-0010 |
 
 <!-- arch:generated -->

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,8 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W29
 
+- `90be6dc` — docs(adr): resolve 5 ADR-drift rollups (#9950 #9779 #9781 #9775 #9418) (#9953) (#9953) *(2026-07-18)*
+- `0c27386` — fix(ul): single-flight guard — at most one open UL-graph bot PR across the family (#9893, #9890) (#9939) (#9939) *(2026-07-18)*
 - `4d20d74` — feat(ul): entry-evidence — 3 new entry links across 3 terms (#9926) (#9926) *(2026-07-18)*
 - `cb09ea0` — feat(ul): edge-proposer — 3 new edges across 3 terms (#9912) (#9912) *(2026-07-18)*
 - `15bbcac` — feat(ul): edge-proposer — 81 new edges across 40 terms (#9896) (#9896) *(2026-07-18)*

--- a/tests/architecture/test_adr_source_citations_exist.py
+++ b/tests/architecture/test_adr_source_citations_exist.py
@@ -1,0 +1,130 @@
+"""Ratchet: every live ADR's ``src/...py`` citation must resolve to a real file.
+
+Issue #9649 (umbrella; subsumes #9514, #9824, #9497, #9920, #9921). ADRs cite
+source files as ``` `src/foo.py` ``` or ``` `src/foo.py:Symbol` ```. When a
+module is renamed, split into a package, or deleted, those citations rot: the
+P2 drift gate (``adr_index.adrs_touching``) can never fire for the cited path
+because nothing at that path is ever touched, so the ADR silently loses its
+drift coverage (the #9514 double-colon typo was the same failure mode — an
+unparseable citation is a dead one).
+
+This test extracts citations with the SAME regex the runtime uses
+(``adr_index._SOURCE_FILE_CITATION_RE``) so the test's notion of "a citation"
+is exactly the drift gate's, then asserts each cited path exists. It is a
+one-way ratchet: no NEW dead citation can be added to a live (Accepted /
+Proposed) ADR, and the two documented exceptions below stay explicit.
+
+Scope decisions:
+  * Only Accepted / Proposed ADRs are checked — Superseded / Deprecated ADRs
+    never fire the drift gate, so a dead citation there is harmless history.
+  * Glob / placeholder citations (``src/**/*.py``, ``src/*_loop.py``,
+    ``src/<domain>/*.py``) are skipped — they are patterns, not file paths.
+  * ``_PERMANENT_ALLOWLIST`` holds paths that are *intentionally* absent and
+    documented as such by their citing ADR. It is guarded (see
+    ``test_permanent_allowlist_entries_are_actually_missing``) so it cannot
+    silently accrue stale entries.
+  * ``_GRANDFATHER`` holds not-yet-repointed dead paths so the ratchet can be
+    landed green and burned down later. It is empty today (everything
+    resolvable was repointed in #9649) and may only SHRINK.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from adr_index import scan_adr_directory
+
+# Paths deliberately absent from the tree, documented by their citing ADR.
+_PERMANENT_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # ADR-0065 (Accepted) documents the intentional REMOVAL of this loop.
+        "src/code_grooming_loop.py",
+        # ADR-0087 (Proposed) is aspirational; prompt_template.py is future
+        # work that was never built. Repoint or drop when the ADR is decided.
+        "src/prompt_template.py",
+    }
+)
+
+# Not-yet-repointed dead citations. May only SHRINK. Empty by design.
+_GRANDFATHER: frozenset[str] = frozenset()
+
+_LIVE_STATUSES = frozenset({"Accepted", "Proposed"})
+
+
+def _is_glob(path: str) -> bool:
+    """True for pattern citations (globs / ``<placeholder>`` templates)."""
+    return any(ch in path for ch in "*<>?[")
+
+
+def _cited_paths_by_adr(adr_dir: Path) -> list[tuple[int, str]]:
+    """(adr_number, cited_path) for every non-glob citation in a live ADR.
+
+    Uses the same directory scan + citation regex the runtime drift gate uses.
+    """
+    pairs: list[tuple[int, str]] = []
+    for adr in scan_adr_directory(adr_dir):
+        if adr.status not in _LIVE_STATUSES:
+            continue
+        for path in sorted(adr.source_files):
+            if _is_glob(path):
+                continue
+            pairs.append((adr.number, path))
+    return pairs
+
+
+def test_live_adr_source_citations_resolve(real_repo_root: Path) -> None:
+    adr_dir = real_repo_root / "docs" / "adr"
+    dead: list[str] = []
+    for number, path in _cited_paths_by_adr(adr_dir):
+        if path in _PERMANENT_ALLOWLIST or path in _GRANDFATHER:
+            continue
+        if not (real_repo_root / path).exists():
+            dead.append(f"ADR-{number:04d}: `{path}` does not exist")
+
+    assert dead == [], (
+        "Live ADRs cite source paths that no longer exist. Repoint each "
+        "citation to the file/symbol's real home, or (if the code was "
+        "intentionally removed) mark the ADR Superseded / reword the citation "
+        "to plain prose. Dead citations silently disable the P2 drift gate for "
+        "that ADR.\n  " + "\n  ".join(dead)
+    )
+
+
+def test_grandfather_entries_still_dead(real_repo_root: Path) -> None:
+    """The grandfather list may only shrink: an entry that now resolves must
+    be removed (and its citation is already correct)."""
+    resurfaced = [path for path in _GRANDFATHER if (real_repo_root / path).exists()]
+    assert resurfaced == [], (
+        "These grandfathered paths now exist — remove them from _GRANDFATHER:\n  "
+        + "\n  ".join(sorted(resurfaced))
+    )
+
+
+def test_permanent_allowlist_entries_are_actually_missing(
+    real_repo_root: Path,
+) -> None:
+    """Guard the permanent allowlist against rot: each entry must be a path
+    that is genuinely absent (removed or never-built code). If one reappears,
+    the allowlist entry is stale — repoint the citation and drop it here."""
+    present = [
+        path for path in _PERMANENT_ALLOWLIST if (real_repo_root / path).exists()
+    ]
+    assert present == [], (
+        "These permanent-allowlist paths now exist in the tree — the code was "
+        "(re)introduced, so the citation should be repointed and the entry "
+        "removed from _PERMANENT_ALLOWLIST:\n  " + "\n  ".join(sorted(present))
+    )
+
+
+def test_permanent_allowlist_entries_are_cited_by_a_live_adr(
+    real_repo_root: Path,
+) -> None:
+    """Guard against dead allowlist entries: every permanent exception must
+    still be cited by some live ADR, otherwise it is dead config to delete."""
+    adr_dir = real_repo_root / "docs" / "adr"
+    cited = {path for _number, path in _cited_paths_by_adr(adr_dir)}
+    orphaned = sorted(_PERMANENT_ALLOWLIST - cited)
+    assert orphaned == [], (
+        "These permanent-allowlist paths are no longer cited by any live ADR — "
+        "delete them from _PERMANENT_ALLOWLIST:\n  " + "\n  ".join(orphaned)
+    )


### PR DESCRIPTION
## Summary

Dead ADR→source citations silently disable the P2 drift gate (`adr_index.adrs_touching`): a citation that points at a renamed/split/deleted path can never match a touched file, so the ADR loses drift coverage. This PR repoints every resolvable citation to the real file/symbol, refreshes/supersedes the ADRs whose underlying layer was removed, and adds a one-way ratchet so no new dead citation can be introduced.

Resolves #9649 (umbrella). Closes #9514, #9824, #9497, #9920, #9921.

## What changed

**#9514 — ADR-0046 double-colon typo:** `file.py::Sym` → `file.py:Sym` (the regex is single-colon only, so the double-colon citation was unparseable = zero drift coverage).

**#9824 / #9497 — dead-path repoints** (monolith → package splits, all verified against the live tree):
- `worktree.py:WorktreeManager` → `workspace.py:WorkspaceManager` — ADR-0003, 0010
- `dashboard_routes.py` → `dashboard_routes/_{routes,epic_routes,reports_routes,state_routes}.py` — ADR-0007, 0008, 0013, 0019, 0038
- `state.py` → `state/` package (`__init__.py:StateTracker`, `_session.py`, `_report.py`) — ADR-0006, 0013, 0014, 0017, 0024, 0071
- `review_phase.py` → `review_phase/_phase.py` — ADR-0012, 0014, 0015, 0031, 0059
- `preflight.py` → `preflight/__init__.py` — ADR-0043

**#9920 — ADR-0007 REFRESH** (stays Accepted): the supervisor TCP layer is gone but the repo-aware dashboard API decision is still live (enforced by `tests/test_dashboard_routes_repo.py`). Context reworded to `src/repo_runtime.py` under one `server:main` process; Related repointed to `repo_runtime.py` + `dashboard_routes/_state_routes.py`.

**#9921 — ADR-0036 SUPERSEDE:** the argparse CLI was removed entirely (no `cli.py`, no `build_config`, no `hf_cli/`). Status Accepted → Superseded; Enforced-by → `n/a (decision reverted — CLI removed)`; header note added (entrypoint is now `hydraflow = server:main`). No successor ADR.

**#9649 — durable ratchet:** `tests/architecture/test_adr_source_citations_exist.py` asserts every non-glob `src/*.py` citation in a live (Accepted/Proposed) ADR resolves, using the same scan the drift gate uses. Guards:
- Permanent allowlist (documented, intentionally absent): `code_grooming_loop.py` (ADR-0065, removed) + `prompt_template.py` (ADR-0087, aspirational). Both are guarded so they can't rot (must stay missing AND still cited).
- Grandfather list is **empty** — everything resolvable was repointed.
- Superseded/Deprecated ADRs and glob citations are excluded (they never fire the gate / aren't paths).

`docs/arch/generated/*` regenerated via `make arch-regen`.

## Verification
- `tests/architecture/test_adr_source_citations_exist.py` — pass (4)
- `tests/test_adr_conformance_coverage.py`, `tests/architecture/test_adr_numbers_unique.py` — pass
- Also ran `test_adr_drift`, `test_adr_index`, `test_adr_touchpoints`, `test_issue_9406` — pass (70 total)
- `make arch-check` — clean (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)