### PR TITLE
fix(tests): collect 72 dormant regression files — 289 tests were never running (#9801, #9872)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,10 @@ skips = ["B101"]
 # === Pytest ===
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# regression_*.py: 72 legacy tests/regressions/regression_issue_NNNN.py files
+# never matched the default test_*.py glob and silently provided ZERO
+# coverage since creation (#9801/#9872). Collected explicitly here.
+python_files = ["test_*.py", "regression_*.py"]
 asyncio_mode = "auto"
 addopts = [
     "-q",

--- a/tests/regressions/test_issue_9801_collection.py
+++ b/tests/regressions/test_issue_9801_collection.py
@@ -1,0 +1,40 @@
+"""Regression: 72 regression_issue_*.py files were never collected (#9801/#9872).
+
+pyproject's pytest config had no ``python_files`` override, so the default
+``test_*.py`` glob silently skipped every ``regression_issue_NNNN.py`` file —
+289 pinned-bug tests providing zero coverage since creation. This meta-guard
+asserts every Python file in tests/regressions/ matches a configured
+collection pattern, so a glob change can never silently orphan them again.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import tomllib
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_every_regression_file_matches_a_collection_pattern() -> None:
+    config = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text())
+    patterns = config["tool"]["pytest"]["ini_options"]["python_files"]
+
+    orphans = [
+        path.name
+        for path in sorted((_REPO_ROOT / "tests" / "regressions").glob("*.py"))
+        if path.name != "__init__.py"
+        and not any(fnmatch.fnmatch(path.name, pat) for pat in patterns)
+    ]
+
+    assert orphans == [], (
+        f"{len(orphans)} file(s) in tests/regressions/ match no pytest "
+        f"python_files pattern and will silently never run: {orphans[:5]}"
+    )
+
+
+def test_legacy_regression_glob_is_configured() -> None:
+    config = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text())
+    patterns = config["tool"]["pytest"]["ini_options"]["python_files"]
+
+    assert any(fnmatch.fnmatch("regression_issue_6408.py", pat) for pat in patterns)


### PR DESCRIPTION
## Problem (#9801 / #9872)

pyproject's pytest config had no `python_files` override, so the default `test_*.py` glob silently skipped every `tests/regressions/regression_issue_NNNN.py` file: **72 files, 289 pinned-bug tests, zero coverage since creation**. The regression safety net was one-third holes.

## Change

- `python_files = ["test_*.py", "regression_*.py"]` — collection goes 569 → 858 tests in tests/regressions/. **All 289 awakened tests pass on current staging** (no bit-rot, verified before enabling).
- Meta-guard `tests/regressions/test_issue_9801_collection.py`: every .py file in tests/regressions/ must match a configured collection pattern — a future glob change can never silently orphan the suite again.

## Verification

Full `make quality` green (exit 0) with the widened collection — the entire awakened suite runs in the standard gate from now on.

Closes #9801
Closes #9872

🤖 Generated with [Claude Code](https://claude.com/claude-code)