### PR TITLE
fix(hitl): surface gh close failures — 502 + row stays instead of fake success (#9812)

### DIFF
--- a/src/dashboard_routes/_hitl_routes.py
+++ b/src/dashboard_routes/_hitl_routes.py
@@ -371,7 +371,18 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
             return JSONResponse({"status": "no orchestrator"}, status_code=400)
 
         pr_manager = ctx.pr_manager_for(_cfg, _bus)
-        await pr_manager.close_issue(issue_number)
+        if not await pr_manager.close_issue(issue_number):
+            # Do NOT run local cleanup: the row must stay, truthfully (#9812).
+            return JSONResponse(
+                {
+                    "status": "error",
+                    "detail": (
+                        f"GitHub close failed for issue #{issue_number} — "
+                        "item left in the HITL queue"
+                    ),
+                },
+                status_code=502,
+            )
 
         return await _resolve_hitl_item(
             issue_number,
@@ -398,7 +409,18 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         if not orch:
             return JSONResponse({"status": "no orchestrator"}, status_code=400)
         pr_manager = ctx.pr_manager_for(_cfg, _bus)
-        await pr_manager.close_issue(issue_number)
+        if not await pr_manager.close_issue(issue_number):
+            # Do NOT run local cleanup: the row must stay, truthfully (#9812).
+            return JSONResponse(
+                {
+                    "status": "error",
+                    "detail": (
+                        f"GitHub close failed for issue #{issue_number} — "
+                        "item left in the HITL queue"
+                    ),
+                },
+                status_code=502,
+            )
 
         return await _resolve_hitl_item(
             issue_number,

--- a/src/mockworld/fakes/fake_github.py
+++ b/src/mockworld/fakes/fake_github.py
@@ -454,16 +454,18 @@ class FakeGitHub:
         if issue_number in self._issues:
             self._issues[issue_number].state = "closed"
 
-    async def close_issue(self, issue_number: int) -> None:
+    async def close_issue(self, issue_number: int) -> bool:
         self._maybe_rate_limit()
         if issue_number in self._issues:
             self._issues[issue_number].state = "closed"
+        return True
 
-    async def close_pr(self, pr_number: int) -> None:
+    async def close_pr(self, pr_number: int) -> bool:
         self._maybe_rate_limit()
         pr = self._prs.get(pr_number)
         if pr is not None:
             pr.closed = True
+        return True
 
     async def find_existing_issue(self, title: str) -> int:
         self._maybe_rate_limit()

--- a/src/ports.py
+++ b/src/ports.py
@@ -304,12 +304,22 @@ class PRPort(Protocol):
 
     # --- Issue management ---
 
-    async def close_issue(self, issue_number: int) -> None:
-        """Close GitHub issue *issue_number*."""
+    async def close_issue(self, issue_number: int) -> bool:
+        """Close GitHub issue *issue_number*.
+
+        Returns True when the close reached GitHub, False when the
+        underlying call failed (fail-soft: no raise). Background callers
+        may ignore the return; INTERACTIVE callers (HITL routes) MUST
+        check it — pretending a failed close succeeded makes the row
+        vanish and reappear on refresh (#9812).
+        """
         ...
 
-    async def close_pr(self, pr_number: int) -> None:
+    async def close_pr(self, pr_number: int) -> bool:
         """Close GitHub pull request *pr_number* without merging.
+
+        Returns True on success, False when the gh call failed (#9812 —
+        same contract as :meth:`close_issue`).
 
         Distinct from :meth:`close_issue`: a PR and an issue share the
         repo's number space but are different GraphQL/REST node types, so

--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -1614,11 +1614,11 @@ class PRManager:
         url = parts[1] if len(parts) > 1 else ""
         return (conclusion, url)
 
-    async def close_issue(self, issue_number: int) -> None:
-        """Close a GitHub issue."""
+    async def close_issue(self, issue_number: int) -> bool:
+        """Close a GitHub issue. Returns False when the gh call failed (#9812)."""
         self._assert_repo()
         if self._config.dry_run:
-            return
+            return True
         try:
             await self._run_gh(
                 "gh",
@@ -1634,8 +1634,10 @@ class PRManager:
                 issue_number,
                 exc,
             )
+            return False
+        return True
 
-    async def close_pr(self, pr_number: int) -> None:
+    async def close_pr(self, pr_number: int) -> bool:
         """Close a GitHub pull request without merging it.
 
         ``gh pr close`` (not ``gh issue close`` — the latter resolves only
@@ -1643,7 +1645,7 @@ class PRManager:
         """
         self._assert_repo()
         if self._config.dry_run:
-            return
+            return True
         try:
             await self._run_gh(
                 "gh",
@@ -1659,6 +1661,8 @@ class PRManager:
                 pr_number,
                 exc,
             )
+            return False
+        return True
 
     async def update_issue_body(self, issue_number: int, body: str) -> None:
         """Update the body of a GitHub issue using ``--body-file``."""

--- a/tests/regressions/test_issue_9812_hitl_close_failure_surfaces.py
+++ b/tests/regressions/test_issue_9812_hitl_close_failure_surfaces.py
@@ -1,0 +1,90 @@
+"""Regression: HITL close/skip silently 'succeeded' on gh failures (#9812).
+
+``PRManager.close_issue``/``close_pr`` swallowed the gh RuntimeError and
+returned normally, so ``/api/hitl/{n}/close`` and ``/skip`` ran their local
+cleanup (row removed, outcome recorded, comment posted) while the issue
+stayed OPEN on GitHub — the row vanished and reappeared on refresh, with the
+HITL counter stuck.
+
+Contract pinned here: the port methods return bool; on False the routes
+return HTTP 502, run ZERO local cleanup, and leave the row in the queue —
+the UI tells the truth.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from models import HITLCloseRequest, HITLSkipRequest
+from tests.helpers import find_endpoint, make_dashboard_router
+
+
+def _router_with_failing_close(config, event_bus, state, tmp_path):
+    mock_orch = MagicMock()
+    mock_orch.skip_hitl_issue = MagicMock()
+    router, pr_mgr = make_dashboard_router(
+        config, event_bus, state, tmp_path, get_orch=lambda: mock_orch
+    )
+    pr_mgr.close_issue = AsyncMock(return_value=False)  # gh call failed
+    pr_mgr.post_comment = AsyncMock()
+    pr_mgr.remove_label = AsyncMock()
+    pr_mgr.add_labels = AsyncMock()
+    pr_mgr.swap_pipeline_labels = AsyncMock()
+    return router, pr_mgr, mock_orch
+
+
+@pytest.mark.asyncio
+async def test_close_route_returns_502_and_skips_local_cleanup(
+    config, event_bus, state, tmp_path
+) -> None:
+    router, pr_mgr, mock_orch = _router_with_failing_close(
+        config, event_bus, state, tmp_path
+    )
+
+    close = find_endpoint(router, "/api/hitl/{issue_number}/close")
+    assert close is not None
+    response = await close(42, HITLCloseRequest(reason="obsolete"))
+
+    assert response.status_code == 502
+    detail = json.loads(response.body)
+    assert "left in the HITL queue" in detail["detail"]
+    pr_mgr.post_comment.assert_not_awaited()  # no cleanup ran
+    mock_orch.skip_hitl_issue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_skip_route_returns_502_and_skips_local_cleanup(
+    config, event_bus, state, tmp_path
+) -> None:
+    state.set_hitl_origin(42, "hydraflow-review")
+    router, pr_mgr, mock_orch = _router_with_failing_close(
+        config, event_bus, state, tmp_path
+    )
+
+    skip = find_endpoint(router, "/api/hitl/{issue_number}/skip")
+    assert skip is not None
+    response = await skip(42, HITLSkipRequest(reason="not needed"))
+
+    assert response.status_code == 502
+    pr_mgr.post_comment.assert_not_awaited()
+    mock_orch.skip_hitl_issue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_successful_close_still_resolves_the_item(
+    config, event_bus, state, tmp_path
+) -> None:
+    router, pr_mgr, mock_orch = _router_with_failing_close(
+        config, event_bus, state, tmp_path
+    )
+    pr_mgr.close_issue = AsyncMock(return_value=True)
+
+    close = find_endpoint(router, "/api/hitl/{issue_number}/close")
+    assert close is not None
+    response = await close(42, HITLCloseRequest(reason="done"))
+
+    assert response.status_code == 200
+    pr_mgr.close_issue.assert_awaited_once_with(42)


### PR DESCRIPTION
## Problem (#9812)

`PRManager.close_issue`/`close_pr` swallowed the gh RuntimeError and returned normally, so `/api/hitl/{n}/close` and `/skip` ran their full local cleanup (row removed, outcome recorded, comment posted) while the issue stayed OPEN on GitHub — the row vanished and reappeared on refresh with the HITL counter stuck. Requeue-with-feedback was already honest (`swap_pipeline_labels` raises on add-failure).

## Change (port triplet moves together)

- `PRPort.close_issue`/`close_pr` → `bool` (True = reached GitHub; False = call failed; still no raise). The 28 background call sites keep fail-soft semantics by ignoring the return; INTERACTIVE callers must check — documented on the protocol.
- `PRManager` returns False on the swallowed RuntimeError (True on dry-run).
- `FakeGitHub` returns True.
- HITL close/skip routes: on False → **HTTP 502** with detail and **zero local cleanup** — the row stays, truthfully.

## Tests

`tests/regressions/test_issue_9812_hitl_close_failure_surfaces.py`: 502 + no cleanup on both routes; success path still resolves. HITL route suites + multirepo + pr_manager suites green. Full `make quality` green (exit 0).

Closes #9812

🤖 Generated with [Claude Code](https://claude.com/claude-code)