### PR TITLE
docs(adr): sync README status cells + add consistency guard (#9456)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -53,7 +53,7 @@ cadence and files remediation issues on drift.
 | [0012](0012-epic-merge-coordination-architecture.md) | Epic Merge Coordination Architecture | Accepted |
 | [0013](0013-screenshot-capture-pipeline.md) | Screenshot Capture Pipeline Architecture | Superseded |
 | [0014](0014-session-counter-forward-progression-semantics.md) | Session Counter Forward-Progression Semantics | Accepted |
-| [0015](0015-protocol-callback-gate-pattern.md) | Protocol-Based Callback Injection Gate Pattern | Proposed |
+| [0015](0015-protocol-callback-gate-pattern.md) | Protocol-Based Callback Injection Gate Pattern | Accepted |
 | [0016](0016-visual-validation-skipped-override-semantics.md) | VisualValidation SKIPPED Override Semantics | Accepted |
 | [0017](0017-auto-decompose-triage-counter-exclusion.md) | Auto-Decompose Triage Counter Exclusion | Accepted |
 | [0018](0018-screenshot-capture-pipeline.md) | Screenshot Capture Pipeline Architecture | Accepted |
@@ -61,19 +61,19 @@ cadence and files remediation issues on drift.
 | [0020](0020-autoApproveRow-border-context-awareness.md) | autoApproveRow Border Context Awareness | Superseded |
 | [0021](0021-persistence-architecture-and-data-layout.md) | Persistence Architecture and Data Layout | Accepted |
 | [0022](0022-integration-test-architecture-cross-phase.md) | Integration Test Architecture — Cross-Phase Pipeline Harness | Accepted |
-| [0023](0023-dead-class-artifacts-in-mock-based-tests.md) | Require Instantiation Verification for Test-Local Classes | Proposed |
+| [0023](0023-dead-class-artifacts-in-mock-based-tests.md) | Require Instantiation Verification for Test-Local Classes | Accepted |
 | [0024](0024-implementation-retry-recovery-architecture.md) | Implementation Retry Recovery Architecture | Accepted |
 | [0025](0025-symmetric-field-assertion-checklist-shared-return-types.md) | Symmetric Field Assertion Checklist for Shared Return Types | Accepted |
-| [0027](0027-duplicate-class-merge-artifact-pattern.md) | Duplicate Class Definitions — Merge-Artifact Pattern | Proposed |
+| [0027](0027-duplicate-class-merge-artifact-pattern.md) | Duplicate Class Definitions — Merge-Artifact Pattern | Accepted |
 | [0028](0028-event-driven-report-pipeline.md) | Event-Driven Report Pipeline with Extractable Widget | Accepted |
 | [0029](0029-caretaker-loop-pattern.md) | Caretaker Background Loop Pattern | Accepted |
 | [0030](0030-routes-domain-decomposition.md) | Dashboard Routes Domain Decomposition | Accepted |
-| [0031](0031-product-track-architecture.md) | Product Track Architecture — Discover and Shape Phases | Proposed |
+| [0031](0031-product-track-architecture.md) | Product Track Architecture — Discover and Shape Phases | Accepted |
 | [0032](0032-per-repo-wiki-knowledge-base.md) | Per-Repo Wiki Knowledge Base (Karpathy Pattern) | Accepted |
 | [0033](0033-gate-triage-call-not-hitl-fallback.md) | Gate Triage Call on Config Toggle, Not Just HITL Fallback | Superseded |
 | [0034](0034-auto-triage-toggle-must-gate-routing.md) | Auto-Triage Toggle Must Gate Routing, Not Just Stat Tracking | Accepted |
-| [0035](0035-tests-must-match-toggle-state-they-assert.md) | Tests Must Match Toggle State They Assert | Proposed |
-| [0036](0036-cli-argparse-config-builder-pattern.md) | CLI Architecture — argparse with Config Builder Pattern | Proposed |
+| [0035](0035-tests-must-match-toggle-state-they-assert.md) | Tests Must Match Toggle State They Assert | Accepted |
+| [0036](0036-cli-argparse-config-builder-pattern.md) | CLI Architecture — argparse with Config Builder Pattern | Superseded |
 | [0037](0037-supersession-regex-all-verb-forms.md) | Supersession Regex Must Include All Verb Forms | Accepted |
 | [0038](0038-multi-repo-architecture-wiring-pattern.md) | Multi-Repo Architecture Wiring Pattern | Proposed |
 | [0039](0039-stats-counter-placement-in-delegating-helpers.md) | Stats Counter Placement in Delegating Helpers | Rejected |
@@ -84,7 +84,7 @@ cadence and files remediation issues on drift.
 | [0044](0044-hydraflow-principles.md) | HydraFlow Principles — the audit contract for new and existing repos | Proposed |
 | [0045](0045-trust-architecture-hardening.md) | Trust Architecture Hardening — Lights-Off Trust Fleet (10 loops + 2 non-loop subsystems) | Accepted |
 | [0046](0046-meta-observability-bounded-recursion.md) | Meta-observability with bounded recursion — one layer of meta, no more | Proposed |
-| [0047](0047-fake-adapter-contract-testing-cassettes.md) | Fake-adapter contract testing via cassette record/replay | Proposed |
+| [0047](0047-fake-adapter-contract-testing-cassettes.md) | Fake-adapter contract testing via cassette record/replay | Accepted |
 | [0048](0048-auto-revert-on-rc-red.md) | Auto-revert on RC red (extends ADR-0042) | Proposed |
 | [0049](0049-trust-loop-kill-switch-convention.md) | Trust-loop kill-switch convention (`enabled_cb` only, no config-only) | Accepted |
 | [0050](0050-auto-agent-hitl-preflight.md) | Auto-Agent HITL Pre-Flight Loop | Accepted |
@@ -97,18 +97,18 @@ cadence and files remediation issues on drift.
 | [0057](0057-term-pruner-loop.md) | Term-Pruner Loop (Dark-Factory Glossary Hygiene) | Accepted |
 | [0058](0058-edge-proposer-loop.md) | Edge-Proposer Loop (Dark-Factory Graph Densification) | Accepted |
 | [0059](0059-advisor-pattern-self-repairing-review.md) | Advisor Pattern — Self-Repairing Review | Proposed |
-| [0060](0060-atlas-graph-view-and-provenance.md) | Atlas Graph View and Provenance | Proposed |
-| [0061](0061-atlas-entries-as-evidence.md) | Atlas Entries as Evidence | Proposed |
+| [0060](0060-atlas-graph-view-and-provenance.md) | Atlas Graph View and Provenance | Accepted |
+| [0061](0061-atlas-entries-as-evidence.md) | Atlas Entries as Evidence | Accepted |
 | [0062](0062-entry-evidence-loop.md) | Entry-Evidence Loop | Accepted |
 | [0063](0063-factory-phase-drift-mitigation.md) | Factory-Phase Drift Mitigation | Proposed |
-| [0064](0064-earlier-adversarial-pipeline.md) | Earlier Adversarial Pipeline | Proposed |
+| [0064](0064-earlier-adversarial-pipeline.md) | Earlier Adversarial Pipeline | Accepted |
 | [0065](0065-remove-code-grooming-loop.md) | Remove CodeGroomingLoop | Accepted |
 | [0066](0066-agent-port.md) | AgentPort: Dependency-Injection Boundary for Agent Runner | Proposed |
 | [0067](0067-issue-fetcher-port.md) | IssueFetcherPort: GitHub Issue Fetching Boundary | Proposed |
 | [0068](0068-bot-pr-port.md) | BotPRPort: Minimal Interface for Caretaker Bot-PRs | Proposed |
 | [0069](0069-workspace-gc-loop.md) | WorkspaceGCLoop: Autonomous Worktree Garbage Collection | Proposed |
 | [0070](0070-review-insight-store-port.md) | ReviewInsightStorePort: Persistence Boundary for Review Feedback Patterns | Proposed |
-| [0071](0071-route-back-counter-port.md) | RouteBackCounterPort: Testable Counter for Precondition Route-Backs | Proposed |
+| [0071](0071-route-back-counter-port.md) | RouteBackCounterPort: Testable Counter for Precondition Route-Backs | Accepted |
 | [0072](0072-stale-issue-loop.md) | StaleIssueLoop: Auto-Close Stale General Issues | Proposed |
 | [0073](0073-runs-gc-loop.md) | RunsGCLoop: Artifact Retention Enforcement | Proposed |
 | [0074](0074-retrospective-loop.md) | RetrospectiveLoop: Durable-Queue Pattern Analysis | Proposed |

--- a/tests/architecture/test_adr_numbers_unique.py
+++ b/tests/architecture/test_adr_numbers_unique.py
@@ -17,6 +17,11 @@ Invariants:
      ``docs/adr/`` resolves to an existing file whose number matches the link.
   4. README completeness — every ADR file has exactly one README row and no
      number appears twice.
+  5. README status consistency — each README row's Status cell matches its ADR
+     file's own ``**Status:**`` / ``## Status`` word (#9456). Compared against
+     the file's RAW status word, not ``scan_adr_directory``'s normalized status
+     (which buckets ``Rejected`` -> ``Unknown``), so ``Rejected``/``Superseded``
+     round-trip and 0039/0040 are not false-flagged.
 """
 
 from __future__ import annotations
@@ -100,3 +105,46 @@ def test_readme_has_one_row_per_adr(real_repo_root: Path) -> None:
     }
     missing = file_numbers - set(row_numbers)
     assert missing == set(), f"ADR files with no README row: {sorted(missing)}"
+
+
+_README_STATUS_ROW_RE = re.compile(
+    r"^\|\s*\[(\d{4})\]\(\d{4}-[^)]+\.md\)\s*\|[^|]*\|\s*([A-Za-z]+)\s*\|"
+)
+_STATUS_INLINE_RE = re.compile(r"^\*\*Status:\*\*\s*(\w+)", re.MULTILINE)
+_STATUS_H2_RE = re.compile(r"^##\s*Status\s*\n+\s*[-*]?\s*\*?\*?(\w+)", re.MULTILINE)
+
+
+def _file_raw_status(path: Path) -> str | None:
+    """The ADR file's own status WORD (raw, not normalized).
+
+    Handles ``**Status:** X`` and the ``## Status`` section form. ``Superseded
+    by ADR-NNNN`` collapses to ``Superseded``. Returns None if unparseable.
+    """
+    text = path.read_text(encoding="utf-8")
+    m = _STATUS_INLINE_RE.search(text) or _STATUS_H2_RE.search(text)
+    return m.group(1) if m else None
+
+
+def test_readme_status_matches_file(real_repo_root: Path) -> None:
+    """Each README Status cell matches its ADR file's own status word (#9456)."""
+    adr_dir = real_repo_root / "docs" / "adr"
+    readme = (adr_dir / "README.md").read_text(encoding="utf-8")
+
+    drift: list[str] = []
+    for line in readme.split("\n"):
+        m = _README_STATUS_ROW_RE.match(line)
+        if not m:
+            continue
+        num, row_status = m.group(1), m.group(2)
+        files = list(adr_dir.glob(f"{num}-*.md"))
+        if not files:
+            continue  # completeness is covered by test_readme_has_one_row_per_adr
+        file_status = _file_raw_status(files[0])
+        if file_status and file_status.lower() != row_status.lower():
+            drift.append(
+                f"ADR-{num}: README says '{row_status}' but file says '{file_status}'"
+            )
+
+    assert drift == [], "README Status column drifts from ADR files:\n  " + "\n  ".join(
+        drift
+    )


### PR DESCRIPTION
Fixes #9456. 11 README Status cells drifted from their ADR files (10 Proposed→Accepted; ADR-0036 Proposed→Superseded per #9921). Corrected them and added `test_readme_status_matches_file` comparing each README row to the file's **raw** status word (not scan_adr_directory's normalized status, so Rejected/Superseded round-trip; 0039/0040 stay correct). 104 rows == 104 files preserved; arch tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)