### PR TITLE
fix(review): bounded requeue for review-labeled issues with no agent PR (#9815)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -258,6 +258,8 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
     ("sentry_signal_cooldown_hours", "SENTRY_SIGNAL_COOLDOWN_HOURS", 24),
     ("security_patch_interval", "HYDRAFLOW_SECURITY_PATCH_INTERVAL", 3600),
     ("repo_wiki_interval", "HYDRAFLOW_REPO_WIKI_INTERVAL", 3600),
+    ("review_orphan_strike_threshold", "HYDRAFLOW_REVIEW_ORPHAN_STRIKE_THRESHOLD", 3),
+    ("review_orphan_max_requeues", "HYDRAFLOW_REVIEW_ORPHAN_MAX_REQUEUES", 3),
     ("repo_wiki_min_batch_files", "HYDRAFLOW_REPO_WIKI_MIN_BATCH_FILES", 8),
     ("repo_wiki_max_batch_age_hours", "HYDRAFLOW_REPO_WIKI_MAX_BATCH_AGE_HOURS", 24),
     ("max_repo_wiki_chars", "HYDRAFLOW_MAX_REPO_WIKI_CHARS", 15_000),
@@ -1961,6 +1963,27 @@ class HydraFlowConfig(BaseModel):
         ge=300,
         le=604800,
         description="Seconds between repo wiki lint cycles",
+    )
+    review_orphan_strike_threshold: int = Field(
+        default=3,
+        ge=1,
+        le=20,
+        description=(
+            "Consecutive PR-less sightings of a review-labeled issue before "
+            "it is treated as an orphan and requeued to ready (#9815). "
+            "Below the threshold the review loop keeps waiting for PR "
+            "propagation as before."
+        ),
+    )
+    review_orphan_max_requeues: int = Field(
+        default=3,
+        ge=0,
+        le=10,
+        description=(
+            "Bounded orphan requeues per issue before escalating to HITL "
+            "instead (#9815). 0 disables orphan requeue entirely (legacy "
+            "wait-forever behavior)."
+        ),
     )
     repo_wiki_min_batch_files: int = Field(
         default=8,

--- a/src/models.py
+++ b/src/models.py
@@ -2086,6 +2086,11 @@ class StateData(BaseModel):
     # JSON-compat with the rest of StateData. See route_back.py and
     # state/_route_back.py.
     route_back_counts: dict[str, int] = Field(default_factory=dict)
+    # Review-orphan requeue (#9815): review-labeled issues with no open
+    # agent PR (restart edge case). Strikes count consecutive PR-less
+    # sightings; requeues count bounded ready-relabels before HITL.
+    review_orphan_strikes: dict[str, int] = Field(default_factory=dict)
+    review_orphan_requeues: dict[str, int] = Field(default_factory=dict)
     ci_monitor_settings: CIMonitorSettings = Field(default_factory=CIMonitorSettings)
     ci_monitor_tracked_failures: dict[str, str] = Field(default_factory=dict)
     # Trust fleet — RCBudgetLoop (spec §4.8)

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -1680,12 +1680,17 @@ class HydraFlowOrchestrator:
                 active_in_store, prefetched_issues=[gh_issue]
             )
             if not prs:
-                # PR not visible yet — wait before re-queuing so the
-                # review pool doesn't tight-loop on issues whose PRs
-                # haven't propagated to the GitHub API yet.
+                # PR not visible yet — usually propagation delay, but after a
+                # restart mid-implement the PR may NOT EXIST and the issue
+                # would otherwise sit review-labeled forever (#9815). Count
+                # strikes; at the threshold, requeue with fresh budget
+                # (bounded, then HITL) instead of waiting eternally.
+                if await self._handle_review_orphan(issue):
+                    return False
                 await self._sleep_or_stop(min(self._config.poll_interval, 30))
                 self._svc.store.enqueue_transition(issue, "review")
                 return False
+            self._state.clear_review_orphan_strikes(issue.id)
 
             review_results = await self._svc.reviewer.review_prs(
                 prs, [i.to_task() for i in gh_issues]
@@ -1698,6 +1703,75 @@ class HydraFlowOrchestrator:
             return True
         finally:
             release_batch_in_flight(self._svc.store, {issue.id})
+
+    async def _handle_review_orphan(self, issue: Task) -> bool:
+        """Requeue a review-labeled issue whose agent PR does not exist (#9815).
+
+        Returns True when the issue was requeued (to ready) or escalated (to
+        HITL) — the caller must NOT re-enqueue it to review. Returns False
+        while strikes are below the threshold (normal PR-propagation wait) or
+        when the feature is disabled (``review_orphan_max_requeues=0``).
+        Every gh failure is fail-soft back to the legacy wait path.
+        """
+        if self._config.review_orphan_max_requeues <= 0:
+            return False
+        strikes = self._state.increment_review_orphan_strike(issue.id)
+        if strikes < self._config.review_orphan_strike_threshold:
+            return False
+
+        self._state.clear_review_orphan_strikes(issue.id)
+        requeues = self._state.increment_review_orphan_requeue(issue.id)
+        try:
+            if requeues > self._config.review_orphan_max_requeues:
+                cause = (
+                    f"review-labeled with no agent PR after "
+                    f"{requeues - 1} orphan requeue(s) — needs a human"
+                )
+                self._state.set_hitl_cause(issue.id, cause)
+                await self._svc.prs.swap_pipeline_labels(
+                    issue.id, self._config.hitl_label[0]
+                )
+                await self._svc.prs.post_comment(
+                    issue.id,
+                    "## Review Orphan Escalation\n\n"
+                    f"{cause}. Escalating to HITL (#9815).",
+                )
+                logger.warning(
+                    "Issue #%d: review orphan exhausted %d requeues — HITL",
+                    issue.id,
+                    self._config.review_orphan_max_requeues,
+                )
+                return True
+
+            self._state.reset_issue_attempts(issue.id)
+            self._state.clear_diagnostic_state(issue.id)
+            await self._svc.prs.swap_pipeline_labels(
+                issue.id, self._config.ready_label[0]
+            )
+            await self._svc.prs.post_comment(
+                issue.id,
+                "## Review Orphan Requeue\n\n"
+                "This issue was review-labeled with no open agent PR "
+                "(interrupted implement, e.g. a factory restart). Attempt "
+                f"counters reset; requeued to ready for a fresh build "
+                f"(requeue {requeues}/"
+                f"{self._config.review_orphan_max_requeues}, #9815).",
+            )
+            logger.info(
+                "Issue #%d: review orphan requeued to ready (%d/%d)",
+                issue.id,
+                requeues,
+                self._config.review_orphan_max_requeues,
+            )
+            return True
+        except RuntimeError as exc:
+            logger.warning(
+                "Issue #%d: review orphan handling failed (%s) — keeping "
+                "legacy review wait",
+                issue.id,
+                exc,
+            )
+            return False
 
     async def _sleep_or_stop(self, seconds: int | float) -> None:
         """Sleep for *seconds*, waking early if stop is requested."""

--- a/src/state/__init__.py
+++ b/src/state/__init__.py
@@ -49,6 +49,7 @@ from ._principles_audit import PrinciplesAuditStateMixin
 from ._rc_budget import RCBudgetStateMixin
 from ._report import ReportStateMixin
 from ._review import ReviewStateMixin
+from ._review_orphan import ReviewOrphanStateMixin
 from ._rollup_issues import RollupIssueStateMixin
 from ._route_back import RouteBackStateMixin
 from ._sandbox_failure_fixer import SandboxFailureFixerStateMixin
@@ -78,6 +79,7 @@ class StateTracker(
     WorkspaceStateMixin,
     HITLStateMixin,
     ReviewStateMixin,
+    ReviewOrphanStateMixin,
     RouteBackStateMixin,
     EpicStateMixin,
     LifetimeStatsMixin,

--- a/src/state/_review_orphan.py
+++ b/src/state/_review_orphan.py
@@ -1,0 +1,50 @@
+"""Review-orphan requeue counters (#9815).
+
+A factory restart mid-implement can leave an issue review-labeled with no
+open ``agent/issue-N`` PR — unreviewable and never requeued. These counters
+let the review loop distinguish "PR not propagated yet" (strikes below the
+threshold) from a genuine orphan (requeue with fresh budget, bounded before
+HITL escalation). Persisted so a crash cannot reset the bound.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from models import StateData
+
+
+class ReviewOrphanStateMixin:
+    """Per-issue strike + requeue counters for PR-less review issues."""
+
+    _data: StateData
+
+    def save(self) -> None: ...  # provided by CoreMixin
+
+    @staticmethod
+    def _key(issue_id: int | str) -> str: ...  # provided by StateTracker
+
+    def increment_review_orphan_strike(self, issue_id: int) -> int:
+        """Record one PR-less sighting; returns the new strike count."""
+        key = self._key(issue_id)
+        new = self._data.review_orphan_strikes.get(key, 0) + 1
+        self._data.review_orphan_strikes[key] = new
+        self.save()
+        return new
+
+    def clear_review_orphan_strikes(self, issue_id: int) -> None:
+        """Reset strikes (PR appeared, or a requeue was performed)."""
+        if self._data.review_orphan_strikes.pop(self._key(issue_id), None) is not None:
+            self.save()
+
+    def increment_review_orphan_requeue(self, issue_id: int) -> int:
+        """Record one orphan requeue; returns the new requeue count."""
+        key = self._key(issue_id)
+        new = self._data.review_orphan_requeues.get(key, 0) + 1
+        self._data.review_orphan_requeues[key] = new
+        self.save()
+        return new
+
+    def get_review_orphan_requeues(self, issue_id: int) -> int:
+        return self._data.review_orphan_requeues.get(self._key(issue_id), 0)

--- a/tests/regressions/test_issue_9815_review_orphan_requeue.py
+++ b/tests/regressions/test_issue_9815_review_orphan_requeue.py
@@ -1,0 +1,125 @@
+"""Regression: review-labeled issues with no agent PR sat idle forever (#9815).
+
+A factory restart mid-implement leaves an issue on ``hydraflow-review`` with
+no open ``agent/issue-N`` PR. The review loop found no PR and re-enqueued the
+issue to review eternally (live example: #9553, attempts exhausted, no PR,
+never picked again).
+
+Pinned contract for ``_handle_review_orphan``: strikes below the threshold
+keep the legacy propagation wait; at the threshold the issue is requeued to
+ready with fresh attempt budget; requeues are bounded and then escalate to
+HITL; gh failures and the ``max_requeues=0`` kill-switch fall back to legacy
+behavior.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from models import Task
+from orchestrator import HydraFlowOrchestrator
+
+
+def _issue(n: int = 42) -> Task:
+    return Task(
+        id=n,
+        title="Stuck after restart",
+        body="x" * 60,
+        tags=[],
+        comments=[],
+        source_url="",
+        links=[],
+        complexity_score=0,
+        created_at="",
+        metadata={},
+    )
+
+
+def _orch(state, *, threshold: int = 3, max_requeues: int = 3):
+    config = MagicMock()
+    config.review_orphan_strike_threshold = threshold
+    config.review_orphan_max_requeues = max_requeues
+    config.ready_label = ["hydraflow-ready"]
+    config.hitl_label = ["hydraflow-hitl"]
+    prs = MagicMock()
+    prs.swap_pipeline_labels = AsyncMock()
+    prs.post_comment = AsyncMock()
+    return (
+        SimpleNamespace(_config=config, _state=state, _svc=SimpleNamespace(prs=prs)),
+        prs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_below_threshold_keeps_legacy_wait(state) -> None:
+    orch, prs = _orch(state)
+
+    handled = await HydraFlowOrchestrator._handle_review_orphan(orch, _issue())
+
+    assert handled is False
+    prs.swap_pipeline_labels.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_threshold_strike_requeues_to_ready_with_fresh_budget(state) -> None:
+    orch, prs = _orch(state)
+    issue = _issue()
+    state.increment_issue_attempts(issue.id)
+    state.increment_issue_attempts(issue.id)
+
+    handled = False
+    for _ in range(3):
+        handled = await HydraFlowOrchestrator._handle_review_orphan(orch, issue)
+
+    assert handled is True
+    prs.swap_pipeline_labels.assert_awaited_once_with(issue.id, "hydraflow-ready")
+    prs.post_comment.assert_awaited_once()
+    assert state.get_issue_attempts(issue.id) == 0  # fresh budget
+    assert state.get_review_orphan_requeues(issue.id) == 1
+    # Strikes reset — the next PR-less sighting starts a new streak.
+    assert state.increment_review_orphan_strike(issue.id) == 1
+
+
+@pytest.mark.asyncio
+async def test_exhausted_requeues_escalate_to_hitl(state) -> None:
+    orch, prs = _orch(state, max_requeues=1)
+    issue = _issue()
+    for _ in range(3):  # first orphan round -> requeue 1/1
+        await HydraFlowOrchestrator._handle_review_orphan(orch, issue)
+    prs.swap_pipeline_labels.reset_mock()
+    prs.post_comment.reset_mock()
+
+    handled = False
+    for _ in range(3):  # second orphan round exceeds the bound
+        handled = await HydraFlowOrchestrator._handle_review_orphan(orch, issue)
+
+    assert handled is True
+    prs.swap_pipeline_labels.assert_awaited_once_with(issue.id, "hydraflow-hitl")
+    assert "needs a human" in (state.get_hitl_cause(issue.id) or "")
+
+
+@pytest.mark.asyncio
+async def test_zero_max_requeues_disables_feature(state) -> None:
+    orch, prs = _orch(state, max_requeues=0)
+
+    for _ in range(10):
+        assert (
+            await HydraFlowOrchestrator._handle_review_orphan(orch, _issue()) is False
+        )
+    prs.swap_pipeline_labels.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_gh_failure_falls_back_to_legacy_wait(state) -> None:
+    orch, prs = _orch(state)
+    prs.swap_pipeline_labels = AsyncMock(side_effect=RuntimeError("gh down"))
+    issue = _issue()
+
+    handled = True
+    for _ in range(3):
+        handled = await HydraFlowOrchestrator._handle_review_orphan(orch, issue)
+
+    assert handled is False  # caller keeps the legacy review wait

--- a/tests/test_state_tracking.py
+++ b/tests/test_state_tracking.py
@@ -103,6 +103,8 @@ class TestInitialization:
             "log_ingest_cursor",
             "sentry_signal_cooldown",
             "trace_runs",
+            "review_orphan_requeues",
+            "review_orphan_strikes",
             "route_back_counts",
             # Trust-arch-hardening mixins (spec §4.1–§4.9 + §12.1)
             "auto_reverts_in_cycle",


### PR DESCRIPTION
## Problem (#9815)

A factory restart mid-implement leaves an issue on `hydraflow-review` with no open `agent/issue-N` PR. `_review_single_issue` found no PR and re-enqueued the issue to review **forever** (live case: #9553 — attempts exhausted, no PR, never picked again).

## Change

`_handle_review_orphan` in the empty-PRs branch:
- **Strike counter** (persisted) distinguishes PR-propagation delay from a real orphan; below `review_orphan_strike_threshold` (default 3) the legacy wait continues; strikes clear the moment a PR appears.
- **At the threshold:** `reset_issue_attempts` + `clear_diagnostic_state`, swap back to `hydraflow-ready` with an explanatory comment — a fresh build with fresh budget.
- **Bounded** by `review_orphan_max_requeues` (default 3; **0 = kill-switch** for legacy behavior): exhaustion swaps to `hydraflow-hitl` with a cause instead of looping.
- Every gh failure fails soft back to the legacy wait.

State: additive `review_orphan_strikes`/`review_orphan_requeues` + mixin (persisted so a crash can't reset the bound); schema-keys pin updated. Knobs env-overridable with table parity.

## Tests

`tests/regressions/test_issue_9815_review_orphan_requeue.py` — legacy wait below threshold, requeue-with-fresh-budget, HITL on exhaustion, kill-switch, gh-failure fail-soft. Full `make quality` green (exit 0).

Closes #9815

🤖 Generated with [Claude Code](https://claude.com/claude-code)