### PR TITLE
fix(gates): discover/shape rubrics skip when the artifact never existed (#9817, #9823)

### DIFF
--- a/src/discover_completeness.py
+++ b/src/discover_completeness.py
@@ -39,7 +39,17 @@ def build_discover_completeness_prompt(
     fenced via :func:`fenced_steering_guidance`, which returns ``""``
     when there is no guidance so behavior is unchanged when the feature
     is off.
+
+    Returns "" when *brief* is empty/absent (#9817/#9823): a plain bugfix
+    routed straight to implement never produced a Discover brief, and an
+    empty document trivially fails criterion 1 (missing-section:intent) —
+    a BLOCKING rubric fail that burned real implementation attempts on
+    process. The skill loop treats an empty prompt as "no input data" and
+    passes; the DiscoverRunner path always supplies a non-empty brief, so
+    its behavior is unchanged.
     """
+    if not brief.strip():
+        return ""
     prompt = f"""You are running the Discover Completeness skill for issue #{issue_number}: {issue_title}.
 
 You are evaluating a DISCOVERY BRIEF against the five-criterion rubric

--- a/src/shape_coherence.py
+++ b/src/shape_coherence.py
@@ -37,6 +37,13 @@ def build_shape_coherence_prompt(
     when there is no guidance so behavior is unchanged when the feature
     is off.
     """
+    if not proposal.strip():
+        # No Shape proposal exists (#9823): issues that skipped Shape must
+        # not fail a rubric over an absent document. Empty prompt = the
+        # skill loop's "no input data" pass; ShapeRunner always supplies a
+        # real proposal, unchanged.
+        return ""
+
     prompt = f"""You are running the Shape Coherence skill for issue #{issue_number}: {issue_title}.
 
 You are evaluating a SHAPE PROPOSAL against the five-criterion rubric

--- a/tests/regressions/test_issue_9817_gate_skips_absent_artifacts.py
+++ b/tests/regressions/test_issue_9817_gate_skips_absent_artifacts.py
@@ -1,0 +1,71 @@
+"""Regression: blocking gates failed issues over ABSENT artifacts (#9817, #9823).
+
+The post-implementation skill loop (src/agent.py) runs discover-completeness
+and shape-coherence as BLOCKING gates on every issue, but never passes a
+``brief``/``proposal`` — so a plain bugfix routed straight to implement was
+rubric-failed over an empty document (``missing-section:intent``), discarding
+clean, quality-passing attempts (live case: #9553's 16-minute run-2).
+
+Contract: the prompt builders return "" when their artifact is absent — the
+skill loop's existing empty-prompt escape then passes with "no input data".
+Real artifacts still produce full rubric prompts.
+"""
+
+from __future__ import annotations
+
+from discover_completeness import build_discover_completeness_prompt
+from shape_coherence import build_shape_coherence_prompt
+
+
+def test_absent_brief_yields_no_prompt_instead_of_rubric_fail() -> None:
+    prompt = build_discover_completeness_prompt(
+        issue_number=9553,
+        issue_title="subprocess reaping on watchdog cancellation",
+        diff="+ real code change",  # what the agent.py skill loop passes
+        plan_text="fix plan",
+    )
+
+    assert prompt == ""
+
+
+def test_whitespace_brief_is_treated_as_absent() -> None:
+    assert (
+        build_discover_completeness_prompt(
+            issue_number=1, issue_title="t", brief="   \n  "
+        )
+        == ""
+    )
+
+
+def test_real_brief_still_gets_the_full_rubric_prompt() -> None:
+    prompt = build_discover_completeness_prompt(
+        issue_number=1,
+        issue_title="t",
+        issue_body="original issue",
+        brief="## Intent\nReal discovery content.",
+    )
+
+    assert "five-criterion rubric" in prompt
+    assert "Real discovery content." in prompt
+
+
+def test_absent_shape_proposal_yields_no_prompt() -> None:
+    assert (
+        build_shape_coherence_prompt(
+            issue_number=9553,
+            issue_title="t",
+            diff="+ change",
+            plan_text="plan",
+        )
+        == ""
+    )
+
+
+def test_real_shape_proposal_still_prompts() -> None:
+    prompt = build_shape_coherence_prompt(
+        issue_number=1,
+        issue_title="t",
+        proposal="## Direction A\nreal proposal",
+    )
+
+    assert "real proposal" in prompt

--- a/tests/scenarios/test_agent_realistic.py
+++ b/tests/scenarios/test_agent_realistic.py
@@ -374,10 +374,11 @@ async def test_A10_quality_fix_loop_retries_then_passes(tmp_path) -> None:
         f"expected merged=True; outcome={result.issue(1)!r}; "
         f"docker_invocations={len(world.docker.invocations)}"
     )
-    # Exactly 9 FakeDocker invocations:
-    # 1 agent + 3 skills + 2 pre-quality + 1 make-quality-fail + 1 fix-agent +
-    # 1 make-quality-pass
-    assert len(world.docker.invocations) >= 9
+    # FakeDocker invocations:
+    # 1 agent + 2 skills + 2 pre-quality + 1 make-quality-fail + 1 fix-agent +
+    # 1 make-quality-pass = 8. (Was 9: discover-completeness no longer spends
+    # a subprocess turn when no Discover brief exists — #9817.)
+    assert len(world.docker.invocations) >= 8
 
 
 async def test_A11_review_fix_ci_loop_resolves(tmp_path) -> None:


### PR DESCRIPTION
## Problem (#9817 / #9823)

The post-implementation skill loop (`src/agent.py`) runs discover-completeness and shape-coherence as **blocking** gates on every issue but never passes a `brief`/`proposal` — a plain bugfix routed straight to implement was rubric-failed over an EMPTY document (`missing-section:intent`), discarding clean, quality-passing attempts (live case: #9553's 16-minute run-2 with 20 on-plan edits — burned on process, not product).

## Change

One guard at the choke point both callers share: the prompt builders return `""` when `brief`/`proposal` is empty. The skill loop's existing empty-prompt escape then passes with `"no input data"`. DiscoverRunner/ShapeRunner always supply real artifacts, so their rubric behavior is byte-identical.

## Tests

`tests/regressions/test_issue_9817_gate_skips_absent_artifacts.py`: agent-loop kwargs yield no prompt; whitespace = absent; real artifacts still get the full rubric. Full `make quality` green (exit 0).

Closes #9817
Closes #9823

🤖 Generated with [Claude Code](https://claude.com/claude-code)