### PR TITLE
fix(credit): throttle false-positive suppression + delayed loop restart (#9888)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -258,6 +258,11 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
     ("sentry_signal_cooldown_hours", "SENTRY_SIGNAL_COOLDOWN_HOURS", 24),
     ("security_patch_interval", "HYDRAFLOW_SECURITY_PATCH_INTERVAL", 3600),
     ("repo_wiki_interval", "HYDRAFLOW_REPO_WIKI_INTERVAL", 3600),
+    (
+        "credit_fp_suppress_cooldown_seconds",
+        "HYDRAFLOW_CREDIT_FP_SUPPRESS_COOLDOWN_SECONDS",
+        300,
+    ),
     ("repo_wiki_min_batch_files", "HYDRAFLOW_REPO_WIKI_MIN_BATCH_FILES", 8),
     ("repo_wiki_max_batch_age_hours", "HYDRAFLOW_REPO_WIKI_MAX_BATCH_AGE_HOURS", 24),
     ("max_repo_wiki_chars", "HYDRAFLOW_MAX_REPO_WIKI_CHARS", 15_000),
@@ -3299,6 +3304,17 @@ class HydraFlowConfig(BaseModel):
         ge=0,
         le=30,
         description="Extra minutes to wait after reported credit reset time",
+    )
+    credit_fp_suppress_cooldown_seconds: int = Field(
+        default=300,
+        ge=10,
+        le=3600,
+        description=(
+            "Cooldown after suppressing a false-positive credit signal from a "
+            "source: within it, repeat signals from that source are log-only "
+            "(no probe, no banner) and the raising loop restarts with a delay "
+            "instead of a tight spin (#9888)."
+        ),
     )
     credit_pause_require_probe: bool = Field(
         default=True,

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -122,6 +122,8 @@ class HydraFlowOrchestrator:
         self._auth_failed = False
         # Credit pause — set when API credits are exhausted
         self._credits_paused_until: datetime | None = None
+        # Per-source last false-positive suppression (#9888 throttle).
+        self._credit_fp_last: dict[str, datetime] = {}
         self._credit_pause_lock = asyncio.Lock()
         self._credit_resume_event = asyncio.Event()
         # Session tracking
@@ -1107,7 +1109,19 @@ class HydraFlowOrchestrator:
         """
         paused = await self._pause_for_credits(exc, loop_name, tasks, loop_factories)
         if not paused:
-            await self._restart_loop(loop_name, exc, tasks, loop_factories)
+            # Suppressed false positive: restart with a delay so a loop that
+            # re-raises the same quoted-prose signal cannot tight-spin the
+            # supervisor (#9888). The delay lives inside the restarted task,
+            # never blocking supervision of other loops.
+            await self._restart_loop(
+                loop_name,
+                exc,
+                tasks,
+                loop_factories,
+                restart_delay=min(
+                    float(self._config.credit_fp_suppress_cooldown_seconds), 60.0
+                ),
+            )
 
     async def _restart_loop(
         self,
@@ -1115,8 +1129,14 @@ class HydraFlowOrchestrator:
         exc: BaseException,
         tasks: dict[str, asyncio.Task[None]],
         loop_factories: list[tuple[str, Callable[[], Coroutine[Any, Any, None]]]],
+        restart_delay: float = 0.0,
     ) -> None:
-        """Log, publish ERROR event, create a new loop task."""
+        """Log, publish ERROR event, create a new loop task.
+
+        ``restart_delay`` > 0 sleeps INSIDE the recreated task before the
+        loop body starts (#9888 suppressed-credit backoff) — the supervisor
+        is never blocked and the task stays tracked in the map.
+        """
         logger.error("Loop %r crashed — restarting: %s", loop_name, exc)
         data: ErrorPayload = {
             "message": f"Loop {loop_name} crashed and was restarted",
@@ -1129,8 +1149,14 @@ class HydraFlowOrchestrator:
             )
         )
         factory_fn = dict(loop_factories)[loop_name]
+
+        async def _run_after_delay() -> None:
+            if restart_delay > 0:
+                await asyncio.sleep(restart_delay)
+            await factory_fn()
+
         tasks[loop_name] = asyncio.create_task(
-            factory_fn(), name=f"hydraflow-{loop_name}"
+            _run_after_delay(), name=f"hydraflow-{loop_name}"
         )
 
     async def restart_loop_task(self, name: str) -> bool:
@@ -1777,10 +1803,28 @@ class HydraFlowOrchestrator:
             # ``credit_pause_require_probe=False`` reverts to pause-on-text.
             # ``and`` short-circuits: with the kill-switch off, the probe is
             # never called (pause-on-text, the legacy behavior).
+            # Throttle repeat false positives from the same source (#9888):
+            # within the cooldown, skip the probe AND the banner — log-only.
+            # Six suppression banners landed in 3ms before this guard.
+            fp_last = self._credit_fp_last.get(source)
+            cooldown = float(self._config.credit_fp_suppress_cooldown_seconds)
+            if (
+                self._config.credit_pause_require_probe
+                and fp_last is not None
+                and (datetime.now(UTC) - fp_last).total_seconds() < cooldown
+            ):
+                logger.debug(
+                    "Credit FP from %r within %.0fs cooldown — suppressed (log-only)",
+                    source,
+                    cooldown,
+                )
+                return False
+
             if (
                 self._config.credit_pause_require_probe
                 and await probe_credit_availability()
             ):
+                self._credit_fp_last[source] = datetime.now(UTC)
                 logger.warning(
                     "Credit-exhaustion signal from %r NOT corroborated by live "
                     "API probe — treating as a false positive (likely quoted "

--- a/tests/regressions/test_issue_9888_credit_fp_throttle.py
+++ b/tests/regressions/test_issue_9888_credit_fp_throttle.py
@@ -1,0 +1,107 @@
+"""Regression: false-positive credit suppression flooded alerts + spun (#9888).
+
+After #9869's probe corroboration, a loop repeatedly raising a FALSE
+CreditExhaustedError (quoted prose) spun: probe → banner → immediate loop
+restart → re-raise. Observed six "NOT corroborated" SYSTEM_ALERTs in 3ms.
+
+Pins:
+1. Within the cooldown, repeat signals from the same source are log-only —
+   no probe call, no banner.
+2. After the cooldown expires, suppression (probe + single banner) resumes.
+3. A suppressed-credit restart delays the loop body inside the recreated
+   task (supervisor never blocked, task tracked).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from events import EventType
+from orchestrator import HydraFlowOrchestrator
+from subprocess_util import CreditExhaustedError
+
+
+def _alert_count(bus_mock) -> int:
+    return sum(
+        1
+        for call in bus_mock.publish.await_args_list
+        if call.args[0].type is EventType.SYSTEM_ALERT
+    )
+
+
+@pytest.mark.asyncio
+async def test_repeat_false_positives_within_cooldown_are_log_only(config) -> None:
+    orch = HydraFlowOrchestrator(config)
+    orch._bus = AsyncMock()
+    exc = CreditExhaustedError("Your credit balance is too low")
+    probe = AsyncMock(return_value=True)
+
+    with patch("orchestrator.probe_credit_availability", probe):
+        for _ in range(6):  # the observed 6-in-3ms storm
+            paused = await orch._pause_for_credits(exc, "diagnostic", {}, [])
+            assert paused is False
+
+    assert probe.await_count == 1  # only the first signal probed
+    assert _alert_count(orch._bus) == 1  # exactly one banner
+    assert orch._credits_paused_until is None
+
+
+@pytest.mark.asyncio
+async def test_cooldown_expiry_resumes_suppression_banner(config) -> None:
+    orch = HydraFlowOrchestrator(config)
+    orch._bus = AsyncMock()
+    exc = CreditExhaustedError("usage limit reached")
+    probe = AsyncMock(return_value=True)
+
+    with patch("orchestrator.probe_credit_availability", probe):
+        await orch._pause_for_credits(exc, "diagnostic", {}, [])
+        # Backdate the suppression past the cooldown (clock-free test).
+        orch._credit_fp_last["diagnostic"] = datetime.now(UTC) - timedelta(
+            seconds=config.credit_fp_suppress_cooldown_seconds + 1
+        )
+        await orch._pause_for_credits(exc, "diagnostic", {}, [])
+
+    assert probe.await_count == 2
+    assert _alert_count(orch._bus) == 2
+
+
+@pytest.mark.asyncio
+async def test_sources_are_throttled_independently(config) -> None:
+    orch = HydraFlowOrchestrator(config)
+    orch._bus = AsyncMock()
+    exc = CreditExhaustedError("credit balance too low")
+    probe = AsyncMock(return_value=True)
+
+    with patch("orchestrator.probe_credit_availability", probe):
+        await orch._pause_for_credits(exc, "diagnostic", {}, [])
+        await orch._pause_for_credits(exc, "reviewer", {}, [])
+
+    assert probe.await_count == 2  # per-source cooldowns
+
+
+@pytest.mark.asyncio
+async def test_restart_delay_runs_inside_the_recreated_task(config) -> None:
+    orch = HydraFlowOrchestrator(config)
+    orch._bus = AsyncMock()
+    started = asyncio.Event()
+
+    async def factory() -> None:
+        started.set()
+
+    tasks: dict[str, asyncio.Task[None]] = {}
+    await orch._restart_loop(
+        "diagnostic",
+        RuntimeError("x"),
+        tasks,
+        [("diagnostic", factory)],
+        restart_delay=0.05,
+    )
+
+    assert "diagnostic" in tasks  # tracked immediately — supervisor not blocked
+    assert not started.is_set()  # loop body has NOT run yet
+    await asyncio.wait_for(tasks["diagnostic"], timeout=2)
+    assert started.is_set()


### PR DESCRIPTION
## Problem (#9888 — regression from #9869)

A loop repeatedly raising a FALSE CreditExhaustedError (quoted prose) spun through the probe early-return: probe → banner → immediate restart → re-raise. Observed **six 'NOT corroborated' SYSTEM_ALERTs in 3ms**, flooding the UI banner and starving the event loop.

## Change

- **Per-source cooldown** (`credit_fp_suppress_cooldown_seconds`, default 300, env-overridable): within it, repeat signals from that source are log-only — no probe call, no banner. First suppression per window still probes and shows the single yellow banner (#9884).
- **Backoff on restart:** suppressed-credit restarts pass `restart_delay` to `_restart_loop`; the sleep runs INSIDE the recreated task (tracked in the map, supervisor never blocked — preserves the #9924 no-orphan contract).

## Tests

`tests/regressions/test_issue_9888_credit_fp_throttle.py`: the 6-in-a-row storm yields exactly 1 probe + 1 banner; cooldown expiry resumes suppression; per-source independence; delayed restart runs inside the tracked task. Full credit suites green; `make quality` exit 0.

Closes #9888

🤖 Generated with [Claude Code](https://claude.com/claude-code)