### PR TITLE
fix(epics): end the principles_audit anomaly→epic runaway — 3 causes (#9855, #9805, #9914)

### DIFF
--- a/src/issue_decomposer.py
+++ b/src/issue_decomposer.py
@@ -208,6 +208,17 @@ class IssueDecomposer:
                 source_task.id,
                 epic_number,
             )
+            # Close the just-created epic loudly (#9855): the 2026-07-18
+            # label-registration failure orphaned 23 of these in one day —
+            # "rare" only when child creation cannot systematically fail.
+            await self._prs.post_comment(
+                epic_number,
+                "## Decomposition Aborted\n\n"
+                "Every child-issue creation failed, so this epic has no "
+                f"children. Source #{source_task.id} stays open for "
+                "human-required escalation. Closing this orphan (#9855).",
+            )
+            await self._prs.close_issue(epic_number)
             return None
 
         # Register with EpicManager

--- a/src/prep.py
+++ b/src/prep.py
@@ -26,6 +26,11 @@ HYDRAFLOW_LABELS: tuple[tuple[str, str, str], ...] = (
     ("dup_label", "cfd3d7", "Issue already satisfied — no changes needed"),
     ("epic_label", "5319e7", "Epic tracking issue with linked sub-issues"),
     ("epic_child_label", "9b59b6", "Child issue linked to a HydraFlow epic"),
+    (
+        "auto_decomposed_child_label",
+        "9b59b6",
+        "Child created by decompose-to-converge (ADR-0105) — depth guard",
+    ),
     ("verify_label", "c2e0c6", "Post-merge verification pending"),
     ("parked_label", "c5c5c5", "Issue parked — awaiting author clarification"),
     ("diagnose_label", "1d76db", "Issue under diagnostic analysis before HITL"),
@@ -93,6 +98,16 @@ HYDRAFLOW_LITERAL_LABELS: tuple[tuple[str, str, str], ...] = (
     # --- escalation root (bare literal; config field resolves to the
     #     hydraflow-prefixed variant, so this bare name is never created by it) ---
     ("hitl-escalation", "b60205", "Stuck-loop HITL escalation (bare literal label)"),
+    (
+        "sandbox-fail-auto-fix",
+        "d93f0b",
+        "Sandbox suite failed — SandboxFailureFixerLoop dispatches the auto-agent",
+    ),
+    (
+        "sandbox-hitl",
+        "b60205",
+        "Sandbox auto-fix exhausted — needs a human (System tab HITL queue)",
+    ),
     # --- rc-red / RC-duration / revert family (operator-urgent, reddish) ---
     ("rc-red-attribution", "b60205", "Auto-revert culprit attribution for a red RC"),
     ("rc-red-bisect-exhausted", "b60205", "RC bisect exhausted without a culprit"),

--- a/src/principles_audit_loop.py
+++ b/src/principles_audit_loop.py
@@ -203,13 +203,22 @@ class PrinciplesAuditLoop(BaseBackgroundLoop):
                 continue
             if self._state.get_onboarding_status(mr.slug) != "blocked":
                 continue
-            snapshot = await self._audit_managed_repo(mr)
-            report = await self._fetch_last_report(mr)
-            fails = self._p1_p5_fails(report.get("findings", []))
-            if not fails:
-                self._state.set_onboarding_status(mr.slug, "ready")
-                self._state.set_last_green_audit(mr.slug, snapshot)
-                flipped += 1
+            # Per-target isolation (#9855/#9805) — see _reconcile_onboarding.
+            try:
+                snapshot = await self._audit_managed_repo(mr)
+                report = await self._fetch_last_report(mr)
+                fails = self._p1_p5_fails(report.get("findings", []))
+                if not fails:
+                    self._state.set_onboarding_status(mr.slug, "ready")
+                    self._state.set_last_green_audit(mr.slug, snapshot)
+                    flipped += 1
+            except (RuntimeError, OSError, ValueError, TimeoutError) as exc:
+                reraise_on_credit_or_bug(exc)
+                logger.warning(
+                    "principles_audit retry-blocked failed for %s: %s",
+                    mr.slug,
+                    exc,
+                )
         return flipped
 
     async def _run_audit(self, slug: str, repo_root: Path) -> dict[str, Any]:
@@ -585,12 +594,23 @@ class PrinciplesAuditLoop(BaseBackgroundLoop):
         for mr in self._config.managed_repos:
             if not mr.enabled:
                 continue
-            status = self._state.get_onboarding_status(mr.slug)
-            if status is None:
-                self._state.set_onboarding_status(mr.slug, "pending")
-                await self._run_onboarding_audit(mr)
-                count += 1
-            elif status == "pending":
-                await self._run_onboarding_audit(mr)
-                count += 1
+            # Per-target isolation (#9855/#9805): one unreachable managed
+            # repo must not kill the whole tick — that pegged
+            # tick_error_ratio at 1.0 and fed the anomaly->epic runaway.
+            try:
+                status = self._state.get_onboarding_status(mr.slug)
+                if status is None:
+                    self._state.set_onboarding_status(mr.slug, "pending")
+                    await self._run_onboarding_audit(mr)
+                    count += 1
+                elif status == "pending":
+                    await self._run_onboarding_audit(mr)
+                    count += 1
+            except (RuntimeError, OSError, ValueError, TimeoutError) as exc:
+                reraise_on_credit_or_bug(exc)
+                logger.warning(
+                    "principles_audit onboarding failed for %s: %s",
+                    mr.slug,
+                    exc,
+                )
         return count

--- a/src/trust_fleet_sanity_loop.py
+++ b/src/trust_fleet_sanity_loop.py
@@ -348,12 +348,74 @@ class TrustFleetSanityLoop(BaseBackgroundLoop):
             "filed": filed,
         }
 
+    async def _find_open_escalation(self, worker: str, kind: str) -> int:
+        """Open issue/epic already covering this anomaly, or 0 (#9855).
+
+        Triage may CLOSE the filed anomaly issue by decomposing it into an
+        epic; the reconcile pass then clears the dedup key even though the
+        anomaly is not resolved — and the detector minted a fresh epic
+        every cycle (23 orphans on 2026-07-18). GitHub is the source of
+        truth: when ANY open issue still references this worker+kind
+        (the original escalation or a derived epic), reuse it instead of
+        filing again. Fail-open (0) on gh errors — filing is the safe
+        degradation.
+        """
+        cmd = [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            self._config.repo,
+            "--state",
+            "open",
+            "--search",
+            f"{kind} in:title",
+            "--limit",
+            "50",
+            "--json",
+            "number,title",
+        ]
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                stdout, _ = await asyncio.wait_for(
+                    proc.communicate(), timeout=_RECONCILE_GH_TIMEOUT_SECONDS
+                )
+            except TimeoutError:
+                proc.kill()
+                logger.warning("open-escalation probe timed out — filing anyway")
+                return 0
+            rows = json.loads(stdout.decode() or "[]")
+        except (OSError, ValueError, RuntimeError) as exc:
+            reraise_on_credit_or_bug(exc)
+            logger.debug("open-escalation probe failed: %s", exc)
+            return 0
+        for row in rows:
+            title = str(row.get("title", ""))
+            if worker in title and kind in title:
+                return int(row.get("number") or 0)
+        return 0
+
     async def _file_anomaly(
         self,
         worker: str,
         kind: str,
         details: dict[str, Any],
     ) -> int:
+        existing = await self._find_open_escalation(worker, kind)
+        if existing > 0:
+            logger.info(
+                "trust_fleet_sanity: open issue #%d already covers %s/%s — "
+                "reusing instead of re-filing (#9855)",
+                existing,
+                worker,
+                kind,
+            )
+            return existing
         title = f"HITL: trust-loop anomaly — {worker} {kind}"
         detail_lines = "\n".join(
             f"- `{k}`: `{v}`" for k, v in sorted(details.items()) if k not in {"worker"}

--- a/tests/regressions/test_decompose_empty_children.py
+++ b/tests/regressions/test_decompose_empty_children.py
@@ -63,11 +63,13 @@ async def test_all_children_fail_keeps_source_open_for_hitl(tmp_path: Path) -> N
         source_task=source, result=_two_child_result()
     )
 
-    # Nothing was superseded: no epic registered, source neither closed nor
-    # marked decomposed — it falls through to human-required.
+    # Nothing was superseded: no epic registered, SOURCE stays open and
+    # unmarked — it falls through to human-required. The just-created epic
+    # itself is closed loudly rather than left as orphan litter (#9855:
+    # 23 childless epics in one day when child labels broke repo-wide).
     assert epic_number is None
     epic_manager.register_epic.assert_not_awaited()
-    prs.close_issue.assert_not_awaited()
+    prs.close_issue.assert_awaited_once_with(500)  # the orphan epic, NOT #42
     assert state.get_issue_status(42) != "decomposed"
 
 

--- a/tests/regressions/test_issue_9855_epic_runaway.py
+++ b/tests/regressions/test_issue_9855_epic_runaway.py
@@ -1,0 +1,147 @@
+"""Regression: 23 orphaned principles_audit epics in one day (#9855, #9805).
+
+Three compounding defects, each pinned here:
+1. The decomposer's child label (``auto-decomposed-child``) was never
+   registered repo-wide, so every child creation hard-failed and each epic
+   was born childless — and the orphan epic was left OPEN as litter.
+2. ``principles_audit``'s ``_reconcile_onboarding``/``_retry_blocked`` had no
+   per-target isolation: one unreachable managed repo killed the whole tick,
+   pegging ``tick_error_ratio=1.0`` (#9805 — recurred 6×).
+3. ``TrustFleetSanityLoop`` cleared the anomaly dedup key when the filed
+   issue closed — but triage closes it BY DECOMPOSING it, so an unresolved
+   anomaly minted a fresh epic every cycle.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from models import EpicDecompResult, NewIssueSpec
+from prep import HYDRAFLOW_LABELS, HYDRAFLOW_LITERAL_LABELS
+from principles_audit_loop import PrinciplesAuditLoop
+from subprocess_util import CreditExhaustedError
+from trust_fleet_sanity_loop import TrustFleetSanityLoop
+
+
+def test_decomposer_labels_are_registered_at_startup() -> None:
+    config_fields = {row[0] for row in HYDRAFLOW_LABELS}
+    literals = {row[0] for row in HYDRAFLOW_LITERAL_LABELS}
+
+    assert "auto_decomposed_child_label" in config_fields  # root cause 1
+    assert "sandbox-fail-auto-fix" in literals  # #9914 durable check
+    assert "sandbox-hitl" in literals
+
+
+class TestPerTargetIsolation:
+    @staticmethod
+    def _loop(repos, audit_side_effects):
+        state = MagicMock()
+        state.get_onboarding_status = MagicMock(return_value=None)
+        state.set_onboarding_status = MagicMock()
+        loop = SimpleNamespace(
+            _config=SimpleNamespace(managed_repos=repos),
+            _state=state,
+            _run_onboarding_audit=AsyncMock(side_effect=audit_side_effects),
+        )
+        return loop
+
+    @pytest.mark.asyncio
+    async def test_one_unreachable_target_does_not_kill_the_tick(self) -> None:
+        repos = [
+            SimpleNamespace(enabled=True, slug="acme/dead"),
+            SimpleNamespace(enabled=True, slug="acme/alive"),
+        ]
+        loop = self._loop(repos, [RuntimeError("unreachable"), None])
+
+        count = await PrinciplesAuditLoop._reconcile_onboarding(loop)
+
+        assert count == 1  # the healthy target was still processed
+        assert loop._run_onboarding_audit.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_credit_exhaustion_still_propagates(self) -> None:
+        repos = [SimpleNamespace(enabled=True, slug="acme/x")]
+        loop = self._loop(repos, [CreditExhaustedError("cap")])
+
+        with pytest.raises(CreditExhaustedError):
+            await PrinciplesAuditLoop._reconcile_onboarding(loop)
+
+
+class TestAnomalyMintGuard:
+    @pytest.mark.asyncio
+    async def test_open_escalation_is_reused_instead_of_refiled(self) -> None:
+        loop = SimpleNamespace(
+            _find_open_escalation=AsyncMock(return_value=77),
+            _pr=MagicMock(create_issue=AsyncMock()),
+            _config=MagicMock(),
+        )
+
+        number = await TrustFleetSanityLoop._file_anomaly(
+            loop, "principles_audit", "tick_error_ratio", {"ratio": 1.0}
+        )
+
+        assert number == 77
+        loop._pr.create_issue.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_open_escalation_files_normally(self) -> None:
+        loop = SimpleNamespace(
+            _find_open_escalation=AsyncMock(return_value=0),
+            _pr=MagicMock(create_issue=AsyncMock(return_value=101)),
+            _config=MagicMock(),
+        )
+
+        number = await TrustFleetSanityLoop._file_anomaly(
+            loop, "principles_audit", "tick_error_ratio", {"ratio": 1.0}
+        )
+
+        assert number == 101
+        loop._pr.create_issue.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_childless_decomposition_closes_the_orphan_epic(
+    tmp_path: Path,
+) -> None:
+    from issue_decomposer import IssueDecomposer
+    from mockworld.fakes.fake_github import FakeGitHub
+    from tests.conftest import TaskFactory
+    from tests.helpers import ConfigFactory, make_tracker
+
+    config = ConfigFactory.create(repo_root=tmp_path / "repo")
+    prs = FakeGitHub()
+    epic_manager = MagicMock()
+    epic_manager.register_epic = AsyncMock()
+    decomposer = IssueDecomposer(prs, epic_manager, make_tracker(tmp_path), config)
+    prs.add_issue(10, "Source issue", "Original body")
+
+    real_create = prs.create_issue
+    calls = {"n": 0}
+
+    async def epic_only(title, body, labels=None):  # children fail (#9855 rc 1)
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return await real_create(title, body, labels)
+        return 0
+
+    prs.create_issue = epic_only  # type: ignore[method-assign]
+
+    result = await decomposer.create_epic_from_result(
+        source_task=TaskFactory.create(id=10),
+        result=EpicDecompResult(
+            should_decompose=True,
+            epic_title="Epic: doomed",
+            epic_body="## Sub-issues",
+            children=[NewIssueSpec(title="Child 1", body="Do 1")],
+            reasoning="r",
+        ),
+    )
+
+    assert result is None  # source stays open for human-required
+    epic = next(i for i in prs._issues.values() if i.title == "Epic: doomed")
+    assert epic.state == "closed"  # no more orphan litter
+    epic_manager.register_epic.assert_not_awaited()

--- a/tests/test_pr_manager_core.py
+++ b/tests/test_pr_manager_core.py
@@ -1816,6 +1816,7 @@ async def test_ensure_labels_exist_uses_config_label_names(config, event_bus, tm
         "custom-dup",
         "custom-epic",
         "custom-epic-child",
+        "auto-decomposed-child",  # #9855: decomposer child label now startup-ensured
         "custom-verify",
         "hydraflow-parked",
         "hydraflow-diagnose",
@@ -1825,6 +1826,8 @@ async def test_ensure_labels_exist_uses_config_label_names(config, event_bus, tm
         "hydraflow-test-helper",
         "hydraflow-fake-coverage-stuck",
         "rc-promotion-stuck",
+        "sandbox-fail-auto-fix",  # #9914 durable startup check
+        "sandbox-hitl",
         "hydraflow-adr-drift",
         "hydraflow-adr-drift-stuck",
         "hydraflow-log-ingest",


### PR DESCRIPTION
## Problem (#9855)

23 orphaned 'principles_audit tick_error_ratio anomaly' epics minted in one day (04:11→15:35), all childless, all HITL-free. Three compounding defects — fixing any one alone is insufficient.

## Changes

1. **Labels (root cause 1 + #9914's durable check):** prep's startup registry never included `auto_decomposed_child_label`, so EVERY decompose child creation hard-failed repo-wide. Added it, plus the `sandbox-fail-auto-fix`/`sandbox-hitl` literals (the SandboxFailureFixerLoop routing labels — closing #9914's remaining scope). And the decomposer now **closes the just-created epic loudly** (comment + close) when zero children were created — 'rare orphan' was disproven 23 times in a day. Source still stays open for human-required.
2. **Per-target tick isolation (#9805, recurred 6×):** `_reconcile_onboarding`/`_retry_blocked` wrap each managed repo in a concrete-exception try (credit-exhaustion reraised first) — one unreachable target no longer pegs `tick_error_ratio=1.0`.
3. **Mint guard (root cause 3):** triage closes the anomaly issue BY DECOMPOSING it, which cleared the dedup key while the anomaly was unresolved → a fresh epic every cycle. `_file_anomaly` now probes GitHub for ANY open issue referencing the worker+kind (original escalation OR derived epic) and reuses it; fail-open to filing on probe errors.

## Tests

`tests/regressions/test_issue_9855_epic_runaway.py` (6 pins: label rows, isolation + credit propagation, mint-guard reuse/file, childless-epic close). Updated the two prior pins to the sharper contracts (empty-children closes the orphan epic — with the source untouched; ensure-labels exact set). Full `make quality` green (exit 0).

Closes #9855
Closes #9805
Closes #9914

🤖 Generated with [Claude Code](https://claude.com/claude-code)