### PR TITLE
fix(ui): StreamView queued count derives from the rendered rows (#9793)

### DIFF
--- a/src/ui/src/components/StreamView.jsx
+++ b/src/ui/src/components/StreamView.jsx
@@ -164,8 +164,17 @@ function EpicContainer({ epicNumber, issues, children }) {
 }
 
 function StageSection({ stage, issues, workerCount, workerCap, queuedCount, intentMap, onRequestChanges, open, onToggle, enabled, dotColor, workers, prs }) {
-  const failedCount = issues.filter(i => i.overallStatus === 'failed').length
-  const hitlCount = issues.filter(i => i.overallStatus === 'hitl').length
+  const safeIssues = issues || []
+  const failedCount = safeIssues.filter(i => i.overallStatus === 'failed').length
+  const hitlCount = safeIssues.filter(i => i.overallStatus === 'hitl').length
+  // #9793: the header count and the expanded list previously came from two
+  // sources (orchestrator live counters vs the label-derived /api/pipeline
+  // snapshot) — "1 queued" could render zero queued rows. The count shown is
+  // now derived from the SAME rows the expansion renders; when the
+  // orchestrator is ahead of the snapshot the delta is shown honestly as
+  // "syncing" instead of a phantom row count.
+  const listQueuedCount = safeIssues.filter(i => i.overallStatus === 'queued').length
+  const syncingCount = Math.max(0, (queuedCount || 0) - listQueuedCount)
   const hasRole = !!stage.role
 
   return (
@@ -186,7 +195,10 @@ function StageSection({ stage, issues, workerCount, workerCap, queuedCount, inte
         <span style={sectionCountStyles[stage.key]}>
           {hasRole ? (
             <>
-              <span>{queuedCount} queued</span>
+              <span data-testid={`stage-queued-${stage.key}`}>
+                {listQueuedCount} queued
+                {syncingCount > 0 && ` (+${syncingCount} syncing)`}
+              </span>
               {failedCount > 0 && <span style={styles.failedBadge}> · {failedCount} failed</span>}
               {hitlCount > 0 && <span style={styles.hitlBadge}> · {hitlCount} hitl</span>}
               <span>
@@ -196,7 +208,7 @@ function StageSection({ stage, issues, workerCount, workerCap, queuedCount, inte
               </span>
             </>
           ) : (
-            <span>{issues.length} {NO_ROLE_COUNT_LABELS[stage.key] ?? 'merged'}</span>
+            <span>{safeIssues.length} {NO_ROLE_COUNT_LABELS[stage.key] ?? 'merged'}</span>
           )}
         </span>
         <span
@@ -208,7 +220,7 @@ function StageSection({ stage, issues, workerCount, workerCap, queuedCount, inte
         // Group epic children by epicNumber, keep standalone separate
         const epicGroups = {}
         const standalone = []
-        for (const issue of issues) {
+        for (const issue of safeIssues) {
           if (issue.isEpicChild && issue.epicNumber > 0) {
             if (!epicGroups[issue.epicNumber]) epicGroups[issue.epicNumber] = []
             epicGroups[issue.epicNumber].push(issue)

--- a/src/ui/src/components/__tests__/StreamView.test.jsx
+++ b/src/ui/src/components/__tests__/StreamView.test.jsx
@@ -996,3 +996,43 @@ describe('StreamView transcript integration', () => {
     expect(screen.queryByTestId('transcript-preview')).not.toBeInTheDocument()
   })
 })
+
+describe('StageSection reconciled queued count (#9793)', () => {
+  it('derives the queued count from the rendered rows, showing snapshot lag as syncing', () => {
+    // Orchestrator says 3 queued, snapshot has 1 row: header must match the
+    // list (1) and surface the lag honestly instead of a phantom count.
+    const ctx = defaultHydraFlowContext({
+      pipelineIssues: {
+        plan: [{ issue_number: 1, title: 'Q1', status: 'queued' }],
+      },
+    })
+    ctx.stageStatus = {
+      ...ctx.stageStatus,
+      plan: { ...(ctx.stageStatus.plan || {}), enabled: true, queuedCount: 3, workerCount: 0 },
+    }
+    mockUseHydraFlow.mockReturnValue(ctx)
+    render(<StreamView {...defaultProps} />)
+
+    const queued = screen.getByTestId('stage-queued-plan')
+    expect(queued.textContent).toContain('1 queued')
+    expect(queued.textContent).toContain('(+2 syncing)')
+  })
+
+  it('shows no syncing suffix when header and list agree', () => {
+    const ctx = defaultHydraFlowContext({
+      pipelineIssues: {
+        plan: [{ issue_number: 2, title: 'Q2', status: 'queued' }],
+      },
+    })
+    ctx.stageStatus = {
+      ...ctx.stageStatus,
+      plan: { ...(ctx.stageStatus.plan || {}), enabled: true, queuedCount: 1, workerCount: 0 },
+    }
+    mockUseHydraFlow.mockReturnValue(ctx)
+    render(<StreamView {...defaultProps} />)
+
+    const queued = screen.getByTestId('stage-queued-plan')
+    expect(queued.textContent).toContain('1 queued')
+    expect(queued.textContent).not.toContain('syncing')
+  })
+})


### PR DESCRIPTION
## Problem (#9793)

A phase header could show '1 queued' while its expansion rendered zero queued rows: header from orchestrator live counters, list from the label-derived /api/pipeline snapshot — two sources, one truth gap.

## Change

Header queued count now derives from the SAME rows the expansion renders; when the orchestrator is ahead of the snapshot the delta shows honestly as '(+N syncing)'. StageSection hardened against undefined issues (the reported 'reading length' vite errors).

## Tests

2 new vitest cases (lagging snapshot → syncing suffix; agreement → none). Full UI suite: 1179 passed. `make quality` exit 0.

Closes #9793

🤖 Generated with [Claude Code](https://claude.com/claude-code)