### PR TITLE
fix(repos): idle repos can be unregistered — slug round-trip reconciled (#9887)

### DIFF
--- a/src/repo_store.py
+++ b/src/repo_store.py
@@ -140,15 +140,39 @@ class RepoRegistryStore:
         return record
 
     def remove(self, slug: str) -> bool:
+        """Remove a record by slug — raw OR path-sanitized form (#9887).
+
+        ``/api/repos`` renders ``slug.replace("/", "-")`` (path-safe for the
+        DELETE URL), so the UI can only ever send back the sanitized form —
+        which previously never matched a raw ``owner/name`` record and made
+        idle registrations undeletable (404 on the exact slug the listing
+        emitted).
+        """
         slug = slug.strip()
         if not slug:
             return False
         records = self.load()
-        filtered = [r for r in records if r.slug != slug]
+        filtered = [
+            r for r in records if r.slug != slug and r.slug.replace("/", "-") != slug
+        ]
         if len(filtered) == len(records):
             return False
         self.save(filtered)
         return True
+
+    def resolve_slug(self, slug: str) -> str | None:
+        """Return the RAW record slug for *slug* (raw or sanitized), or None.
+
+        Registry keys use the raw slug; callers holding a sanitized one
+        (every UI DELETE) must resolve before touching the registry (#9887).
+        """
+        slug = slug.strip()
+        if not slug:
+            return None
+        for r in self.load():
+            if r.slug == slug or r.slug.replace("/", "-") == slug:
+                return r.slug
+        return None
 
     def update_overrides(self, slug: str, updates: dict[str, Any]) -> bool:
         slug = slug.strip()

--- a/src/server.py
+++ b/src/server.py
@@ -288,10 +288,13 @@ async def _run_with_dashboard(config: HydraFlowConfig) -> None:
         return record, repo_cfg
 
     async def _remove_repo(slug: str) -> bool:
-        rt = registry.remove(slug)
+        # The UI sends the path-sanitized slug the listing emitted; the
+        # registry is keyed by the RAW record slug — resolve first (#9887).
+        raw = repo_store.resolve_slug(slug) or slug
+        rt = registry.remove(raw)
         if rt is not None:
             await rt.stop()
-        return repo_store.remove(slug)
+        return repo_store.remove(raw)
 
     credentials = build_credentials(config)
 

--- a/tests/regressions/test_issue_9887_repo_unregister_slug.py
+++ b/tests/regressions/test_issue_9887_repo_unregister_slug.py
@@ -1,0 +1,54 @@
+"""Regression: idle repos could never be unregistered (#9887).
+
+``/api/repos`` renders a path-sanitized slug (``owner/name`` →
+``owner-name``) for the DELETE URL, but ``repo_store.remove`` matched only
+the RAW record slug — so the exact slug the listing emitted always 404'd
+and idle registrations were stuck in the UI forever.
+
+Pins: removal accepts both forms; ``resolve_slug`` maps a sanitized slug
+back to the raw registry key; misses stay misses.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from repo_store import RepoRecord, RepoStore
+
+
+def _store_with(tmp_path: Path, slug: str) -> RepoStore:
+    store = RepoStore(tmp_path / "repos.json")
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(exist_ok=True)
+    store.upsert(RepoRecord(slug=slug, repo="T-rav/amplifier", path=str(repo_dir)))
+    return store
+
+
+def test_remove_accepts_the_sanitized_slug_the_listing_emits(tmp_path: Path) -> None:
+    store = _store_with(tmp_path, "T-rav/amplifier")
+
+    assert store.remove("T-rav-amplifier") is True  # the exact UI DELETE value
+    assert store.list() == []
+
+
+def test_remove_still_accepts_the_raw_slug(tmp_path: Path) -> None:
+    store = _store_with(tmp_path, "T-rav/amplifier")
+
+    assert store.remove("T-rav/amplifier") is True
+    assert store.list() == []
+
+
+def test_resolve_slug_maps_sanitized_to_raw_registry_key(tmp_path: Path) -> None:
+    store = _store_with(tmp_path, "T-rav/amplifier")
+
+    assert store.resolve_slug("T-rav-amplifier") == "T-rav/amplifier"
+    assert store.resolve_slug("T-rav/amplifier") == "T-rav/amplifier"
+    assert store.resolve_slug("nope") is None
+    assert store.resolve_slug("  ") is None
+
+
+def test_miss_still_returns_false(tmp_path: Path) -> None:
+    store = _store_with(tmp_path, "T-rav/amplifier")
+
+    assert store.remove("other-repo") is False
+    assert len(store.list()) == 1


### PR DESCRIPTION
## Problem (#9887)

`/api/repos` renders a path-sanitized slug (`owner/name` → `owner-name`) for the DELETE URL, but `repo_store.remove` matched only the RAW record slug — the exact slug the listing emitted always 404'd. Idle registrations (T-rav-amplifier, T-rav-harvestd) were stuck in the UI forever; `DELETE /api/runtimes` only handles running runtimes.

## Change

- `repo_store.remove` accepts raw AND sanitized forms.
- New `repo_store.resolve_slug` maps sanitized → raw; `server._remove_repo` resolves before touching the registry, so deleting a RUNNING repo via the sanitized slug also stops its runtime.
- `DELETE /api/repos/{slug}` now removes idle registrations (registry miss is fine — the store is the source of truth).

## Tests

`tests/regressions/test_issue_9887_repo_unregister_slug.py` (sanitized removal — the exact UI value; raw still works; resolve_slug both forms + misses; miss stays False). `make quality` exit 0.

Closes #9887

🤖 Generated with [Claude Code](https://claude.com/claude-code)