### PR TITLE
test(triage): pin bug_not_present ADVANCE ledger recording (#9678)

### DIFF
--- a/tests/test_triage_phase.py
+++ b/tests/test_triage_phase.py
@@ -712,3 +712,120 @@ class TestTriageConvergenceLedger:
         ledger = state.get_convergence_ledger(102)
         assert ledger is not None, "Ledger must be created"
         assert ledger.stage_state["triage"].last_verdict == "LOOP_BACK"
+
+    @pytest.mark.asyncio
+    async def test_bug_not_present_records_advance_verdict(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """bug_not_present early-return site -> ledger triage verdict == 'ADVANCE'.
+
+        Regression guard (issue #9678): the ``bug_not_present`` recording is a
+        SEPARATE call-site from the fall-through one — it lives inside the
+        bug-reproducer block and ``return``s before the fall-through site is
+        reached. The other ledger tests exercise only the fall-through site, so a
+        future edit could silently regress this early-return recording while they
+        stay green. This test pins it.
+        """
+        from models import ReproductionOutcome, ReproductionResult
+
+        phase, state, triage, prs, store, _stop = make_triage_phase(config)
+        issue = TaskFactory.create(
+            id=103,
+            title="Crash in validate_config",
+            body="A" * 100,
+        )
+        # Ready + bug + default clarity (10 >= threshold) routes to 'plan',
+        # which is the only path that reaches the bug-reproducer block.
+        triage.evaluate = AsyncMock(
+            return_value=TriageResultFactory.create(
+                issue_number=103, ready=True, issue_type="bug"
+            )
+        )
+        store.get_triageable = supply_once([issue])
+
+        from unittest.mock import MagicMock
+
+        from bug_reproducer import BugReproducer
+        from issue_cache import IssueCache
+
+        # The bug-reproducer block guard requires BOTH _bug_reproducer and
+        # _issue_cache to be non-None (see src/triage_phase.py) — omitting
+        # either would route past the early-return site and pass for the wrong
+        # reason.
+        mock_reproducer = MagicMock(spec=BugReproducer)
+        mock_reproducer.reproduce = AsyncMock(
+            return_value=ReproductionResult(
+                issue_number=103,
+                outcome=ReproductionOutcome.NOT_PRESENT,
+                confidence=0.0,
+                investigation="validate_config does not exist in src/",
+            )
+        )
+        phase._bug_reproducer = mock_reproducer
+
+        mock_cache = MagicMock(spec=IssueCache)
+        mock_cache.record_classification = MagicMock()
+        mock_cache.record_reproduction_stored = MagicMock()
+        phase._issue_cache = mock_cache
+
+        await phase.triage_issues()
+
+        ledger = state.get_convergence_ledger(103)
+        assert ledger is not None, "Ledger must be created"
+        assert ledger.stage_state["triage"].last_verdict == "ADVANCE"
+
+    @pytest.mark.asyncio
+    async def test_discover_routing_records_loop_back_verdict(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Issue routed to discovery -> ledger triage verdict == 'LOOP_BACK'.
+
+        Symmetry coverage for the 'discover' fall-through outcome (distinct from
+        the 'parked' outcome already covered).
+        """
+        phase, state, triage, prs, store, _stop = make_triage_phase(config)
+        issue = TaskFactory.create(id=104, title="Make it better", body="A" * 100)
+
+        triage.evaluate = AsyncMock(
+            return_value=TriageResultFactory.create(
+                issue_number=104, ready=True, needs_discovery=True
+            )
+        )
+        store.get_triageable = supply_once([issue])
+
+        await phase.triage_issues()
+
+        ledger = state.get_convergence_ledger(104)
+        assert ledger is not None, "Ledger must be created"
+        assert ledger.stage_state["triage"].last_verdict == "LOOP_BACK"
+
+    @pytest.mark.asyncio
+    async def test_sentry_noise_closed_records_advance_verdict(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Sentry-noise auto-close -> ledger triage verdict == 'ADVANCE'.
+
+        Symmetry coverage for the 'sentry_noise_closed' fall-through outcome: a
+        not-ready Sentry-originated issue is auto-closed and recorded as ADVANCE.
+        """
+        phase, state, triage, prs, store, _stop = make_triage_phase(config)
+        issue = TaskFactory.create(
+            id=105,
+            title="TypeError in worker",
+            body="<!-- [sentry:issue-abc] -->\nAutomated Sentry report.",
+        )
+
+        triage.evaluate = AsyncMock(
+            return_value=TriageResultFactory.create(
+                issue_number=105,
+                ready=False,
+                reasons=["Transient infrastructure error, not a code bug"],
+            )
+        )
+        store.get_triageable = supply_once([issue])
+
+        await phase.triage_issues()
+
+        ledger = state.get_convergence_ledger(105)
+        assert ledger is not None, "Ledger must be created"
+        assert ledger.stage_state["triage"].last_verdict == "ADVANCE"


### PR DESCRIPTION
## Summary

Closes #9678.

The Triage phase records a convergence-ledger boundary verdict at **two** independent `record_stage_verdict` call-sites:
1. An **early-return site** inside the bug-reproducer block (`bug_not_present` → `ADVANCE`), which `return`s before the fall-through site is reached.
2. The shared **fall-through site** (`plan`/`discover`/`parked`/`sentry_noise_closed`/`already_addressed`/`epic_decomposed`).

The existing `TestTriageConvergenceLedger` tests only exercised the fall-through site (`plan`→ADVANCE, `parked`→LOOP_BACK). The early-return `bug_not_present` recording had no dedicated ledger assertion, so a future edit could silently regress it while the fall-through tests stay green.

## Changes

`tests/test_triage_phase.py` — three new tests in `TestTriageConvergenceLedger`:
- **`test_bug_not_present_records_advance_verdict`** (required) — drives a ready `bug` issue whose reproducer returns `NOT_PRESENT`, asserts `stage_state["triage"].last_verdict == "ADVANCE"`, exercising the early-return site.
- **`test_discover_routing_records_loop_back_verdict`** (symmetry) — `discover` → `LOOP_BACK`.
- **`test_sentry_noise_closed_records_advance_verdict`** (symmetry) — `sentry_noise_closed` → `ADVANCE`.

Test-only change; no production code touched.

## Notes

- Follows the existing gateless pattern. `convergence_gate_enabled` was removed (ADR-0102) and recording is now unconditional, so the new tests do **not** reference that flag (the issue's literal instruction to set it is stale context).
- Fixture mirrors the proven `test_not_present_repro_auto_closes_issue` — both `_bug_reproducer` and `_issue_cache` mocks set, `issue_type="bug"`, default clarity so routing lands on `plan` and reaches the reproducer block.
- **Mutation check**: temporarily removing the `bug_not_present` → `ADVANCE` mapping makes the new test fail (ledger is `None`), confirming it guards the early-return site rather than passing via the fall-through.

## Verification

- `pytest tests/test_triage_phase.py::TestTriageConvergenceLedger` — 5 passed
- `pytest tests/test_triage_phase.py tests/test_convergence_recording.py` — 39 passed
- `ruff check` + `ruff format --check` on `tests/test_triage_phase.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)