### PR TITLE
feat(control-status): expose boot SHA + commits-behind for staleness observability (#9663)

### DIFF
--- a/src/dashboard_routes/_control_routes.py
+++ b/src/dashboard_routes/_control_routes.py
@@ -24,6 +24,7 @@ from config import HydraFlowConfig, save_config_file
 from dashboard_routes._common import _INTERVAL_BOUNDS
 from dashboard_routes._routes import RouteContext
 from events import EventType, HydraFlowEvent
+from git_revision import get_boot_sha, get_commits_behind
 from models import (
     BackgroundWorkersResponse,
     BackgroundWorkerState,
@@ -575,12 +576,19 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
     )
 
     def _control_status_config(
-        cfg: HydraFlowConfig, *, latest_version: str, update_available: bool
+        cfg: HydraFlowConfig,
+        *,
+        latest_version: str,
+        update_available: bool,
+        boot_sha: str | None,
+        commits_behind: int | None,
     ) -> ControlStatusConfig:
         return ControlStatusConfig(
             app_version=get_app_version(),
             latest_version=latest_version,
             update_available=update_available,
+            boot_sha=boot_sha,
+            commits_behind=commits_behind,
             repo=cfg.repo,
             ready_label=cfg.ready_label,
             find_label=cfg.find_label,
@@ -637,6 +645,11 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
         update_available = (
             update_result.update_available if update_result is not None else False
         )
+        # Boot SHA + commits-behind describe the running *process*, not any one
+        # managed repo, so compute them once and reuse across the rollup. Both
+        # are cheap, local, failure-tolerant git reads (None when unavailable).
+        boot_sha = get_boot_sha()
+        commits_behind = get_commits_behind()
 
         if repo is not None and repo.strip().lower() == REPO_ALL:
             per_repo: list[dict[str, Any]] = []
@@ -659,6 +672,8 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
                             _cfg,
                             latest_version=latest_version,
                             update_available=update_available,
+                            boot_sha=boot_sha,
+                            commits_behind=commits_behind,
                         ).model_dump(),
                     }
                 )
@@ -673,6 +688,8 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
                     d_cfg,
                     latest_version=latest_version,
                     update_available=update_available,
+                    boot_sha=boot_sha,
+                    commits_behind=commits_behind,
                 ),
                 mockworld_active=mockworld_any,
                 repos=per_repo,
@@ -692,6 +709,8 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
                 _cfg,
                 latest_version=latest_version,
                 update_available=update_available,
+                boot_sha=boot_sha,
+                commits_behind=commits_behind,
             ),
             mockworld_active=mockworld_active,
         )

--- a/src/git_revision.py
+++ b/src/git_revision.py
@@ -1,0 +1,92 @@
+"""Git revision helpers for runtime staleness observability.
+
+Exposes the process **boot SHA** (captured once, in-memory, at first access)
+and a cheap, failure-tolerant **commits-behind** count relative to the remote
+tracking branch.  Consumed by ``GET /api/control/status`` so operators get an
+always-on "you are N commits behind" indicator without waiting for the
+StaleCodeWatcher HITL threshold to trip.
+
+Design notes:
+
+* ``get_app_version()`` reports the installed *package* version, which is
+  unchanged across commits in a ``pip install -e .`` checkout — useless for
+  staleness detection.  The git SHA is the real revision signal.
+* The boot SHA is cached the first time it is read and never re-read: a
+  ``git pull`` without a process restart advances ``HEAD`` while the running
+  bytecode stays stale, so re-reading ``HEAD`` each call would silently mask
+  that drift.
+* All git reads are local (no network fetch), bounded by a short timeout, and
+  failure-tolerant — they return ``None`` rather than raising or hanging, so
+  the status endpoint can never wedge on a broken git process.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+# Short timeout: these are all local, read-only git operations (no network).
+# Bounded so the status endpoint can never hang on a wedged git process.
+_GIT_TIMEOUT_SECS = 5
+# The staging branch is the promotion target the running factory tracks
+# (ADR-0042); commits-behind is measured against its remote-tracking ref.
+_DEFAULT_BASE_REF = "origin/staging"
+
+# Sentinel distinguishing "not yet captured" from "captured, unavailable".
+_UNSET: object = object()
+# Single-slot mutable container so the cache can be rebound without `global`
+# (PLW0603). Index 0 holds the captured boot SHA (``str`` or ``None`` once
+# captured, ``_UNSET`` before first read).
+_BOOT_SHA_SLOT: list[object | str | None] = [_UNSET]
+
+
+def _run_git(args: list[str]) -> str | None:
+    """Run a read-only git command, returning stripped stdout or ``None``.
+
+    Failure-tolerant: git missing, non-zero exit, timeout, or "not a repo" all
+    return ``None`` rather than raising, so callers never hang or crash.
+    """
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_SECS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    out = result.stdout.strip()
+    return out or None
+
+
+def get_boot_sha() -> str | None:
+    """Return the git ``HEAD`` SHA captured once, in-memory, at first access.
+
+    The value is cached on first read and never re-read (see module docstring).
+    Returns ``None`` if the SHA is unavailable.
+    """
+    if _BOOT_SHA_SLOT[0] is _UNSET:
+        _BOOT_SHA_SLOT[0] = _run_git(["rev-parse", "HEAD"])
+    return _BOOT_SHA_SLOT[0]  # type: ignore[return-value]
+
+
+def get_commits_behind(base_ref: str = _DEFAULT_BASE_REF) -> int | None:
+    """Return how many commits the boot SHA is behind ``base_ref``.
+
+    Compares the in-memory boot SHA against the *local* remote-tracking ref
+    (no network fetch) via ``git rev-list --count <boot_sha>..<base_ref>``.
+    Cheap and failure-tolerant: returns ``None`` on any error or if the boot
+    SHA / base ref is unavailable.
+    """
+    boot = get_boot_sha()
+    if boot is None:
+        return None
+    out = _run_git(["rev-list", "--count", f"{boot}..{base_ref}"])
+    if out is None:
+        return None
+    try:
+        return int(out)
+    except ValueError:
+        return None

--- a/src/git_revision.py
+++ b/src/git_revision.py
@@ -23,6 +23,7 @@ Design notes:
 from __future__ import annotations
 
 import subprocess
+from typing import cast
 
 # Short timeout: these are all local, read-only git operations (no network).
 # Bounded so the status endpoint can never hang on a wedged git process.
@@ -69,7 +70,11 @@ def get_boot_sha() -> str | None:
     """
     if _BOOT_SHA_SLOT[0] is _UNSET:
         _BOOT_SHA_SLOT[0] = _run_git(["rev-parse", "HEAD"])
-    return _BOOT_SHA_SLOT[0]  # type: ignore[return-value]
+    # After the sentinel check the slot holds a captured ``str | None``; the
+    # ``_UNSET`` sentinel is typed ``object`` (indistinct from the union's
+    # ``object`` member) so identity narrowing can't exclude it — cast instead
+    # of a blanket ``type: ignore`` (which the suppressions ratchet forbids).
+    return cast("str | None", _BOOT_SHA_SLOT[0])
 
 
 def get_commits_behind(base_ref: str = _DEFAULT_BASE_REF) -> int | None:

--- a/src/models.py
+++ b/src/models.py
@@ -2587,6 +2587,11 @@ class ControlStatusConfig(BaseModel):
     app_version: str = ""
     latest_version: str = ""
     update_available: bool = False
+    # #9663: in-memory boot SHA + commits-behind for at-a-glance staleness
+    # observability. Both are best-effort git reads: ``None`` when unavailable
+    # (git missing, detached, non-repo) rather than a fabricated value.
+    boot_sha: str | None = None
+    commits_behind: int | None = None
     repo: str = ""
     ready_label: list[str] = Field(default_factory=list)
     find_label: list[str] = Field(default_factory=list)

--- a/tests/test_dashboard_routes_control.py
+++ b/tests/test_dashboard_routes_control.py
@@ -76,6 +76,58 @@ class TestControlStatusAppVersion:
         assert data["config"]["update_available"] is True
 
 
+class TestControlStatusBootShaCommitsBehind:
+    @pytest.mark.asyncio
+    async def test_status_includes_boot_sha_and_commits_behind(
+        self, config, event_bus: EventBus, state, tmp_path: Path, monkeypatch
+    ) -> None:
+        """GET /api/control/status projects the in-memory boot SHA and a
+        cheap commits-behind count for at-a-glance staleness observability."""
+        monkeypatch.setattr(
+            "dashboard_routes._control_routes.get_boot_sha",
+            lambda: "abc1234deadbeef",
+        )
+        monkeypatch.setattr(
+            "dashboard_routes._control_routes.get_commits_behind",
+            lambda: 5,
+        )
+
+        router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+
+        get_control_status = find_endpoint(router, "/api/control/status")
+
+        assert get_control_status is not None
+        response = await get_control_status()
+        data = json.loads(response.body)
+        assert data["config"]["boot_sha"] == "abc1234deadbeef"
+        assert data["config"]["commits_behind"] == 5
+
+    @pytest.mark.asyncio
+    async def test_status_tolerates_unavailable_git(
+        self, config, event_bus: EventBus, state, tmp_path: Path, monkeypatch
+    ) -> None:
+        """When the git reads fail, the fields are null and the endpoint still
+        responds (never hangs or raises)."""
+        monkeypatch.setattr(
+            "dashboard_routes._control_routes.get_boot_sha",
+            lambda: None,
+        )
+        monkeypatch.setattr(
+            "dashboard_routes._control_routes.get_commits_behind",
+            lambda: None,
+        )
+
+        router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+
+        get_control_status = find_endpoint(router, "/api/control/status")
+
+        assert get_control_status is not None
+        response = await get_control_status()
+        data = json.loads(response.body)
+        assert data["config"]["boot_sha"] is None
+        assert data["config"]["commits_behind"] is None
+
+
 class TestPatchConfigUnknownField:
     @pytest.mark.asyncio
     async def test_patch_config_ignored_field(

--- a/tests/test_git_revision.py
+++ b/tests/test_git_revision.py
@@ -1,0 +1,134 @@
+"""Tests for git_revision — boot SHA + commits-behind staleness helpers."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import git_revision
+
+
+@pytest.fixture(autouse=True)
+def _reset_boot_sha_cache():
+    """Each test starts with an uncaptured boot SHA."""
+    git_revision._BOOT_SHA_SLOT[0] = git_revision._UNSET
+    yield
+    git_revision._BOOT_SHA_SLOT[0] = git_revision._UNSET
+
+
+def _fake_run(mapping):
+    """Return a subprocess.run stub keyed on the git subcommand."""
+
+    def _run(cmd, *_args, **_kwargs):
+        key = cmd[1]  # cmd == ["git", <subcommand>, ...]
+        rc, out = mapping[key]
+        return subprocess.CompletedProcess(cmd, rc, stdout=out, stderr="")
+
+    return _run
+
+
+class TestBootSha:
+    def test_returns_head_sha(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            git_revision.subprocess,
+            "run",
+            _fake_run({"rev-parse": (0, "abc123\n")}),
+        )
+        assert git_revision.get_boot_sha() == "abc123"
+
+    def test_captured_once_and_not_reread(self, monkeypatch) -> None:
+        # First read captures "abc123"; HEAD then advances (git pull, no
+        # restart) but the cached boot SHA must NOT change.
+        monkeypatch.setattr(
+            git_revision.subprocess,
+            "run",
+            _fake_run({"rev-parse": (0, "abc123\n")}),
+        )
+        assert git_revision.get_boot_sha() == "abc123"
+
+        monkeypatch.setattr(
+            git_revision.subprocess,
+            "run",
+            _fake_run({"rev-parse": (0, "def456\n")}),
+        )
+        assert git_revision.get_boot_sha() == "abc123"
+
+    def test_returns_none_on_nonzero_exit(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            git_revision.subprocess,
+            "run",
+            _fake_run({"rev-parse": (128, "")}),
+        )
+        assert git_revision.get_boot_sha() is None
+
+    def test_returns_none_when_git_missing(self, monkeypatch) -> None:
+        def _boom(*_a, **_k):
+            raise FileNotFoundError("git not found")
+
+        monkeypatch.setattr(git_revision.subprocess, "run", _boom)
+        assert git_revision.get_boot_sha() is None
+
+    def test_returns_none_on_timeout(self, monkeypatch) -> None:
+        def _boom(*_a, **_k):
+            raise subprocess.TimeoutExpired(cmd="git", timeout=5)
+
+        monkeypatch.setattr(git_revision.subprocess, "run", _boom)
+        assert git_revision.get_boot_sha() is None
+
+
+class TestCommitsBehind:
+    def test_counts_commits_behind_base_ref(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            git_revision.subprocess,
+            "run",
+            _fake_run({"rev-parse": (0, "abc123\n"), "rev-list": (0, "7\n")}),
+        )
+        assert git_revision.get_commits_behind() == 7
+
+    def test_zero_when_up_to_date(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            git_revision.subprocess,
+            "run",
+            _fake_run({"rev-parse": (0, "abc123\n"), "rev-list": (0, "0\n")}),
+        )
+        assert git_revision.get_commits_behind() == 0
+
+    def test_none_when_boot_sha_unavailable(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            git_revision.subprocess,
+            "run",
+            _fake_run({"rev-parse": (128, "")}),
+        )
+        assert git_revision.get_commits_behind() is None
+
+    def test_none_on_rev_list_failure(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            git_revision.subprocess,
+            "run",
+            _fake_run({"rev-parse": (0, "abc123\n"), "rev-list": (128, "")}),
+        )
+        assert git_revision.get_commits_behind() is None
+
+    def test_none_on_unparseable_count(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            git_revision.subprocess,
+            "run",
+            _fake_run(
+                {"rev-parse": (0, "abc123\n"), "rev-list": (0, "not-a-number\n")}
+            ),
+        )
+        assert git_revision.get_commits_behind() is None
+
+    def test_none_on_timeout(self, monkeypatch) -> None:
+        def _run(cmd, *_a, **_k):
+            if cmd[1] == "rev-parse":
+                return subprocess.CompletedProcess(cmd, 0, stdout="abc123\n", stderr="")
+            raise subprocess.TimeoutExpired(cmd="git", timeout=5)
+
+        monkeypatch.setattr(git_revision.subprocess, "run", _run)
+        assert git_revision.get_commits_behind() is None


### PR DESCRIPTION
Closes #9663.

## What
Projects the running instance's **boot SHA** and a cheap **commits-behind** count into `ControlStatusConfig` / `GET /api/control/status`, giving operators an always-on "you are N commits behind" indicator instead of waiting for the StaleCodeWatcher HITL threshold to trip. Complements `get_app_version()`, which reports the package version (unchanged across commits in a `pip install -e .` checkout) rather than the git revision.

## How
- **New `src/git_revision.py`**
  - `get_boot_sha()` captures `git rev-parse HEAD` **once**, in-memory, on first access and never re-reads it — a `git pull` without a process restart advances `HEAD` while the running bytecode stays stale, so re-reading each call would silently clear the signal (the 2026-06-18 incident). Uses a single-slot mutable container (no `global`, PLW0603-clean).
  - `get_commits_behind()` runs `git rev-list --count <boot_sha>..origin/staging` against the **local** remote-tracking ref (no network fetch).
  - Both git reads are bounded by a short timeout and **failure-tolerant**: git missing, non-zero exit, timeout, or not-a-repo all return `None` rather than raising or hanging, so the status endpoint can never wedge.
- **`ControlStatusConfig`** gains `boot_sha: str | None` and `commits_behind: int | None`.
- Computed **once per request** (they describe the running process, not any managed repo) and threaded into every `_control_status_config` call site, including the `__all__` rollup.

Scope note: this PR delivers the API/observability surface. The System-tab Header rendering mentioned in the issue is a follow-up (would carry its own vitest coverage).

## Tests (TDD, red → green)
- `tests/test_git_revision.py` — boot-SHA caching (captured-once-not-reread), failure tolerance (nonzero exit, git-missing, timeout), commits-behind count parsing + `None` on unparseable/failed reads.
- `tests/test_dashboard_routes_control.py` — endpoint payload includes `boot_sha` + `commits_behind` (populated), and is null-tolerant when git is unavailable.

Verification: `test_git_revision` + `test_dashboard_routes_control` + `test_dashboard_routes_control_multirepo` + `test_control_routes_settings` + `test_models_config` = **140 passed**; ruff clean on changed files; live sanity check returns a real SHA and `commits_behind=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)