### PR TITLE
refactor(insights): extract shared word-boundary keyword matcher (#9659)

### DIFF
--- a/src/harness_insights.py
+++ b/src/harness_insights.py
@@ -7,7 +7,6 @@ escalations, detects recurring patterns, and generates improvement suggestions.
 from __future__ import annotations
 
 import logging
-import re
 from collections import Counter
 from datetime import UTC, datetime
 from enum import StrEnum
@@ -17,6 +16,7 @@ from typing import TYPE_CHECKING, Literal
 from pydantic import BaseModel, Field
 
 from models import IsoTimestamp, PipelineStage
+from text_match import keyword_matches
 
 if TYPE_CHECKING:
     from config import HydraFlowConfig
@@ -131,19 +131,6 @@ class ImprovementSuggestion(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def _keyword_matches(keyword: str, lowered_details: str) -> bool:
-    """Whole-word / phrase match of *keyword* against *lowered_details*.
-
-    Uses ``\\b`` boundaries around the keyword so a short token like "test"
-    matches "test"/"tests" but never inside a larger word like "latest", and so
-    broad terms ("type", "format") can never match inside a larger identifier
-    ("prototype", "typescript", "information"). Non-word characters inside a
-    keyword ("try/except") are matched literally (#9566).
-    """
-    pattern = r"\b" + re.escape(keyword) + r"\b"
-    return re.search(pattern, lowered_details) is not None
-
-
 def extract_subcategories(details: str) -> list[str]:
     """Extract subcategories from failure details using keyword matching.
 
@@ -157,7 +144,7 @@ def extract_subcategories(details: str) -> list[str]:
     return [
         sub
         for sub, keywords in SUBCATEGORY_KEYWORDS.items()
-        if any(_keyword_matches(kw.lower(), lower) for kw in keywords)
+        if any(keyword_matches(kw.lower(), lower) for kw in keywords)
     ]
 
 

--- a/src/review_insights.py
+++ b/src/review_insights.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -12,6 +11,7 @@ from pydantic import BaseModel
 
 from dedup_store import DedupStore
 from models import IsoTimestamp, ReviewVerdict
+from text_match import keyword_matches
 
 if TYPE_CHECKING:
     from ports import ObservabilityPort, ReviewInsightStorePort  # noqa: TCH004
@@ -226,19 +226,6 @@ def is_infra_failure_summary(summary: str) -> bool:
     return lowered.startswith(_INFRA_FAILURE_PREFIXES)
 
 
-def _keyword_matches(keyword: str, lowered_summary: str) -> bool:
-    """Whole-word / phrase match of *keyword* against *lowered_summary*.
-
-    Uses ``\\b`` boundaries around the keyword's leading/trailing word
-    characters so the 3-char "test" matches "test"/"tests" but not "latest",
-    and so dropped-but-historically-broad terms can never match inside a
-    larger identifier (e.g. "type" inside ``TypeError``). Non-word characters
-    inside a keyword (``try/except``) are matched literally.
-    """
-    pattern = r"\b" + re.escape(keyword) + r"\b"
-    return re.search(pattern, lowered_summary) is not None
-
-
 def extract_categories(summary: str) -> list[str]:
     """Extract feedback categories from a review summary using keyword matching.
 
@@ -256,7 +243,7 @@ def extract_categories(summary: str) -> list[str]:
     return [
         cat
         for cat, keywords in CATEGORY_KEYWORDS.items()
-        if any(_keyword_matches(kw.lower(), lower) for kw in keywords)
+        if any(keyword_matches(kw.lower(), lower) for kw in keywords)
     ]
 
 

--- a/src/text_match.py
+++ b/src/text_match.py
@@ -1,0 +1,46 @@
+"""Shared whole-word keyword matcher for the insight classifiers (#9659).
+
+Both :func:`review_insights.extract_categories` (prose review summaries) and
+:func:`harness_insights.extract_subcategories` (failure-log details) classify
+free text by scanning it for category keywords. They previously carried
+near-identical private ``_keyword_matches`` helpers; this module is the single
+place that owns the matching semantics so the two classifiers can never drift
+apart (#9566 aligned them, #9659 consolidated them).
+
+Anchoring policy (explicit, in one place)
+-----------------------------------------
+A keyword matches only on **full word boundaries** — a leading ``\\b`` and a
+trailing ``\\b`` around the escaped keyword. Both the prose and failure-log
+classifiers use this identical anchoring:
+
+* the 3-char ``"test"`` matches ``"test"`` but **not** ``"tests"`` or
+  ``"latest"``;
+* broad terms (``"type"``, ``"format"``) never match inside a larger identifier
+  (``"prototype"``, ``"typescript"``, ``"information"``);
+* non-word characters *inside* a keyword (``"try/except"``) are matched
+  literally, and the trailing boundary applies to the keyword's last word
+  character so ``"try/except"`` does not match inside ``"try/exception"``.
+
+The matcher is case-sensitive by design: callers lowercase both the keyword and
+the text once, up front, and reuse the lowercased text across every keyword.
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = ["keyword_matches"]
+
+
+def keyword_matches(keyword: str, text: str) -> bool:
+    """Return ``True`` when *keyword* occurs in *text* on whole-word boundaries.
+
+    Uses ``\\b`` boundaries around the escaped keyword so a short token matches
+    only as a standalone word/phrase, never inside a larger identifier. See the
+    module docstring for the full anchoring policy.
+
+    Both arguments are matched as-is; for case-insensitive matching callers pass
+    already-lowercased strings.
+    """
+    pattern = r"\b" + re.escape(keyword) + r"\b"
+    return re.search(pattern, text) is not None

--- a/tests/test_text_match.py
+++ b/tests/test_text_match.py
@@ -1,0 +1,71 @@
+"""Tests for text_match.py — the shared whole-word keyword matcher (#9659).
+
+These pin the exact behavior the two insight classifiers
+(``review_insights.extract_categories`` and
+``harness_insights.extract_subcategories``) relied on before their duplicated
+``_keyword_matches`` helpers were consolidated here. The extraction must be
+behavior-preserving, so every case below reflects the original regex
+(``\\b`` on both sides of the escaped keyword) exactly.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from text_match import keyword_matches
+
+
+class TestKeywordMatchesWordBoundaries:
+    def test_matches_standalone_word(self) -> None:
+        assert keyword_matches("test", "test") is True
+
+    def test_matches_word_surrounded_by_spaces(self) -> None:
+        assert keyword_matches("type", "type error") is True
+
+    def test_matches_word_with_trailing_punctuation(self) -> None:
+        # non-word char after the keyword is a boundary
+        assert keyword_matches("type", "wrong type.") is True
+
+    def test_does_not_match_trailing_plural(self) -> None:
+        # full trailing \b means "test" does NOT match "tests"
+        assert keyword_matches("test", "3 tests failed") is False
+
+    def test_does_not_match_inside_larger_word_suffix(self) -> None:
+        assert keyword_matches("test", "latest build") is False
+
+    def test_does_not_match_inside_identifier(self) -> None:
+        assert keyword_matches("type", "typeerror") is False
+        assert keyword_matches("type", "prototype") is False
+        assert keyword_matches("type", "typescript") is False
+
+    def test_does_not_match_substring_of_longer_word(self) -> None:
+        assert keyword_matches("format", "information") is False
+
+
+class TestKeywordMatchesNonWordChars:
+    def test_matches_phrase_with_literal_slash(self) -> None:
+        # non-word characters inside the keyword are matched literally
+        assert keyword_matches("try/except", "use a try/except block") is True
+
+    def test_trailing_boundary_applies_to_last_word_char_of_phrase(self) -> None:
+        # "try/except" must not match inside "try/exception"
+        assert keyword_matches("try/except", "try/exception raised") is False
+
+    def test_matches_multi_word_phrase(self) -> None:
+        assert keyword_matches("merge conflict", "a merge conflict here") is True
+
+
+class TestKeywordMatchesCaseSensitivity:
+    """The matcher itself is case-sensitive; callers pre-lowercase both args."""
+
+    def test_is_case_sensitive_uppercase_text_does_not_match_lower_keyword(
+        self,
+    ) -> None:
+        assert keyword_matches("test", "TEST failed") is False
+
+    def test_lowercased_inputs_match(self) -> None:
+        assert keyword_matches("test".lower(), "TEST failed".lower()) is True


### PR DESCRIPTION
## What

Extracts the duplicated word-boundary keyword matcher from `review_insights.py` and `harness_insights.py` into a single shared helper, `keyword_matches` in the new `src/text_match.py`, and routes both classifiers through it. Closes #9659.

## Why

After #9566 both modules carried a near-identical private `_keyword_matches` (both using full `\b…\b` word boundaries). The issue's original premise — that the failure-log side was left-`\b`-only — was already stale: on `staging` the two helpers were byte-for-byte identical in semantics. This consolidates the matching logic so the two classifiers can never drift, and documents the anchoring policy in one place.

## Behavior preservation (this is a refactor)

- Both modules already used **identical** full-boundary matching, so match results are **unchanged**.
- `import re` is now removed from both modules (it was used only by the local helper).
- Case-folding stays where it was — at the callers (`kw.lower()` / `summary.lower()`); the shared matcher operates on the already-lowercased inputs, matching the prior `_keyword_matches` contract exactly (no perf change: the text is lowercased once per call, not per keyword).

## Tests

- New `tests/test_text_match.py` pins the exact boundary semantics verified empirically against the original code: `"test"` does **not** match `"tests"`/`"latest"`; `"type"` does **not** match `"prototype"`/`"typeerror"`/`"typescript"`; non-word chars inside a phrase (`"try/except"`) are literal and the trailing boundary still applies (`"try/exception"` is not a match); matcher is case-sensitive (callers pre-lowercase).
- Full `test_review_insights.py`, `test_harness_insights.py`, `test_harness_insights_integration.py`, and `test_fake_review_insight_store.py` suites stay green (202 passed) — the existing guard suites (incl. harness subcategory guards) prove no regression.
- `ruff check` + `ruff format --check` clean on all changed files; pre-commit lint/arch/test-sludge hooks pass.

Note: sibling PR #9979 (issue #9658, adds `TestCategoryKeywordRatchet` + neutral-praise corpus guard) is still open and touches only `tests/test_review_insights.py`; this PR does not modify that file, so no conflict is expected, and the behavior-preserving matcher keeps those guards green whenever #9979 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)