### PR TITLE
test(mockworld): fake branch-protection ruleset seed surface (#9644)

### DIFF
--- a/src/mockworld/fakes/fake_github.py
+++ b/src/mockworld/fakes/fake_github.py
@@ -7,6 +7,7 @@ that phases call via PipelineHarness.
 
 from __future__ import annotations
 
+import copy
 from collections import deque
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -147,6 +148,10 @@ class FakeGitHub:
         # attribute directly when constructing `gh` CLI args via _run_gh.
         # The value never reaches a real GitHub API in the sandbox.
         self._repo: str = "owner/repo"
+        # Branch-protection rulesets keyed by name, served by fetch_rulesets
+        # (ADR-0082, #9644). Mirrors the shape gh_fetch_rulesets returns:
+        # {name: {name, target, enforcement, conditions, rules, ...}}.
+        self._rulesets: dict[str, dict[str, Any]] = {}
 
     @classmethod
     def from_seed(cls, seed: MockWorldSeed) -> FakeGitHub:
@@ -183,6 +188,8 @@ class FakeGitHub:
         conclusion, url = seed.main_branch_ci_status
         if conclusion != "success":
             gh.set_ci_main_status(conclusion, url)
+        for name, cfg in seed.rulesets.items():
+            gh.add_ruleset(name, cfg)
         return gh
 
     # --- Seed API ---
@@ -260,6 +267,17 @@ class FakeGitHub:
     def add_alerts(self, *, branch: str, alerts: list[Any]) -> None:
         """Script code-scanning alerts returned by fetch_code_scanning_alerts."""
         self._alerts[branch] = list(alerts)
+
+    def add_ruleset(self, name: str, config: dict[str, Any]) -> None:
+        """Seed-API helper: register a live branch-protection ruleset by name.
+
+        The stored config is what ``fetch_rulesets`` serves — shaped like
+        GitHub's ``/repos/{repo}/rulesets/{id}`` response so it can be diffed
+        against the canonical contract by ``branch_protection_audit`` (#9644).
+        Stored as a shallow copy so later mutation of the caller's dict does
+        not retroactively alter seeded state.
+        """
+        self._rulesets[name] = dict(config)
 
     def script_ci(self, pr_number: int, results: list[tuple[bool, str]]) -> None:
         self._ci_scripts[pr_number] = deque(results)
@@ -969,6 +987,23 @@ class FakeGitHub:
 
     async def apply_staging_branch_protection(self, branch: str) -> dict[str, Any]:
         return {"status": "protected", "branch": branch}
+
+    def fetch_rulesets(self, repo: str) -> dict[str, dict[str, Any]]:
+        """Serve seeded branch-protection rulesets, keyed by ruleset name.
+
+        Sync mirror of ``branch_protection_audit.gh_fetch_rulesets`` (which
+        shells out to ``gh api /repos/{repo}/rulesets``). Injectable verbatim
+        as the ``fetch_rulesets=`` seam of ``branch_protection_audit.audit_repo``
+        so a sandbox / scenario ``branch_protection_auditor`` run observes drift
+        against the canonical contract without a real network fetch — the seam
+        the s41 scenario needs (#9644, ADR-0082).
+
+        ``repo`` is accepted for signature parity with ``gh_fetch_rulesets`` but
+        ignored: the Fake serves one repo's worth of seeded state. Returns a
+        deep copy so a caller mutating the result cannot corrupt seeded state.
+        """
+        _ = repo
+        return copy.deepcopy(self._rulesets)
 
     # --- Concrete-only PRManager methods invoked at orchestrator boot ---
 

--- a/src/mockworld/seed.py
+++ b/src/mockworld/seed.py
@@ -117,6 +117,22 @@ class MockWorldSeed:
     # naive duty-cycle estimate would suggest.
     plan_hold_seconds: float = 0.0
 
+    # Branch-protection rulesets served by ``FakeGitHub.fetch_rulesets`` for the
+    # ``branch_protection_auditor`` loop (ADR-0082, #9644). Keyed by ruleset name
+    # (e.g. ``"main protect"`` / ``"staging protect"``); each value is the ruleset
+    # config dict shaped like GitHub's ``/repos/{repo}/rulesets/{id}`` response
+    # (``name`` / ``target`` / ``enforcement`` / ``conditions`` / ``rules``).
+    #
+    # In production the auditor fetches live rulesets via ``gh_fetch_rulesets``
+    # (a ``gh api`` shell-out) — unreachable on the air-gapped sandbox network.
+    # Seeding this field lets a scenario stand up a *drifted* (or clean) live
+    # ruleset so the auditor produces an observable drift outcome without any
+    # real network fetch. All keys/values are JSON-native (string keys, list/dict
+    # values), so no ``from_json`` coercion is needed. Default empty:
+    # ``FakeGitHub.fetch_rulesets`` returns ``{}``, leaving every existing seed
+    # payload unchanged.
+    rulesets: dict[str, dict[str, Any]] = field(default_factory=dict)
+
     def to_json(self) -> str:
         """Serialize to JSON for cross-process transfer."""
         return json.dumps(asdict(self), indent=2)

--- a/tests/test_fake_github_rulesets.py
+++ b/tests/test_fake_github_rulesets.py
@@ -1,0 +1,107 @@
+"""FakeGitHub branch-protection ruleset seed surface (#9644, ADR-0082).
+
+``BranchProtectionAuditorLoop`` audits live GitHub rulesets against the
+canonical contract by injecting a ``fetch_rulesets`` callable into
+``branch_protection_audit.audit_repo``. In production that callable is
+``gh_fetch_rulesets`` — a ``gh api /repos/{repo}/rulesets`` shell-out that is
+unreachable on the air-gapped sandbox network. ``FakeGitHub.fetch_rulesets`` is
+the sync mirror that serves seeded ruleset state instead, so a sandbox /
+scenario auditor run can observe drift (or a clean audit) without a real
+network fetch. These tests pin the seed surface and prove the Fake fetcher is
+directly injectable into ``audit_repo`` — the seam the s41 scenario needs.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from branch_protection_audit import audit_repo
+from mockworld.fakes import FakeGitHub
+from mockworld.seed import MockWorldSeed
+
+_CANONICAL_DIR = (
+    Path(__file__).resolve().parents[1] / "docs" / "standards" / "branch_protection"
+)
+
+
+def _canonical(name: str) -> dict:
+    return json.loads((_CANONICAL_DIR / name).read_text())
+
+
+def _drifted_staging() -> dict:
+    """The staging ruleset with a rule dropped — reads as drift vs canonical."""
+    cfg = _canonical("staging_ruleset.json")
+    cfg["rules"] = [r for r in cfg["rules"] if r.get("type") != "pull_request"]
+    return cfg
+
+
+def test_from_seed_serves_seeded_rulesets() -> None:
+    ruleset = _drifted_staging()
+    seed = MockWorldSeed(rulesets={"staging protect": ruleset})
+
+    gh = FakeGitHub.from_seed(seed)
+
+    assert gh.fetch_rulesets("owner/repo") == {"staging protect": ruleset}
+
+
+def test_fetch_rulesets_empty_by_default() -> None:
+    gh = FakeGitHub.from_seed(MockWorldSeed())
+    assert gh.fetch_rulesets("owner/repo") == {}
+
+
+def test_add_ruleset_seed_helper() -> None:
+    gh = FakeGitHub()
+    gh.add_ruleset("main protect", {"name": "main protect", "enforcement": "active"})
+
+    assert gh.fetch_rulesets("owner/repo") == {
+        "main protect": {"name": "main protect", "enforcement": "active"}
+    }
+
+
+def test_fetch_rulesets_returns_copies_not_internal_state() -> None:
+    """Mutating the served dict must not corrupt the Fake's seeded state."""
+    ruleset = _drifted_staging()
+    gh = FakeGitHub.from_seed(MockWorldSeed(rulesets={"staging protect": ruleset}))
+
+    served = gh.fetch_rulesets("owner/repo")
+    served["injected"] = {}
+    served["staging protect"]["enforcement"] = "disabled"
+
+    assert gh.fetch_rulesets("owner/repo") == {"staging protect": ruleset}
+
+
+def test_fake_fetcher_injectable_into_audit_repo_reports_drift() -> None:
+    """The Fake fetcher plugs into ``audit_repo`` and yields observable drift.
+
+    This is the seam the s41 branch_protection_auditor sandbox scenario needs:
+    seed a drifted live ruleset, run the real audit engine against the real
+    canonical contract, and get a non-clean report — no network required.
+    """
+    seed = MockWorldSeed(
+        rulesets={
+            "main protect": _canonical("main_ruleset.json"),
+            "staging protect": _drifted_staging(),
+        }
+    )
+    gh = FakeGitHub.from_seed(seed)
+
+    report = audit_repo("owner/repo", _CANONICAL_DIR, fetch_rulesets=gh.fetch_rulesets)
+
+    assert not report.clean
+    assert any("staging protect" in line for line in report.drifts)
+
+
+def test_fake_fetcher_injectable_into_audit_repo_clean_when_matched() -> None:
+    """Seeding the canonical rulesets verbatim yields a clean audit."""
+    seed = MockWorldSeed(
+        rulesets={
+            "main protect": _canonical("main_ruleset.json"),
+            "staging protect": _canonical("staging_ruleset.json"),
+        }
+    )
+    gh = FakeGitHub.from_seed(seed)
+
+    report = audit_repo("owner/repo", _CANONICAL_DIR, fetch_rulesets=gh.fetch_rulesets)
+
+    assert report.clean, report.drifts

--- a/tests/test_mockworld_seed.py
+++ b/tests/test_mockworld_seed.py
@@ -16,6 +16,7 @@ def test_default_seed_is_empty() -> None:
     assert seed.cycles_to_run == 4
     assert seed.loops_enabled is None
     assert seed.plan_hold_seconds == 0.0
+    assert seed.rulesets == {}
 
 
 def test_seed_round_trips_through_json() -> None:
@@ -48,6 +49,35 @@ def test_seed_round_trips_plan_hold_seconds_through_json() -> None:
 
     assert parsed == original
     assert parsed.plan_hold_seconds == 3.0
+
+
+def test_default_seed_has_empty_rulesets() -> None:
+    """Back-compat: every pre-#9644 scenario seed predates ``rulesets``."""
+    assert MockWorldSeed().rulesets == {}
+
+
+def test_seed_round_trips_rulesets_through_json() -> None:
+    """JSON round-trip preserves the branch-protection ruleset seed (#9644).
+
+    Ruleset names are string object keys and every value is JSON-native
+    (nested dicts/lists), so no ``from_json`` key coercion is required — the
+    equality check guards against a future field that would need it.
+    """
+    original = MockWorldSeed(
+        rulesets={
+            "staging protect": {
+                "name": "staging protect",
+                "target": "branch",
+                "enforcement": "active",
+                "conditions": {"ref_name": {"include": ["refs/heads/staging"]}},
+                "rules": [{"type": "deletion"}, {"type": "non_fast_forward"}],
+            },
+        },
+    )
+
+    parsed = MockWorldSeed.from_json(original.to_json())
+
+    assert parsed == original
 
 
 def test_default_seed_has_empty_advisor_scripts() -> None:


### PR DESCRIPTION
## Summary

Closes #9644.

`FakeGitHub` had no branch-protection ruleset state, so the `branch_protection_auditor` loop (ADR-0082) couldn't be exercised against the fake. Its live-ruleset fetch (`gh_fetch_rulesets`) shells out to `gh api /repos/{repo}/rulesets`, which is unreachable on the air-gapped sandbox network — so the `s41_branch_protection_auditor` scenario could only assert an idle heartbeat, never an active drift outcome.

This adds the **seed surface + fake serving** so a scenario can declare live ruleset config and the auditor can observe drift with no real network:

- **`MockWorldSeed.rulesets`** — scenario-declarable branch-protection rulesets keyed by name (e.g. `"main protect"` / `"staging protect"`), shaped like GitHub's `/repos/{repo}/rulesets/{id}` response. JSON-native, so it round-trips across the docker boundary with no `from_json` coercion. Default empty → existing seeds unaffected.
- **`FakeGitHub.fetch_rulesets(repo)`** — sync mirror of `branch_protection_audit.gh_fetch_rulesets`, injectable verbatim as the `audit_repo(fetch_rulesets=...)` seam. Returns a deep copy so callers can't corrupt seeded state.
- **`FakeGitHub.add_ruleset`** seed helper + `from_seed` wiring.

Scope is intentionally right-sized to the seed surface + fake serving (the deliverable). Wiring the sandbox auditor loop to this seam (the follow-up that lights up the s41 active-drift scenario) is left for the scenario PR that consumes it.

## Testing

TDD (RED confirmed with src reverted, then GREEN). New `tests/test_fake_github_rulesets.py` proves the fake fetcher plugs into the **real** `audit_repo` engine against the **real** canonical contract under `docs/standards/branch_protection/`:
- seeded drifted ruleset → non-clean report mentioning the drifted ruleset
- seeded canonical rulesets verbatim → clean report
- seed → serve round-trip, empty-by-default, `add_ruleset` helper, deep-copy isolation

Plus seed default + JSON round-trip tests in `tests/test_mockworld_seed.py`.

Verification run (not full `make quality`, per task scope):
- `tests/test_fake_github_rulesets.py` + `test_mockworld_seed.py` + `test_fake_github_from_seed.py`: green
- fake_github / mockworld / branch_protection suite (146 tests) + sandbox scenario contract + apply_seed (221 tests): green
- `ruff check` + `ruff format --check` on changed files: clean
- `make arch-check`: exit 0 (artifacts not stale)
- pre-commit (test-sludge, lint, arch-check) and pre-push (arch-check, quality-lite incl. bandit) gates: passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)