### PR TITLE
feat(agent): inject Known CI Traps from harness-insights into implement prompts (#9858)

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -170,8 +170,14 @@ Run through this checklist before your final commit:
         bead_mapping: dict[str, str] | None = None,
         human_guidance: str = "",
         attempt_number: int = 0,
+        known_traps: str = "",
     ) -> WorkerResult:
         """Run the implementation agent for *task*.
+
+        ``known_traps`` (#9858) is a pre-rendered "Known CI Traps" section
+        from harness-insights — recurring repo failure classes injected so
+        the agent stops re-hitting documented walls (ratchet, arch-regen,
+        …). Empty string leaves the prompt unchanged.
 
         ``attempt_number`` is the 1-based issue attempt this run represents
         (0 = unknown); on cycling retries it feeds the diverse-retry
@@ -209,6 +215,8 @@ Run through this checklist before your final commit:
                 human_guidance=human_guidance,
                 attempt_number=attempt_number,
             )
+            if known_traps:
+                prompt += "\n\n" + known_traps
             transcript = await self._execute(
                 cmd,
                 prompt,

--- a/src/harness_insights.py
+++ b/src/harness_insights.py
@@ -6,6 +6,7 @@ escalations, detects recurring patterns, and generates improvement suggestions.
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from collections import Counter
@@ -519,3 +520,69 @@ async def auto_file_suggestions(
                 )
     except Exception:  # noqa: BLE001
         logger.warning("auto_file_suggestions failed", exc_info=True)
+
+
+def top_failure_categories(
+    failures_path: Path, *, limit: int = 5, max_records: int = 500
+) -> list[tuple[str, int, str]]:
+    """Aggregate the most recurring failure categories from the JSONL tail.
+
+    Reads at most the last *max_records* lines of ``harness_failures.jsonl``
+    (bounded, no full-file load) and returns ``(category, count,
+    sample_detail)`` tuples sorted by count desc. Malformed lines are
+    skipped; a missing file yields []. LLM-free by design (#9858) — this is
+    the read side of the learn→act loop.
+    """
+    if not failures_path.exists():
+        return []
+    try:
+        lines = failures_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return []
+    counts: dict[str, int] = {}
+    samples: dict[str, str] = {}
+    for line in lines[-max_records:]:
+        try:
+            row = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if not isinstance(row, dict):
+            continue
+        category = str(row.get("category") or "")
+        if not category:
+            continue
+        counts[category] = counts.get(category, 0) + 1
+        detail = str(row.get("detail") or "").strip()
+        if detail and category not in samples:
+            samples[category] = detail[:160]
+    ranked = sorted(counts.items(), key=lambda kv: kv[1], reverse=True)[:limit]
+    return [(cat, n, samples.get(cat, "")) for cat, n in ranked]
+
+
+def format_known_traps_for_prompt(
+    entries: list[tuple[str, int, str]],
+) -> str:
+    """Render recurring failure categories as a prompt section (#9858).
+
+    Empty string when there is nothing recurring (count < 2 entries are
+    noise, not traps) so the prompt is unchanged for healthy repos.
+    """
+    recurring = [(c, n, d) for c, n, d in entries if n >= 2]
+    if not recurring:
+        return ""
+    lines = [
+        "## Known CI Traps (from this repo's failure history)",
+        "",
+        "These failure classes have recurred in this repo. Do not repeat them:",
+        "",
+    ]
+    for category, count, detail in recurring:
+        sample = f" — e.g. {detail}" if detail else ""
+        lines.append(f"- **{category}** (seen {count}x){sample}")
+    lines.append("")
+    lines.append(
+        "Also: the suppression ratchet only shrinks — never add a `# noqa`; "
+        "regenerate `docs/arch/generated/` (make arch-regen) in the same "
+        "commit as any term/ADR/wiki change."
+    )
+    return "\n".join(lines)

--- a/src/implement_phase.py
+++ b/src/implement_phase.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import logging
 import re
+import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -14,7 +15,12 @@ from adr_utils import is_adr_issue_title, next_adr_number
 from agent import AgentRunner
 from beads_manager import BeadsManager
 from config import HydraFlowConfig
-from harness_insights import FailureCategory, HarnessInsightStore
+from harness_insights import (
+    FailureCategory,
+    HarnessInsightStore,
+    format_known_traps_for_prompt,
+    top_failure_categories,
+)
 from implement_spec_reviewer import (
     SpecComplianceReviewer,
     SpecReviewInput,
@@ -110,6 +116,27 @@ class ImplementPhase:
     @property
     def active_issues(self) -> set[int]:
         return self._active_issues
+
+    def _known_traps_section(self) -> str:
+        """Render the harness-insights Known CI Traps section (#9858).
+
+        Cached per phase instance for one hour — the failure distribution
+        moves slowly and run_batch may spawn many agents per tick. Fails
+        open to "" so a store hiccup never blocks implementation.
+        """
+        now = time.monotonic()
+        cached = getattr(self, "_known_traps_cache", None)
+        if cached is not None and now - cached[0] < 3600:
+            return cached[1]
+        section = ""
+        if self._harness_insights is not None:
+            try:
+                entries = top_failure_categories(self._harness_insights._failures_path)
+                section = format_known_traps_for_prompt(entries)
+            except (OSError, ValueError) as exc:
+                logger.debug("known-traps render failed: %s", exc)
+        self._known_traps_cache = (now, section)
+        return section
 
     def _log_adversarial_carryover(self, issue: Task) -> None:
         """Log CRITICAL/HIGH carryover concerns surfaced during plan phase.
@@ -676,6 +703,10 @@ class ImplementPhase:
             "review_feedback": review_feedback,
             "prior_failure": prior_failure,
             "human_guidance": human_guidance,
+            # #9858: recurring repo failure classes from harness-insights,
+            # rendered once and injected so agents stop re-hitting
+            # documented CI traps (ratchet, arch-regen, ...).
+            "known_traps": self._known_traps_section(),
             # Diverse-retry: the agent frames its strategy-delta directive
             # as "attempt N of M" (rendered only when prior_failure is set).
             "attempt_number": self._state.get_issue_attempts(issue.id),

--- a/tests/test_implement_spec_reviewer.py
+++ b/tests/test_implement_spec_reviewer.py
@@ -433,6 +433,7 @@ class TestSpecReviewFeedsNextAttempt:
             bead_mapping: dict[str, str] | None = None,
             human_guidance: str = "",
             attempt_number: int = 0,
+            known_traps: str = "",
         ) -> WorkerResult:
             captured.append(prior_failure)
             return WorkerResultFactory.create(
@@ -482,6 +483,7 @@ class TestSpecReviewFeedsNextAttempt:
             bead_mapping: dict[str, str] | None = None,
             human_guidance: str = "",
             attempt_number: int = 0,
+            known_traps: str = "",
         ) -> WorkerResult:
             captured.append(prior_failure)
             return WorkerResultFactory.create(

--- a/tests/test_known_traps_prompt.py
+++ b/tests/test_known_traps_prompt.py
@@ -1,0 +1,64 @@
+"""Known CI Traps prompt steering from harness-insights (#9858).
+
+The insights store recorded recurring CI failure classes but nothing
+injected them into the next agent's instructions — the fleet kept re-hitting
+documented walls (live case: factory PR #9922 added a `# noqa` and tripped
+the suppression ratchet, a class the store already knew).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from harness_insights import format_known_traps_for_prompt, top_failure_categories
+
+
+def _write_failures(path: Path, rows: list[dict]) -> Path:
+    f = path / "harness_failures.jsonl"
+    f.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    return f
+
+
+def test_recurring_categories_ranked_with_samples(tmp_path: Path) -> None:
+    f = _write_failures(
+        tmp_path,
+        [
+            {"category": "quality_gate", "detail": "ratchet: new noqa"},
+            {"category": "quality_gate", "detail": "ratchet again"},
+            {"category": "quality_gate", "detail": "third"},
+            {"category": "ci_failure", "detail": "arch drift"},
+            {"category": "ci_failure", "detail": "arch drift 2"},
+            {"category": "one_off", "detail": "noise"},
+        ],
+    )
+
+    top = top_failure_categories(f)
+
+    assert top[0][0] == "quality_gate" and top[0][1] == 3
+    assert top[0][2] == "ratchet: new noqa"  # first sample wins
+    assert top[1][0] == "ci_failure" and top[1][1] == 2
+
+
+def test_malformed_lines_and_missing_file_are_safe(tmp_path: Path) -> None:
+    f = tmp_path / "harness_failures.jsonl"
+    f.write_text('not json\n{"category": "x"}\n{"nope": 1}\n')
+
+    assert top_failure_categories(f) == [("x", 1, "")]
+    assert top_failure_categories(tmp_path / "absent.jsonl") == []
+
+
+def test_formatter_renders_only_recurring_classes(tmp_path: Path) -> None:
+    section = format_known_traps_for_prompt(
+        [("quality_gate", 3, "ratchet: new noqa"), ("one_off", 1, "noise")]
+    )
+
+    assert "Known CI Traps" in section
+    assert "quality_gate" in section and "seen 3x" in section
+    assert "one_off" not in section  # count<2 is noise, not a trap
+    assert "noqa" in section  # the standing ratchet warning rides along
+
+
+def test_formatter_empty_for_healthy_repo() -> None:
+    assert format_known_traps_for_prompt([]) == ""
+    assert format_known_traps_for_prompt([("x", 1, "")]) == ""


### PR DESCRIPTION
## Problem (#9858 scope addition)

The harness-insights store records recurring CI failure classes but the learn side dead-ended there — nothing reached the next agent's instructions, so the fleet kept re-hitting documented walls (live case: factory PR #9922 added a `noqa` and tripped the suppression ratchet, a class the store already knew).

## Change

- `harness_insights.top_failure_categories`: bounded JSONL-tail aggregation (last 500 records, malformed-safe, **LLM-free**) ranked by recurrence with a representative sample.
- `format_known_traps_for_prompt`: classes seen ≥2× render as a short **Known CI Traps** section + the standing ratchet/arch-regen warnings; empty for healthy repos (prompt unchanged).
- `AgentRunner.run` gains `known_traps` (appended post-build); `ImplementPhase` renders once per instance-hour (cached, fail-open) and threads it via run_kwargs. MockWorld fakes absorb the kwarg via `**_unused`.

Fittingly, building this feature hit the ratchet + import-sort traps it now teaches — both fixed properly (module-top imports, zero suppressions).

## Tests

`tests/test_known_traps_prompt.py` (ranking+samples, malformed safety, recurrence threshold, healthy-repo no-op); agent realistic scenario suite + spec-reviewer doubles updated to the widened signature. Full `make quality` exit 0.

Closes #9858

🤖 Generated with [Claude Code](https://claude.com/claude-code)