### PR TITLE
fix(auth): corroborate GitHub auth-failure signal with a live probe before halting (#9621)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -3351,6 +3351,20 @@ class HydraFlowConfig(BaseModel):
             "exhaustion). Kill-switch: set False to revert to pause-on-text."
         ),
     )
+    auth_failure_require_probe: bool = Field(
+        default=True,
+        description=(
+            "Before halting ALL loops on a GitHub AuthenticationError, "
+            "corroborate the signal with a live `gh auth status` probe. A "
+            "single gh call's stderr can match an auth pattern during a "
+            "transient network/API blip, which used to stop the whole factory "
+            "for hours (#9621). The probe is ground truth (False only when gh "
+            "confirms the credentials are rejected); on a probe-refuted "
+            "(transient) signal the crashed loop is restarted instead of "
+            "stopping the factory. Kill-switch: set False to revert to "
+            "halt-on-signal."
+        ),
+    )
 
     # Process timeouts
     agent_timeout: int = Field(

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -51,6 +51,7 @@ from state_restorer import StateRestorer
 from subprocess_util import (
     AuthenticationError,
     CreditExhaustedError,
+    probe_auth_availability,
     probe_credit_availability,
 )
 
@@ -80,6 +81,14 @@ def _log_deferred_task_failure(task: asyncio.Task[Any]) -> None:
 
 # Delay after a merge to allow GitHub to propagate the merge state.
 _POST_MERGE_DELAY: int = 5
+
+# Delay before restarting a loop whose AuthenticationError was refuted by the
+# live probe (a transient blip). A restart with no delay would let a loop that
+# runs-on-startup re-crash immediately while a sustained blip lasts, spinning
+# the supervisor and storming WARNING logs — the same hot-loop pathology #9924
+# guarded against on the credit false-positive path. The delay lives inside the
+# recreated task, so it never blocks supervision of the other loops (#9621).
+_AUTH_TRANSIENT_RESTART_DELAY_S: float = 30.0
 
 
 class HydraFlowOrchestrator:
@@ -1069,8 +1078,60 @@ class HydraFlowOrchestrator:
                 self._config.repo_root,
             )
 
-    async def _handle_auth_error(self, loop_name: str) -> None:
-        """Set auth_failed, publish SYSTEM_ALERT, stop all loops."""
+    async def _handle_auth_error(
+        self,
+        loop_name: str,
+        exc: BaseException,
+        tasks: dict[str, asyncio.Task[None]],
+        loop_factories: list[tuple[str, Callable[[], Coroutine[Any, Any, None]]]],
+    ) -> None:
+        """Corroborate the auth signal with a live probe before halting the factory.
+
+        A single gh call's stderr can match an auth pattern during a transient
+        network/API blip; that used to propagate fatally and stop ALL loops for
+        hours (#9621 — a momentary blip stalled the factory ~2.5h; a restart
+        recovered instantly because the token was fine the whole time).
+
+        Mirror the credit-pause corroboration (#9807/#9924): probe live auth
+        with ``gh auth status`` before committing a global halt. If auth is
+        actually fine the signal is a transient false positive — restart the
+        crashed loop (non-fatal, retried next tick) instead of stopping. Only a
+        probe-confirmed, PERSISTENT auth rejection halts the factory (fail-safe).
+        Kill-switch: ``auth_failure_require_probe=False`` reverts to
+        halt-on-signal. ``and`` short-circuits so the probe is skipped when the
+        kill-switch is off.
+        """
+        if self._config.auth_failure_require_probe and await probe_auth_availability():
+            logger.warning(
+                "GitHub auth-failure signal from %r NOT corroborated by a live "
+                "`gh auth status` probe — treating as a transient blip; "
+                "restarting the loop instead of pausing all loops (#9621).",
+                loop_name,
+            )
+            await self._bus.publish(
+                HydraFlowEvent(
+                    type=EventType.SYSTEM_ALERT,
+                    data={
+                        "message": (
+                            "GitHub auth signal not corroborated by a live probe "
+                            "— treating as a transient blip; not pausing."
+                        ),
+                        "source": loop_name,
+                        # Benign: a transient blip was absorbed, nothing paused.
+                        # Render yellow, not the red critical banner.
+                        "severity": "warning",
+                    },
+                )
+            )
+            await self._restart_loop(
+                loop_name,
+                exc,
+                tasks,
+                loop_factories,
+                restart_delay=_AUTH_TRANSIENT_RESTART_DELAY_S,
+            )
+            return
+
         logger.error(
             "GitHub authentication failed in %r — pausing all loops",
             loop_name,
@@ -1203,7 +1264,7 @@ class HydraFlowOrchestrator:
     ) -> None:
         """Handle a crashed loop task — auth failure, credit exhaustion, or generic restart."""
         if isinstance(exc, AuthenticationError):
-            await self._handle_auth_error(name)
+            await self._handle_auth_error(name, exc, tasks, loop_factories)
             return
 
         if isinstance(exc, CreditExhaustedError):

--- a/src/subprocess_util.py
+++ b/src/subprocess_util.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
 import random
 import re
+import shutil
 import subprocess
 import threading
 import time
@@ -593,6 +595,81 @@ async def probe_credit_availability() -> bool:
         # here — they propagate so they surface in logs instead of silently
         # returning False.
         return True
+
+
+# Ground-truth auth-rejection phrases in ``gh auth status`` output. These
+# indicate the stored credentials are genuinely bad/missing (a PERSISTENT
+# failure) rather than a transient network hiccup. Kept broader than the
+# ``_AUTH_PATTERNS`` used to classify per-call stderr because ``gh auth status``
+# renders its own diagnostic wording ("authentication failed", "bad
+# credentials", "token ... is invalid").
+_AUTH_STATUS_REJECTION_PATTERNS = (
+    "not logged in",
+    "not logged into",
+    "authentication failed",
+    "failed to authenticate",
+    "authentication required",
+    "requires authentication",
+    "bad credentials",
+    "token is invalid",
+    "invalid token",
+    "401",
+    "403",
+)
+
+# `gh auth status` can take several seconds on first invocation when the OS
+# keychain unlocks the token; bound it so a hung probe can't block the caller.
+# Module-level so tests can patch a smaller value.
+_GH_AUTH_PROBE_TIMEOUT_S = 15.0
+
+
+async def probe_auth_availability() -> bool:
+    """Corroborate a GitHub auth-failure signal with a live ``gh auth status``.
+
+    Returns ``True`` when auth appears healthy (or the probe cannot be run),
+    and ``False`` **only** when ``gh auth status`` positively confirms the
+    credentials are rejected/missing (a persistent failure).
+
+    Mirrors :func:`probe_credit_availability`'s fail-open philosophy: a single
+    ``AuthenticationError`` from a gh call can be a transient network/API blip
+    (#9621 — one such blip stalled the whole factory ~2.5h). So every
+    un-probeable or transient condition — gh missing, spawn failure, timeout,
+    or a non-auth network error — is treated as "auth is fine" (``True``), and
+    a factory-wide halt is only triggered on ground-truth auth rejection.
+    """
+    if shutil.which("gh") is None:
+        # Cannot probe — assume auth is fine (fail-open), same as the credit probe.
+        return True
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "gh",
+            "auth",
+            "status",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except OSError:
+        # Could not even spawn gh (transient/environmental) — fail-open.
+        return True
+    try:
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(), timeout=_GH_AUTH_PROBE_TIMEOUT_S
+        )
+    except TimeoutError:
+        # Hung probe — transient, not a confirmed rejection. Kill and fail-open.
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        return True
+    if proc.returncode == 0:
+        return True
+    combined = (
+        (stdout or b"").decode(errors="replace")
+        + (stderr or b"").decode(errors="replace")
+    ).lower()
+    # rc != 0 AND the output names an auth rejection → confirmed persistent
+    # failure. Any other non-zero exit (e.g. an unreachable network) is
+    # transient, so fail-open.
+    return not any(p in combined for p in _AUTH_STATUS_REJECTION_PATTERNS)
 
 
 def parse_credit_resume_time(text: str) -> datetime | None:

--- a/tests/regressions/test_issue_9621_auth_transient_nonfatal.py
+++ b/tests/regressions/test_issue_9621_auth_transient_nonfatal.py
@@ -1,0 +1,87 @@
+"""Regression: a TRANSIENT GitHub auth/network blip stopped the whole factory (#9621).
+
+On 2026-06-20 a momentary network/API blip in ``ci_monitor`` surfaced as an
+``AuthenticationError`` (a gh call's stderr matched an auth pattern). That
+propagated fatally: ``reraise_on_credit_or_bug`` re-raised it, ``_polling_loop``
+re-raised it (auth is in its fatal tuple), the supervisor caught it in
+``_handle_loop_exception`` and ``_handle_auth_error`` set ``_auth_failed`` +
+``_stop_event`` — pausing ALL loops and stopping the orchestrator for ~2.5h,
+until a manual ``POST /api/control/start``. The token was actually valid the
+whole time; a restart recovered instantly.
+
+The fix mirrors the credit-pause corroboration (#9807/#9924): before halting
+the factory, ``_handle_auth_error`` corroborates the signal with a live
+``gh auth status`` probe. If auth is actually fine, the signal is a transient
+false positive → restart the crashed loop instead of stopping (non-fatal).
+Only a probe-confirmed, persistent auth rejection halts the factory (fail-safe).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from orchestrator import HydraFlowOrchestrator
+from subprocess_util import AuthenticationError
+
+
+async def _noop_loop() -> None:
+    await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_transient_auth_blip_restarts_loop_not_stopped(config) -> None:
+    """Probe says auth is fine → the crashed loop restarts; factory does NOT stop."""
+    orch = HydraFlowOrchestrator(config)
+
+    old = asyncio.create_task(_noop_loop())
+    await old  # simulate the crashed-and-completed 'ci_monitor' task
+    tasks: dict[str, asyncio.Task[None]] = {"ci_monitor": old}
+    factories: list = [("ci_monitor", _noop_loop)]
+    exc = AuthenticationError("Command ('gh', ...) failed: authentication required")
+
+    with patch("orchestrator.probe_auth_availability", AsyncMock(return_value=True)):
+        await orch._handle_loop_exception("ci_monitor", exc, tasks, factories)
+
+    assert orch._auth_failed is False  # factory NOT marked auth-failed
+    assert not orch._stop_event.is_set()  # factory NOT stopped
+    assert tasks["ci_monitor"] is not old  # crashed loop was restarted, not orphaned
+    tasks["ci_monitor"].cancel()
+    await asyncio.gather(tasks["ci_monitor"], return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_persistent_auth_failure_still_stops(config) -> None:
+    """Probe confirms auth is broken → factory still halts (fail-safe preserved)."""
+    orch = HydraFlowOrchestrator(config)
+    tasks: dict[str, asyncio.Task[None]] = {}
+    factories: list = [("ci_monitor", _noop_loop)]
+    exc = AuthenticationError("Command ('gh', ...) failed: not logged in")
+
+    with patch("orchestrator.probe_auth_availability", AsyncMock(return_value=False)):
+        await orch._handle_loop_exception("ci_monitor", exc, tasks, factories)
+
+    assert orch._auth_failed is True  # factory marked auth-failed
+    assert orch._stop_event.is_set()  # factory stopped
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_reverts_to_halt_on_signal(config) -> None:
+    """With the probe kill-switch off, any auth signal halts (legacy behaviour)."""
+    config.auth_failure_require_probe = False
+    orch = HydraFlowOrchestrator(config)
+    tasks: dict[str, asyncio.Task[None]] = {}
+    factories: list = [("ci_monitor", _noop_loop)]
+    exc = AuthenticationError("transient blip")
+
+    # Probe would say auth is fine, but the kill-switch disables corroboration.
+    with patch(
+        "orchestrator.probe_auth_availability", AsyncMock(return_value=True)
+    ) as probe:
+        await orch._handle_loop_exception("ci_monitor", exc, tasks, factories)
+
+    probe.assert_not_awaited()  # short-circuited: probe never called
+    assert orch._auth_failed is True
+    assert orch._stop_event.is_set()

--- a/tests/test_orchestrator_loops.py
+++ b/tests/test_orchestrator_loops.py
@@ -677,7 +677,7 @@ class TestHITLLoop:
 class TestAuthFailure:
     @pytest.mark.asyncio
     async def test_auth_failure_stops_all_loops(self, config: HydraFlowConfig) -> None:
-        """An AuthenticationError in any loop should stop the orchestrator."""
+        """A probe-confirmed AuthenticationError in any loop stops the orchestrator."""
         orch = HydraFlowOrchestrator(config)
         orch._svc.prs.ensure_labels_exist = AsyncMock()  # type: ignore[method-assign]
         orch._svc.workspaces.enable_rerere = AsyncMock()  # type: ignore[method-assign]
@@ -696,7 +696,12 @@ class TestAuthFailure:
 
         orch._sleep_or_stop = instant_sleep  # type: ignore[method-assign]
 
-        await orch.run()
+        # Probe confirms the auth failure is genuine/persistent (#9621), so the
+        # factory halts rather than treating it as a transient blip.
+        with patch(
+            "orchestrator.probe_auth_availability", AsyncMock(return_value=False)
+        ):
+            await orch.run()
 
         assert not orch.running
         assert orch._stop_event.is_set()
@@ -724,7 +729,10 @@ class TestAuthFailure:
 
         orch._sleep_or_stop = instant_sleep  # type: ignore[method-assign]
 
-        await orch.run()
+        with patch(
+            "orchestrator.probe_auth_availability", AsyncMock(return_value=False)
+        ):
+            await orch.run()
 
         alert_events = [
             e for e in event_bus.get_history() if e.type == EventType.SYSTEM_ALERT
@@ -756,7 +764,10 @@ class TestAuthFailure:
 
         orch._sleep_or_stop = instant_sleep  # type: ignore[method-assign]
 
-        await orch.run()
+        with patch(
+            "orchestrator.probe_auth_availability", AsyncMock(return_value=False)
+        ):
+            await orch.run()
 
         assert orch._auth_failed is True
 
@@ -793,15 +804,18 @@ class TestAuthFailure:
 class TestHandleLoopException:
     @pytest.mark.asyncio
     async def test_auth_error_sets_stop_and_flag(self, config: HydraFlowConfig) -> None:
-        """AuthenticationError should set _auth_failed and stop_event."""
+        """A probe-confirmed AuthenticationError sets _auth_failed and stop_event."""
         bus = EventBus()
         orch = HydraFlowOrchestrator(config, event_bus=bus)
         tasks: dict[str, asyncio.Task[None]] = {}
         factories: list = []
 
-        await orch._handle_loop_exception(
-            "plan", AuthenticationError("401"), tasks, factories
-        )
+        with patch(
+            "orchestrator.probe_auth_availability", AsyncMock(return_value=False)
+        ):
+            await orch._handle_loop_exception(
+                "plan", AuthenticationError("401"), tasks, factories
+            )
 
         assert orch._auth_failed is True
         assert orch._stop_event.is_set()

--- a/tests/test_subprocess_util.py
+++ b/tests/test_subprocess_util.py
@@ -21,6 +21,7 @@ from subprocess_util import (
     make_clean_env,
     make_docker_env,
     parse_credit_resume_time,
+    probe_auth_availability,
     run_subprocess,
     run_subprocess_with_retry,
 )
@@ -1457,3 +1458,59 @@ class TestParseCreditResumeTime:
         caller falls back to its default pause, so parse returns None.
         """
         assert parse_credit_resume_time("You've hit your weekly limit") is None
+
+
+# --- probe_auth_availability (#9621) ---
+
+
+class TestProbeAuthAvailability:
+    """Live ``gh auth status`` corroboration probe for the auth-failure path.
+
+    Fail-open mirror of ``probe_credit_availability``: returns ``False`` ONLY on
+    a ground-truth, persistent auth rejection; every un-probeable/transient
+    condition returns ``True`` so a momentary blip never halts the factory.
+    """
+
+    @pytest.mark.asyncio
+    async def test_returns_true_when_gh_missing(self) -> None:
+        with patch("subprocess_util.shutil.which", return_value=None):
+            assert await probe_auth_availability() is True
+
+    @pytest.mark.asyncio
+    async def test_returns_true_when_authenticated(self) -> None:
+        proc = _make_proc(returncode=0, stdout=b"Logged in to github.com")
+        with (
+            patch("subprocess_util.shutil.which", return_value="/usr/bin/gh"),
+            patch("asyncio.create_subprocess_exec", return_value=proc),
+        ):
+            assert await probe_auth_availability() is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_confirmed_auth_rejection(self) -> None:
+        proc = _make_proc(returncode=1, stderr=b"X github.com: authentication failed")
+        with (
+            patch("subprocess_util.shutil.which", return_value="/usr/bin/gh"),
+            patch("asyncio.create_subprocess_exec", return_value=proc),
+        ):
+            assert await probe_auth_availability() is False
+
+    @pytest.mark.asyncio
+    async def test_returns_true_on_transient_network_failure(self) -> None:
+        # rc != 0 but the output is a network error, not an auth rejection.
+        proc = _make_proc(
+            returncode=1,
+            stderr=b"dial tcp: lookup api.github.com: no such host",
+        )
+        with (
+            patch("subprocess_util.shutil.which", return_value="/usr/bin/gh"),
+            patch("asyncio.create_subprocess_exec", return_value=proc),
+        ):
+            assert await probe_auth_availability() is True
+
+    @pytest.mark.asyncio
+    async def test_returns_true_on_oserror_spawning_gh(self) -> None:
+        with (
+            patch("subprocess_util.shutil.which", return_value="/usr/bin/gh"),
+            patch("asyncio.create_subprocess_exec", side_effect=OSError("boom")),
+        ):
+            assert await probe_auth_availability() is True


### PR DESCRIPTION
## Summary

Fixes #9621. A **transient** GitHub network/API blip in `ci_monitor` used to stop the **whole factory** for ~2.5h (2026-06-20 incident). A single `gh` call's stderr matched an auth pattern, so `subprocess_util` raised `AuthenticationError`, which propagated **fatally** all the way to a global halt — even though the token was valid the entire time (a plain restart recovered instantly).

This is the same class of bug as the credit-stop fix (#9807 / #9924): a **non-corroborated** signal must never take the factory down.

## Root cause — the propagation path fixed

```
ci_monitor._do_work() -> prs.get_latest_ci_status() -> gh call
  transient blip -> stderr matches _AUTH_PATTERNS -> subprocess_util raises AuthenticationError
  -> ci_monitor except: reraise_on_credit_or_bug(exc)   [re-raises auth]
  -> BaseBackgroundLoop._execute_cycle re-raises AuthenticationError  (base_background_loop.py:239)
  -> _supervise_loops observes crashed task
  -> _handle_loop_exception -> _handle_auth_error
       set _auth_failed=True; publish SYSTEM_ALERT; _stop_event.set()   <-- FACTORY STOPS
```
There was **zero corroboration** — unlike the credit path, which probes before pausing.

## Fix

`_handle_auth_error` now corroborates the signal with a live `gh auth status` probe **before** committing a global halt (mirrors `_pause_for_credits` / `probe_credit_availability`):

- **Probe says auth is fine** -> transient false positive -> **restart the crashed loop** (non-fatal, retried next tick), factory keeps running.
- **Probe confirms a persistent rejection** -> **still halts** (fail-safe preserved).

Details:
- `probe_auth_availability()` in `subprocess_util` — fail-open mirror of `probe_credit_availability`. Returns `False` **only** on a ground-truth `gh auth status` rejection; gh-missing / spawn-failure / timeout / non-auth network error all return `True`, so a blip (or a GitHub outage) never halts the factory.
- `auth_failure_require_probe` config knob (default `True`; kill-switch to revert to halt-on-signal).
- Transient restart uses a bounded delay (`_AUTH_TRANSIENT_RESTART_DELAY_S = 30s`) so a *sustained* blip can't hot-loop the supervisor / storm WARNING logs — the pathology #9924 guarded on the credit false-positive path.

Scope note: the issue also floated auto-resume on an interval and a stall watchdog as "consider" items; this PR delivers the core transient-vs-fatal classification. The corroboration path already self-recovers (the loop retries every tick instead of requiring a manual `POST /api/control/start`).

## Tests (TDD: RED -> GREEN)

- `tests/regressions/test_issue_9621_auth_transient_nonfatal.py`:
  - transient blip (probe `True`) -> loop restarted, `_auth_failed` stays `False`, factory NOT stopped
  - persistent failure (probe `False`) -> factory still halts
  - kill-switch off -> probe short-circuited, halt-on-signal
- `tests/test_subprocess_util.py::TestProbeAuthAvailability`: rc==0, confirmed rejection, transient network non-zero (fail-open), gh-missing, spawn `OSError`.
- Existing auth-halt tests in `test_orchestrator_loops.py` updated to mock the probe (were environment-dependent on the machine's real `gh` state; now deterministic).

Ran: new regression + probe unit tests, `test_ci_monitor_loop.py`, `test_orchestrator_loops.py`, `test_orchestrator_integration.py`, `test_orchestrator_core.py`, `test_orchestrator_loop_restart.py`, `test_credit_pause.py`, credit regressions (#9807/#9924), and config suites — all green. `ruff check` + `ruff format` clean on changed files. (Per task scope: not full `make quality`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)