### PR TITLE
feat(guard): proactive guard against runtime caches dirtying the git tree (#9599)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -39,6 +39,19 @@ if [ -n "$STAGED_ALL" ]; then
     fi
 fi
 
+# ── Guard: never git-track runtime caches (#9599) ──
+# Runs over ALL staged files BEFORE the short-circuit below — a docs-only commit
+# (e.g. a bot wiki write) must not bypass it. docs/wiki runtime caches were
+# tracked precisely because no gate inspected a docs-only change (#9537).
+if [ -n "$STAGED_ALL" ]; then
+    # shellcheck disable=SC2086 — word-splitting is intended (one arg per path)
+    if ! python3 "$REPO_ROOT/scripts/check_runtime_cache_tracked.py" $STAGED_ALL; then
+        echo "pre-commit: BLOCKED — staged files look like runtime caches (above)." >&2
+        echo "  Untrack + gitignore them, or add to ALLOWLIST with a justification." >&2
+        exit 1
+    fi
+fi
+
 # Detect Python changes (existing) AND arch source changes (new).
 STAGED_PY=$(git diff --cached --name-only --diff-filter=ACM -- '*.py' || true)
 STAGED_ARCH=$(git diff --cached --name-only --diff-filter=ACM \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,23 @@ jobs:
       - name: Scan tracked files for git conflict markers
         run: python3 scripts/check_conflict_markers.py --tracked
 
+  # Universal backstop (#9599): reject git-tracked runtime caches on EVERY
+  # PR/push, ungated by `changes`. docs/wiki/{log.jsonl,ingest_dedup.json,
+  # index.json} were tracked runtime caches the RepoWikiLoop rewrote every tick,
+  # leaving the working tree perpetually dirty (fixed reactively in #9537). This
+  # gate catches the next one before it lands. stdlib-only; no uv sync needed.
+  runtime-cache-guard:
+    name: Runtime Cache Guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Scan tracked files for runtime caches
+        run: python3 scripts/check_runtime_cache_tracked.py --tracked
+
   lint:
     name: Lint & Format
     needs: changes

--- a/.gitignore
+++ b/.gitignore
@@ -257,7 +257,16 @@ MagicMock/
 # demand and read from disk at runtime. Tracking them left the factory's
 # working tree permanently dirty (the maintenance PR is built in an ephemeral
 # worktree and never cleans the originals). Keep them out of git; see
-# tests/architecture/test_wiki_runtime_caches_untracked.py.
+# tests/architecture/test_wiki_runtime_caches_untracked.py and the proactive
+# guard scripts/check_runtime_cache_tracked.py (#9599).
 docs/wiki/log.jsonl
 docs/wiki/ingest_dedup.json
 docs/wiki/index.json
+
+# FitnessScorecardLoop rewrites this into the live repo root every tick
+# (src/fitness_scorecard_loop.py:_ARTIFACT_REL). Unlike the other tracked
+# docs/arch/generated/*.md (regenerated in a worktree by arch-regen), it was
+# neither tracked nor gitignored, leaving a permanent '??' in git status
+# (#9599 groom 2026-07-19). Ignore it so the loop's rewrites cannot dirty the
+# tree; see scripts/check_runtime_cache_tracked.py.
+docs/arch/generated/loop-fitness.md

--- a/Makefile
+++ b/Makefile
@@ -289,6 +289,13 @@ test-sludge-check: deps
 conflict-check:
 	@cd $(HYDRAFLOW_DIR) && python3 scripts/check_conflict_markers.py $(if $(FILES),$(FILES),--tracked)
 
+# Reject git-tracked runtime caches / untracked loop artifacts (#9599). stdlib-only.
+# FILES is space-separated; defaults to a --tracked scan. The mode-b (untracked
+# loop artifact) scan is run second so a local dev checkout catches both.
+cache-check:
+	@cd $(HYDRAFLOW_DIR) && python3 scripts/check_runtime_cache_tracked.py $(if $(FILES),$(FILES),--tracked)
+	@cd $(HYDRAFLOW_DIR) && python3 scripts/check_runtime_cache_tracked.py --untracked
+
 lint-fix: lint
 	@echo "$(GREEN)Auto-repair complete$(RESET)"
 

--- a/scripts/check_runtime_cache_tracked.py
+++ b/scripts/check_runtime_cache_tracked.py
@@ -1,0 +1,206 @@
+"""Guard against runtime cache/artifact files dirtying the git tree (#9599).
+
+Runtime state that a background loop rewrites every tick must live under the
+gitignored ``data_root`` (``.hydraflow/``) or be gitignored — never committed to
+the tracked repo tree. Two failure modes have bitten the factory:
+
+  (a) *Tracked-churn* — ``docs/wiki/{log.jsonl, ingest_dedup.json, index.json}``
+      were git-tracked runtime caches the ``RepoWikiLoop`` rewrote every cycle, so
+      the dev checkout's working tree was perpetually dirty (fixed reactively in
+      #9537). Maintenance PRs are built in ephemeral worktrees that never clean the
+      originals in ``repo_root``, and the caches churn faster than any PR cadence.
+
+  (b) *Untracked-dirt* — ``FitnessScorecardLoop`` writes
+      ``docs/arch/generated/loop-fitness.md`` into the live repo root every tick.
+      It was neither tracked nor gitignored, so it showed as a permanent ``??`` in
+      ``git status`` (found 2026-07-19). The inverse of mode (a): an artifact under
+      a tracked directory that is neither tracked nor ignored.
+
+This is a proactive, stdlib-only static gate modelled on
+``scripts/check_conflict_markers.py`` (#9482): a pure classifier over
+``git ls-files`` (mode a) / ``git ls-files --others --exclude-standard`` (mode b),
+wired into ``make cache-check``, a dedicated ungated CI job, the pre-commit hook,
+and a ``tests/architecture/`` test. It flags the *next* runtime cache before it
+dirties the tree instead of after an incident.
+
+Detection is deliberately narrow to avoid a false-positive storm: cache-shaped
+**basenames** and **cache-dir path segments**, never whole extensions (a plain
+``*.jsonl`` rule would storm on the tracked per-issue ``repo_wiki/.../log/*.jsonl``
+snapshots and test fixtures). ``tests/`` and ``repo_wiki/`` are excluded wholesale
+and ``ALLOWLIST`` is the escape hatch for any legitimately-tracked exception.
+
+Usage:
+    check_runtime_cache_tracked.py <file> [<file> ...]  # classify given paths (pre-commit)
+    check_runtime_cache_tracked.py --tracked            # scan all git-tracked files (mode a)
+    check_runtime_cache_tracked.py --untracked          # scan untracked/un-ignored files (mode b)
+    check_runtime_cache_tracked.py                       # same as --tracked
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import subprocess
+import sys
+from collections.abc import Iterable
+from pathlib import Path, PurePosixPath
+
+# fnmatch globs matched (case-insensitively) against a path's basename. Narrow by
+# design — these catch the #9537 caches and generic cache shapes without hitting
+# the numbered ``repo_wiki/.../log/NNNN.jsonl`` snapshots or test fixtures.
+CACHE_BASENAME_PATTERNS: tuple[str, ...] = (
+    "log.jsonl",  # ingest log (#9537) — NOT NNNN.jsonl / legacy.jsonl
+    "index.json",  # machine index (#9537)
+    "ingest_dedup.json",  # dedup cache (#9537)
+    "*_dedup.json",  # generic dedup caches
+    "dedup.json",
+    "*_cache.json",  # generic caches
+    "*.cache.json",
+    "*_cache.jsonl",
+    "ingest_*.json",  # ingest state
+)
+
+# A tracked path containing one of these as a path segment is a runtime cache.
+# ``log`` is intentionally excluded: ``repo_wiki/.../log/NNNN.jsonl`` are tracked
+# write-once per-issue snapshots, not caches.
+CACHE_DIR_SEGMENTS: frozenset[str] = frozenset(
+    {"cache", "caches", ".cache", "__cache__", "dedup"}
+)
+
+# Prefixes that legitimately hold cache-shaped tracked files (fixtures, cassettes,
+# corpora, seeds, and the migrated static wiki snapshot per ADR-0032). Excluded
+# wholesale so the guard never storms on them.
+EXCLUDED_PREFIXES: tuple[str, ...] = ("tests/", "repo_wiki/")
+
+# Directories whose contents must be fully tracked OR gitignored — a runtime loop
+# artifact left here un-ignored (mode b) is the FitnessScorecardLoop footgun.
+GENERATED_ARTIFACT_DIRS: tuple[str, ...] = ("docs/arch/generated/",)
+
+# Exact repo-relative paths that match a pattern but are legitimately tracked.
+# Empty by design; each future entry needs an inline "# why:" justification.
+ALLOWLIST: frozenset[str] = frozenset()
+
+
+def _is_excluded(rel: str) -> bool:
+    return any(rel.startswith(prefix) for prefix in EXCLUDED_PREFIXES)
+
+
+def _matches_cache_shape(rel: str) -> bool:
+    parts = PurePosixPath(rel).parts
+    if any(seg in CACHE_DIR_SEGMENTS for seg in parts):
+        return True
+    basename = parts[-1].lower() if parts else ""
+    return any(
+        fnmatch.fnmatchcase(basename, pattern.lower())
+        for pattern in CACHE_BASENAME_PATTERNS
+    )
+
+
+def classify_tracked_paths(paths: Iterable[str]) -> list[str]:
+    """Return sorted paths that look like git-tracked runtime caches (mode a)."""
+    offenders = {
+        rel
+        for rel in paths
+        if rel
+        and rel not in ALLOWLIST
+        and not _is_excluded(rel)
+        and _matches_cache_shape(rel)
+    }
+    return sorted(offenders)
+
+
+def classify_untracked_artifacts(untracked_paths: Iterable[str]) -> list[str]:
+    """Return sorted untracked/un-ignored paths under a generated-artifact dir (mode b)."""
+    offenders = {
+        rel
+        for rel in untracked_paths
+        if rel
+        and rel not in ALLOWLIST
+        and any(rel.startswith(directory) for directory in GENERATED_ARTIFACT_DIRS)
+    }
+    return sorted(offenders)
+
+
+def _repo_root() -> Path:
+    out = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return Path(out.stdout.strip())
+
+
+def _tracked_files(root: Path) -> list[str]:
+    out = subprocess.run(
+        ["git", "ls-files"], cwd=root, capture_output=True, text=True, check=True
+    )
+    return [line for line in out.stdout.splitlines() if line]
+
+
+def _untracked_unignored_files(root: Path) -> list[str]:
+    out = subprocess.run(
+        ["git", "ls-files", "--others", "--exclude-standard"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line for line in out.stdout.splitlines() if line]
+
+
+def _report_tracked(offenders: list[str]) -> None:
+    print(
+        "git-tracked runtime caches found — refusing to proceed. These churn every "
+        "loop tick and leave the working tree perpetually dirty (#9599):",
+        file=sys.stderr,
+    )
+    for rel in offenders:
+        print(f"  {rel}", file=sys.stderr)
+    print(
+        "\nUntrack each and gitignore it:\n"
+        "  git rm --cached <path> && echo <path> >> .gitignore\n"
+        "If it is legitimately tracked, add it to ALLOWLIST in "
+        "scripts/check_runtime_cache_tracked.py with a justification.",
+        file=sys.stderr,
+    )
+
+
+def _report_untracked(offenders: list[str]) -> None:
+    print(
+        "untracked/un-ignored loop artifacts found under a generated dir — a runtime "
+        "loop rewrites these every tick, leaving a permanent '??' in git status "
+        "(#9599):",
+        file=sys.stderr,
+    )
+    for rel in offenders:
+        print(f"  {rel}", file=sys.stderr)
+    print(
+        "\nGitignore each (or commit it into the tracked arch-regen set):\n"
+        "  echo <path> >> .gitignore",
+        file=sys.stderr,
+    )
+
+
+def main(argv: list[str]) -> int:
+    root = _repo_root()
+
+    if "--untracked" in argv:
+        offenders = classify_untracked_artifacts(_untracked_unignored_files(root))
+        if offenders:
+            _report_untracked(offenders)
+            return 1
+        return 0
+
+    file_args = [arg for arg in argv if not arg.startswith("--")]
+    paths = (
+        _tracked_files(root) if ("--tracked" in argv or not file_args) else file_args
+    )
+    offenders = classify_tracked_paths(paths)
+    if offenders:
+        _report_tracked(offenders)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/architecture/test_runtime_caches_not_tracked.py
+++ b/tests/architecture/test_runtime_caches_not_tracked.py
@@ -1,0 +1,90 @@
+"""Proactive guard: no runtime cache/artifact may dirty the tracked tree (#9599).
+
+Generalizes the reactive #9537 fix (``tests/architecture/test_wiki_runtime_caches_untracked.py``,
+which pins three specific ``docs/wiki`` caches). Runtime state a background loop
+rewrites every tick must live under the gitignored ``data_root`` (``.hydraflow/``)
+or be gitignored — never committed to the tracked tree.
+
+Two failure modes are covered:
+
+* **Mode a (tracked-churn):** a cache-shaped file is git-tracked. Runs the pure
+  ``classify_tracked_paths`` engine over the live ``git ls-files`` output and
+  asserts zero offenders. Fails loudly (listing offenders + remediation) if a
+  runtime cache is ever tracked again.
+* **Mode b (untracked-dirt):** ``FitnessScorecardLoop`` writes
+  ``docs/arch/generated/loop-fitness.md`` into the live repo root every tick. It
+  was neither tracked nor gitignored, leaving a permanent ``??`` in
+  ``git status`` (found 2026-07-19). Asserts it is now gitignored so the loop's
+  rewrites cannot dirty the working tree.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[2] / "scripts" / "check_runtime_cache_tracked.py"
+)
+_spec = importlib.util.spec_from_file_location("check_runtime_cache_tracked", _SCRIPT)
+assert _spec and _spec.loader
+guard = importlib.util.module_from_spec(_spec)
+sys.modules["check_runtime_cache_tracked"] = guard
+_spec.loader.exec_module(guard)
+
+# The three #9537 caches — the general guard must remain a superset of the
+# hard-coded regression that first untracked them.
+WIKI_9537_CACHES = (
+    "docs/wiki/log.jsonl",
+    "docs/wiki/ingest_dedup.json",
+    "docs/wiki/index.json",
+)
+
+# The mode-b live offender fixed by this issue (#9599 groom 2026-07-19).
+UNTRACKED_LOOP_ARTIFACT = "docs/arch/generated/loop-fitness.md"
+
+
+def _tracked_files(root: Path) -> list[str]:
+    out = subprocess.run(
+        ["git", "ls-files"],
+        check=True,
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in out.stdout.splitlines() if line]
+
+
+def test_no_runtime_cache_is_git_tracked(real_repo_root: Path) -> None:
+    offenders = guard.classify_tracked_paths(_tracked_files(real_repo_root))
+    assert offenders == [], (
+        "Runtime cache files are git-tracked — they churn every loop tick and "
+        "leave the working tree perpetually dirty. Untrack each "
+        "(git rm --cached <path>) and add it to .gitignore, or, if legitimately "
+        f"tracked, add it to ALLOWLIST in {_SCRIPT.name} with a justification:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+@pytest.mark.parametrize("path", WIKI_9537_CACHES)
+def test_general_guard_flags_the_9537_caches(path: str) -> None:
+    assert guard.classify_tracked_paths([path]) == [path]
+
+
+def test_loop_fitness_artifact_is_gitignored(real_repo_root: Path) -> None:
+    result = subprocess.run(
+        ["git", "check-ignore", UNTRACKED_LOOP_ARTIFACT],
+        check=False,
+        cwd=real_repo_root,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"{UNTRACKED_LOOP_ARTIFACT} is not gitignored. FitnessScorecardLoop "
+        "rewrites it into the live repo root every tick; without a .gitignore "
+        "rule it shows as a permanent '??' in git status. Add it to .gitignore."
+    )

--- a/tests/test_check_runtime_cache_tracked.py
+++ b/tests/test_check_runtime_cache_tracked.py
@@ -1,0 +1,120 @@
+"""Unit tests for the runtime-cache tracking guard.
+
+Covers the pure classifiers (mode a: git-tracked cache files; mode b: untracked
+un-ignored loop artifacts under a generated-artifact dir) and the CLI exit codes.
+The script is loaded via ``importlib`` exactly like
+``tests/test_check_conflict_markers.py`` so no cross-module ``_``-prefixed import
+is needed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_SCRIPT = Path(__file__).parent.parent / "scripts" / "check_runtime_cache_tracked.py"
+_spec = importlib.util.spec_from_file_location("check_runtime_cache_tracked", _SCRIPT)
+assert _spec and _spec.loader
+guard = importlib.util.module_from_spec(_spec)
+sys.modules["check_runtime_cache_tracked"] = guard
+_spec.loader.exec_module(guard)
+
+
+class TestClassifyTrackedPaths:
+    def test_flags_log_jsonl_cache(self) -> None:
+        assert guard.classify_tracked_paths(["docs/foo/log.jsonl"]) == [
+            "docs/foo/log.jsonl"
+        ]
+
+    def test_flags_index_json_cache(self) -> None:
+        assert guard.classify_tracked_paths(["docs/bar/index.json"]) == [
+            "docs/bar/index.json"
+        ]
+
+    def test_flags_dedup_caches(self) -> None:
+        offenders = guard.classify_tracked_paths(
+            ["a/ingest_dedup.json", "b/foo_dedup.json"]
+        )
+        assert offenders == ["a/ingest_dedup.json", "b/foo_dedup.json"]
+
+    def test_flags_generic_cache_basenames(self) -> None:
+        offenders = guard.classify_tracked_paths(["svc/state_cache.json"])
+        assert offenders == ["svc/state_cache.json"]
+
+    def test_flags_path_under_cache_dir_segment(self) -> None:
+        assert guard.classify_tracked_paths(["svc/cache/blob.json"]) == [
+            "svc/cache/blob.json"
+        ]
+
+    def test_numbered_repo_wiki_log_is_not_a_cache(self) -> None:
+        offenders = guard.classify_tracked_paths(
+            ["repo_wiki/T-rav/hydraflow/log/7644.jsonl"]
+        )
+        assert offenders == []
+
+    def test_test_fixtures_are_excluded(self) -> None:
+        paths = ["tests/fixtures/prompts/canary-trace.jsonl", "tests/foo/index.json"]
+        assert guard.classify_tracked_paths(paths) == []
+
+    def test_ordinary_source_files_are_not_caches(self) -> None:
+        paths = ["src/foo.py", "README.md", "src/ui/package.json"]
+        assert guard.classify_tracked_paths(paths) == []
+
+    def test_allowlisted_path_is_exempt(self, monkeypatch) -> None:
+        monkeypatch.setattr(guard, "ALLOWLIST", frozenset({"docs/keep/index.json"}))
+        assert guard.classify_tracked_paths(["docs/keep/index.json"]) == []
+
+    def test_empty_input_returns_empty(self) -> None:
+        assert guard.classify_tracked_paths([]) == []
+
+
+class TestClassifyUntrackedArtifacts:
+    def test_flags_untracked_artifact_under_generated_dir(self) -> None:
+        offenders = guard.classify_untracked_artifacts(
+            ["docs/arch/generated/loop-fitness.md"]
+        )
+        assert offenders == ["docs/arch/generated/loop-fitness.md"]
+
+    def test_ignores_untracked_files_outside_generated_dirs(self) -> None:
+        offenders = guard.classify_untracked_artifacts(
+            ["scratch/notes.md", "tmp/x.json"]
+        )
+        assert offenders == []
+
+    def test_empty_input_returns_empty(self) -> None:
+        assert guard.classify_untracked_artifacts([]) == []
+
+
+class TestMain:
+    def test_explicit_cache_path_returns_1_with_remediation(
+        self, capsys, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(guard, "_repo_root", lambda: Path("/repo"))
+        rc = guard.main(["docs/foo/index.json"])
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "git rm --cached" in captured.err
+
+    def test_explicit_clean_path_returns_0(self, capsys, monkeypatch) -> None:
+        monkeypatch.setattr(guard, "_repo_root", lambda: Path("/repo"))
+        rc = guard.main(["src/foo.py"])
+        assert rc == 0
+        assert capsys.readouterr().err == ""
+
+    def test_tracked_mode_over_live_repo_is_clean(self) -> None:
+        assert guard.main(["--tracked"]) == 0
+
+    def test_untracked_mode_returns_1_when_artifact_present(
+        self, capsys, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(guard, "_repo_root", lambda: Path("/repo"))
+        monkeypatch.setattr(
+            guard,
+            "_untracked_unignored_files",
+            lambda _root: ["docs/arch/generated/loop-fitness.md"],
+        )
+        rc = guard.main(["--untracked"])
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert ".gitignore" in captured.err


### PR DESCRIPTION
Closes #9599.

## Problem

`docs/wiki/{log.jsonl, ingest_dedup.json, index.json}` were git-tracked runtime caches the `RepoWikiLoop` rewrote every tick, so the dev checkout's working tree was perpetually dirty. Fixed **reactively** in #9537 (untracked + gitignored + a hard-coded 3-path regression test). This issue asks for a **proactive** guard so the next one is caught before it dirties the tree.

The owner's groom (2026-07-19) found a live instance of the **inverse** mode: `FitnessScorecardLoop` writes `docs/arch/generated/loop-fitness.md` into the live repo root every tick (`src/fitness_scorecard_loop.py` `_ARTIFACT_REL`), and it was neither tracked nor gitignored → a permanent `??` in `git status`. The guard covers both modes.

## What this adds

A stdlib-only static gate modelled on `scripts/check_conflict_markers.py` (#9482):

- **`scripts/check_runtime_cache_tracked.py`** — pure classifiers + thin subprocess CLI:
  - **mode (a)** `classify_tracked_paths` (`--tracked`): flags git-tracked cache-shaped files.
  - **mode (b)** `classify_untracked_artifacts` (`--untracked`): flags untracked/un-ignored loop artifacts under a generated-artifact dir.
- **Immediate one-off:** `docs/arch/generated/loop-fitness.md` added to `.gitignore` (never committed, not in mkdocs nav — gitignore is the right resolution since the loop regenerates it every tick).

### Detection is deliberately narrow (no false-positive storm)

Cache-shaped **basenames** (`log.jsonl`, `index.json`, `*_dedup.json`, `*_cache.json`, …) and **cache-dir path segments** (`cache/`, `dedup/`, …) — never whole extensions. A plain `*.jsonl` rule would storm on the tracked per-issue `repo_wiki/.../log/*.jsonl` snapshots and test fixtures. `tests/` and `repo_wiki/` are excluded wholesale; `ALLOWLIST` (empty by design) is the escape hatch. **Baseline is green** — verified zero tracked offenders today.

## Enforcement (three layers, mirroring conflict-markers)

- `tests/architecture/test_runtime_caches_not_tracked.py` — runs the engine over live `git ls-files` (required Tests gate); asserts the 3 #9537 caches would each be flagged if reintroduced (superset of the hard-coded regression); asserts `loop-fitness.md` is now gitignored.
- an ungated `runtime-cache-guard` CI job (stdlib-only, no `uv sync`).
- the pre-commit hook (over staged files) + a `make cache-check` target.

The existing `tests/architecture/test_wiki_runtime_caches_untracked.py` is retained (it additionally asserts `git check-ignore` for the exact 3 paths).

## Test results

- `tests/test_check_runtime_cache_tracked.py` + `tests/architecture/test_runtime_caches_not_tracked.py`: all green (RED first — script missing + loop-fitness not yet ignored — then GREEN after implementing + gitignoring).
- Full `tests/architecture/` suite: 192 passed.
- `ruff check` + `ruff format --check` on changed files: clean.
- `make arch-check`: passes (no drift).
- `make cache-check`: exits 0 on the clean tree; exits non-zero with remediation on an injected offender.

## Scope notes

No MockWorld scenario / sandbox e2e: this is CI/pre-commit tooling with no orchestrator/loop/docker/UI surface (identical rationale to `check_conflict_markers.py`, which ships unit + CI coverage only). No new `BaseBackgroundLoop`/runner → ADR-0049 kill-switch N/A. The guard calls `git` via `subprocess` directly (not a Port), consistent with every `scripts/` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)