### PR TITLE
fix(wiki): repo-specificity gate on issue-synthesis entries (#9954)

### DIFF
--- a/disturbance/baselines/suppressions.yaml
+++ b/disturbance/baselines/suppressions.yaml
@@ -234,7 +234,7 @@ entries:
   src/rc_budget_loop.py::noqa:PLC0415: 1
   src/rc_budget_loop.py::noqa:TCH001: 2
   src/repo_wiki.py::noqa:BLE001: 3
-  src/repo_wiki.py::noqa:PLC0415: 5
+  src/repo_wiki.py::noqa:PLC0415: 6
   "src/repo_wiki.py::noqa:PLC0415\u2014isolatedhere,notamodule-leveldep": 1
   src/repo_wiki.py::type-ignore[return-value]: 1
   src/repo_wiki_ingest.py::noqa:BLE001: 1
@@ -338,6 +338,7 @@ entries:
   "src/ubiquitous_language.py::noqa:PLR0911\u2014linearF1guards,eachwithitsownfailpath": 1
   src/verification_judge.py::noqa:PLC0415: 1
   src/whatsapp_bridge.py::noqa:PLC0415: 1
+  src/wiki_anchor_gate.py::noqa:PLC0415: 1
   src/wiki_compiler.py::noqa:BLE001: 3
   src/wiki_compiler.py::noqa:PLC0415: 5
   src/wiki_drift_detector.py::noqa:BLE001: 1

--- a/src/config.py
+++ b/src/config.py
@@ -2491,6 +2491,20 @@ class HydraFlowConfig(BaseModel):
             "to the next tick."
         ),
     )
+    wiki_anchor_prune_enabled: bool = Field(
+        default=False,
+        description=(
+            "When True (#9954), RepoWikiLoop runs a deterministic prune pass "
+            "that marks active tracked wiki entries stale when they lack a "
+            "repo-specific anchor (a src/*.py path, ADR number, loop/Port "
+            "class name, or config field) — i.e. generic best-practice "
+            "platitudes. Mark-only (never deletes); the flips ride the "
+            "normal batched maintenance PR. Off by default: enabling it does "
+            "the one-time cleanup of the accumulated platitude backlog. The "
+            "synthesis-time gate that blocks NEW anchor-less entries is "
+            "always on and independent of this flag."
+        ),
+    )
 
     # Paths (auto-detected)
     repo_root: Path = Field(default=Path("."), description="Repository root directory")

--- a/src/knowledge_metrics.py
+++ b/src/knowledge_metrics.py
@@ -23,6 +23,10 @@ _COUNTER_NAMES = (
     "adr_drafts_judged",
     "adr_drafts_opened",
     "reflections_bridged",
+    # #9954: synthesis/lint entries dropped or flagged for lacking a
+    # repo-specific anchor (generic best-practice platitudes).
+    "wiki_entries_rejected_no_anchor",
+    "wiki_entries_flagged_no_anchor",
 )
 
 

--- a/src/repo_wiki.py
+++ b/src/repo_wiki.py
@@ -509,6 +509,77 @@ def active_lint_tracked(
     return result
 
 
+def flag_generic_entries_stale(
+    tracked_root: Path,
+    repo_slug: str,
+    *,
+    anchor_vocabulary: frozenset[str] | None = None,
+) -> int:
+    """Mark active tracked entries stale when they lack a repo-specific anchor.
+
+    The prune pass for #9954: the gotcha store had accumulated generic
+    coding truisms ("Use ``is None`` for optional sentinels") that dilute
+    the wiki context injected into agent prompts (``max_repo_wiki_chars``
+    truncates, so platitudes crowd out real gotchas). This pass scores
+    every ``status: active`` per-entry file with the same deterministic
+    heuristic the synthesis-time gate uses
+    (:func:`wiki_anchor_gate.has_repo_anchor`) and flips anchor-less ones
+    to ``status: stale`` with a ``stale_reason``.
+
+    Mark-only — never deletes. The flips land as uncommitted diffs the
+    maintenance PR rolls up (reviewable), and the existing age-based prune
+    in :func:`active_lint_tracked` removes them on a later tick. Stale
+    entries are already filtered out of prompt injection, so injection
+    favors anchored entries immediately.
+
+    Returns the number of entries newly flagged stale. No-op (returns 0)
+    when *anchor_vocabulary* is ``None`` so callers opt in explicitly and
+    existing ``active_lint_tracked`` behavior is untouched.
+    """
+    from file_util import atomic_write  # noqa: PLC0415
+    from wiki_anchor_gate import has_repo_anchor  # noqa: PLC0415
+
+    if anchor_vocabulary is None:
+        return 0
+    repo_dir = tracked_root / repo_slug
+    if not repo_dir.is_dir():
+        return 0
+
+    flagged = 0
+    for topic_name in _TRACKED_TOPICS:
+        topic_dir = repo_dir / topic_name
+        if not topic_dir.is_dir():
+            continue
+        for entry_path in sorted(topic_dir.glob("*.md")):
+            try:
+                text = entry_path.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            fields, _block, body = _split_tracked_entry(text)
+            if not fields or fields.get("status", "active") != "active":
+                continue
+            # ``body`` carries the ``# Title`` heading plus content — enough
+            # signal for the anchor heuristic.
+            if has_repo_anchor(body, config_fields=anchor_vocabulary):
+                continue
+            updated = _update_tracked_entry_status(
+                text,
+                status="stale",
+                stale_reason="no repo-specific anchor (generic best-practice)",
+            )
+            if updated is None:
+                continue
+            try:
+                atomic_write(entry_path, updated)
+            except OSError:
+                logger.warning(
+                    "flag_generic_entries_stale: failed to rewrite %s", entry_path
+                )
+                continue
+            flagged += 1
+    return flagged
+
+
 class WikiEntry(BaseModel):
     """A single knowledge entry within a topic page."""
 

--- a/src/repo_wiki.py
+++ b/src/repo_wiki.py
@@ -27,6 +27,7 @@ from pydantic import BaseModel, Field, model_validator
 from ulid import ULID
 
 from staleness import evaluate as evaluate_staleness
+from wiki_anchor_gate import has_repo_anchor
 
 if TYPE_CHECKING:
     from dedup_store import DedupStore
@@ -537,7 +538,6 @@ def flag_generic_entries_stale(
     existing ``active_lint_tracked`` behavior is untouched.
     """
     from file_util import atomic_write  # noqa: PLC0415
-    from wiki_anchor_gate import has_repo_anchor  # noqa: PLC0415
 
     if anchor_vocabulary is None:
         return 0

--- a/src/repo_wiki_loop.py
+++ b/src/repo_wiki_loop.py
@@ -17,9 +17,16 @@ from config import Credentials, HydraFlowConfig
 from events import EventType, HydraFlowEvent
 from exception_classify import reraise_on_credit_or_bug
 from knowledge_metrics import metrics as _metrics
-from repo_wiki import DEFAULT_TOPICS, RepoWikiStore, WikiEntry, active_lint_tracked
+from repo_wiki import (
+    DEFAULT_TOPICS,
+    RepoWikiStore,
+    WikiEntry,
+    active_lint_tracked,
+    flag_generic_entries_stale,
+)
 from staleness import evaluate as evaluate_staleness
 from subprocess_util import run_subprocess
+from wiki_anchor_gate import config_field_vocabulary
 from wiki_drift_detector import (
     apply_drift_markers,
     detect_drift,
@@ -285,7 +292,12 @@ class RepoWikiLoop(BaseBackgroundLoop):
         total_marked_stale = 0
         total_pruned = 0
         total_compiled = 0
+        total_anchor_flagged = 0
         empty_topics: list[str] = []
+
+        # Resolved once — the anchor vocabulary is the same for every repo
+        # this tick (#9954).
+        anchor_vocab = config_field_vocabulary()
 
         for slug in repos:
             # Phase 1: Active lint — self-healing pass
@@ -312,6 +324,26 @@ class RepoWikiLoop(BaseBackgroundLoop):
                 total_entries += tracked.total_entries
                 total_marked_stale += tracked.entries_marked_stale
                 total_pruned += tracked.orphans_pruned
+
+                # #9954 prune pass: flag anchor-less generic platitudes
+                # stale so they drop out of prompt injection. Mark-only —
+                # the age-based prune in active_lint_tracked removes them on
+                # a later tick; the flips ride this maintenance PR. Gated
+                # off by default: enabling it does the one-time backlog
+                # cleanup. The synthesis-time gate (always on) prevents new
+                # anchor-less entries regardless of this flag.
+                if self._config.wiki_anchor_prune_enabled:
+                    flagged = await asyncio.to_thread(
+                        flag_generic_entries_stale,
+                        tracked_root,
+                        slug,
+                        anchor_vocabulary=anchor_vocab,
+                    )
+                    if flagged:
+                        total_stale += flagged
+                        total_marked_stale += flagged
+                        total_anchor_flagged += flagged
+                        _metrics.increment("wiki_entries_flagged_no_anchor", flagged)
 
             # Phase 2: LLM compilation — synthesize topics with many entries
             if self._wiki_compiler is not None:
@@ -382,6 +414,7 @@ class RepoWikiLoop(BaseBackgroundLoop):
             "entries_marked_stale": total_marked_stale,
             "entries_pruned": total_pruned,
             "entries_compiled": total_compiled,
+            "anchor_flagged": total_anchor_flagged,
             "empty_topics": len(empty_topics),
         }
 

--- a/src/wiki_anchor_gate.py
+++ b/src/wiki_anchor_gate.py
@@ -1,0 +1,129 @@
+"""Repo-specificity gate for wiki synthesis entries (#9954).
+
+The wiki issue-synthesis pipeline (:meth:`WikiCompiler.compile_topic_tracked`)
+was minting generic coding truisms — "Use ``is None`` for optional
+sentinels", "Delete code blocks bottom-to-top" — as durable
+repo-knowledge entries. Those platitudes dilute the wiki context injected
+into agent prompts (``max_repo_wiki_chars`` truncates, so platitudes crowd
+out the real gotchas), inflate synthesis/compile cost, and drove the
+maintenance-PR treadmill.
+
+An entry earns its place only if it references something *specific to this
+repository*. This module is the cheap, deterministic heuristic:
+
+``has_repo_anchor(text)`` is ``True`` when *text* mentions at least one of
+
+- a ``.py`` module path (``src/repo_wiki.py`` or ``wiki_compiler.py``),
+- an ADR number (``ADR-0042`` / ``adr 53``),
+- a HydraFlow class name by convention — a CamelCase word ending in a
+  loop/port/runner/store/… suffix, or a ``Fake*``/``Mock*`` test double,
+- a known ``HydraFlowConfig`` field (``rc_cadence_hours``,
+  ``max_repo_wiki_chars``) when a config-field vocabulary is supplied.
+
+The config-field vocabulary is derived at call time from
+``HydraFlowConfig.model_fields`` so the gate tracks the real config surface
+without a hand-maintained list. The heuristic is side-effect-free and
+pure (given ``config_fields``) so it is trivially unit-testable and cheap
+enough to run on every synthesized entry.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+# --- structural anchors (no external vocabulary needed) --------------------
+
+# A ``.py`` module reference, slashed or bare (``src/foo/bar.py`` or
+# ``bar.py``). The ``.py`` suffix is required so ordinary dotted prose
+# ("e.g.", "3.11") never matches; a word char must precede ``.py`` so a
+# bare ".py" does not match either.
+_PY_PATH_RE = re.compile(r"\b[\w./-]*\w\.py\b")
+
+# ADR reference: ``ADR-0042`` / ``ADR 42`` / ``adr-0053``.
+_ADR_RE = re.compile(r"\badr[-\s]?\d{1,4}\b", re.IGNORECASE)
+
+# HydraFlow class names by convention: a CamelCase word ending in one of the
+# load-bearing infra suffixes (see docs/arch/generated/loops.md + ports.md),
+# or a ``Fake*`` / ``Mock*`` test double. A prefix segment is required (the
+# suffix cannot stand alone) so a bare English word like "Store" or "Queue"
+# is not mistaken for a class name.
+_CLASS_SUFFIXES = (
+    "Loop",
+    "Port",
+    "Runner",
+    "Store",
+    "Manager",
+    "Coordinator",
+    "Gate",
+    "Detector",
+    "Queue",
+    "Watcher",
+    "Reconciler",
+    "Registry",
+    "Tracker",
+    "Auditor",
+    "Sweeper",
+    "Sensor",
+    "Monitor",
+    "Dampener",
+    "Proposer",
+    "Scorecard",
+)
+_CLASS_RE = re.compile(
+    r"\b(?:[A-Z][a-zA-Z0-9]*(?:" + "|".join(_CLASS_SUFFIXES) + r")"
+    r"|(?:Fake|Mock)[A-Z][a-zA-Z0-9]+)\b"
+)
+
+# Snake_case token extractor for config-field matching.
+_SNAKE_TOKEN_RE = re.compile(r"[a-z][a-z0-9]*(?:_[a-z0-9]+)+")
+
+
+def _distinctive_config_fields(field_names: Iterable[str]) -> frozenset[str]:
+    """Keep only multi-token (snake_case) field names.
+
+    Single-word fields like ``model`` / ``repo`` appear in ordinary prose and
+    would false-positive the gate; requiring an underscore restricts the
+    vocabulary to distinctive identifiers.
+    """
+    return frozenset(f for f in field_names if "_" in f)
+
+
+def config_field_vocabulary() -> frozenset[str]:
+    """Distinctive ``HydraFlowConfig`` field names, resolved at call time.
+
+    ``config`` is imported lazily so this module stays import-cheap and can
+    be unit-tested without constructing a config instance.
+    """
+    from config import HydraFlowConfig  # noqa: PLC0415
+
+    return _distinctive_config_fields(HydraFlowConfig.model_fields)
+
+
+def has_repo_anchor(
+    text: str,
+    *,
+    config_fields: Iterable[str] | None = None,
+) -> bool:
+    """Return ``True`` when *text* references something repo-specific.
+
+    Deterministic and side-effect-free. Structural anchors (``.py`` paths,
+    ADR numbers, HydraFlow class names) need no vocabulary. Pass
+    *config_fields* (e.g. :func:`config_field_vocabulary`) to also anchor on
+    a known config-field mention — omit it for structural-only checks.
+    """
+    if not text:
+        return False
+    if _PY_PATH_RE.search(text) or _ADR_RE.search(text) or _CLASS_RE.search(text):
+        return True
+    if config_fields is not None:
+        vocab = (
+            config_fields
+            if isinstance(config_fields, frozenset | set)
+            else frozenset(config_fields)
+        )
+        if vocab:
+            for token in _SNAKE_TOKEN_RE.findall(text):
+                if token in vocab:
+                    return True
+    return False

--- a/src/wiki_compiler.py
+++ b/src/wiki_compiler.py
@@ -29,6 +29,7 @@ from prompt_gate_alerts import (
     is_prompt_gate_blocked,
 )
 from repo_wiki import WikiEntry
+from wiki_anchor_gate import config_field_vocabulary, has_repo_anchor
 
 _SYNTHESIS_ID_RE = re.compile(r"^(\d+)-")
 
@@ -153,6 +154,23 @@ Example of the required format:
 - Restating the title in the first sentence.
 - Inline JSON or code fences spanning more than 5 lines (link to the
   source instead).
+
+## Repo-specificity requirement (load-bearing — entries are gated on this)
+
+Every entry MUST be grounded in **{repo}** — reference at least one
+concrete repo anchor: a `src/*.py` module or file path, a registered
+loop/worker/Port/runner/store name (e.g. `RepoWikiLoop`, `WorkspacePort`),
+a config field (e.g. `rc_cadence_hours`), an ADR number (e.g. `ADR-0042`),
+or a fake/double name (e.g. `FakeGitHub`).
+
+**DROP any entry that reads as generic programming best-practice** — a rule
+that would apply verbatim to any Python project and names nothing from this
+repo. Examples to DROP, not emit: "Use `is None` for optional sentinels",
+"Create a specialized method rather than overloading", "Use portable shell
+commands in Alpine containers", "Delete code blocks bottom-to-top." A
+downstream deterministic gate rejects anchor-less entries and logs them, so
+emitting them wastes the slot — fold their durable, repo-specific corollary
+(if any) into an anchored entry instead.
 
 ## Compilation rules (apply only after the structure rules above)
 
@@ -314,6 +332,17 @@ Anti-patterns to avoid:
 - Restating the title in the first sentence.
 - Inline JSON or code fences spanning more than 5 lines (link to the
   source instead).
+
+## Repo-specificity requirement (load-bearing — entries are gated on this)
+
+Every entry MUST be grounded in **{repo}** — reference at least one
+concrete repo anchor: a `src/*.py` module or file path, a registered
+loop/worker/Port/runner/store name (e.g. `RepoWikiLoop`), a config field
+(e.g. `rc_cadence_hours`), an ADR number (e.g. `ADR-0042`), or a fake name
+(e.g. `FakeGitHub`). **Skip any insight that reads as generic programming
+best-practice** — a rule that would apply verbatim to any Python project
+and names nothing from this repo. A downstream deterministic gate rejects
+anchor-less entries, so emitting them wastes the slot.
 
 ## Output format
 
@@ -555,6 +584,21 @@ class WikiCompiler:
             )
             return len(entries)
 
+        # Repo-specificity gate (#9954): drop anchor-less platitudes so
+        # synthesis never overwrites the topic page with generic best
+        # practice. Empty result → keep the originals untouched.
+        compiled = self._filter_anchored_entries(
+            compiled, repo=repo, topic=topic, context="compile"
+        )
+        if not compiled:
+            logger.info(
+                "Wiki compile for %s/%s: all synthesized entries lacked a "
+                "repo anchor — keeping originals",
+                repo,
+                topic,
+            )
+            return len(entries)
+
         store._write_topic_page(topic_path, topic, compiled)
         store._rebuild_index(repo)
         store._append_log(
@@ -644,6 +688,22 @@ class WikiCompiler:
             logger.warning(
                 "Wiki compile_tracked for %s/%s produced no valid entries — "
                 "keeping originals",
+                repo,
+                topic,
+            )
+            return 0
+
+        # Repo-specificity gate (#9954): drop anchor-less platitudes before
+        # they are written as synthesis entries. Keeping originals when the
+        # gate empties the batch is the fail-safe — never supersede the
+        # inputs with nothing.
+        compiled = self._filter_anchored_entries(
+            compiled, repo=repo, topic=topic, context="compile_tracked"
+        )
+        if not compiled:
+            logger.info(
+                "Wiki compile_tracked for %s/%s: all synthesized entries "
+                "lacked a repo anchor — keeping originals",
                 repo,
                 topic,
             )
@@ -941,6 +1001,45 @@ class WikiCompiler:
         except (OSError, FileNotFoundError, NotImplementedError) as exc:
             logger.warning("Wiki compilation model unavailable: %s", exc)
             return None
+
+    @staticmethod
+    def _filter_anchored_entries(
+        entries: list[WikiEntry],
+        *,
+        repo: str,
+        topic: str,
+        context: str,
+    ) -> list[WikiEntry]:
+        """Drop entries lacking a repo-specific anchor (#9954).
+
+        A synthesized entry earns its place only if its title/content
+        references something specific to this repo — a ``.py`` module, an
+        ADR number, a loop/Port/runner class name, or a known config
+        field. Generic best-practice platitudes ("Use ``is None`` for
+        optional sentinels") dilute the wiki context injected into agent
+        prompts (``max_repo_wiki_chars`` truncates) and are rejected here.
+        Each drop is logged and counted so the gate stays observable and
+        cannot silently regress.
+        """
+        vocab = config_field_vocabulary()
+        kept: list[WikiEntry] = []
+        dropped = 0
+        for entry in entries:
+            text = f"{entry.title}\n{entry.content}"
+            if has_repo_anchor(text, config_fields=vocab):
+                kept.append(entry)
+                continue
+            dropped += 1
+            logger.info(
+                "Wiki %s gate dropped anchor-less entry for %s/%s: %r",
+                context,
+                repo,
+                topic,
+                entry.title,
+            )
+        if dropped:
+            _metrics.increment("wiki_entries_rejected_no_anchor", dropped)
+        return kept
 
     @staticmethod
     def _parse_entries(raw: str) -> list[WikiEntry]:

--- a/tests/test_compile_topic_tracked.py
+++ b/tests/test_compile_topic_tracked.py
@@ -290,8 +290,9 @@ class TestCompileTopicTracked:
         compiler, tracked_root = compiler_with_active_entries
 
         compiler._call_model = AsyncMock(
-            return_value='[{"title":"Merged","content":"Unified body.",'
-            '"source_type":"synthesis"}]'
+            # Anchored content (names RepoWikiLoop) so the #9954 gate keeps it.
+            return_value='[{"title":"Merged","content":"RepoWikiLoop unifies '
+            'these. See `src/repo_wiki.py`.","source_type":"synthesis"}]'
         )
 
         count = await compiler.compile_topic_tracked(tracked_root, REPO, "patterns")

--- a/tests/test_repo_wiki_loop_pr.py
+++ b/tests/test_repo_wiki_loop_pr.py
@@ -623,7 +623,9 @@ class TestTrackedCompileStatsReporting:
                 "source_phase: plan\n"
                 f"created_at: {datetime.now(UTC).isoformat()}\n"
                 "status: active\n"
-                "---\n\n# Entry\n",
+                # Anchored body so the #9954 prune pass leaves it active and
+                # the 5-entry compile threshold is still met.
+                "---\n\n# Entry\n\nUse `src/repo_wiki.py`.\n",
                 encoding="utf-8",
             )
 
@@ -768,3 +770,85 @@ class TestHealLeavesRepoRootClean:
         pushed = _git(remote, "show", f"{branch}:{entry_rel}")
         assert "status: stale" in pushed
         assert "stale_reason: source issue #42 closed" in pushed
+
+
+class TestAnchorPruneFlagGating:
+    """The #9954 prune pass runs only when ``wiki_anchor_prune_enabled`` is
+    True. Default-off keeps the aggressive one-time backlog cleanup a
+    deliberate operator action; the synthesis-time gate is independent.
+    """
+
+    def _seed_anchorless(self, git_repo: Path) -> Path:
+        from datetime import UTC, datetime
+
+        tracked_root = git_repo / "repo_wiki"
+        topic_dir = tracked_root / "acme" / "widget" / "gotchas"
+        topic_dir.mkdir(parents=True)
+        for i in range(2):
+            (topic_dir / f"000{i}-issue-{i}-x.md").write_text(
+                "---\n"
+                f"id: 000{i}\n"
+                "topic: gotchas\n"
+                f"source_issue: {i}\n"
+                "source_phase: plan\n"
+                f"created_at: {datetime.now(UTC).isoformat()}\n"
+                "status: active\n"
+                # No repo anchor — a generic platitude.
+                "---\n\n# Use is None for optional sentinels\n\nAvoid `==`.\n",
+                encoding="utf-8",
+            )
+        return tracked_root
+
+    def _store(self, git_repo: Path):
+        from unittest.mock import MagicMock
+
+        from repo_wiki import RepoWikiStore
+
+        store = MagicMock(spec=RepoWikiStore)
+        store.active_lint.return_value = MagicMock(
+            stale_entries=0,
+            orphan_entries=0,
+            total_entries=0,
+            entries_marked_stale=0,
+            orphans_pruned=0,
+            empty_topics=[],
+        )
+        return store
+
+    @pytest.mark.asyncio
+    async def test_prune_runs_when_flag_enabled(self, git_repo: Path) -> None:
+        tracked_root = self._seed_anchorless(git_repo)
+        config = _make_config(git_repo).model_copy(
+            update={"wiki_anchor_prune_enabled": True}
+        )
+        loop = _stub_loop(config)
+        loop._wiki_compiler = None  # skip Phase 2/8 compilation
+
+        result = await loop._lint_and_compile_repos(
+            ["acme/widget"], tracked_root, set(), store=self._store(git_repo)
+        )
+
+        assert result["anchor_flagged"] == 2
+        topic_dir = tracked_root / "acme" / "widget" / "gotchas"
+        for i in range(2):
+            text = (topic_dir / f"000{i}-issue-{i}-x.md").read_text()
+            assert "status: stale" in text
+            assert "no repo-specific anchor" in text
+
+    @pytest.mark.asyncio
+    async def test_prune_skipped_when_flag_disabled(self, git_repo: Path) -> None:
+        tracked_root = self._seed_anchorless(git_repo)
+        # _make_config defaults wiki_anchor_prune_enabled to False.
+        loop = _stub_loop(_make_config(git_repo))
+        loop._wiki_compiler = None
+
+        result = await loop._lint_and_compile_repos(
+            ["acme/widget"], tracked_root, set(), store=self._store(git_repo)
+        )
+
+        assert result["anchor_flagged"] == 0
+        topic_dir = tracked_root / "acme" / "widget" / "gotchas"
+        for i in range(2):
+            assert (
+                "status: active" in (topic_dir / f"000{i}-issue-{i}-x.md").read_text()
+            )

--- a/tests/test_wiki_anchor_gate.py
+++ b/tests/test_wiki_anchor_gate.py
@@ -1,0 +1,159 @@
+"""Tests for the repo-specificity anchor gate (#9954).
+
+The wiki issue-synthesis pipeline was minting generic coding truisms as
+durable repo-knowledge entries. ``has_repo_anchor`` is the deterministic
+heuristic that decides whether an entry earns its place: it must reference
+something specific to *this* repo (a ``.py`` module, an ADR number, a
+HydraFlow class name, or a known config field).
+
+The platitude / real-gotcha fixtures below are verbatim examples from the
+issue and from the live wiki so the gate is pinned against real content,
+not synthetic strings.
+"""
+
+from __future__ import annotations
+
+from wiki_anchor_gate import (
+    config_field_vocabulary,
+    has_repo_anchor,
+)
+
+# Verbatim platitudes named in issue #9954 — these MUST be rejected.
+_PLATITUDES = [
+    (
+        "Use is None and is not None for optional sentinels",
+        "Use `is None` and `is not None` for optional objects. Example: "
+        "`if callback is None: return`. Avoid `==` comparison for sentinels; "
+        "custom `__eq__` can hide subtle bugs. **Why:** identity checks are "
+        "immune to overridden `__eq__`.",
+    ),
+    (
+        "Create a specialized method rather than overloading",
+        "Prefer a dedicated method over a flag argument that switches "
+        "behavior. Example: split `save(force=True)` into `save()` and "
+        "`force_save()`. **Why:** boolean flags obscure call sites.",
+    ),
+    (
+        "Use portable shell commands in Alpine containers — Python is absent",
+        "In Alpine-based Docker containers, avoid Python and non-standard "
+        "utilities. Use portable POSIX commands for memory/CPU operations. "
+        "Example: `dd if=/dev/zero bs=1M count=32 of=/dev/null`. **Why:** "
+        "Alpine's minimal tooling excludes many GNU utilities.",
+    ),
+    (
+        "Delete code blocks bottom-to-top to avoid line-number shifts",
+        "When removing multiple ranges, edit from the last line upward. "
+        "**Why:** deleting from the top renumbers everything below it.",
+    ),
+]
+
+# Real repo-specific gotchas — these MUST land.
+_ANCHORED = [
+    (
+        "Error-tolerance tests must cover CreditExhaustedError re-raise",
+        "When testing that a loop tolerates port failures, include a case "
+        "asserting `CreditExhaustedError` is not swallowed. See "
+        "`test_review_phase_core.py:1919`. **Why:** `reraise_on_credit_or_bug` "
+        "is load-bearing.",
+    ),
+    (
+        "StagingPromotionLoop cuts RC PRs on a cadence",
+        "The StagingPromotionLoop opens rc/ promotion PRs every "
+        "`rc_cadence_hours`. **Why:** main only advances via RC promotion.",
+    ),
+    (
+        "RepoWikiLoop maintenance PRs coalesce",
+        "Subsequent ticks append to the same branch when "
+        "`repo_wiki_maintenance_pr_coalesce` is true. **Why:** avoids "
+        "duplicate maintenance PRs.",
+    ),
+    (
+        "Two-tier branch promotion",
+        "PRs target staging per ADR-0042; main advances via rc/ PRs. "
+        "**Why:** staging gates promotion.",
+    ),
+    (
+        "Fail-closed Port ownership",
+        "A Port should raise rather than swallow so the FakeGitHub double "
+        "surfaces the failure. **Why:** silent swallow hides real errors.",
+    ),
+]
+
+
+class TestStructuralAnchors:
+    def test_py_path_is_anchor(self) -> None:
+        assert has_repo_anchor("See src/repo_wiki.py for the mint logic.")
+
+    def test_bare_py_filename_is_anchor(self) -> None:
+        assert has_repo_anchor("wiki_compiler.py owns the synthesis prompt.")
+
+    def test_adr_number_is_anchor(self) -> None:
+        assert has_repo_anchor("PRs target staging per ADR-0042.")
+        assert has_repo_anchor("see adr 53 for the glossary")
+
+    def test_loop_classname_is_anchor(self) -> None:
+        assert has_repo_anchor("RepoWikiLoop keeps the wiki fresh.")
+
+    def test_port_classname_is_anchor(self) -> None:
+        assert has_repo_anchor("Route reads through WorkspacePort.")
+
+    def test_fake_classname_is_anchor(self) -> None:
+        assert has_repo_anchor("FakeGitHub records the command.")
+
+    def test_ecase_dot_prose_is_not_a_py_path(self) -> None:
+        # "e.g." and ordinary dotted prose must not be read as a .py path.
+        assert not has_repo_anchor("Prefer small functions, e.g. one job each.")
+
+    def test_bare_capitalized_word_is_not_a_classname(self) -> None:
+        assert not has_repo_anchor("Store the value. Manage the queue.")
+
+
+class TestConfigFieldAnchors:
+    def test_known_config_field_is_anchor(self) -> None:
+        vocab = frozenset({"rc_cadence_hours", "max_repo_wiki_chars"})
+        assert has_repo_anchor(
+            "Cut RC PRs every rc_cadence_hours.", config_fields=vocab
+        )
+
+    def test_unknown_snake_case_is_not_anchor(self) -> None:
+        vocab = frozenset({"rc_cadence_hours"})
+        assert not has_repo_anchor(
+            "Set source_type when you ingest.", config_fields=vocab
+        )
+
+    def test_no_vocab_means_structural_only(self) -> None:
+        # Without a vocabulary, a bare config-field mention is not enough.
+        assert not has_repo_anchor("tune rc_cadence_hours as needed")
+
+
+class TestRealCorpus:
+    def test_all_named_platitudes_rejected(self) -> None:
+        vocab = config_field_vocabulary()
+        for title, body in _PLATITUDES:
+            assert not has_repo_anchor(f"{title}\n{body}", config_fields=vocab), (
+                f"platitude wrongly anchored: {title!r}"
+            )
+
+    def test_all_real_gotchas_kept(self) -> None:
+        vocab = config_field_vocabulary()
+        for title, body in _ANCHORED:
+            assert has_repo_anchor(f"{title}\n{body}", config_fields=vocab), (
+                f"real gotcha wrongly rejected: {title!r}"
+            )
+
+    def test_empty_text_is_not_anchored(self) -> None:
+        assert not has_repo_anchor("")
+
+
+class TestConfigFieldVocabulary:
+    def test_includes_distinctive_fields(self) -> None:
+        vocab = config_field_vocabulary()
+        assert "rc_cadence_hours" in vocab
+        assert "max_repo_wiki_chars" in vocab
+
+    def test_excludes_single_token_fields(self) -> None:
+        # Single-word fields ("model", "repo") appear in ordinary prose and
+        # would false-positive the gate.
+        vocab = config_field_vocabulary()
+        assert "model" not in vocab
+        assert "repo" not in vocab

--- a/tests/test_wiki_compiler.py
+++ b/tests/test_wiki_compiler.py
@@ -145,7 +145,9 @@ class TestCompileTopic:
             [
                 {
                     "title": "Error handling patterns",
-                    "content": "Use pattern C (preferred over A and B). See also: gotchas — edge cases.",
+                    # Anchored on a real module so the #9954 repo-specificity
+                    # gate keeps it (generic placeholders are now dropped).
+                    "content": "Use pattern C (preferred over A and B) in `src/error_hierarchy.py`. See also: gotchas — edge cases.",
                     "source_type": "compiled",
                     "source_issue": None,
                 },

--- a/tests/test_wiki_synthesis_anchor_gate.py
+++ b/tests/test_wiki_synthesis_anchor_gate.py
@@ -1,0 +1,287 @@
+"""Ratchet + prune tests for the wiki repo-specificity gate (#9954).
+
+Two behaviors are pinned here so they can't silently regress:
+
+1. **Synthesis-time gate** — ``WikiCompiler.compile_topic_tracked`` /
+   ``compile_topic`` drop anchor-less platitudes before they are written
+   as ``issue-synthesis-*`` entries, and keep originals when the gate
+   empties the batch.
+2. **Prune pass** — ``flag_generic_entries_stale`` marks existing
+   anchor-less active entries stale (mark-only) while leaving anchored
+   ones active.
+
+The synthesis prompts are also asserted to carry the repo-specificity
+requirement so the LLM is steered, not only post-filtered.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from knowledge_metrics import metrics
+from repo_wiki import RepoWikiStore, flag_generic_entries_stale
+from wiki_anchor_gate import config_field_vocabulary
+from wiki_compiler import (
+    _COMPILE_TOPIC_PROMPT,
+    _SYNTHESIZE_INGEST_PROMPT,
+    WikiCompiler,
+)
+
+REPO = "acme/widget"
+
+# A real platitude from the issue and a real anchored gotcha, as the LLM
+# would emit them in a synthesis JSON array.
+_PLATITUDE = {
+    "title": "Use is None and is not None for optional sentinels",
+    "content": (
+        "Use `is None` for optional objects. Avoid `==` for sentinels; "
+        "custom `__eq__` can hide bugs. **Why:** identity checks are safe."
+    ),
+    "source_type": "synthesis",
+}
+_ANCHORED = {
+    "title": "RepoWikiLoop maintenance PRs coalesce on one branch",
+    "content": (
+        "Subsequent ticks append to the same branch when "
+        "`repo_wiki_maintenance_pr_coalesce` is true. **Why:** avoids "
+        "duplicate maintenance PRs."
+    ),
+    "source_type": "synthesis",
+}
+
+
+def _write_entry_file(
+    path: Path,
+    *,
+    entry_id: str,
+    topic: str = "gotchas",
+    status: str = "active",
+    source_issue: str | int = 1,
+    title: str = "Existing entry",
+    body: str = "Content body.",
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(UTC).isoformat()
+    path.write_text(
+        "---\n"
+        f"id: {entry_id}\n"
+        f"topic: {topic}\n"
+        f"source_issue: {source_issue}\n"
+        "source_phase: plan\n"
+        f"created_at: {now}\n"
+        f"status: {status}\n"
+        "---\n"
+        "\n"
+        f"# {title}\n\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+def _compiler() -> WikiCompiler:
+    compiler = WikiCompiler.__new__(WikiCompiler)
+    compiler._config = MagicMock()
+    compiler._credentials = MagicMock()
+    compiler._credentials.gh_token = ""
+    compiler._runner = MagicMock()
+    return compiler
+
+
+@pytest.fixture(autouse=True)
+def _reset_metrics() -> None:
+    metrics.reset()
+
+
+class TestSynthesisPromptGrounding:
+    def test_compile_prompt_requires_repo_anchor(self) -> None:
+        assert "Repo-specificity requirement" in _COMPILE_TOPIC_PROMPT
+        assert "ADR-0042" in _COMPILE_TOPIC_PROMPT
+        assert "rc_cadence_hours" in _COMPILE_TOPIC_PROMPT
+
+    def test_ingest_prompt_requires_repo_anchor(self) -> None:
+        assert "Repo-specificity requirement" in _SYNTHESIZE_INGEST_PROMPT
+
+
+class TestFilterAnchoredEntries:
+    def test_platitude_dropped_anchored_kept(self) -> None:
+        entries = WikiCompiler._parse_entries(json.dumps([_PLATITUDE, _ANCHORED]))
+        kept = WikiCompiler._filter_anchored_entries(
+            entries, repo=REPO, topic="gotchas", context="test"
+        )
+        assert [e.title for e in kept] == [_ANCHORED["title"]]
+        assert metrics.snapshot()["wiki_entries_rejected_no_anchor"] == 1
+
+
+class TestCompileTopicTrackedGate:
+    def _seed(self, tmp_path: Path) -> Path:
+        tracked_root = tmp_path / "repo_wiki"
+        topic_dir = tracked_root / REPO / "gotchas"
+        for i in range(3):
+            _write_entry_file(
+                topic_dir / f"000{i + 1}-issue-{i + 1}-orig.md",
+                entry_id=f"000{i + 1}",
+                source_issue=i + 1,
+                title=f"Original {i + 1}",
+            )
+        return tracked_root
+
+    @pytest.mark.asyncio
+    async def test_drops_platitude_keeps_anchored(self, tmp_path: Path) -> None:
+        tracked_root = self._seed(tmp_path)
+        compiler = _compiler()
+        compiler._call_model = AsyncMock(
+            return_value=json.dumps([_PLATITUDE, _ANCHORED])
+        )
+
+        count = await compiler.compile_topic_tracked(tracked_root, REPO, "gotchas")
+
+        # Only the anchored entry survives the gate.
+        assert count == 1
+        topic_dir = tracked_root / REPO / "gotchas"
+        synthesis = list(topic_dir.glob("*-issue-synthesis-*.md"))
+        assert len(synthesis) == 1
+        text = synthesis[0].read_text()
+        assert "RepoWikiLoop" in text
+        assert "optional sentinels" not in text
+        assert metrics.snapshot()["wiki_entries_rejected_no_anchor"] == 1
+        # Inputs are superseded because at least one anchored entry landed.
+        for i in range(3):
+            assert (
+                "status: superseded"
+                in (topic_dir / f"000{i + 1}-issue-{i + 1}-orig.md").read_text()
+            )
+
+    @pytest.mark.asyncio
+    async def test_all_platitudes_keeps_originals(self, tmp_path: Path) -> None:
+        tracked_root = self._seed(tmp_path)
+        compiler = _compiler()
+        compiler._call_model = AsyncMock(
+            return_value=json.dumps([_PLATITUDE, dict(_PLATITUDE, title="Another one")])
+        )
+
+        count = await compiler.compile_topic_tracked(tracked_root, REPO, "gotchas")
+
+        assert count == 0
+        topic_dir = tracked_root / REPO / "gotchas"
+        assert list(topic_dir.glob("*-issue-synthesis-*.md")) == []
+        # Fail-safe: originals stay active — never superseded by nothing.
+        for i in range(3):
+            assert (
+                "status: active"
+                in (topic_dir / f"000{i + 1}-issue-{i + 1}-orig.md").read_text()
+            )
+
+
+class TestFlagGenericEntriesStale:
+    def test_marks_anchorless_stale_leaves_anchored_active(
+        self, tmp_path: Path
+    ) -> None:
+        tracked_root = tmp_path / "repo_wiki"
+        topic_dir = tracked_root / REPO / "gotchas"
+        _write_entry_file(
+            topic_dir / "0001-issue-synthesis-platitude.md",
+            entry_id="0001",
+            title="Use is None for optional sentinels",
+            body="Avoid `==` for sentinels. **Why:** identity is safe.",
+        )
+        _write_entry_file(
+            topic_dir / "0002-issue-synthesis-anchored.md",
+            entry_id="0002",
+            title="RepoWikiLoop coalesces maintenance PRs",
+            body="Uses `repo_wiki_maintenance_pr_coalesce`. **Why:** dedup.",
+        )
+
+        flagged = flag_generic_entries_stale(
+            tracked_root, REPO, anchor_vocabulary=config_field_vocabulary()
+        )
+
+        assert flagged == 1
+        platitude = (topic_dir / "0001-issue-synthesis-platitude.md").read_text()
+        anchored = (topic_dir / "0002-issue-synthesis-anchored.md").read_text()
+        assert "status: stale" in platitude
+        assert "no repo-specific anchor" in platitude
+        assert "status: active" in anchored
+
+    def test_mark_only_never_deletes(self, tmp_path: Path) -> None:
+        tracked_root = tmp_path / "repo_wiki"
+        topic_dir = tracked_root / REPO / "gotchas"
+        path = topic_dir / "0001-issue-synthesis-platitude.md"
+        _write_entry_file(
+            path,
+            entry_id="0001",
+            title="Delete code blocks bottom-to-top",
+            body="Edit from the last line upward. **Why:** line numbers shift.",
+        )
+
+        flag_generic_entries_stale(
+            tracked_root, REPO, anchor_vocabulary=config_field_vocabulary()
+        )
+
+        assert path.exists()
+
+    def test_noop_without_vocabulary(self, tmp_path: Path) -> None:
+        tracked_root = tmp_path / "repo_wiki"
+        topic_dir = tracked_root / REPO / "gotchas"
+        path = topic_dir / "0001-issue-synthesis-platitude.md"
+        _write_entry_file(
+            path, entry_id="0001", title="Generic tip", body="Do the thing."
+        )
+
+        assert flag_generic_entries_stale(tracked_root, REPO) == 0
+        assert "status: active" in path.read_text()
+
+    def test_idempotent_second_pass_flags_nothing(self, tmp_path: Path) -> None:
+        tracked_root = tmp_path / "repo_wiki"
+        topic_dir = tracked_root / REPO / "gotchas"
+        _write_entry_file(
+            topic_dir / "0001-issue-synthesis-platitude.md",
+            entry_id="0001",
+            title="Generic best practice",
+            body="Do the thing well. **Why:** quality.",
+        )
+        vocab = config_field_vocabulary()
+
+        assert (
+            flag_generic_entries_stale(tracked_root, REPO, anchor_vocabulary=vocab) == 1
+        )
+        # Already stale → not re-flagged.
+        assert (
+            flag_generic_entries_stale(tracked_root, REPO, anchor_vocabulary=vocab) == 0
+        )
+
+
+class TestRepoWikiStoreInjectionFavorsAnchored:
+    """After the prune pass, stale platitudes drop out of prompt injection."""
+
+    def test_query_excludes_flagged_entries(self, tmp_path: Path) -> None:
+        tracked_root = tmp_path / "repo_wiki"
+        wiki_root = tmp_path / "wiki"
+        topic_dir = tracked_root / REPO / "gotchas"
+        _write_entry_file(
+            topic_dir / "0001-issue-synthesis-platitude.md",
+            entry_id="0001",
+            title="Use is None for optional sentinels",
+            body="Avoid `==`. **Why:** identity is safe.",
+        )
+        _write_entry_file(
+            topic_dir / "0002-issue-synthesis-anchored.md",
+            entry_id="0002",
+            title="WorkspacePort owns git reads",
+            body="Route git reads through WorkspacePort. **Why:** air-gap.",
+        )
+        store = RepoWikiStore(wiki_root, tracked_root=tracked_root)
+
+        before = store.query(REPO, topics=["gotchas"])
+        assert "optional sentinels" in before
+
+        flag_generic_entries_stale(
+            tracked_root, REPO, anchor_vocabulary=config_field_vocabulary()
+        )
+
+        after = store.query(REPO, topics=["gotchas"])
+        assert "optional sentinels" not in after
+        assert "WorkspacePort" in after


### PR DESCRIPTION
Closes #9954.

## Problem

The wiki issue-synthesis pipeline (`WikiCompiler.compile_topic_tracked`) mined every topic into `issue-synthesis-*` entries with **no repo-specificity gate**, minting generic coding truisms as durable repo knowledge:

- `Use is None and is not None for optional sentinels`
- `Create a specialized method rather than overloading`
- `Use portable shell commands in Alpine containers`

These platitudes dilute the wiki context injected into agent prompts (`max_repo_wiki_chars` truncates, so they crowd out real gotchas) and inflate synthesis cost. Measured on the live store: **216 / 261 active entries (83%) carry no repo-specific anchor.**

## Fix

A deterministic **repo-specificity anchor** heuristic, `wiki_anchor_gate.has_repo_anchor(text)` (pure, side-effect-free): an entry is anchored when it references a `.py` module path, an ADR number, a HydraFlow class name (loop / `Port` / runner / store / … / `Fake*`), or a known `HydraFlowConfig` field. The config-field vocabulary is derived at call time from `HydraFlowConfig.model_fields` (distinctive snake_case only) so it tracks the real config surface with no hand-maintained list.

Wired in three places:

1. **Synthesis-time gate** — `compile_topic_tracked` / `compile_topic` drop anchor-less entries before writing, logging + counting each drop (`wiki_entries_rejected_no_anchor`). Fail-safe: if the gate empties the batch, originals are kept, never superseded by nothing.
2. **Prompt grounding** — both synthesis prompts now require a repo anchor and instruct the model to drop generic best-practice, so the LLM is steered, not only post-filtered.
3. **Prune pass** — `repo_wiki.flag_generic_entries_stale` marks existing anchor-less active tracked entries stale (mark-only, never deletes; stale entries drop out of prompt injection immediately and the existing age-prune removes them later). Wired into `RepoWikiLoop` behind the **`wiki_anchor_prune_enabled` kill-switch (default `False`)**.

### Why the prune is default-off

The one-time cleanup would flip ~216 entries stale in a single auto-merging maintenance PR. That is high blast radius for an autonomous default, so it is gated behind a deliberate operator enable. The **synthesis-time gate is always on** and independent of the flag — it stops new noise immediately. Flip `wiki_anchor_prune_enabled=true` to run the backlog cleanup (rides the normal batched maintenance PR; mark-only + git-recoverable).

## Tests

26 new unit tests (ratchet, per issue AC #3):

- `test_wiki_anchor_gate.py` — heuristic pinned against verbatim platitudes from the issue and real gotchas from the live store; structural anchors; config-field vocabulary.
- `test_wiki_synthesis_anchor_gate.py` — synthesis-time drop + fail-safe (keep originals when all dropped), prompt grounding, prune pass (mark-only, idempotent, injection excludes flagged).
- `test_repo_wiki_loop_pr.py::TestAnchorPruneFlagGating` — the loop runs the prune only when the flag is enabled.

Two pre-existing tests updated to use repo-anchored placeholder content (their stub LLM output was generic and is now correctly dropped by the gate).

## Verification

- Targeted suite: 353 wiki/config/loop tests green
- `ruff check` + `ruff format --check` clean on all changed files
- `pyright`: 0 errors on changed source
- `make arch-check`: pass