### PR TITLE
feat(shepherd): bounded update-branch heal for CI-failed bot PRs (#9889)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -258,6 +258,11 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
     ("sentry_signal_cooldown_hours", "SENTRY_SIGNAL_COOLDOWN_HOURS", 24),
     ("security_patch_interval", "HYDRAFLOW_SECURITY_PATCH_INTERVAL", 3600),
     ("repo_wiki_interval", "HYDRAFLOW_REPO_WIKI_INTERVAL", 3600),
+    (
+        "dependabot_update_branch_max_attempts",
+        "HYDRAFLOW_DEPENDABOT_UPDATE_BRANCH_MAX_ATTEMPTS",
+        1,
+    ),
     ("review_orphan_strike_threshold", "HYDRAFLOW_REVIEW_ORPHAN_STRIKE_THRESHOLD", 3),
     ("review_orphan_max_requeues", "HYDRAFLOW_REVIEW_ORPHAN_MAX_REQUEUES", 3),
     ("repo_wiki_min_batch_files", "HYDRAFLOW_REPO_WIKI_MIN_BATCH_FILES", 8),
@@ -1963,6 +1968,16 @@ class HydraFlowConfig(BaseModel):
         ge=300,
         le=604800,
         description="Seconds between repo wiki lint cycles",
+    )
+    dependabot_update_branch_max_attempts: int = Field(
+        default=1,
+        ge=0,
+        le=5,
+        description=(
+            "Bounded update-branch heals per CI-failed bot PR (#9889): a "
+            "behind-base PR gets a fresh merge ref + full CI re-run before "
+            "the failure strategy applies. 0 disables."
+        ),
     )
     review_orphan_strike_threshold: int = Field(
         default=3,

--- a/src/dependabot_merge_loop.py
+++ b/src/dependabot_merge_loop.py
@@ -269,6 +269,30 @@ class DependabotMergeLoop(BaseBackgroundLoop):
                     pr.pr,
                 )
 
+            # Shepherd heal class 2 (#9889): a CI-failed bot PR that is
+            # BEHIND its base often fails on state the base already fixed
+            # (baseline advances, sibling regens) — and re-running failed
+            # jobs pins the OLD merge ref (the #9884 lesson). One bounded
+            # update-branch forces a fresh merge ref + full CI re-run.
+            # update_pr_branch returns False when already up to date or on
+            # API refusal, so this never loops on an actually-broken PR.
+            ub_cap = self._config.dependabot_update_branch_max_attempts
+            if (
+                ub_cap > 0
+                and self._state.get_dependabot_update_branch_attempts(pr.pr) < ub_cap
+                and await self._prs.update_pr_branch(pr.pr, method="merge")
+            ):
+                self._state.bump_dependabot_update_branch_attempts(pr.pr)
+                skipped += 1
+                logger.info(
+                    "Bot PR #%d CI failed while behind base — updated branch "
+                    "for a fresh merge ref; CI will re-run (attempt %d/%d)",
+                    pr.pr,
+                    self._state.get_dependabot_update_branch_attempts(pr.pr),
+                    ub_cap,
+                )
+                continue
+
             # CI truly failed — apply failure strategy
             strategy = settings.failure_strategy
             if strategy == "skip":

--- a/src/models.py
+++ b/src/models.py
@@ -2074,6 +2074,9 @@ class StateData(BaseModel):
     # the merge+arch-regen+push retry so a real (non-arch) failure eventually
     # falls through to ``failure_strategy``. Cleared when the PR is merged/closed.
     dependabot_arch_refresh_attempts: dict[str, int] = Field(default_factory=dict)
+    # #9889 shepherd: bounded update-branch heals per bot PR (stale merge
+    # ref class — reruns pin the old base; update-branch forces fresh CI).
+    dependabot_update_branch_attempts: dict[str, int] = Field(default_factory=dict)
     shape_conversations: dict[str, ShapeConversation] = Field(default_factory=dict)
     shape_responses: dict[str, str] = Field(default_factory=dict)
     stale_issue_settings: StaleIssueSettings = Field(default_factory=StaleIssueSettings)

--- a/src/state/_dependabot_merge.py
+++ b/src/state/_dependabot_merge.py
@@ -45,6 +45,24 @@ class DependabotMergeStateMixin:
         self._data.dependabot_arch_refresh_attempts.pop(str(pr_number), None)
         self.save()
 
+    def get_dependabot_update_branch_attempts(self, pr_number: int) -> int:
+        """Bounded update-branch heals for *pr_number* (#9889)."""
+        return self._data.dependabot_update_branch_attempts.get(str(pr_number), 0)
+
+    def bump_dependabot_update_branch_attempts(self, pr_number: int) -> int:
+        key = str(pr_number)
+        new = self._data.dependabot_update_branch_attempts.get(key, 0) + 1
+        self._data.dependabot_update_branch_attempts[key] = new
+        self.save()
+        return new
+
+    def clear_dependabot_update_branch_attempts(self, pr_number: int) -> None:
+        if (
+            self._data.dependabot_update_branch_attempts.pop(str(pr_number), None)
+            is not None
+        ):
+            self.save()
+
     def get_dependabot_arch_refresh_attempts(self, pr_number: int) -> int:
         """Return how many arch-staleness self-heal refreshes have run on *pr_number*."""
         return self._data.dependabot_arch_refresh_attempts.get(str(pr_number), 0)

--- a/tests/regressions/test_issue_9422_botpr_arch_autoheal.py
+++ b/tests/regressions/test_issue_9422_botpr_arch_autoheal.py
@@ -59,6 +59,9 @@ def _make_loop(
     from dependabot_merge_loop import DependabotMergeLoop
 
     deps = make_bg_loop_deps(tmp_path, dependabot_merge_interval=60)
+    # #9889 heal class 2 (update-branch) defaults OFF here: this file pins
+    # the ARCH-staleness heal contracts in isolation.
+    object.__setattr__(deps.config, "dependabot_update_branch_max_attempts", 0)
 
     cache = MagicMock()
     cache.get_open_prs.return_value = open_prs

--- a/tests/regressions/test_issue_9889_update_branch_heal.py
+++ b/tests/regressions/test_issue_9889_update_branch_heal.py
@@ -1,0 +1,93 @@
+"""Shepherd heal class 2: update-branch for CI-failed bot PRs (#9889).
+
+Re-running failed jobs pins the OLD merge ref (the #9884 lesson) — a bot PR
+red on state the base already fixed (baseline advances, sibling regens)
+stayed red forever under retry. One bounded update-branch forces a fresh
+merge ref and a full CI re-run before the failure strategy applies.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.test_dependabot_merge_loop import _make_loop, _make_pr
+
+
+@pytest.mark.asyncio
+async def test_ci_failed_pr_gets_update_branch_before_strategy(
+    tmp_path: Path,
+) -> None:
+    loop, _, _, prs, state = _make_loop(
+        tmp_path,
+        open_prs=[_make_pr(9884, author="hydraflow-ul-bot", branch="ul-x")],
+        ci_result=(False, "Failed checks: Principles Audit"),
+        failure_strategy="hitl",
+        authors=["hydraflow-ul-bot"],
+        update_branch_max_attempts=1,
+    )
+
+    result = await loop._do_work()
+
+    prs.update_pr_branch.assert_awaited_once_with(9884, method="merge")
+    state.bump_dependabot_update_branch_attempts.assert_called_once_with(9884)
+    assert result["skipped"] == 1
+    assert result["failed"] == 0
+    prs.add_labels.assert_not_awaited()  # no strategy side effects
+
+
+@pytest.mark.asyncio
+async def test_cap_reached_falls_through_to_strategy(tmp_path: Path) -> None:
+    loop, _, _, prs, state = _make_loop(
+        tmp_path,
+        open_prs=[_make_pr(9885, author="hydraflow-ul-bot", branch="ul-y")],
+        ci_result=(False, "Failed checks: Tests"),
+        failure_strategy="hitl",
+        authors=["hydraflow-ul-bot"],
+        update_branch_max_attempts=1,
+    )
+    state.get_dependabot_update_branch_attempts.side_effect = lambda _n: 1
+
+    result = await loop._do_work()
+
+    prs.update_pr_branch.assert_not_awaited()
+    assert result["failed"] == 1  # hitl strategy applied
+    prs.add_labels.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_already_up_to_date_falls_through_without_burning_budget(
+    tmp_path: Path,
+) -> None:
+    loop, _, _, prs, state = _make_loop(
+        tmp_path,
+        open_prs=[_make_pr(9886, author="hydraflow-ul-bot", branch="ul-z")],
+        ci_result=(False, "Failed checks: Tests"),
+        failure_strategy="skip",
+        authors=["hydraflow-ul-bot"],
+        update_branch_max_attempts=1,
+        update_branch_result=False,  # GitHub: already up to date / refused
+    )
+
+    result = await loop._do_work()
+
+    prs.update_pr_branch.assert_awaited_once()
+    state.bump_dependabot_update_branch_attempts.assert_not_called()
+    assert result["skipped"] == 1  # skip strategy, budget intact
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_zero_disables_heal(tmp_path: Path) -> None:
+    loop, _, _, prs, _ = _make_loop(
+        tmp_path,
+        open_prs=[_make_pr(9887, author="hydraflow-ul-bot", branch="ul-w")],
+        ci_result=(False, "Failed checks: Tests"),
+        failure_strategy="skip",
+        authors=["hydraflow-ul-bot"],
+        update_branch_max_attempts=0,
+    )
+
+    await loop._do_work()
+
+    prs.update_pr_branch.assert_not_awaited()

--- a/tests/scenarios/test_loops.py
+++ b/tests/scenarios/test_loops.py
@@ -289,7 +289,12 @@ class TestL7DependabotMergeAutoMerges:
 class TestL8DependabotMergeSkipsOnFailure:
     """L8: Bot PRs with failing CI are skipped (strategy=skip)."""
 
-    async def test_bot_pr_skipped_on_ci_failure(self, tmp_path):
+    async def test_bot_pr_skipped_on_ci_failure(self, tmp_path, monkeypatch):
+        # Pin the #9889 update-branch heal OFF: this scenario asserts the
+        # strategy=skip contract, not the heal-first path (covered by
+        # tests/regressions/test_issue_9889_update_branch_heal.py).
+        # Env pin because run_with_loops builds a FRESH bg config.
+        monkeypatch.setenv("HYDRAFLOW_DEPENDABOT_UPDATE_BRANCH_MAX_ATTEMPTS", "0")
         world = MockWorld(tmp_path)
 
         from mockworld.fakes.fake_github import FakePR
@@ -437,8 +442,12 @@ class TestL7cDependabotArchSelfHeal:
         # No further refresh needed.
         assert world.github.arch_refresh_call_count(9422) == 1
 
-    async def test_real_failure_not_arch_falls_through_to_skip(self, tmp_path):
+    async def test_real_failure_not_arch_falls_through_to_skip(
+        self, tmp_path, monkeypatch
+    ):
         """A non-arch CI failure must NOT trigger the arch self-heal."""
+        # Pin the #9889 update-branch heal OFF (see L8 note above).
+        monkeypatch.setenv("HYDRAFLOW_DEPENDABOT_UPDATE_BRANCH_MAX_ATTEMPTS", "0")
         world = MockWorld(tmp_path)
 
         from mockworld.fakes.fake_github import FakePR

--- a/tests/test_dependabot_merge_loop.py
+++ b/tests/test_dependabot_merge_loop.py
@@ -65,6 +65,18 @@ def _make_state(
         counter[pr_number] = counter.get(pr_number, 0) + 1
         return counter[pr_number]
 
+    ub_counter: dict[int, int] = {}
+
+    def _get_ub(pr_number: int) -> int:
+        return ub_counter.get(pr_number, 0)
+
+    def _bump_ub(pr_number: int) -> int:
+        ub_counter[pr_number] = ub_counter.get(pr_number, 0) + 1
+        return ub_counter[pr_number]
+
+    state.get_dependabot_update_branch_attempts.side_effect = _get_ub
+    state.bump_dependabot_update_branch_attempts.side_effect = _bump_ub
+
     state.get_dependabot_arch_refresh_attempts.side_effect = _get_attempts
     state.bump_dependabot_arch_refresh_attempts.side_effect = _bump_attempts
     state._arch_refresh_counter = counter  # exposed for assertions
@@ -85,6 +97,8 @@ def _make_loop(
     arch_refresh_attempts: dict[int, int] | None = None,
     arch_refresh_result: bool = True,
     arch_autoheal_max_attempts: int | None = None,
+    update_branch_max_attempts: int | None = None,
+    update_branch_result: bool = True,
 ) -> tuple[DependabotMergeLoop, asyncio.Event, MagicMock, MagicMock, MagicMock]:
     """Build a DependabotMergeLoop with test-friendly defaults.
 
@@ -99,6 +113,13 @@ def _make_loop(
             "dependabot_arch_autoheal_max_attempts",
             arch_autoheal_max_attempts,
         )
+    # #9889 heal class 2 defaults OFF in this harness so failure-strategy
+    # tests keep exercising the strategy path; tests opt in explicitly.
+    object.__setattr__(
+        deps.config,
+        "dependabot_update_branch_max_attempts",
+        update_branch_max_attempts if update_branch_max_attempts is not None else 0,
+    )
 
     cache = MagicMock()
     # DependabotMergeLoop reads the label-agnostic snapshot (get_all_open_prs);
@@ -110,6 +131,7 @@ def _make_loop(
     prs.wait_for_ci = AsyncMock(return_value=ci_result)
     prs.submit_review = AsyncMock(return_value=True)
     prs.merge_pr = AsyncMock(return_value=merge_result)
+    prs.update_pr_branch = AsyncMock(return_value=update_branch_result)
     prs.add_labels = AsyncMock()
     prs.post_comment = AsyncMock()
     prs.close_issue = AsyncMock()

--- a/tests/test_state_tracking.py
+++ b/tests/test_state_tracking.py
@@ -49,6 +49,7 @@ class TestInitialization:
             "bg_worker_states",
             "dependabot_merge_processed",
             "dependabot_arch_refresh_attempts",
+            "dependabot_update_branch_attempts",
             "dependabot_merge_settings",
             "ci_monitor_settings",
             "ci_monitor_tracked_failures",


### PR DESCRIPTION
## Problem (#9889, shepherd heal class 2)

Re-running failed jobs pins the OLD merge ref (the #9884 lesson) — a bot PR red on state the base already fixed (baseline advances, sibling regens) stayed red forever under retry.

## Change

DependabotMergeLoop's CI-failed branch, after the arch-staleness heal declines: **one bounded `update_pr_branch(method=merge)`** forces a fresh merge ref + full CI re-run before `failure_strategy` applies.

- `dependabot_update_branch_max_attempts` (default 1, **0 = kill-switch**, env parity) bounds it; already-up-to-date/refused updates do NOT burn budget.
- Persisted counter (state field + mixin, schema pin updated) survives restarts.
- Port triplet untouched — `update_pr_branch` already existed on PRPort/PRManager/FakeGitHub.
- Every strategy-path contract test (unit harness, L7c/L8 MockWorld scenarios, the #9422 regression file) explicitly pins the knob OFF so their contracts stay exact; the new class has its own loop-level regression pins.

## Tests

`tests/regressions/test_issue_9889_update_branch_heal.py` — heal-before-strategy, cap fall-through, no-budget-burn on up-to-date, kill-switch. Full `make quality` exit 0.

Refs #9889 (class 2 of 5; class 5 — human-branch shepherding — remains open, wants operator sign-off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)