### PR TITLE
feat(wiki-rot): guard shipped-claim drift in wiki knowledge entries (#9598)

### DIFF
--- a/src/wiki_rot_citations.py
+++ b/src/wiki_rot_citations.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import ast
 import difflib
+import json
 import logging
 import re
 from dataclasses import dataclass
@@ -176,6 +177,74 @@ _BUILTINS_DENY: frozenset[str] = frozenset(
         "None",
     }
 )
+
+
+# ---------------------------------------------------------------------------
+# Shipped-claim extraction (issue #9598)
+# ---------------------------------------------------------------------------
+
+# ``json:entry`` machine blocks — the RepoWikiStore house format. Both the
+# single-line compiled shape and the multi-line manual shape are captured;
+# the JSON body is parsed leniently below.
+_JSON_ENTRY_RE = re.compile(r"```json:entry\s*\n(.*?)```", re.DOTALL)
+
+
+@dataclass(frozen=True)
+class ShippedClaim:
+    """A structured "shipped in #NNNN" assertion from a wiki entry.
+
+    Sourced from the ``fixed_in_pr`` field of a ``json:entry`` machine
+    block — the one machine-readable shape in the RepoWikiStore format that
+    asserts a fix *landed* in a specific PR.  ``code_refs`` carries the
+    entry's own corroborating code references (``path.py:symbol`` strings);
+    the loop verifies the claim by resolving them against the codebase.
+
+    Provenance footers (``_Source: #NNNN (plan)_``) are deliberately **not**
+    shipped claims and are never extracted here.
+    """
+
+    pr_ref: str  # e.g. "#8713"
+    code_refs: tuple[str, ...]
+    raw: str  # verbatim block body, for excerpting in issue bodies
+
+
+def extract_shipped_claims(text: str) -> list[ShippedClaim]:
+    """Extract structured shipped claims (``fixed_in_pr``) from *text*.
+
+    Scans every ``json:entry`` block, parses its JSON body leniently, and
+    emits a :class:`ShippedClaim` for each block carrying a non-empty
+    ``fixed_in_pr``.  Blocks with malformed JSON, no ``fixed_in_pr``, or a
+    blank ``fixed_in_pr`` are skipped — the function never raises on bad
+    input.  Deduplicated by ``(pr_ref, code_refs)``.
+    """
+    seen: set[tuple[str, tuple[str, ...]]] = set()
+    out: list[ShippedClaim] = []
+
+    for block in _JSON_ENTRY_RE.finditer(text):
+        body = block.group(1)
+        try:
+            data = json.loads(body)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        pr_ref = data.get("fixed_in_pr")
+        if not isinstance(pr_ref, str) or not pr_ref.strip():
+            continue
+        pr_ref = pr_ref.strip()
+
+        raw_refs = data.get("code_refs", [])
+        code_refs: tuple[str, ...] = ()
+        if isinstance(raw_refs, list):
+            code_refs = tuple(r for r in raw_refs if isinstance(r, str) and r.strip())
+
+        key = (pr_ref, code_refs)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(ShippedClaim(pr_ref=pr_ref, code_refs=code_refs, raw=body.strip()))
+
+    return out
 
 
 # ---------------------------------------------------------------------------

--- a/src/wiki_rot_detector_loop.py
+++ b/src/wiki_rot_detector_loop.py
@@ -11,6 +11,17 @@ fences — hints only), and verifies each hard cite against:
   AST verification across every managed repo is out of scope for v1
   and noted below as a follow-up.
 
+A second **shipped-claim pass** (issue #9598) verifies structured
+``fixed_in_pr`` assertions in ``json:entry`` blocks: a claim that a fix
+shipped in ``#NNNN`` is corroborated iff at least one of its ``code_refs``
+resolves against the checked-out source. An uncorroborated claim is the
+#9455-shape drift ("shipped" asserted, no surviving code) and files an
+entry-level finding naming the PR; its dead refs are suppressed from the
+per-cite pass so each stale claim yields one finding, not N. Verifying the
+cited PR actually *merged* (network ``get_pr_merge_state``) is the split-out
+follow-up #9664; auto-memory notes outside the repo are out of CI scope
+(#9935). Self-repo only — corroboration needs AST over real source.
+
 For each broken cite the loop files a ``hydraflow-find`` + ``wiki-rot``
 issue through :class:`PRManager` with a fuzzy-match suggestion (via
 :func:`difflib.get_close_matches`) when the containing module exists.
@@ -34,8 +45,10 @@ from exception_classify import reraise_on_credit_or_bug
 from models import WorkCycleResult
 from wiki_rot_citations import (
     Cite,
+    ShippedClaim,
     extract_cites,
     extract_fenced_hints,
+    extract_shipped_claims,
     fuzzy_suggest,
     verify_cite_ast,
     verify_cite_grep,
@@ -236,7 +249,25 @@ class WikiRotDetectorLoop(BaseBackgroundLoop):
         for title, body, entry_path in entries:
             cites = extract_cites(body)
             hints = extract_fenced_hints(body)
+
+            # Shipped-claim pass (issue #9598): structured ``fixed_in_pr``
+            # claims are corroborated against their own code_refs. Refs of an
+            # *uncorroborated* claim are suppressed from the per-cite pass so a
+            # stale shipped claim yields ONE entry-level finding (naming the
+            # PR + revert/rename remediation) instead of N per-cite findings.
+            # Self-repo only — corroboration needs AST over checked-out source.
+            uncorroborated: list[ShippedClaim] = []
+            suppressed_refs: set[str] = set()
+            if is_self:
+                for claim in extract_shipped_claims(body):
+                    if self._shipped_claim_corroborated(claim, repo_root):
+                        continue
+                    uncorroborated.append(claim)
+                    suppressed_refs.update(claim.code_refs)
+
             for cite in cites:
+                if cite.raw in suppressed_refs:
+                    continue  # covered by the shipped-claim finding below
                 broken, suggestion = self._check_cite(cite, repo_root, is_self)
                 if not broken:
                     continue
@@ -265,6 +296,34 @@ class WikiRotDetectorLoop(BaseBackgroundLoop):
                     await self._file_escalation(
                         slug=slug,
                         cite=cite,
+                        attempts=attempts,
+                    )
+                    escalated += 1
+
+            for claim in uncorroborated:
+                subject = f"{slug}:shipped {claim.pr_ref}"
+                # Counted before the dedup guard so a live-but-filed claim
+                # keeps its escalation alive (mirrors the per-cite path).
+                broken_subjects.add(subject)
+                dedup_key = f"wiki_rot_detector:{subject}"
+                if dedup_key in dedup_seen:
+                    continue
+
+                filed += 1
+                await self._file_shipped_find(
+                    slug=slug,
+                    entry_title=title,
+                    entry_path=str(entry_path),
+                    body=body,
+                    claim=claim,
+                )
+                dedup_seen.add(dedup_key)
+
+                attempts = self._state.inc_wiki_rot_attempts(subject)
+                if attempts >= _MAX_ATTEMPTS:
+                    await self._file_shipped_escalation(
+                        slug=slug,
+                        claim=claim,
                         attempts=attempts,
                     )
                     escalated += 1
@@ -343,6 +402,34 @@ class WikiRotDetectorLoop(BaseBackgroundLoop):
         ok = verify_cite_grep(repo_root, module_path, cite.symbol)
         return (not ok, None)
 
+    def _shipped_claim_corroborated(
+        self,
+        claim: ShippedClaim,
+        repo_root: Path,
+    ) -> bool:
+        """Return ``True`` iff *claim* is backed by live code.
+
+        A ``fixed_in_pr`` claim is corroborated when at least one of its
+        ``code_refs`` resolves against the checked-out source — a
+        ``path.py:symbol`` ref via AST (with a grep fallback for
+        re-exports / non-Python targets), or a bare file ref by existence.
+        A claim with **no** ``code_refs`` is unverifiable offline and
+        therefore uncorroborated — the PR-merge-state network check that
+        would settle it is the split-out follow-up (#9664); auto-memory
+        notes outside the repo are out of scope for CI (#9935).
+        """
+        if not claim.code_refs:
+            return False
+        for ref in claim.code_refs:
+            module_path, sep, symbol = ref.partition(":")
+            if sep and symbol:
+                ok, _ = verify_cite_ast(repo_root, module_path, symbol)
+                if ok or verify_cite_grep(repo_root, module_path, symbol):
+                    return True
+            elif (repo_root / module_path).is_file():
+                return True
+        return False
+
     async def _file_find(
         self,
         *,
@@ -404,6 +491,86 @@ class WikiRotDetectorLoop(BaseBackgroundLoop):
             "Human: resolve the cite or remove the wiki entry, then "
             "close this issue. The dedup key + attempt counter clear "
             "automatically on close (spec §3.2).\n"
+        )
+        await self._pr.create_issue(
+            title,
+            body,
+            list(_ISSUE_LABELS_ESCALATE),
+        )
+
+    async def _file_shipped_find(
+        self,
+        *,
+        slug: str,
+        entry_title: str,
+        entry_path: str,
+        body: str,
+        claim: ShippedClaim,
+    ) -> None:
+        """File a finding for an uncorroborated ``fixed_in_pr`` claim.
+
+        The entry asserts a fix shipped in ``claim.pr_ref`` but none of its
+        ``code_refs`` resolve at HEAD — the #9455-shape drift: a "shipped"
+        claim with no surviving code. Remediation covers both readings
+        (symbol renamed → update code_refs; reverted / never merged →
+        verify the PR and remove the entry).
+        """
+        title = f"Wiki rot: {entry_title} shipped claim {claim.pr_ref} lacks live code"
+        excerpt = _excerpt_around(body, claim.pr_ref, _EXCERPT_CHARS)
+        refs = ", ".join(f"`{r}`" for r in claim.code_refs) or "(none provided)"
+        lines = [
+            "**Automated detection — WikiRotDetectorLoop shipped-claim pass "
+            "(spec §4.9 / issue #9598).**",
+            "",
+            f"- Repo: `{slug}`",
+            f"- Entry: `{entry_path}` — *{entry_title}*",
+            f"- Shipped claim: `fixed_in_pr = {claim.pr_ref}`",
+            f"- Code references that no longer resolve: {refs}",
+            "",
+            "This entry claims a fix shipped in "
+            f"{claim.pr_ref}, but none of its code references exist at HEAD. "
+            "Either the symbols were renamed (update `code_refs`), or the fix "
+            "was reverted / the PR never merged with content (verify "
+            f"{claim.pr_ref} merged, then correct or remove the entry).",
+            "",
+            "### Entry excerpt",
+            "",
+            "```markdown",
+            excerpt,
+            "```",
+        ]
+        await self._pr.create_issue(
+            title,
+            "\n".join(lines),
+            list(_ISSUE_LABELS_FIND),
+        )
+
+    async def _file_shipped_escalation(
+        self,
+        *,
+        slug: str,
+        claim: ShippedClaim,
+        attempts: int,
+    ) -> None:
+        """Escalate a repeatedly-unresolved shipped claim.
+
+        The title mirrors the per-cite escalation grammar
+        (``... cites missing shipped {pr_ref}``) so the existing
+        :func:`_parse_escalation_subject` reconciler clears its dedup key +
+        attempt counter on close without any parser change.
+        """
+        title = f"Wiki rot stuck: {slug} cites missing shipped {claim.pr_ref}"
+        body = (
+            "**Escalation — WikiRotDetectorLoop shipped-claim pass "
+            "(spec §4.9 / §3.2 / issue #9598).**\n\n"
+            f"- Repo: `{slug}`\n"
+            f"- Shipped claim: `fixed_in_pr = {claim.pr_ref}` — uncorroborated "
+            "by any live code reference.\n"
+            f"- Attempts: `{attempts}` ≥ `{_MAX_ATTEMPTS}` — repair loop "
+            "has not closed the finding within the retry budget.\n\n"
+            f"Human: verify {claim.pr_ref} merged and fix the code references, "
+            "or remove the stale entry, then close this issue. The dedup key "
+            "+ attempt counter clear automatically on close (spec §3.2).\n"
         )
         await self._pr.create_issue(
             title,

--- a/tests/scenarios/test_wiki_rot_detector_scenario.py
+++ b/tests/scenarios/test_wiki_rot_detector_scenario.py
@@ -151,6 +151,63 @@ class TestWikiRotDetectorScenario:
         assert stats["wiki_rot_detector"]["issues_filed"] == 0, stats
         assert await world.github.list_issues_by_label("wiki-rot") == []
 
+    async def test_fires_on_uncorroborated_shipped_claim(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A ``fixed_in_pr`` claim whose code_refs are all dead ⇒ exactly one
+        entry-level shipped-claim find (issue #9598).
+
+        The seeded source tree defines ``other`` but not ``vanished``, so the
+        claim's sole code_ref does not resolve — the loop files a single
+        ``hydraflow-find`` + ``wiki-rot`` issue naming the PR, and suppresses
+        the redundant per-cite finding for the same dead ref.
+        """
+        world = MockWorld(tmp_path)
+
+        wiki_dir = tmp_path / "wiki" / _SLUG
+        wiki_dir.mkdir(parents=True)
+        (wiki_dir / "gotchas.md").write_text(
+            "# Gotchas\n\n## Swap boundary\n\nProse.\n\n"
+            "```json:entry\n"
+            '{"id": "swap", "rule": "r", '
+            '"code_refs": ["src/foo.py:vanished"], "fixed_in_pr": "#8715"}\n'
+            "```\n"
+        )
+        _seed_source(tmp_path)
+
+        fake_state = MagicMock()
+        fake_state.get_wiki_rot_attempts.return_value = 0
+        fake_state.inc_wiki_rot_attempts.return_value = 1
+
+        fake_dedup = MagicMock()
+        fake_dedup.get.return_value = set()
+
+        fake_wiki_store = MagicMock()
+        fake_wiki_store.list_repos.return_value = [_SLUG]
+        fake_wiki_store.repo_dir.return_value = wiki_dir
+
+        _seed_ports(
+            world,
+            wiki_rot_state=fake_state,
+            wiki_rot_dedup=fake_dedup,
+            wiki_store=fake_wiki_store,
+        )
+
+        stats = await world.run_with_loops(["wiki_rot_detector"], cycles=1)
+
+        assert stats["wiki_rot_detector"]["status"] == "fired", stats
+        assert stats["wiki_rot_detector"]["issues_filed"] == 1, stats
+        assert stats["wiki_rot_detector"]["escalations"] == 0, stats
+
+        issues = await world.github.list_issues_by_label("wiki-rot")
+        assert len(issues) == 1, issues
+        issue = world.github.issue(issues[0]["number"])
+        assert "#8715" in issue.title
+        assert "shipped claim" in issue.title
+        assert "hydraflow-find" in issue.labels
+        assert "wiki-rot" in issue.labels
+
     async def test_reconcile_clears_closed_escalation(
         self,
         tmp_path: Path,

--- a/tests/test_wiki_rot_citations.py
+++ b/tests/test_wiki_rot_citations.py
@@ -6,8 +6,10 @@ from pathlib import Path
 
 from wiki_rot_citations import (
     Cite,
+    ShippedClaim,
     extract_cites,
     extract_fenced_hints,
+    extract_shipped_claims,
     fuzzy_suggest,
     verify_cite_ast,
     verify_cite_grep,
@@ -116,3 +118,88 @@ def test_fuzzy_suggest_close_match() -> None:
 
 def test_fuzzy_suggest_no_match() -> None:
     assert fuzzy_suggest("zzzzzz", ["alpha", "beta"]) is None
+
+
+# ---------------------------------------------------------------------------
+# Shipped-claim extraction (issue #9598)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_shipped_claims_from_json_entry_block() -> None:
+    md = (
+        "# Gotcha\n\nSome prose.\n\n"
+        "```json:entry\n"
+        "{\n"
+        '  "id": "example",\n'
+        '  "rule": "do the thing",\n'
+        '  "code_refs": ["src/foo.py:bar", "src/foo.py:baz"],\n'
+        '  "fixed_in_pr": "#8713",\n'
+        '  "added": "2026-05-07"\n'
+        "}\n"
+        "```\n"
+    )
+    claims = extract_shipped_claims(md)
+    assert len(claims) == 1
+    claim = claims[0]
+    assert isinstance(claim, ShippedClaim)
+    assert claim.pr_ref == "#8713"
+    assert claim.code_refs == ("src/foo.py:bar", "src/foo.py:baz")
+
+
+def test_extract_shipped_claims_ignores_entries_without_fixed_in_pr() -> None:
+    md = (
+        "```json:entry\n"
+        '{"id": "compiled", "title": "x", "source_issue": 6295, "stale": false}\n'
+        "```\n"
+    )
+    assert extract_shipped_claims(md) == []
+
+
+def test_extract_shipped_claims_ignores_source_footer_prose() -> None:
+    # ``_Source: #6295 (plan)_`` footers are provenance, not shipped claims.
+    md = "# Entry\n\nBody text.\n\n_Source: #6295 (plan)_\n"
+    assert extract_shipped_claims(md) == []
+
+
+def test_extract_shipped_claims_handles_missing_code_refs() -> None:
+    md = '```json:entry\n{"id": "x", "fixed_in_pr": "#9001"}\n```\n'
+    claims = extract_shipped_claims(md)
+    assert len(claims) == 1
+    assert claims[0].pr_ref == "#9001"
+    assert claims[0].code_refs == ()
+
+
+def test_extract_shipped_claims_tolerates_malformed_json() -> None:
+    md = (
+        "```json:entry\n"
+        "{ this is not valid json,, }\n"
+        "```\n"
+        "```json:entry\n"
+        '{"id": "ok", "fixed_in_pr": "#42", "code_refs": ["src/x.py:y"]}\n'
+        "```\n"
+    )
+    claims = extract_shipped_claims(md)
+    assert len(claims) == 1
+    assert claims[0].pr_ref == "#42"
+
+
+def test_extract_shipped_claims_multiple_blocks() -> None:
+    md = (
+        "```json:entry\n"
+        '{"id": "a", "fixed_in_pr": "#1", "code_refs": ["src/a.py:f"]}\n'
+        "```\n"
+        "```json:entry\n"
+        '{"id": "b", "fixed_in_pr": "#2", "code_refs": ["src/b.py:g"]}\n'
+        "```\n"
+    )
+    claims = extract_shipped_claims(md)
+    assert {c.pr_ref for c in claims} == {"#1", "#2"}
+
+
+def test_extract_shipped_claims_skips_blank_fixed_in_pr() -> None:
+    md = (
+        "```json:entry\n"
+        '{"id": "x", "fixed_in_pr": "", "code_refs": ["src/x.py:y"]}\n'
+        "```\n"
+    )
+    assert extract_shipped_claims(md) == []

--- a/tests/test_wiki_rot_detector_loop.py
+++ b/tests/test_wiki_rot_detector_loop.py
@@ -257,6 +257,163 @@ async def test_tick_repo_escalates_on_third_attempt(
     assert set(labels_escalate) == {"hitl-escalation", "wiki-rot-stuck"}
 
 
+def _shipped_entry(pr_ref: str, code_refs: list[str]) -> str:
+    """A wiki entry with a structured ``fixed_in_pr`` shipped claim."""
+    import json
+
+    block = json.dumps(
+        {"id": "x", "rule": "r", "code_refs": code_refs, "fixed_in_pr": pr_ref}
+    )
+    return f"# Entry\n\nProse.\n\n```json:entry\n{block}\n```\n"
+
+
+async def test_shipped_claim_fires_when_code_refs_all_dead(
+    tmp_path: Path, loop_env
+) -> None:
+    """A ``fixed_in_pr`` claim whose code_refs no longer resolve is drift."""
+    cfg, state, pr, dedup, wiki_store = loop_env
+    slug = "hydra/hydraflow"
+    wiki_dir = tmp_path / "wiki" / slug
+    wiki_dir.mkdir(parents=True)
+    (wiki_dir / "gotchas.md").write_text(
+        _shipped_entry("#8715", ["src/gone.py:vanished"])
+    )
+    wiki_store.repo_dir.return_value = wiki_dir
+    wiki_store.list_repos.return_value = [slug]
+    (tmp_path / "src").mkdir(exist_ok=True)  # module absent → code_ref dead
+    cfg.repo_root = tmp_path  # type: ignore[misc]
+
+    loop = _loop((cfg, state, pr, dedup, wiki_store))
+    loop._reconcile_closed_escalations = AsyncMock(return_value=None)
+    stats = await loop._do_work()
+
+    assert stats["issues_filed"] == 1, stats
+    title, body, labels = pr.create_issue.await_args.args
+    assert "#8715" in title
+    assert "#8715" in body
+    assert set(labels) == {"hydraflow-find", "wiki-rot"}
+
+
+async def test_shipped_claim_clean_when_a_code_ref_resolves(
+    tmp_path: Path, loop_env
+) -> None:
+    """At least one resolving code_ref corroborates the shipped claim."""
+    cfg, state, pr, dedup, wiki_store = loop_env
+    slug = "hydra/hydraflow"
+    wiki_dir = tmp_path / "wiki" / slug
+    wiki_dir.mkdir(parents=True)
+    (wiki_dir / "gotchas.md").write_text(
+        _shipped_entry("#8713", ["src/live.py:present", "src/gone.py:vanished"])
+    )
+    wiki_store.repo_dir.return_value = wiki_dir
+    wiki_store.list_repos.return_value = [slug]
+    (tmp_path / "src").mkdir(exist_ok=True)
+    (tmp_path / "src" / "live.py").write_text("def present():\n    return 1\n")
+    cfg.repo_root = tmp_path  # type: ignore[misc]
+
+    loop = _loop((cfg, state, pr, dedup, wiki_store))
+    loop._reconcile_closed_escalations = AsyncMock(return_value=None)
+    await loop._do_work()
+
+    # The resolving code_ref corroborates the claim — but the dead second
+    # code_ref still fires the ordinary per-cite pass. The shipped-claim
+    # finding itself must NOT fire.
+    assert not any("#8713" in c.args[0] for c in pr.create_issue.await_args_list), (
+        pr.create_issue.await_args_list
+    )
+
+
+async def test_shipped_claim_dedups_repeat(tmp_path: Path, loop_env) -> None:
+    cfg, state, pr, dedup, wiki_store = loop_env
+    slug = "hydra/hydraflow"
+    dedup.get.return_value = {f"wiki_rot_detector:{slug}:shipped #8715"}
+    wiki_dir = tmp_path / "wiki" / slug
+    wiki_dir.mkdir(parents=True)
+    (wiki_dir / "gotchas.md").write_text(
+        _shipped_entry("#8715", ["src/gone.py:vanished"])
+    )
+    wiki_store.repo_dir.return_value = wiki_dir
+    wiki_store.list_repos.return_value = [slug]
+    (tmp_path / "src").mkdir(exist_ok=True)
+    cfg.repo_root = tmp_path  # type: ignore[misc]
+
+    loop = _loop((cfg, state, pr, dedup, wiki_store))
+    loop._reconcile_closed_escalations = AsyncMock(return_value=None)
+    await loop._do_work()
+
+    assert not any("#8715" in c.args[0] for c in pr.create_issue.await_args_list)
+
+
+async def test_shipped_claim_escalates_on_third_attempt(
+    tmp_path: Path, loop_env
+) -> None:
+    cfg, state, pr, dedup, wiki_store = loop_env
+    slug = "hydra/hydraflow"
+    dedup.get.return_value = set()
+    state.get_wiki_rot_attempts.return_value = 2
+    state.inc_wiki_rot_attempts.return_value = 3
+    wiki_dir = tmp_path / "wiki" / slug
+    wiki_dir.mkdir(parents=True)
+    (wiki_dir / "gotchas.md").write_text(
+        _shipped_entry("#8715", ["src/gone.py:vanished"])
+    )
+    wiki_store.repo_dir.return_value = wiki_dir
+    wiki_store.list_repos.return_value = [slug]
+    (tmp_path / "src").mkdir(exist_ok=True)
+    cfg.repo_root = tmp_path  # type: ignore[misc]
+
+    loop = _loop((cfg, state, pr, dedup, wiki_store))
+    loop._reconcile_closed_escalations = AsyncMock(return_value=None)
+    stats = await loop._do_work()
+
+    assert stats["escalations"] == 1, stats
+    escalation = pr.create_issue.await_args_list[-1]
+    title, _body, labels = escalation.args
+    assert set(labels) == {"hitl-escalation", "wiki-rot-stuck"}
+    # Escalation title must parse back to the shipped subject via the
+    # existing reconciler (``... cites missing shipped #8715``).
+    assert "cites missing shipped #8715" in title
+
+
+async def test_shipped_claim_escalation_subject_roundtrips(
+    tmp_path: Path, loop_env
+) -> None:
+    """The shipped escalation title parses back to its dedup subject so the
+    existing close-to-clear reconcile works unchanged."""
+    from wiki_rot_detector_loop import _parse_escalation_subject
+
+    slug = "hydra/hydraflow"
+    title = f"Wiki rot stuck: {slug} cites missing shipped #8715"
+    assert _parse_escalation_subject(title, "") == f"{slug}:shipped #8715"
+
+
+async def test_shipped_claim_skipped_for_managed_repo(tmp_path: Path, loop_env) -> None:
+    """Shipped-claim corroboration uses self-repo AST; managed repos (grep
+    over wiki mirrors) are out of scope and must not fire it."""
+    cfg, state, pr, dedup, wiki_store = loop_env
+    slug = "other/managed"  # != cfg.repo (hydra/hydraflow)
+    managed_dir = tmp_path / "wiki" / slug
+    managed_dir.mkdir(parents=True)
+    (managed_dir / "gotchas.md").write_text(
+        _shipped_entry("#8715", ["src/gone.py:vanished"])
+    )
+    self_dir = tmp_path / "wiki" / "hydra" / "hydraflow"  # empty self wiki
+    self_dir.mkdir(parents=True)
+
+    def _repo_dir(s: str):
+        return managed_dir if s == slug else self_dir
+
+    wiki_store.repo_dir.side_effect = _repo_dir
+    wiki_store.list_repos.return_value = [slug]
+    cfg.repo_root = tmp_path  # type: ignore[misc]
+
+    loop = _loop((cfg, state, pr, dedup, wiki_store))
+    loop._reconcile_closed_escalations = AsyncMock(return_value=None)
+    await loop._do_work()
+
+    assert not any("#8715" in c.args[0] for c in pr.create_issue.await_args_list)
+
+
 async def test_reconcile_clears_dedup_and_attempts(
     loop_env,
 ) -> None:


### PR DESCRIPTION
## What & why

Closes #9598 (canonical knowledge-claim guard — #9664 and #9935 were folded into it on 2026-07-19).

`WikiRotDetectorLoop` verified code-symbol cites but never verified **"shipped in #NNNN"** claims. The #9455 incident (a note asserting a watchdog shipped in a PR that never merged with content) is exactly this gap. This PR adds a **shipped-claim pass** that corroborates structured `fixed_in_pr` assertions in `json:entry` blocks against live code.

## What it does

- **`extract_shipped_claims(text)`** (`src/wiki_rot_citations.py`) — pure, side-effect-free extractor. Parses every `json:entry` block, emits a `ShippedClaim(pr_ref, code_refs, raw)` for each block carrying a non-empty `fixed_in_pr`. Tolerates malformed JSON; excludes `_Source: #NNNN (plan)_` provenance footers (those are not ship-claims).
- **Shipped-claim pass** in `_tick_repo` (self-repo only) — a claim is *corroborated* iff ≥1 of its `code_refs` resolves against the checked-out source (AST, with grep / file-existence fallbacks). An **uncorroborated** claim (all refs dead, or none provided) files one entry-level `hydraflow-find` + `wiki-rot` issue naming the PR, with rename-vs-revert remediation.
- **Low-noise / additive** — dead refs of an uncorroborated claim are suppressed from the per-cite pass, so each stale shipped claim yields *one* entry-level finding instead of N per-cite ones. Corroborated claims with a single renamed ref still get the ordinary per-cite "did you mean" finding.
- **Zero new surface** — dedup, attempt counters, escalation, and close-to-clear reconcile reuse existing machinery. The escalation subject (`{slug}:shipped {pr_ref}`) and title mirror the per-cite grammar, so `_parse_escalation_subject` needs no change. No new loop, config field, `StateData` field, or label.

## Scope boundary

This is the **offline, code-evidence** half of #9598. Verifying the cited PR actually *merged* (network `PRPort.get_pr_merge_state`, the empty-diff-branch case) is the split-out follow-up **#9664**; auto-memory notes live outside the repo and are not CI-checkable (**#9935**). Both are documented in the loop docstring and `_shipped_claim_corroborated`.

## Verified against the live wiki

- `#8713` (implement_phase refs) → corroborated → no fire.
- `#8715` (`swap-pipeline-labels` entry) → **uncorroborated** → fires. Its sole `code_ref` `_resolve_or_release_back_to_hitl` was renamed to `_release_back_to_hitl` — genuine stale drift.

## Tests

- Unit: 7 extractor tests + 6 loop tests (`tests/test_wiki_rot_citations.py`, `tests/test_wiki_rot_detector_loop.py`).
- MockWorld scenario: `test_fires_on_uncorroborated_shipped_claim` (`tests/scenarios/test_wiki_rot_detector_scenario.py`).
- All 53 wiki-rot tests green; `ruff check` + `ruff format` + `pyright` + `make arch-check` clean.

Sandbox e2e was not added: this is a pure offline verification pass inside an already-wired loop (no new docker/UI/Port/wiring surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)