### PR TITLE
fix(reap): guard proc.kill() against ProcessLookupError in sibling loops (#9883)

### DIFF
--- a/src/contract_refresh_loop.py
+++ b/src/contract_refresh_loop.py
@@ -49,6 +49,7 @@ Spec: ``docs/superpowers/specs/2026-04-22-trust-architecture-hardening-design.md
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import json
 import logging
@@ -510,8 +511,13 @@ class ContractRefreshLoop(BaseBackgroundLoop):
                 proc.communicate(), timeout=_REPLAY_GATE_TIMEOUT_SECONDS
             )
         except TimeoutError:
-            proc.kill()
-            await proc.wait()
+            # proc.kill() itself raises ProcessLookupError when the child
+            # already exited — suppress it (and proc.wait()) so the timeout is
+            # handled as a failure instead of crashing the loop cycle.
+            # (#9794/#9816/#9883)
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+                await proc.wait()
             logger.warning(
                 "Replay gate timed out after %ss; treating as failure",
                 _REPLAY_GATE_TIMEOUT_SECONDS,

--- a/src/corpus_learning_loop.py
+++ b/src/corpus_learning_loop.py
@@ -121,8 +121,12 @@ async def _communicate_bounded(
     try:
         return await asyncio.wait_for(proc.communicate(), timeout=_GH_TIMEOUT_SECONDS)
     except TimeoutError:
-        proc.kill()
+        # proc.kill() itself raises ProcessLookupError when the child already
+        # exited — suppress it too, not just proc.wait() — so the TimeoutError
+        # (the intended failed-read signal) propagates instead of crashing the
+        # caller with ProcessLookupError. (#9794/#9816)
         with contextlib.suppress(ProcessLookupError):
+            proc.kill()
             await proc.wait()
         raise
 

--- a/src/memory_backlog_loop.py
+++ b/src/memory_backlog_loop.py
@@ -64,8 +64,12 @@ async def _communicate_bounded(
             proc.communicate(), timeout=_SUBPROCESS_TIMEOUT_SECONDS
         )
     except TimeoutError:
-        proc.kill()
+        # proc.kill() itself raises ProcessLookupError when the child already
+        # exited — suppress it too, not just proc.wait() — so the TimeoutError
+        # (the intended failed-read signal) propagates instead of crashing the
+        # caller with ProcessLookupError. (#9794/#9816)
         with contextlib.suppress(ProcessLookupError):
+            proc.kill()
             await proc.wait()
         raise
 

--- a/src/mockworld/fakes/fake_subprocess_runner.py
+++ b/src/mockworld/fakes/fake_subprocess_runner.py
@@ -187,8 +187,12 @@ class FakeSubprocessRunner:
                 proc.communicate(input=input), timeout=timeout
             )
         except TimeoutError:
-            proc.kill()
-            await proc.wait()
+            # proc.kill() itself raises ProcessLookupError when the child
+            # already exited — suppress it (and proc.wait()) so the TimeoutError
+            # propagates instead of crashing the caller. (#9794/#9816/#9883)
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+                await proc.wait()
             raise
         return SimpleResult(
             stdout=stdout_bytes.decode(errors="replace").strip()

--- a/src/principles_audit_loop.py
+++ b/src/principles_audit_loop.py
@@ -50,8 +50,12 @@ async def _communicate_bounded(
     try:
         return await asyncio.wait_for(proc.communicate(), timeout=timeout)
     except TimeoutError:
-        proc.kill()
+        # proc.kill() itself raises ProcessLookupError when the child already
+        # exited — suppress it too, not just proc.wait() — so the TimeoutError
+        # (the intended failed-read signal) propagates instead of crashing the
+        # caller with ProcessLookupError. (#9794/#9816)
         with contextlib.suppress(ProcessLookupError):
+            proc.kill()
             await proc.wait()
         raise
 

--- a/src/skill_prompt_eval_loop.py
+++ b/src/skill_prompt_eval_loop.py
@@ -79,8 +79,12 @@ async def _communicate_bounded(
     try:
         return await asyncio.wait_for(proc.communicate(), timeout=timeout)
     except TimeoutError:
-        proc.kill()
+        # proc.kill() itself raises ProcessLookupError when the child already
+        # exited — suppress it too, not just proc.wait() — so the TimeoutError
+        # (the intended failed-read signal) propagates instead of crashing the
+        # caller with ProcessLookupError. (#9794/#9816)
         with contextlib.suppress(ProcessLookupError):
+            proc.kill()
             await proc.wait()
         raise
 

--- a/src/staging_bisect_loop.py
+++ b/src/staging_bisect_loop.py
@@ -188,8 +188,13 @@ class StagingBisectLoop(BaseBackgroundLoop):
                     proc.communicate(), timeout=timeout_s
                 )
             except TimeoutError:
-                proc.kill()
-                await proc.wait()
+                # proc.kill() itself raises ProcessLookupError when the child
+                # already exited — suppress it (and proc.wait()) so the timeout
+                # surfaces as a probe failure instead of crashing the loop.
+                # (#9794/#9816/#9883)
+                with contextlib.suppress(ProcessLookupError):
+                    proc.kill()
+                    await proc.wait()
                 exit_code = 124  # bash convention
                 stderr_excerpt = f"timeout after {timeout_s}s"
                 self._emit_trace(t0, cmd, exit_code, stderr_excerpt)
@@ -489,7 +494,11 @@ class StagingBisectLoop(BaseBackgroundLoop):
         while True:
             remaining = deadline - asyncio.get_event_loop().time()
             if remaining <= 0:
-                proc.kill()
+                # proc.kill() raises ProcessLookupError if the child already
+                # exited — suppress it so the intended TimeoutError propagates
+                # instead of crashing the loop cycle. (#9794/#9816/#9883)
+                with contextlib.suppress(ProcessLookupError):
+                    proc.kill()
                 with contextlib.suppress(asyncio.CancelledError):
                     await comm_task
                 raise TimeoutError(f"git command exceeded {timeout}s")
@@ -504,7 +513,11 @@ class StagingBisectLoop(BaseBackgroundLoop):
                     "staging_bisect: kill-switch tripped mid-run — "
                     "terminating git subprocess"
                 )
-                proc.kill()
+                # proc.kill() raises ProcessLookupError if the child already
+                # exited — suppress it so the intended BisectCancelledError
+                # propagates instead of crashing the loop cycle. (#9794/#9816/#9883)
+                with contextlib.suppress(ProcessLookupError):
+                    proc.kill()
                 with contextlib.suppress(asyncio.CancelledError):
                     await comm_task
                 raise BisectCancelledError("kill-switch tripped during git bisect run")
@@ -583,8 +596,12 @@ class StagingBisectLoop(BaseBackgroundLoop):
                 proc.communicate(), timeout=_GH_TIMEOUT_SECONDS
             )
         except TimeoutError as exc:
-            proc.kill()
+            # proc.kill() itself raises ProcessLookupError when the child
+            # already exited — suppress it too, not just proc.wait(), so the
+            # RuntimeError below propagates instead of crashing the loop cycle.
+            # (#9794/#9816/#9883)
             with contextlib.suppress(ProcessLookupError):
+                proc.kill()
                 await proc.wait()
             raise RuntimeError(
                 f"gh timed out after {_GH_TIMEOUT_SECONDS}s: {' '.join(cmd)}"

--- a/src/trust_fleet_sanity_loop.py
+++ b/src/trust_fleet_sanity_loop.py
@@ -21,6 +21,7 @@ by Plan 6b (§4.11 factory-cost work).
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import re
@@ -386,7 +387,11 @@ class TrustFleetSanityLoop(BaseBackgroundLoop):
                     proc.communicate(), timeout=_RECONCILE_GH_TIMEOUT_SECONDS
                 )
             except TimeoutError:
-                proc.kill()
+                # proc.kill() raises ProcessLookupError if the child already
+                # exited — suppress it so the timeout is handled here instead of
+                # crashing the loop cycle. (#9794/#9816/#9883)
+                with contextlib.suppress(ProcessLookupError):
+                    proc.kill()
                 logger.warning("open-escalation probe timed out — filing anyway")
                 return 0
             rows = json.loads(stdout.decode() or "[]")
@@ -485,7 +490,11 @@ class TrustFleetSanityLoop(BaseBackgroundLoop):
                 # than hang the cycle forever; the next tick retries. A visible
                 # warning (not debug) is deliberate — the original failure was a
                 # *silent* stall that only the dead-man-switch caught (#9410).
-                proc.kill()
+                # proc.kill() raises ProcessLookupError if the child already
+                # exited — suppress it so the timeout is handled here instead of
+                # crashing the loop cycle. (#9794/#9816/#9883)
+                with contextlib.suppress(ProcessLookupError):
+                    proc.kill()
                 logger.warning(
                     "gh issue list timed out after %ss; skipping reconcile pass",
                     _RECONCILE_GH_TIMEOUT_SECONDS,

--- a/tests/regressions/test_reap_processlookuperror.py
+++ b/tests/regressions/test_reap_processlookuperror.py
@@ -9,17 +9,31 @@ loop ``_communicate_bounded`` helpers the ``contextlib.suppress`` wrapped only
 ``proc.wait()`` (not ``proc.kill()``), and ``execution.run_simple`` had no
 suppress at all — so the ``ProcessLookupError`` escaped and crashed the loop
 iteration instead of the caller handling the timeout. See #9794 / #9814.
+
+#9883 found the guard from #9794/#9816 had only reached a subset of the reap
+sites sharing this shape: four more ``_communicate_bounded`` helpers
+(``corpus_learning_loop``, ``memory_backlog_loop``, ``skill_prompt_eval_loop``,
+``principles_audit_loop``) plus inline reaps in ``staging_bisect_loop``,
+``contract_refresh_loop``, ``trust_fleet_sanity_loop`` and the MockWorld
+``fake_subprocess_runner`` host path still killed the child outside the
+``suppress``. The parametrized helper tests below pin the named helpers; the
+AST sweep (``test_no_loop_reaps_proc_kill_outside_processlookup_suppress``)
+pins the class fleet-wide across ``src/*_loop.py`` so a fifth site can't
+regress silently — mirroring the ``communicate()``-bounding sweep in
+``test_issue_9508.py``.
 """
 
 from __future__ import annotations
 
+import ast
 import asyncio
 import sys
 from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+SRC_DIR = Path(__file__).resolve().parent.parent.parent / "src"
+sys.path.insert(0, str(SRC_DIR))
 
 
 class _DeadProc:
@@ -47,17 +61,29 @@ class _DeadProc:
         ("rc_budget_loop", "_GH_TIMEOUT_SECONDS"),
         ("fake_coverage_auditor_loop", "_SUBPROCESS_TIMEOUT_SECONDS"),
         ("adr_touchpoint_auditor_loop", "_GH_TIMEOUT_SECONDS"),
+        # #9883: four sibling loops that shared the identical unguarded shape.
+        ("corpus_learning_loop", "_GH_TIMEOUT_SECONDS"),
+        ("memory_backlog_loop", "_SUBPROCESS_TIMEOUT_SECONDS"),
+        # These two take the timeout as a call argument (no module-level attr),
+        # signalled by timeout_attr=None below.
+        ("skill_prompt_eval_loop", None),
+        ("principles_audit_loop", None),
     ],
 )
 async def test_communicate_bounded_surfaces_timeout_not_processlookup(
     monkeypatch, module_name, timeout_attr
 ):
     module = __import__(module_name)
-    monkeypatch.setattr(module, timeout_attr, 0.01)
+    if timeout_attr is None:
+        # ``_communicate_bounded(proc, timeout)`` — timeout is a call arg.
+        coro = module._communicate_bounded(_DeadProc(), timeout=0.01)
+    else:
+        monkeypatch.setattr(module, timeout_attr, 0.01)
+        coro = module._communicate_bounded(_DeadProc())
     # Must raise TimeoutError (caller treats as failed read), never the
     # ProcessLookupError from the already-dead child's proc.kill().
     with pytest.raises(TimeoutError):
-        await module._communicate_bounded(_DeadProc())
+        await coro
 
 
 @pytest.mark.asyncio
@@ -71,3 +97,107 @@ async def test_host_runner_run_simple_surfaces_timeout_not_processlookup(monkeyp
     runner = execution.HostRunner()
     with pytest.raises(TimeoutError):
         await runner.run_simple(["gh", "issue", "list"], timeout=0.01)
+
+
+@pytest.mark.asyncio
+async def test_fake_subprocess_runner_host_reap_surfaces_timeout_not_processlookup(
+    monkeypatch,
+):
+    """The MockWorld fake's host path (git/make run for real) must reap with the
+    same guard — a real reaped child there raises ProcessLookupError too (#9883)."""
+    from mockworld.fakes.fake_subprocess_runner import FakeSubprocessRunner
+
+    async def _fake_create(*_a, **_kw):
+        return _DeadProc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_create)
+    with pytest.raises(TimeoutError):
+        await FakeSubprocessRunner._run_on_host(["git", "status"], timeout=0.01)
+
+
+# --------------------------------------------------------------------------- #
+# Fleet-wide AST sweep: every ``proc.kill()`` in a background-loop file must sit
+# inside a ``contextlib.suppress(ProcessLookupError)`` block, so the reap of an
+# already-exited child surfaces the intended TimeoutError instead of crashing
+# the loop cycle. Mirrors the ``communicate()``-bounding sweep in
+# ``test_issue_9508.py`` so this gap class (#9794/#9816/#9883) can't recur
+# silently in a new or edited loop.
+# --------------------------------------------------------------------------- #
+
+
+def _callee_name(func: ast.expr) -> str | None:
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _arg_name(arg: ast.expr) -> str | None:
+    if isinstance(arg, ast.Name):
+        return arg.id
+    if isinstance(arg, ast.Attribute):
+        return arg.attr
+    return None
+
+
+def _suppresses_processlookup(item: ast.withitem) -> bool:
+    """True if a ``with`` item is ``contextlib.suppress(..., ProcessLookupError, ...)``."""
+    expr = item.context_expr
+    if not isinstance(expr, ast.Call) or _callee_name(expr.func) != "suppress":
+        return False
+    return any(_arg_name(a) == "ProcessLookupError" for a in expr.args)
+
+
+class _UnguardedProcKillFinder(ast.NodeVisitor):
+    """Collect line numbers of ``proc.kill()`` calls not lexically enclosed by a
+    ``contextlib.suppress(ProcessLookupError)`` block."""
+
+    def __init__(self) -> None:
+        self.violations: list[int] = []
+        self._guard_depth = 0
+
+    def _visit_with(self, node: ast.With | ast.AsyncWith) -> None:
+        guarded = any(_suppresses_processlookup(item) for item in node.items)
+        if guarded:
+            self._guard_depth += 1
+        self.generic_visit(node)
+        if guarded:
+            self._guard_depth -= 1
+
+    def visit_With(self, node: ast.With) -> None:
+        self._visit_with(node)
+
+    def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
+        self._visit_with(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        func = node.func
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "kill"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "proc"
+            and self._guard_depth == 0
+        ):
+            self.violations.append(node.lineno)
+        self.generic_visit(node)
+
+
+def test_no_loop_reaps_proc_kill_outside_processlookup_suppress() -> None:
+    offenders: dict[str, list[int]] = {}
+    for path in sorted(SRC_DIR.rglob("*_loop.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        finder = _UnguardedProcKillFinder()
+        finder.visit(tree)
+        if finder.violations:
+            offenders[str(path.relative_to(SRC_DIR))] = finder.violations
+
+    assert not offenders, (
+        "Background loops must reap a timed-out subprocess with `proc.kill()` "
+        "inside `contextlib.suppress(ProcessLookupError)` — an already-exited "
+        "child makes `proc.kill()` raise ProcessLookupError, which otherwise "
+        "escapes and crashes the loop cycle instead of surfacing the intended "
+        "TimeoutError (gh-timeout storm; #9794/#9816/#9883). "
+        f"Unguarded proc.kill() sites: {offenders}"
+    )


### PR DESCRIPTION
## Summary

Closes #9883. The bounded-communicate reap guard from #9794/#9816 (move `proc.kill()` inside `contextlib.suppress(ProcessLookupError)`) had only reached a subset of the reap sites sharing this shape. On a gh/subprocess-timeout storm, reaping an already-exited child makes `proc.kill()` raise `ProcessLookupError`, which escapes and crashes the loop cycle instead of surfacing the intended `TimeoutError` — orphaning subprocesses and eating `CreditExhaustedError`.

This applies the identical guard to the **4 sibling loops named in the issue** plus the **additional inline reap sites flagged in the owner's groom comment**.

## Loops guarded

**The 4 named `_communicate_bounded` helpers (issue body):**
- `corpus_learning_loop` — `proc.kill()` moved inside the `suppress`
- `memory_backlog_loop` — same
- `skill_prompt_eval_loop` — same (helper takes `timeout` as a call arg)
- `principles_audit_loop` — same (helper takes `timeout` as a call arg)

**Additional inline reap sites (groom comment):**
- `contract_refresh_loop` (replay gate) — wrapped `kill`+`wait` in `suppress` (had none)
- `staging_bisect_loop` — guarded all 4 kills: bisect probe, the two git-poll kills (kept the existing `CancelledError` suppress for `comm_task`), and `_run_gh`
- `trust_fleet_sanity_loop` — open-escalation probe + reconcile-pass kills
- `mockworld/fakes/fake_subprocess_runner._run_on_host` — the fake host path runs git/make for real; wrapped `kill`+`wait` in `suppress`

Added `import contextlib` to `contract_refresh_loop` and `trust_fleet_sanity_loop` (previously had no `suppress`).

## Tests (`tests/regressions/test_reap_processlookuperror.py`)
- Added the 4 named loops to the parametrized `_communicate_bounded` cases (two take `timeout` as a call arg → `timeout_attr=None` branch).
- Added a runtime test for the fake host-runner reap.
- Added a **fleet-wide AST sweep** asserting every `proc.kill()` in `src/*_loop.py` sits inside `contextlib.suppress(ProcessLookupError)` — mirroring the `communicate()`-bounding sweep in `test_issue_9508.py` so a new/edited loop can't reintroduce this gap silently. This is the recurrence guard the issue + groom asked for.

TDD: confirmed RED first (the AST sweep listed every unguarded site; the 4 new parametrize cases + fake test raised `ProcessLookupError`), then GREEN after the fix.

## Verification
- `tests/regressions/test_reap_processlookuperror.py`: **11 passed**
- Touched loops' unit tests (7 files): **202 passed**
- `tests/regressions/test_issue_9508.py` (sibling AST sweep): passed
- `ruff check` + `ruff format --check`: clean (9 files)
- `make arch-check`: OK; test-sludge check: 0 sludge
- pre-commit hooks (lint-check + arch-check) passed on commit

## Notes
- Scope is the reap guard only. `contract_refresh_loop` and `staging_bisect_loop` don't call `reraise_on_credit_or_bug` — that's correct: they spawn `make`/`git`/`gh`, not the LLM CLI, so they don't produce `CreditExhaustedError`. The 4 named loops all already import and call it.
- Per the groom comment, this is the tactical crash-class fix to land before the #9554 migration (which will delete the `_communicate_bounded` copies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)