### PR TITLE
fix(trust-loops): route remaining reconcilers off raw gh through PRPort (#9932)

### DIFF
--- a/src/adr_touchpoint_auditor_loop.py
+++ b/src/adr_touchpoint_auditor_loop.py
@@ -26,12 +26,14 @@ import asyncio
 import contextlib
 import json
 import logging
+import re
 import time
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from adr_drift import compute_drift_by_adr
 from base_background_loop import BaseBackgroundLoop, LoopDeps  # noqa: TCH001
+from escalation_reconcile import EscalationReconciler
 from models import WorkCycleResult  # noqa: TCH001
 
 if TYPE_CHECKING:
@@ -83,6 +85,17 @@ def _dedup_key(adr_number: int) -> str:
     return f"adr_touchpoint_auditor:{_rollup_key(adr_number)}"
 
 
+# Parses ``_file_drift_escalation`` titles back to the dedup-key subject
+# (the ``ADR-NNNN`` rollup key). Returns ``None`` for titles that aren't ours
+# so the shared ``EscalationReconciler`` skips operator-created issues.
+_ESCALATION_TITLE_RE = re.compile(r"^HITL: ADR drift (.+?) unresolved after ")
+
+
+def _escalation_subject(title: str) -> str | None:
+    m = _ESCALATION_TITLE_RE.match(title)
+    return m.group(1) if m else None
+
+
 def _adr_num_from_key(rollup_key: str) -> int | None:
     """Parse the ADR number out of an ``ADR-NNNN`` rollup key.
 
@@ -124,6 +137,22 @@ class AdrTouchpointAuditorLoop(BaseBackgroundLoop):
         self._pr = pr_manager
         self._dedup = dedup
         self._adr_index = adr_index
+        self._escalations = EscalationReconciler(
+            prs=pr_manager,
+            dedup=dedup,
+            key_prefix="adr_touchpoint_auditor",
+            stuck_label=config.adr_drift_stuck_label[0],
+            clear_attempts=self._clear_drift_state,
+            subject_from_title=_escalation_subject,
+        )
+
+    def _clear_drift_state(self, subject: str) -> None:
+        """Clear both the attempt counter and the rollup state for *subject*
+        (an ``ADR-NNNN`` rollup key). The pre-migration reconciler cleared
+        both on a closed escalation; the shared reconciler drives this via a
+        single ``clear_attempts`` callback."""
+        self._state.clear_adr_audit_attempts(subject)
+        self._state.clear_adr_rollup(subject)
 
     def _get_default_interval(self) -> int:
         return self._config.adr_touchpoint_auditor_interval
@@ -319,61 +348,16 @@ class AdrTouchpointAuditorLoop(BaseBackgroundLoop):
         )
 
     async def _reconcile_closed_escalations(self) -> None:
-        """Clear dedup keys + attempt counters for closed drift escalations."""
-        cmd = [
-            "gh",
-            "issue",
-            "list",
-            "--repo",
-            self._config.repo,
-            "--state",
-            "closed",
-        ]
-        for label in (
-            *self._config.hitl_escalation_label,
-            *self._config.adr_drift_stuck_label,
-        ):
-            cmd.extend(["--label", label])
-        cmd.extend(
-            [
-                "--author",
-                "@me",
-                "--limit",
-                "100",
-                "--json",
-                "title",
-            ]
-        )
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        try:
-            stdout, _ = await _communicate_bounded(proc)
-        except TimeoutError:
-            return
-        if proc.returncode != 0:
-            return
-        try:
-            closed = json.loads(stdout.decode() or "[]")
-        except json.JSONDecodeError:
-            return
-        current = self._dedup.get()
-        keep = set(current)
-        for issue in closed:
-            title = issue.get("title", "")
-            for key in list(keep):
-                if (
-                    key.startswith("adr_touchpoint_auditor:")
-                    and key.split(":", 1)[1] in title
-                ):
-                    keep.discard(key)
-                    attempt_id = key.split(":", 1)[1]
-                    self._state.clear_adr_audit_attempts(attempt_id)
-                    self._state.clear_adr_rollup(attempt_id)
-        if keep != current:
-            self._dedup.set_all(keep)
+        """Clear dedup keys + attempt counters for closed drift escalations.
+
+        Delegates to the shared :class:`EscalationReconciler` (PRPort-based;
+        replaced the raw ``gh issue list`` subprocess — #9932). Subjects (the
+        ``ADR-NNNN`` rollup key) are parsed from the escalation-title shape
+        ``"HITL: ADR drift <ADR-NNNN> unresolved after N"``; the matching
+        ``adr_touchpoint_auditor:<ADR-NNNN>`` dedup key, attempt counter, and
+        rollup state (:meth:`_clear_drift_state`) are cleared.
+        """
+        await self._escalations.reconcile_closed()
 
     def _adrs_updated_in_diff(self, changed_files: list[str]) -> set[int]:
         """Return ADR numbers whose own markdown file appears in *changed_files*."""

--- a/src/corpus_learning_loop.py
+++ b/src/corpus_learning_loop.py
@@ -53,9 +53,7 @@ Kill-switch: :meth:`LoopDeps.enabled_cb` with ``worker_name="corpus_learning"``
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import difflib
-import json
 import logging
 import re
 import time
@@ -102,30 +100,6 @@ DEFAULT_LOOKBACK_DAYS = 30
 #: Spec §4.1 v2 step 5: 3 consecutive self-validation failures on the
 #: same escape issue trigger a `corpus-learning-stuck` escalation.
 _CORPUS_STUCK_ATTEMPTS = 3
-
-#: Hard cap on the ``gh`` reconcile read. A wedged ``gh`` child must not hang
-#: the loop cycle forever and freeze its heartbeat — the #9410 silent-stall
-#: failure class (#9454 / #9508).
-_GH_TIMEOUT_SECONDS = 120
-
-
-async def _communicate_bounded(
-    proc: asyncio.subprocess.Process,
-) -> tuple[bytes, bytes]:
-    """``proc.communicate()`` bounded by ``_GH_TIMEOUT_SECONDS``.
-
-    On timeout the wedged child is killed and a ``TimeoutError`` propagates so
-    the caller can treat it as a failed read (rather than hanging the loop
-    cycle indefinitely).
-    """
-    try:
-        return await asyncio.wait_for(proc.communicate(), timeout=_GH_TIMEOUT_SECONDS)
-    except TimeoutError:
-        proc.kill()
-        with contextlib.suppress(ProcessLookupError):
-            await proc.wait()
-        raise
-
 
 #: Parses ``Corpus learning stuck on escape #1234: …`` titles for
 #: reconcile-on-close (spec §3.2 lifecycle).
@@ -772,35 +746,27 @@ class CorpusLearningLoop(BaseBackgroundLoop):
 
         Spec §3.2 lifecycle: an operator closing the escalation issue
         must clear the per-issue counter so the loop will retry on the
-        next tick. Best-effort — gh-list failures or parse errors log
-        and return; reconciliation is bounded by the loop interval.
+        next tick. Best-effort — PRPort failures or parse errors log and
+        return; reconciliation is bounded by the loop interval.
+
+        The closed-escalation read routes through
+        :meth:`PRPort.list_closed_issues_by_label` (#9932) — no longer a raw
+        ``gh issue list`` subprocess, so it stays inside the MockWorld
+        air-gap and uses the hardened ``run_subprocess`` runner. This loop
+        keeps its bespoke reset rather than adopting the shared
+        :class:`EscalationReconciler`: its escalation state is a
+        per-``issue_number`` counter (reset unconditionally on close), not a
+        DedupStore key, so the reconciler's dedup-key-gated ``clear_attempts``
+        does not map onto it.
         """
         if self._state is None or not hasattr(
             self._state, "reset_corpus_validation_attempts"
         ):
             return
         try:
-            proc = await asyncio.create_subprocess_exec(
-                "gh",
-                "issue",
-                "list",
-                "--repo",
-                self._config.repo,
-                "--state",
-                "closed",
-                "--label",
-                "corpus-learning-stuck",
-                "--json",
-                "title",
-                "--limit",
-                "100",
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
+            issues = await self._prs.list_closed_issues_by_label(
+                "corpus-learning-stuck", limit=100
             )
-            out, _ = await _communicate_bounded(proc)
-            if proc.returncode != 0:
-                return
-            issues = json.loads(out or b"[]")
         except Exception as exc:  # noqa: BLE001
             reraise_on_credit_or_bug(exc)
             logger.debug("corpus-learning reconcile: skipped", exc_info=True)

--- a/src/memory_backlog_loop.py
+++ b/src/memory_backlog_loop.py
@@ -15,11 +15,12 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import json
 import logging
+import re
 from typing import TYPE_CHECKING
 
 from base_background_loop import BaseBackgroundLoop, LoopDeps  # noqa: TCH001
+from escalation_reconcile import EscalationReconciler
 from exception_classify import reraise_on_credit_or_bug
 from memory_backlog_mirror import (
     dedup_key_for,
@@ -43,6 +44,18 @@ logger = logging.getLogger("hydraflow.memory_backlog_loop")
 _MAX_ATTEMPTS = 3
 _MIRROR_SUBPATH = ("docs", "wiki", "memory-feedback")
 _DEDUP_PREFIX = "memory_backlog:"
+
+# Parses ``_file_escalation`` titles back to the slug subject. Returns
+# ``None`` for titles that aren't ours so the shared ``EscalationReconciler``
+# skips operator-created issues untouched. ``(.+?)`` non-greedy up to the
+# `` unresolved after `` sentinel so spaced slugs stay reconcilable.
+_ESCALATION_TITLE_RE = re.compile(r"^HITL: memory backlog (.+?) unresolved after ")
+
+
+def _escalation_subject(title: str) -> str | None:
+    m = _ESCALATION_TITLE_RE.match(title)
+    return m.group(1) if m else None
+
 
 # Hard cap on each ``git``/``gh`` child. A wedged subprocess must not hang the
 # loop cycle forever and freeze its heartbeat — the #9410 silent-stall failure
@@ -91,6 +104,19 @@ class MemoryBacklogLoop(BaseBackgroundLoop):
         self._state = state
         self._pr = pr_manager
         self._dedup = dedup
+        # ``clear_memory_backlog_attempts`` is keyed on the FULL dedup key
+        # (``memory_backlog:<slug>``), not the bare subject — wrap so the
+        # reconciler passes the counter the same key it discards from dedup.
+        self._escalations = EscalationReconciler(
+            prs=pr_manager,
+            dedup=dedup,
+            key_prefix="memory_backlog",
+            stuck_label=config.memory_backlog_stuck_label[0],
+            clear_attempts=lambda subject: state.clear_memory_backlog_attempts(
+                f"{_DEDUP_PREFIX}{subject}"
+            ),
+            subject_from_title=_escalation_subject,
+        )
 
     def _get_default_interval(self) -> int:
         return self._config.memory_backlog_interval_seconds
@@ -261,56 +287,11 @@ class MemoryBacklogLoop(BaseBackgroundLoop):
     async def _reconcile_closed_escalations(self) -> None:
         """Clear dedup keys + attempt counters for closed escalations.
 
-        Mirrors `FakeCoverageAuditorLoop._reconcile_closed_escalations`:
-        scans `gh issue list --state closed` for memory-backlog-stuck
-        escalations the bot filed, then clears the matching dedup key
-        and StateTracker attempt counter so the entry can re-file fresh.
+        Delegates to the shared :class:`EscalationReconciler` (PRPort-based;
+        replaced the raw ``gh issue list`` subprocess — #9932). Subjects are
+        parsed from the escalation-title shape
+        ``"HITL: memory backlog <slug> unresolved after N"``; the matching
+        ``memory_backlog:<slug>`` dedup key + StateTracker attempt counter are
+        cleared so the entry can re-file fresh.
         """
-        stuck_label = self._config.memory_backlog_stuck_label[0]
-        cmd = [
-            "gh",
-            "issue",
-            "list",
-            "--repo",
-            self._config.repo,
-            "--state",
-            "closed",
-            "--label",
-            "hitl-escalation",
-            "--label",
-            stuck_label,
-            "--author",
-            "@me",
-            "--limit",
-            "100",
-            "--json",
-            "title",
-        ]
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        try:
-            stdout, _ = await _communicate_bounded(proc)
-        except TimeoutError:
-            return
-        if proc.returncode != 0:
-            return
-        try:
-            closed = json.loads(stdout.decode() or "[]")
-        except json.JSONDecodeError:
-            return
-        current = self._dedup.get()
-        keep = set(current)
-        for issue in closed:
-            title = issue.get("title", "")
-            for key in list(keep):
-                if not key.startswith(_DEDUP_PREFIX):
-                    continue
-                slug = key.split(":", 1)[1]
-                if slug in title:
-                    keep.discard(key)
-                    self._state.clear_memory_backlog_attempts(key)
-        if keep != current:
-            self._dedup.set_all(keep)
+        await self._escalations.reconcile_closed()

--- a/src/rc_budget_loop.py
+++ b/src/rc_budget_loop.py
@@ -25,6 +25,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import re
 import statistics
 import tempfile
 import time
@@ -34,6 +35,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from base_background_loop import BaseBackgroundLoop, LoopDeps  # noqa: TCH001
+from escalation_reconcile import EscalationReconciler
 from models import WorkCycleResult  # noqa: TCH001
 
 if TYPE_CHECKING:
@@ -50,6 +52,24 @@ _HISTORY_CAP = 60
 _RECENT_N = 5
 _MIN_HISTORY = 5
 _WORKFLOW = "rc-promotion-scenario.yml"
+
+# Marker label on the HITL escalation issue (paired with ``hitl-escalation``).
+# Single-sourced so the filing path (`_file_escalation`) and the reconciler
+# can never drift apart.
+_STUCK_LABEL = "rc-duration-stuck"
+
+# Parses ``_file_escalation`` titles back to the dedup-key subject
+# (``median``/``spike``). Returns ``None`` for titles that aren't ours so the
+# shared ``EscalationReconciler`` skips operator-created issues untouched.
+_ESCALATION_TITLE_RE = re.compile(
+    r"^HITL: RC gate duration regression \((median|spike)\) unresolved after "
+)
+
+
+def _escalation_subject(title: str) -> str | None:
+    m = _ESCALATION_TITLE_RE.match(title)
+    return m.group(1) if m else None
+
 
 # Hard cap on each ``gh`` read/download. A wedged child must not hang the loop
 # cycle forever and freeze its heartbeat — the #9410 silent-stall failure
@@ -108,6 +128,14 @@ class RCBudgetLoop(BaseBackgroundLoop):
         self._state = state
         self._pr = pr_manager
         self._dedup = dedup
+        self._escalations = EscalationReconciler(
+            prs=pr_manager,
+            dedup=dedup,
+            key_prefix="rc_budget",
+            stuck_label=_STUCK_LABEL,
+            clear_attempts=state.clear_rc_budget_attempts,
+            subject_from_title=_escalation_subject,
+        )
 
     def _get_default_interval(self) -> int:
         return self._config.rc_budget_interval
@@ -434,52 +462,14 @@ class RCBudgetLoop(BaseBackgroundLoop):
         )
 
     async def _reconcile_closed_escalations(self) -> None:
-        """Clear dedup keys + attempt counters for closed HITL issues (§3.2)."""
-        cmd = [
-            "gh",
-            "issue",
-            "list",
-            "--repo",
-            self._config.repo,
-            "--state",
-            "closed",
-            "--label",
-            "hitl-escalation",
-            "--label",
-            "rc-duration-stuck",
-            "--author",
-            "@me",
-            "--limit",
-            "100",
-            "--json",
-            "title",
-        ]
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        try:
-            stdout, _ = await _communicate_bounded(proc)
-        except TimeoutError:
-            return
-        if proc.returncode != 0:
-            return
-        try:
-            closed = json.loads(stdout.decode() or "[]")
-        except json.JSONDecodeError:
-            return
-        current = self._dedup.get()
-        keep = set(current)
-        for issue in closed:
-            title = issue.get("title", "")
-            for kind in ("median", "spike"):
-                key = f"rc_budget:{kind}"
-                if key in keep and f"({kind})" in title:
-                    keep.discard(key)
-                    self._state.clear_rc_budget_attempts(kind)
-        if keep != current:
-            self._dedup.set_all(keep)
+        """Clear dedup keys + attempt counters for closed HITL issues (§3.2).
+
+        Delegates to the shared :class:`EscalationReconciler` (PRPort-based;
+        replaced the raw ``gh issue list`` subprocess — #9932). Subjects
+        (``median``/``spike``) are parsed from the escalation-title shape
+        ``"HITL: RC gate duration regression (<kind>) unresolved after N …"``.
+        """
+        await self._escalations.reconcile_closed()
 
     def _emit_trace(self, t0: float, *, runs_seen: int, signals: int) -> None:
         """Best-effort subprocess trace via lazy-imported ``trace_collector``."""

--- a/tests/regressions/test_issue_9454.py
+++ b/tests/regressions/test_issue_9454.py
@@ -48,8 +48,12 @@ _REPO = Path(__file__).resolve().parent.parent.parent
 # false-positive against the ``assert communicate_count`` guard below. The
 # fleet-wide AST scan in ``test_issue_9508.py`` is the authoritative source of
 # truth and correctly does not flag it.
+#
+# ``corpus_learning_loop.py`` left the list with #9932: its remaining raw
+# ``gh`` reconcile read moved behind the PRPort (shared EscalationReconciler),
+# so the module no longer spawns subprocesses at all — same shape as the
+# ``wiki_rot_detector_loop.py`` exclusion above.
 _UNHARDENED_COMMUNICATE_MODULES = [
-    "src/corpus_learning_loop.py",
     "src/memory_backlog_loop.py",
     "src/adr_touchpoint_auditor_loop.py",
     "src/rc_budget_loop.py",

--- a/tests/test_adr_touchpoint_auditor_loop.py
+++ b/tests/test_adr_touchpoint_auditor_loop.py
@@ -8,7 +8,6 @@ drifted it. Subsequent ticks update the body. Dedup key is
 from __future__ import annotations
 
 import asyncio
-import json
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -594,23 +593,25 @@ async def test_close_reconcile_clears_dedup(loop_env, monkeypatch) -> None:
         deps=_deps(stop),
     )
 
-    closed_payload = json.dumps(
-        [{"title": f"HITL: ADR drift {stuck_attempt_key} unresolved after 3"}]
-    ).encode()
+    pr.list_closed_issues_by_label.return_value = [
+        {
+            "number": 9701,
+            "title": f"HITL: ADR drift {stuck_attempt_key} unresolved after 3",
+            "body": "",
+            "updated_at": "",
+        }
+    ]
 
-    class _FakeProc:
-        returncode = 0
+    def _no_subprocess(*_args, **_kwargs):
+        raise AssertionError("reconcile must route through the PRPort, not raw gh")
 
-        async def communicate(self):
-            return closed_payload, b""
-
-    async def fake_exec(*_args, **_kwargs):
-        return _FakeProc()
-
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _no_subprocess)
 
     await loop._reconcile_closed_escalations()
 
+    pr.list_closed_issues_by_label.assert_awaited_once_with(
+        cfg.adr_drift_stuck_label[0], limit=100
+    )
     dedup.set_all.assert_called_once()
     remaining = dedup.set_all.call_args.args[0]
     assert full_dedup_key not in remaining

--- a/tests/test_corpus_learning_loop.py
+++ b/tests/test_corpus_learning_loop.py
@@ -1143,3 +1143,52 @@ def test_do_work_caps_prs_per_tick(tmp_path: Path) -> None:
     assert result["cases_filed"] == 5
     assert result["cases_validated"] == 25  # all validated, just deferred
     assert loop._open_pr_for_case.await_count == 5
+
+
+async def test_reconcile_closed_corpus_escalations_routes_through_prport(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Closed `corpus-learning-stuck` issues reset the per-issue counter.
+
+    The read routes through ``PRPort.list_closed_issues_by_label`` (#9932)
+    rather than a raw ``gh issue list`` subprocess, so it stays inside the
+    MockWorld air-gap. corpus_learning keeps its bespoke reset — the escalation
+    state is a per-``issue_number`` counter, not a DedupStore key, so it does
+    NOT adopt the dedup-key-gated shared ``EscalationReconciler``. The
+    ``create_subprocess_exec`` guard proves the raw path is gone.
+    """
+    prs = AsyncMock()
+    prs.list_closed_issues_by_label.return_value = [
+        {
+            "number": 4321,
+            "title": "Corpus learning stuck on escape #1234: flaky retry marker",
+            "body": "",
+            "updated_at": "",
+        },
+        {
+            "number": 4322,
+            "title": "Operator-created issue that does not parse",
+            "body": "",
+            "updated_at": "",
+        },
+    ]
+    state = MagicMock()
+    loop = CorpusLearningLoop(
+        config=HydraFlowConfig(data_root=tmp_path, repo="hydra/hydraflow"),
+        prs=prs,
+        dedup=MagicMock(),
+        deps=_deps(asyncio.Event()),
+        state=state,
+    )
+
+    def _no_subprocess(*_args, **_kwargs):
+        raise AssertionError("reconcile must route through the PRPort, not raw gh")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _no_subprocess)
+
+    await loop._reconcile_closed_corpus_escalations()
+
+    prs.list_closed_issues_by_label.assert_awaited_once_with(
+        "corpus-learning-stuck", limit=100
+    )
+    state.reset_corpus_validation_attempts.assert_called_once_with(1234)

--- a/tests/test_memory_backlog_loop.py
+++ b/tests/test_memory_backlog_loop.py
@@ -307,3 +307,46 @@ async def test_auth_error_propagates_not_swallowed(env) -> None:
 
     with pytest.raises(AuthenticationError):
         await loop._do_work()
+
+
+async def test_reconcile_closed_escalations_routes_through_prport(
+    env, monkeypatch
+) -> None:
+    """Closed memory-backlog-stuck escalations clear dedup key + counter.
+
+    The read goes through ``PRPort.list_closed_issues_by_label`` (shared
+    ``EscalationReconciler``) instead of a raw ``gh`` subprocess (#9932); the
+    ``create_subprocess_exec`` guard fails the test if the reconcile path
+    escapes the MockWorld air-gap. ``clear_memory_backlog_attempts`` is keyed
+    on the FULL dedup key, so the reconciler must pass ``memory_backlog:<slug>``.
+    """
+    cfg, state, pr, dedup, _ = env
+    dedup.get.return_value = {"memory_backlog:some-slug", "memory_backlog:other"}
+    loop = _make_loop(env)
+
+    pr.list_closed_issues_by_label.return_value = [
+        {
+            "number": 9702,
+            "title": "HITL: memory backlog some-slug unresolved after 3",
+            "body": "",
+            "updated_at": "",
+        }
+    ]
+
+    def _no_subprocess(*_args, **_kwargs):
+        raise AssertionError("reconcile must route through the PRPort, not raw gh")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _no_subprocess)
+
+    await loop._reconcile_closed_escalations()
+
+    pr.list_closed_issues_by_label.assert_awaited_once_with(
+        cfg.memory_backlog_stuck_label[0], limit=100
+    )
+    dedup.set_all.assert_called_once()
+    remaining = dedup.set_all.call_args.args[0]
+    assert "memory_backlog:some-slug" not in remaining
+    assert "memory_backlog:other" in remaining
+    state.clear_memory_backlog_attempts.assert_called_once_with(
+        "memory_backlog:some-slug"
+    )

--- a/tests/test_rc_budget_loop.py
+++ b/tests/test_rc_budget_loop.py
@@ -211,25 +211,38 @@ async def test_escalation_fires_after_three_attempts(loop_env) -> None:
 
 
 async def test_reconcile_closed_escalations_clears_dedup(loop_env, monkeypatch) -> None:
+    """Closed `rc-duration-stuck` escalations clear their dedup key + counter.
+
+    The read routes through ``PRPort.list_closed_issues_by_label`` (shared
+    ``EscalationReconciler``) — never a raw ``gh`` subprocess (#9932). The
+    ``create_subprocess_exec`` guard fails the test if the reconcile path
+    escapes the MockWorld air-gap.
+    """
     cfg, state, pr, dedup = loop_env
     dedup.get.return_value = {"rc_budget:median", "rc_budget:spike"}
     loop = _loop(loop_env)
 
-    class _P:
-        returncode = 0
+    pr.list_closed_issues_by_label.return_value = [
+        {
+            "number": 9700,
+            "title": (
+                "HITL: RC gate duration regression (median) unresolved after 3 attempts"
+            ),
+            "body": "",
+            "updated_at": "",
+        }
+    ]
 
-        async def communicate(self):
-            return (
-                b'[{"title": "HITL: RC gate duration regression (median) '
-                b'unresolved after 3 attempts"}]',
-                b"",
-            )
+    def _no_subprocess(*_args, **_kwargs):
+        raise AssertionError("reconcile must route through the PRPort, not raw gh")
 
-    async def fake_subproc(*args, **kwargs):
-        return _P()
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _no_subprocess)
 
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subproc)
     await loop._reconcile_closed_escalations()
+
+    pr.list_closed_issues_by_label.assert_awaited_once_with(
+        "rc-duration-stuck", limit=100
+    )
     dedup.set_all.assert_called_once()
     remaining = dedup.set_all.call_args.args[0]
     assert "rc_budget:median" not in remaining


### PR DESCRIPTION
## What

Migrates the last four trust-loop reconcilers off raw `gh issue list` (spawned via `asyncio.create_subprocess_exec`, killed with `proc.kill()` and **no** `start_new_session`) onto `PRPort.list_closed_issues_by_label`. Raw `gh` escapes the MockWorld air-gap (fails-closed under the sandbox network) and orphans `gh` grandchildren — the same class fixed for TrustFleetSanityLoop in #9660.

Fixes #9932.

## How

`list_closed_issues_by_label` **already exists** (protocol in `ports.py`, real impl in `pr_manager.py` via the hardened `run_subprocess_with_retry`, fake in `fake_github.py`, registered in `test_ports.py`) — no new Port method, no new cassette/dispatcher needed.

- **rc_budget_loop**, **memory_backlog_loop**, **adr_touchpoint_auditor_loop** adopt the shared `EscalationReconciler` (exactly as SkillPromptEvalLoop / FakeCoverageAuditorLoop / FlakeTrackerLoop / WikiRotDetectorLoop). Each wires `key_prefix` + a title parser (`subject_from_title`) + a `clear_attempts` callback:
  - rc_budget: subject = `median|spike` → `clear_rc_budget_attempts`
  - memory_backlog: subject = slug; the callback wraps the **full** `memory_backlog:<slug>` key (the counter is keyed on the full dedup key)
  - adr_touchpoint: subject = `ADR-NNNN`; new `_clear_drift_state` clears **both** the attempt counter and the rollup state (preserving prior behavior)
- **corpus_learning_loop** routes its read through the same PRPort method but **keeps its bespoke reset**. Its escalation state is a per-`issue_number` counter reset *unconditionally* on close — not a `DedupStore` key — so the reconciler's dedup-key-gated `clear_attempts` does not map onto it. Adopting the shared reconciler there would silently stop resetting the counter. Transport-only migration achieves the air-gap goal without a behavior regression.

Removed now-dead `_communicate_bounded`/`_GH_TIMEOUT_SECONDS` + unused `json`/`contextlib` imports from corpus_learning; dropped the unused `json` import from memory_backlog.

### Behavior note
The prior raw calls filtered by `--author @me` + two labels; `list_closed_issues_by_label` filters by the single stuck label with no author filter. This matches the established sibling-loop pattern — the stuck labels are bot-only and `subject_from_title` skips any title that doesn't match the escalation shape, so operator-created issues are ignored.

## Tests

TDD — RED first (guard trips on the current subprocess path), then GREEN:
- Rewrote the rc_budget + adr_touchpoint reconcile tests to seed the PRPort return value instead of monkeypatching `create_subprocess_exec`.
- Added reconcile tests for memory_backlog + corpus_learning.
- All four assert `create_subprocess_exec` is **never** invoked on the reconcile path (air-gap guard) and that dedup keys / attempt counters clear correctly.

Verified: touched loop suites + `test_escalation_reconcile` + `test_ports` + `test_fake_github_contract` + fake-coverage auditor + regression 8511/9622 (all green), `ruff check`/`format`, `pyright` (0 errors on changed files), `make arch-check` (clean — no new Port method).

🤖 Generated with [Claude Code](https://claude.com/claude-code)