### PR TITLE
fix(ui): cap Pipeline Flow dots at 10 with a +N overflow badge (#9863)

### DIFF
--- a/src/ui/src/components/StreamView.jsx
+++ b/src/ui/src/components/StreamView.jsx
@@ -54,12 +54,17 @@ function PipelineFlow({ stageGroups }) {
     return { mergedCount: merged, failedCount: failed }
   }, [stageGroups])
 
+  // #9863: a big backlog (67 queued in PLAN) rendered 67 dots in one
+  // non-wrapping row and blew out the strip. Cap the dots and show the
+  // remainder as a +N badge — the count survives, the layout does too.
+  const FLOW_DOT_CAP = 10
+
   const renderFlowStage = (group) => (
     <div style={styles.flowStage} key={group.stage.key}>
       <span style={flowLabelStyles[group.stage.key]}>{group.stage.label}</span>
       {group.issues.length > 0 && (
         <div style={styles.flowDots}>
-          {group.issues.map(issue => {
+          {group.issues.slice(0, FLOW_DOT_CAP).map(issue => {
             const isEpic = issue.isEpicChild || issue.epicNumber > 0
             const dotStyles = isEpic ? epicFlowDotStyleMap : regularFlowDotStyleMap
             const dotStyle =
@@ -79,6 +84,15 @@ function PipelineFlow({ stageGroups }) {
               </span>
             )
           })}
+          {group.issues.length > FLOW_DOT_CAP && (
+            <span
+              style={styles.flowDotOverflow}
+              title={`${group.issues.length - FLOW_DOT_CAP} more in ${group.stage.label}`}
+              data-testid={`flow-overflow-${group.stage.key}`}
+            >
+              +{group.issues.length - FLOW_DOT_CAP}
+            </span>
+          )}
         </div>
       )}
     </div>
@@ -701,6 +715,13 @@ const styles = {
     display: 'flex',
     gap: 4,
     alignItems: 'center',
+  },
+  flowDotOverflow: {
+    fontSize: 9,
+    fontWeight: 700,
+    color: theme.textMuted,
+    marginLeft: 2,
+    whiteSpace: 'nowrap',
   },
   flowConnector: {
     width: 16,

--- a/src/ui/src/components/__tests__/StreamView.test.jsx
+++ b/src/ui/src/components/__tests__/StreamView.test.jsx
@@ -1036,3 +1036,38 @@ describe('StageSection reconciled queued count (#9793)', () => {
     expect(queued.textContent).not.toContain('syncing')
   })
 })
+
+describe('PipelineFlow dot cap (#9863)', () => {
+  it('caps a large backlog at 10 dots with a +N overflow badge', () => {
+    const many = Array.from({ length: 67 }, (_, i) => ({
+      issue_number: 1000 + i,
+      title: `Q${i}`,
+      status: 'queued',
+    }))
+    mockUseHydraFlow.mockReturnValue(defaultHydraFlowContext({
+      pipelineIssues: { plan: many },
+    }))
+    render(<StreamView {...defaultProps} />)
+
+    const overflow = screen.getByTestId('flow-overflow-plan')
+    expect(overflow.textContent).toBe('+57')
+    // Only the capped dots render (first 10 issue numbers).
+    expect(screen.getByTestId('flow-dot-1009')).toBeTruthy()
+    expect(screen.queryByTestId('flow-dot-1010')).toBeNull()
+  })
+
+  it('renders no overflow badge at or under the cap', () => {
+    const few = Array.from({ length: 10 }, (_, i) => ({
+      issue_number: 2000 + i,
+      title: `Q${i}`,
+      status: 'queued',
+    }))
+    mockUseHydraFlow.mockReturnValue(defaultHydraFlowContext({
+      pipelineIssues: { plan: few },
+    }))
+    render(<StreamView {...defaultProps} />)
+
+    expect(screen.queryByTestId('flow-overflow-plan')).toBeNull()
+    expect(screen.getByTestId('flow-dot-2009')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Problem (#9863)

A large backlog (67 queued in PLAN) rendered 67 dots in one non-wrapping row, stretching the strip and pushing IMPLEMENT/REVIEW and the terminal fork off-screen.

## Change

Stages render at most 10 dots; the remainder shows as a **+N** badge with a hover title naming the stage. Count survives, layout survives.

## Tests

Cap+badge at 67 issues (first 10 dots render, +57 badge), no badge at/under the cap. Full UI suite green (1181). `make quality` exit 0.

Closes #9863

🤖 Generated with [Claude Code](https://claude.com/claude-code)