### PR TITLE
fix(diagnostic): transcript prose can no longer raise false credit exhaustion + HITL comment dedup (#9895)

### DIFF
--- a/src/base_runner.py
+++ b/src/base_runner.py
@@ -66,6 +66,12 @@ class BaseRunner:
 
     _log: ClassVar[logging.Logger]
     _phase_name: ClassVar[str] = "unknown"
+    # #9895: opt-out for scanning agent stdout prose for credit-exhaustion
+    # phrases. Runners whose agents ANALYZE failure transcripts (and thus
+    # quote credit-error prose) must set this False so only the CLI's own
+    # stderr signal can raise CreditExhaustedError. Mirrors the
+    # LONG_LLM_CYCLE ClassVar opt-in pattern.
+    CREDIT_PROSE_SCAN: ClassVar[bool] = True
 
     def __init__(
         self,
@@ -244,6 +250,7 @@ class BaseRunner:
                             usage_stats=usage_stats,
                             gh_token=self._credentials.gh_token,
                             trace_collector=trace_collector,
+                            credit_prose_scan=self.CREDIT_PROSE_SCAN,
                         ),
                     )
                     succeeded = True

--- a/src/diagnostic_loop.py
+++ b/src/diagnostic_loop.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import HydraFlowConfig
+from dedup_store import DedupStore
 from events import EventType, HydraFlowEvent
 from exception_classify import reraise_on_credit_or_bug
 from models import AttemptRecord, Severity
@@ -86,6 +88,14 @@ class DiagnosticLoop(BaseBackgroundLoop):
         self._prs = prs
         self._state = state
         self._workspaces = workspaces
+        # #9895 (absorbed #9845): during the 2026-06 exhaustion the loop
+        # posted ~33 identical no-op diagnosis comments on one issue. Keyed
+        # by issue + content hash, at most one key per issue (replaced when
+        # the diagnosis text changes), so re-runs re-post only NEW content.
+        self._hitl_comment_dedup = DedupStore(
+            "diagnostic_hitl_comments",
+            config.data_root / "dedup" / "diagnostic_hitl_comments.json",
+        )
 
     def _get_default_interval(self) -> int:
         return self._config.diagnostic_interval
@@ -443,14 +453,31 @@ class DiagnosticLoop(BaseBackgroundLoop):
         involved. The Auto-Agent routes a *resolved* diagnose-failed issue back
         to review.
         """
-        try:
-            await self._prs.post_comment(issue_number, comment)
-        except Exception:
-            logger.warning(
-                "Diagnostic: failed to post comment for issue #%d",
+        digest = hashlib.sha256(comment.encode("utf-8")).hexdigest()[:16]
+        dedup_key = f"{issue_number}:{digest}"
+        seen = self._hitl_comment_dedup.get()
+        if dedup_key in seen:
+            logger.info(
+                "Diagnostic: identical diagnosis comment already posted on "
+                "issue #%d — skipping re-post (labels still applied)",
                 issue_number,
-                exc_info=True,
             )
+        else:
+            try:
+                await self._prs.post_comment(issue_number, comment)
+            except Exception:
+                logger.warning(
+                    "Diagnostic: failed to post comment for issue #%d",
+                    issue_number,
+                    exc_info=True,
+                )
+            else:
+                # Replace any previous hash for this issue: bounded at one
+                # key per issue, and a CHANGED diagnosis re-posts.
+                prefix = f"{issue_number}:"
+                self._hitl_comment_dedup.set_all(
+                    {k for k in seen if not k.startswith(prefix)} | {dedup_key}
+                )
         try:
             await self._prs.swap_pipeline_labels(
                 issue_number, self._config.hitl_label[0]

--- a/src/diagnostic_runner.py
+++ b/src/diagnostic_runner.py
@@ -93,6 +93,12 @@ def _build_diagnosis_prompt(
 class DiagnosticRunner(BaseRunner):
     """Two-stage diagnostic agent: diagnose (read-only), then fix (in worktree)."""
 
+    # #9895: diagnosis agents quote credit-error prose from the failed
+    # issue's transcripts; scanning that prose raised a false global
+    # CreditExhaustedError on essentially every run (the flood that got
+    # this loop kill-switched). Structured/stderr credit signals still fire.
+    CREDIT_PROSE_SCAN = False
+
     _log = logger
 
     def _build_command(self, _worktree_path: Path | None = None) -> list[str]:

--- a/src/runner_utils.py
+++ b/src/runner_utils.py
@@ -87,6 +87,12 @@ class StreamConfig:
     usage_stats: dict[str, object] | None = field(default=None)
     gh_token: str = ""
     trace_collector: TraceCollector | None = None
+    # #9895: when False, credit exhaustion is detected from stderr (the
+    # CLI's own signal) only — agent stdout prose is NOT scanned. Runners
+    # that analyze failure transcripts (DiagnosticRunner) quote credit-error
+    # prose routinely; scanning it raised a false global CreditExhaustedError
+    # on essentially every diagnostic run (mirrors the _is_auth_failure rule).
+    credit_prose_scan: bool = True
 
 
 def _route_prompt_to_cmd(cmd: list[str], prompt: str) -> tuple[list[str], int]:
@@ -158,7 +164,11 @@ def _post_stream_result(
             "~/.gemini/settings.json / CODEX_HOME)"
         )
 
-    combined = f"{stderr_text}\n{accumulated_text}"
+    combined = (
+        f"{stderr_text}\n{accumulated_text}"
+        if config.credit_prose_scan
+        else stderr_text
+    )
     if not early_killed and is_credit_exhaustion(combined):
         resume_at = parse_credit_resume_time(combined)
         raise CreditExhaustedError("API credit limit reached", resume_at=resume_at)

--- a/tests/regressions/test_issue_9895_diagnostic_credit_prose.py
+++ b/tests/regressions/test_issue_9895_diagnostic_credit_prose.py
@@ -1,0 +1,159 @@
+"""Regression: diagnostic transcript prose raised false credit exhaustion (#9895).
+
+DiagnosticLoop analyzes FAILED issues' transcripts, which routinely quote
+credit-error prose ("usage limit reached", "credit balance is too low").
+The stream runner scanned stderr + accumulated stdout for those phrases, so
+essentially every diagnostic run raised a false global CreditExhaustedError
+— the flood (#9888) that got the loop kill-switched (#9898). Compounding it
+(absorbed #9845), ``_escalate_to_hitl`` posted unconditionally: ~33
+identical no-op diagnosis comments landed on one issue during the 2026-06
+exhaustion.
+
+Pins:
+- ``StreamConfig.credit_prose_scan=False`` limits credit detection to
+  stderr (the CLI's own signal); agent stdout prose cannot raise. True
+  (the default) keeps the old broad scan for every other runner.
+- ``DiagnosticRunner.CREDIT_PROSE_SCAN`` is False, ``BaseRunner``'s default
+  is True, and ``_execute`` threads the ClassVar into StreamConfig.
+- ``_escalate_to_hitl`` dedups identical comments per issue (bounded at one
+  hash key per issue; a CHANGED diagnosis re-posts and replaces the key).
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from base_runner import BaseRunner
+from diagnostic_loop import DiagnosticLoop
+from diagnostic_runner import DiagnosticRunner
+from runner_utils import StreamConfig, _post_stream_result
+from subprocess_util import CreditExhaustedError
+from tests.helpers import make_bg_loop_deps
+
+_CREDIT_PROSE = "the run failed because your credit balance is too low"
+
+
+def _post(*, accumulated: str = "", stderr: str = "", scan: bool) -> str:
+    return _post_stream_result(
+        raw_lines=[accumulated] if accumulated else [],
+        accumulated_text=accumulated,
+        result_text="analysis complete",
+        early_killed=False,
+        returncode=0,
+        stderr_text=stderr,
+        parser=MagicMock(),
+        config=StreamConfig(credit_prose_scan=scan),
+        logger=logging.getLogger("test"),
+    )
+
+
+class TestCreditProseScanFlag:
+    def test_prose_in_stdout_raises_under_default_scan(self) -> None:
+        with pytest.raises(CreditExhaustedError):
+            _post(accumulated=_CREDIT_PROSE, scan=True)
+
+    def test_prose_in_stdout_does_not_raise_when_scan_disabled(self) -> None:
+        transcript = _post(accumulated=_CREDIT_PROSE, scan=False)
+        assert transcript == "analysis complete"
+
+    def test_stderr_signal_still_raises_when_scan_disabled(self) -> None:
+        """The CLI's OWN billing failure must fire in both modes."""
+        with pytest.raises(CreditExhaustedError):
+            _post(stderr="Error: credit balance is too low", scan=False)
+
+
+class TestRunnerClassVarThreading:
+    def test_diagnostic_runner_opts_out_and_base_default_is_broad(self) -> None:
+        assert BaseRunner.CREDIT_PROSE_SCAN is True
+        assert DiagnosticRunner.CREDIT_PROSE_SCAN is False
+
+    @pytest.mark.asyncio
+    async def test_execute_threads_the_classvar_into_stream_config(
+        self, config, event_bus
+    ) -> None:
+        runner = DiagnosticRunner(config=config, event_bus=event_bus)
+        captured: dict[str, StreamConfig] = {}
+
+        async def fake_stream(**kwargs):
+            captured["config"] = kwargs["config"]
+            return "ok"
+
+        with patch("base_runner.stream_claude_process", side_effect=fake_stream):
+            await runner._execute(
+                ["claude", "-p"],
+                "prompt",
+                config.repo_root,
+                {"issue": 1, "source": "diagnostic"},
+            )
+
+        assert captured["config"].credit_prose_scan is False
+
+
+class TestEscalateCommentDedup:
+    def _make_loop(self, tmp_path: Path) -> tuple[DiagnosticLoop, MagicMock]:
+        deps = make_bg_loop_deps(tmp_path)
+        object.__setattr__(deps.config, "diagnostic_loop_enabled", True)
+        prs = MagicMock()
+        prs.post_comment = AsyncMock()
+        prs.swap_pipeline_labels = AsyncMock()
+        prs.add_labels = AsyncMock()
+        loop = DiagnosticLoop(
+            config=deps.config,
+            runner=MagicMock(),
+            prs=prs,
+            state=MagicMock(),
+            deps=deps.loop_deps,
+        )
+        return loop, prs
+
+    @pytest.mark.asyncio
+    async def test_identical_comment_posted_once(self, tmp_path: Path) -> None:
+        loop, prs = self._make_loop(tmp_path)
+
+        await loop._escalate_to_hitl(42, comment="same diagnosis")
+        await loop._escalate_to_hitl(42, comment="same diagnosis")
+
+        prs.post_comment.assert_awaited_once_with(42, "same diagnosis")
+        # Labeling still runs on every escalation (idempotent on GitHub).
+        assert prs.swap_pipeline_labels.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_changed_comment_reposts_and_replaces_key(
+        self, tmp_path: Path
+    ) -> None:
+        loop, prs = self._make_loop(tmp_path)
+
+        await loop._escalate_to_hitl(42, comment="first diagnosis")
+        await loop._escalate_to_hitl(42, comment="second diagnosis")
+
+        assert prs.post_comment.await_count == 2
+        # Bounded: exactly one dedup key per issue survives.
+        keys = {k for k in loop._hitl_comment_dedup.get() if k.startswith("42:")}
+        assert len(keys) == 1
+
+    @pytest.mark.asyncio
+    async def test_issues_are_deduped_independently(self, tmp_path: Path) -> None:
+        loop, prs = self._make_loop(tmp_path)
+
+        await loop._escalate_to_hitl(42, comment="same diagnosis")
+        await loop._escalate_to_hitl(43, comment="same diagnosis")
+
+        assert prs.post_comment.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_failed_post_is_not_marked_seen(self, tmp_path: Path) -> None:
+        """A failed comment post must retry next escalation, not dedup away."""
+        loop, prs = self._make_loop(tmp_path)
+        prs.post_comment.side_effect = [RuntimeError("gh down"), None]
+
+        await loop._escalate_to_hitl(42, comment="same diagnosis")
+        await loop._escalate_to_hitl(42, comment="same diagnosis")
+
+        assert prs.post_comment.await_count == 2


### PR DESCRIPTION
## Problem (#9895 re-enable checklist, items 1 + 4)

DiagnosticLoop analyzes FAILED issues' transcripts — which routinely quote credit-error prose ("usage limit reached", "credit balance is too low"). The stream runner scanned stderr + stdout prose for those phrases, so essentially every diagnostic run raised a false global `CreditExhaustedError` — the #9888 flood that got the loop kill-switched (#9898). Compounding it (absorbed #9845), `_escalate_to_hitl` posted unconditionally: ~33 identical no-op comments on one issue during the 2026-06 exhaustion.

## Fix

- **`StreamConfig.credit_prose_scan`** (default `True` — unchanged for every other runner): when `False`, credit detection reads **stderr only** — the CLI's own signal — mirroring the `_is_auth_failure` rule. `BaseRunner` threads a `CREDIT_PROSE_SCAN` ClassVar (the `LONG_LLM_CYCLE` opt-in pattern); `DiagnosticRunner` opts out.
- **`_escalate_to_hitl` content dedup** via `DedupStore`, keyed issue + content hash, bounded at ONE key per issue: identical re-escalations skip the post (labels still run — idempotent), a CHANGED diagnosis re-posts and replaces the key, a FAILED post is not marked seen.

`diagnostic_loop_enabled` default stays **OFF** — #9879 (Stage 1 blocks the event loop) is the remaining re-enable blocker.

## Tests

Regression pins: prose-in-stdout raises under default scan / cannot raise when disabled / stderr signal fires in both modes; ClassVar threading into StreamConfig via a captured `stream_claude_process`; dedup once/changed/per-issue/failed-post paths. Full `make quality` exit 0.

Relates #9895 (#9888 landed separately; #9879 remains open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)