### PR TITLE
fix(shutdown): reap ALL tracked subprocess groups on stop (#9911)

### DIFF
--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -40,6 +40,7 @@ from phase_utils import (
     log_exception_with_bug_classification,
     release_batch_in_flight,
 )
+from runner_utils import reap_all_tracked_processes
 from service_registry import (
     ServiceRegistry,
     WorkerRegistryCallbacks,
@@ -460,6 +461,17 @@ class HydraFlowOrchestrator:
         self._svc.agents.terminate()
         self._svc.reviewers.terminate()
         self._svc.hitl_runner.terminate()
+        # #9911: the four runner sets above are only part of the picture —
+        # acceptance_criteria / verification_judge / sentry / report_issue
+        # (and any future stream_claude_process caller) register in the
+        # runtime-wide registry; reap the union so nothing reparents to
+        # launchd and burns CPU after "idle".
+        reaped = reap_all_tracked_processes()
+        if reaped:
+            logger.info(
+                "Stop: reaped %d subprocess group(s) beyond the runner-owned sets",
+                reaped,
+            )
 
         # Checkpoint interrupted issues before cancelling tasks
         interrupted = await self._build_interrupted_issues()
@@ -1414,6 +1426,10 @@ class HydraFlowOrchestrator:
             for task in tasks.values():
                 task.cancel()
             await asyncio.gather(*tasks.values(), return_exceptions=True)
+            # #9911: cancelled loop bodies unwind without running their
+            # subprocess cleanup when cancellation lands inside wait_for;
+            # reap whatever the drained loops left behind.
+            reap_all_tracked_processes()
 
     async def _polling_loop(
         self,
@@ -1884,6 +1900,7 @@ class HydraFlowOrchestrator:
         self._svc.agents.terminate()
         self._svc.reviewers.terminate()
         self._svc.hitl_runner.terminate()
+        reap_all_tracked_processes()
 
     async def _sleep_until_resume(self, resume_at: datetime) -> None:
         """Sleep until *resume_at* (interruptible by stop or credit-resume event)."""

--- a/src/runner_utils.py
+++ b/src/runner_utils.py
@@ -381,8 +381,14 @@ def _kill_proc_group(proc: asyncio.subprocess.Process) -> None:
     grandchildren (sub-make, pytest workers) to launchd (#9911).
     """
     with contextlib.suppress(ProcessLookupError, OSError):
-        if proc.pid is not None:
-            os.killpg(proc.pid, signal.SIGKILL)
+        pid = proc.pid
+        # Group-kill ONLY for a real positive pid. Mock procs' auto-created
+        # .pid coerces to 1 via __index__, so an unguarded killpg would
+        # signal pgid 1 (or, for a pid-0 fake, the CALLER'S OWN group —
+        # killing the test runner mid-suite; the CI smoke-job deaths on
+        # #10002). Same guard the #9648 run_simple fix landed.
+        if isinstance(pid, int) and pid > 0:
+            os.killpg(pid, signal.SIGKILL)
         else:
             proc.kill()
 

--- a/src/runner_utils.py
+++ b/src/runner_utils.py
@@ -218,10 +218,9 @@ async def _stream_and_collect(
             and config.on_output(accumulated_text)
         ):
             early_killed = True
-            # The process may have already exited between the last read and
-            # this kill; suppress ProcessLookupError so it does not escape.
-            with contextlib.suppress(ProcessLookupError, OSError):
-                proc.kill()
+            # Group kill (self-suppressing): the early-kill previously
+            # reaped only the direct child, leaking its group (#9911).
+            _kill_proc_group(proc)
             break
 
         # Emit structured activity event (additive — does not replace TRANSCRIPT_LINE)
@@ -315,6 +314,7 @@ async def stream_claude_process(
         start_new_session=True,  # Own process group for reliable cleanup
     )
     active_procs.add(proc)
+    _ALL_TRACKED_PROCS.add(proc)
 
     stderr_task: asyncio.Task[bytes] | None = None
     try:
@@ -357,30 +357,63 @@ async def stream_claude_process(
         # process raises ProcessLookupError out of the cleanup path. Mirror the
         # guard in terminate_processes().
         with contextlib.suppress(ProcessLookupError, OSError):
-            proc.kill()
+            _kill_proc_group(proc)
             await proc.wait()
         raise RuntimeError(f"Agent process timed out after {config.timeout}s") from exc
     except asyncio.CancelledError:
-        # On cancellation the process may already have exited; suppress
-        # ProcessLookupError so it does not escape the cancel path.
-        with contextlib.suppress(ProcessLookupError, OSError):
-            proc.kill()
+        # On cancellation the process may already have exited; the group
+        # kill is self-suppressing (#9911: group, not just the child).
+        _kill_proc_group(proc)
         raise
     finally:
         if stderr_task is not None and not stderr_task.done():
             stderr_task.cancel()
             await asyncio.gather(stderr_task, return_exceptions=True)
         active_procs.discard(proc)
+        _ALL_TRACKED_PROCS.discard(proc)
+
+
+def _kill_proc_group(proc: asyncio.subprocess.Process) -> None:
+    """SIGKILL *proc*'s whole process group (best-effort, never raises).
+
+    Every spawn in this module uses ``start_new_session=True`` so pid ==
+    pgid; a plain ``proc.kill()`` reaps only the direct child and leaks
+    grandchildren (sub-make, pytest workers) to launchd (#9911).
+    """
+    with contextlib.suppress(ProcessLookupError, OSError):
+        if proc.pid is not None:
+            os.killpg(proc.pid, signal.SIGKILL)
+        else:
+            proc.kill()
 
 
 def terminate_processes(active_procs: set[asyncio.subprocess.Process]) -> None:
     """Kill all processes in *active_procs* and their process groups."""
     for proc in list(active_procs):
-        with contextlib.suppress(ProcessLookupError, OSError):
-            if proc.pid is not None:
-                os.killpg(proc.pid, signal.SIGKILL)
-            else:
-                proc.kill()
+        _kill_proc_group(proc)
+
+
+# #9911: runtime-wide registry of every live agent subprocess. Per-caller
+# ``active_procs`` ownership is fragmented (four runners the stop path
+# terminates, plus acceptance_criteria / verification_judge / sentry /
+# report_issue sets it never reached — two of those owners have no
+# terminate() at all), so stopping the runtime orphaned their children to
+# launchd for the length of a pytest/make run. stream_claude_process
+# registers every spawn here; the stop/shutdown path reaps the union.
+_ALL_TRACKED_PROCS: set[asyncio.subprocess.Process] = set()
+
+
+def reap_all_tracked_processes() -> int:
+    """SIGKILL the process group of every tracked live subprocess (#9911).
+
+    Returns the number of process groups reaped. Idempotent: group kills
+    are best-effort and already-dead groups are suppressed.
+    """
+    live = [proc for proc in list(_ALL_TRACKED_PROCS) if proc.returncode is None]
+    for proc in live:
+        _kill_proc_group(proc)
+    _ALL_TRACKED_PROCS.clear()
+    return len(live)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -111,6 +111,14 @@ def make_streaming_proc(
     """Build a mock for asyncio.create_subprocess_exec with streaming stdout."""
     mock_proc = MagicMock()
     mock_proc.returncode = returncode
+    # #9911: keep .pid None so any early-kill/timeout reap goes through the
+    # ``proc.pid is None`` branch of runner_utils._kill_proc_group() and calls
+    # the harmless mock ``proc.kill()`` — NOT the real ``os.killpg``. A bare
+    # MagicMock().pid coerces (via __index__) to 1, which would fire
+    # ``os.killpg(1, SIGKILL)`` at init's process group; on Linux CI that
+    # wedged the whole run while passing silently on macOS. Mirrors
+    # docker_runner._FakeProcess, which also defaults pid=None.
+    mock_proc.pid = None
     # stdin.write and stdin.close are sync on StreamWriter; drain is async
     mock_proc.stdin = MagicMock()
     mock_proc.stdin.drain = AsyncMock()

--- a/tests/regressions/test_issue_9911_stop_path_reap.py
+++ b/tests/regressions/test_issue_9911_stop_path_reap.py
@@ -1,0 +1,200 @@
+"""Regression: stop/shutdown path orphaned in-flight subprocesses (#9911).
+
+After "Stop requested — terminating active processes" the runtime reported
+idle, yet a full pytest run spawned by a loop cycle was still alive 22
+minutes later (PID 11989, PPID=1, ELAPSED 52:11) — reparented to launchd,
+its result unconsumable. The stop path terminated only the four
+runner-owned ``_active_procs`` sets; acceptance_criteria,
+verification_judge, sentry_loop and report_issue_loop children (the latter
+two owners have no ``terminate()`` at all) were never reaped, and three
+kill sites used plain ``proc.kill()`` which leaks the process GROUP.
+
+Pins:
+- ``_ALL_TRACKED_PROCS``: every ``stream_claude_process`` spawn registers
+  and deregisters, regardless of which owner's set was passed in.
+- ``reap_all_tracked_processes`` SIGKILLs the whole group of live tracked
+  children (real-subprocess grandchild test — mocks cannot prove a group
+  died) and skips already-exited ones.
+- The timeout / cancel / on_output-early-kill sites group-kill.
+- ``orchestrator.stop()``, ``_supervise_loops``'s finally drain, and
+  ``_cancel_all_loops_and_runners`` all invoke the shared reaper.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import runner_utils
+from orchestrator import HydraFlowOrchestrator
+from runner_utils import reap_all_tracked_processes
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+class _FakeProc:
+    """Minimal proc fake — MUST expose .pid (the #9983 _DeadProc lesson:
+    killpg-based reapers touch .pid, and AttributeError is not caught by
+    the ProcessLookupError/OSError suppression)."""
+
+    def __init__(self, pid: int = 424242, returncode: int | None = None) -> None:
+        self.pid = pid
+        self.returncode = returncode
+        self.killed = False
+
+    def kill(self) -> None:
+        self.killed = True
+
+
+class TestReapAllTrackedProcesses:
+    def test_real_process_group_is_torn_down(self, tmp_path: Path) -> None:
+        """A tracked child's GRANDCHILD dies too — group kill, not child kill."""
+        pidfile = tmp_path / "grandchild.pid"
+        proc = subprocess.Popen(
+            ["bash", "-c", f"sleep 300 & echo $! > {pidfile}; wait"],
+            start_new_session=True,
+        )
+        try:
+            deadline = time.monotonic() + 5
+            while not pidfile.exists() and time.monotonic() < deadline:
+                time.sleep(0.05)
+            grandchild = int(pidfile.read_text().strip())
+            assert _pid_alive(grandchild)
+
+            fake = _FakeProc(pid=proc.pid, returncode=None)
+            runner_utils._ALL_TRACKED_PROCS.add(fake)  # type: ignore[arg-type]
+
+            reaped = reap_all_tracked_processes()
+
+            assert reaped == 1
+            deadline = time.monotonic() + 5
+            while _pid_alive(grandchild) and time.monotonic() < deadline:
+                time.sleep(0.05)
+            assert not _pid_alive(grandchild), "grandchild survived the group kill"
+            assert not runner_utils._ALL_TRACKED_PROCS
+        finally:
+            with contextlib.suppress(ProcessLookupError, OSError):
+                os.killpg(proc.pid, signal.SIGKILL)
+            proc.wait()
+
+    def test_already_exited_children_are_skipped(self) -> None:
+        exited = _FakeProc(pid=111, returncode=0)
+        runner_utils._ALL_TRACKED_PROCS.add(exited)  # type: ignore[arg-type]
+
+        with patch("runner_utils.os.killpg") as killpg:
+            reaped = reap_all_tracked_processes()
+
+        assert reaped == 0
+        killpg.assert_not_called()
+        assert not runner_utils._ALL_TRACKED_PROCS
+
+    def test_live_children_group_killed_via_killpg(self) -> None:
+        live = _FakeProc(pid=4242, returncode=None)
+        runner_utils._ALL_TRACKED_PROCS.add(live)  # type: ignore[arg-type]
+
+        with patch("runner_utils.os.killpg") as killpg:
+            reaped = reap_all_tracked_processes()
+
+        assert reaped == 1
+        killpg.assert_called_once_with(4242, signal.SIGKILL)
+        assert live.killed is False  # group kill, not the child-only fallback
+
+
+class TestStreamRegistersEverySpawn:
+    @pytest.mark.asyncio
+    async def test_spawn_registers_and_finally_deregisters(self) -> None:
+        """The runtime-wide registry sees the proc while running, not after."""
+        from runner_utils import StreamConfig, stream_claude_process
+
+        seen_during: list[bool] = []
+
+        class _Recorder:
+            async def run_simple(self, *args, **kwargs):  # pragma: no cover
+                raise NotImplementedError
+
+            async def cleanup(self) -> None:  # protocol conformance
+                return None
+
+            async def create_streaming_process(self, *args, **kwargs):
+                proc = MagicMock()
+                proc.pid = 777
+                proc.returncode = 0
+
+                async def _aiter():
+                    seen_during.append(proc in runner_utils._ALL_TRACKED_PROCS)
+                    return
+                    yield  # pragma: no cover
+
+                proc.stdout = _aiter()
+                proc.stderr = MagicMock()
+                proc.stderr.read = AsyncMock(return_value=b"")
+                proc.wait = AsyncMock(return_value=0)
+                return proc
+
+        await stream_claude_process(
+            cmd=["claude", "-p"],
+            prompt="x",
+            cwd=Path.cwd(),
+            active_procs=set(),
+            event_bus=MagicMock(publish=AsyncMock()),
+            event_data={"issue": 1, "source": "test"},
+            logger=MagicMock(),
+            config=StreamConfig(runner=_Recorder(), timeout=5),
+        )
+
+        assert seen_during == [True]
+        assert not runner_utils._ALL_TRACKED_PROCS
+
+
+class TestOrchestratorHooksInvokeReaper:
+    def _orch(self, config) -> HydraFlowOrchestrator:
+        orch = HydraFlowOrchestrator(config)
+        orch._svc = MagicMock()
+        orch._state = MagicMock()
+        orch._loop_tasks = {}
+        return orch
+
+    @pytest.mark.asyncio
+    async def test_stop_reaps_tracked_registry(self, config) -> None:
+        orch = self._orch(config)
+        with (
+            patch.object(orch, "_build_interrupted_issues", AsyncMock(return_value=[])),
+            patch("orchestrator.reap_all_tracked_processes", return_value=2) as reap,
+        ):
+            await orch.stop()
+
+        reap.assert_called_once()
+        orch._svc.planners.terminate.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cancel_all_loops_and_runners_reaps(self, config) -> None:
+        orch = self._orch(config)
+
+        async def _noop() -> None:
+            await asyncio.sleep(0)
+
+        task = asyncio.create_task(_noop())
+        with patch("orchestrator.reap_all_tracked_processes") as reap:
+            await orch._cancel_all_loops_and_runners({"x": task})
+
+        reap.assert_called_once()
+

--- a/tests/test_runner_utils.py
+++ b/tests/test_runner_utils.py
@@ -442,6 +442,7 @@ class TestStreamClaudeProcessLifecycle:
 
         mock_proc = AsyncMock()
         mock_proc.returncode = 0
+        mock_proc.pid = 4242
         mock_proc.stdin = MagicMock()
         mock_proc.stdin.drain = AsyncMock()
         mock_proc.stdout = CancellingIter()
@@ -455,13 +456,15 @@ class TestStreamClaudeProcessLifecycle:
 
         with (
             patch("asyncio.create_subprocess_exec", mock_create),
+            patch("runner_utils.os.killpg") as mock_killpg,
             pytest.raises(asyncio.CancelledError),
         ):
             await stream_claude_process(
                 **_default_kwargs(event_bus, active_procs=active_procs)
             )
 
-        mock_proc.kill.assert_called_once()
+        # #9911: group kill, not the child-only proc.kill().
+        mock_killpg.assert_called_once_with(4242, signal.SIGKILL)
         assert mock_proc not in active_procs
 
     @pytest.mark.asyncio
@@ -484,6 +487,7 @@ class TestStreamClaudeProcessLifecycle:
 
         mock_proc = AsyncMock()
         mock_proc.returncode = None
+        mock_proc.pid = 4242
         mock_proc.stdin = MagicMock()
         mock_proc.stdin.drain = AsyncMock()
         mock_proc.stdout = HangingIter()
@@ -496,6 +500,7 @@ class TestStreamClaudeProcessLifecycle:
 
         with (
             patch("asyncio.create_subprocess_exec", mock_create),
+            patch("runner_utils.os.killpg") as mock_killpg,
             pytest.raises(RuntimeError, match="timed out"),
         ):
             await stream_claude_process(
@@ -515,7 +520,8 @@ class TestStreamClaudeProcessLifecycle:
         pending = [t for t in asyncio.all_tasks() if t is not current and not t.done()]
         assert not pending, f"stderr_task was not cleaned up: {pending}"
 
-        mock_proc.kill.assert_called()
+        # #9911: the timeout path group-kills via killpg, not proc.kill().
+        mock_killpg.assert_called_with(4242, signal.SIGKILL)
         mock_proc.wait.assert_awaited()
 
     @pytest.mark.asyncio
@@ -572,6 +578,7 @@ class TestStreamClaudeProcessLifecycle:
 
         mock_proc = AsyncMock()
         mock_proc.returncode = 0
+        mock_proc.pid = 4242
         mock_proc.stdin = MagicMock()
         mock_proc.stdin.drain = AsyncMock()
         mock_proc.stdout = CancellingIter()
@@ -584,6 +591,7 @@ class TestStreamClaudeProcessLifecycle:
 
         with (
             patch("asyncio.create_subprocess_exec", mock_create),
+            patch("runner_utils.os.killpg") as mock_killpg,
             pytest.raises(asyncio.CancelledError),
         ):
             await stream_claude_process(**_default_kwargs(event_bus))
@@ -603,7 +611,8 @@ class TestStreamClaudeProcessLifecycle:
             f"stderr_task was not cleaned up on CancelledError: {pending}"
         )
 
-        mock_proc.kill.assert_called_once()
+        # #9911: the cancel path group-kills via killpg, not proc.kill().
+        mock_killpg.assert_called_once_with(4242, signal.SIGKILL)
 
     @pytest.mark.asyncio
     async def test_timeout_suppresses_process_lookup_error_on_kill(
@@ -626,6 +635,7 @@ class TestStreamClaudeProcessLifecycle:
 
         mock_proc = AsyncMock()
         mock_proc.returncode = None
+        mock_proc.pid = 4242
         mock_proc.stdin = MagicMock()
         mock_proc.stdin.drain = AsyncMock()
         mock_proc.stdout = HangingIter()
@@ -639,6 +649,11 @@ class TestStreamClaudeProcessLifecycle:
 
         with (
             patch("asyncio.create_subprocess_exec", mock_create),
+            # #9911: the group is already gone — killpg raises, and the
+            # timeout handler must still raise RuntimeError, not leak it.
+            patch(
+                "runner_utils.os.killpg", side_effect=ProcessLookupError
+            ) as mock_killpg,
             pytest.raises(RuntimeError, match="timed out"),
         ):
             await stream_claude_process(
@@ -646,7 +661,7 @@ class TestStreamClaudeProcessLifecycle:
                 config=StreamConfig(timeout=0.01),
             )
 
-        mock_proc.kill.assert_called_once()
+        mock_killpg.assert_called_once_with(4242, signal.SIGKILL)
         assert mock_proc not in active_procs
 
     @pytest.mark.asyncio
@@ -670,6 +685,7 @@ class TestStreamClaudeProcessLifecycle:
 
         mock_proc = AsyncMock()
         mock_proc.returncode = 0
+        mock_proc.pid = 4242
         mock_proc.stdin = MagicMock()
         mock_proc.stdin.drain = AsyncMock()
         mock_proc.stdout = CancellingIter()
@@ -683,13 +699,16 @@ class TestStreamClaudeProcessLifecycle:
 
         with (
             patch("asyncio.create_subprocess_exec", mock_create),
+            patch(
+                "runner_utils.os.killpg", side_effect=ProcessLookupError
+            ) as mock_killpg,
             pytest.raises(asyncio.CancelledError),
         ):
             await stream_claude_process(
                 **_default_kwargs(event_bus, active_procs=active_procs)
             )
 
-        mock_proc.kill.assert_called_once()
+        mock_killpg.assert_called_once_with(4242, signal.SIGKILL)
         assert mock_proc not in active_procs
 
     @pytest.mark.asyncio
@@ -838,6 +857,7 @@ class TestStreamClaudeProcessTimeout:
 
         mock_proc = AsyncMock()
         mock_proc.returncode = None
+        mock_proc.pid = 4242
         mock_proc.stdin = MagicMock()
         mock_proc.stdin.drain = AsyncMock()
         mock_proc.stdout = HangingIter()
@@ -851,6 +871,7 @@ class TestStreamClaudeProcessTimeout:
 
         with (
             patch("asyncio.create_subprocess_exec", mock_create),
+            patch("runner_utils.os.killpg") as mock_killpg,
             pytest.raises(RuntimeError, match="timed out after 0.01s"),
         ):
             await stream_claude_process(
@@ -858,7 +879,8 @@ class TestStreamClaudeProcessTimeout:
                 config=StreamConfig(timeout=0.01),
             )
 
-        mock_proc.kill.assert_called_once()
+        # #9911: group kill, not the child-only proc.kill().
+        mock_killpg.assert_called_once_with(4242, signal.SIGKILL)
 
     @pytest.mark.asyncio
     async def test_timeout_cleans_up_active_procs(self, event_bus) -> None:

--- a/tests/test_runner_utils.py
+++ b/tests/test_runner_utils.py
@@ -538,6 +538,13 @@ class TestStreamClaudeProcessLifecycle:
 
         mock_proc = AsyncMock()
         mock_proc.returncode = None
+        # #9911: a concrete int pid is load-bearing. Without it, AsyncMock's
+        # auto-attribute .pid coerces (via __index__) to 1, so the timeout
+        # reap's _kill_proc_group() calls the REAL os.killpg(1, SIGKILL) —
+        # signalling init's process group. On Linux CI (where pytest shares
+        # that group) this wedged the whole run; on macOS it was benign, so
+        # the test passed there and the hang only surfaced in CI.
+        mock_proc.pid = 4242
         mock_proc.stdin = MagicMock()
         mock_proc.stdin.drain = AsyncMock()
         mock_proc.stdout = HangingIter()
@@ -550,6 +557,7 @@ class TestStreamClaudeProcessLifecycle:
 
         with (
             patch("asyncio.create_subprocess_exec", mock_create),
+            patch("runner_utils.os.killpg"),
             pytest.raises(RuntimeError, match="timed out") as exc_info,
         ):
             await stream_claude_process(
@@ -898,6 +906,10 @@ class TestStreamClaudeProcessTimeout:
 
         mock_proc = AsyncMock()
         mock_proc.returncode = None
+        # #9911: concrete int pid + patched killpg, else the timeout reap's
+        # _kill_proc_group() calls the REAL os.killpg on AsyncMock().pid
+        # (which coerces to 1 = init's group) and wedges Linux CI.
+        mock_proc.pid = 4242
         mock_proc.stdin = MagicMock()
         mock_proc.stdin.drain = AsyncMock()
         mock_proc.stdout = HangingIter()
@@ -911,6 +923,7 @@ class TestStreamClaudeProcessTimeout:
 
         with (
             patch("asyncio.create_subprocess_exec", mock_create),
+            patch("runner_utils.os.killpg"),
             pytest.raises(RuntimeError),
         ):
             await stream_claude_process(


### PR DESCRIPTION
## Problem (#9911)

After 'Stop requested — terminating active processes' the runtime reported idle while a loop-spawned pytest run lived on for **52+ minutes at PPID=1**. Two gaps:

1. The stop path terminated only the four runner-owned `_active_procs` sets — acceptance_criteria, verification_judge, sentry_loop and report_issue_loop children were never reaped (the latter two owners have no `terminate()` at all).
2. The timeout / cancel / on_output-early-kill sites used plain `proc.kill()`, which reaps the direct child but leaks its process GROUP (sub-make, pytest workers) — even though every spawn already uses `start_new_session=True`.

## Fix

- **Runtime-wide registry** in runner_utils: every `stream_claude_process` spawn registers/deregisters in `_ALL_TRACKED_PROCS` regardless of owner; `reap_all_tracked_processes()` group-SIGKILLs the live union.
- The three plain-kill sites route through the shared `_kill_proc_group` helper.
- `orchestrator.stop()`, the `_supervise_loops` finally drain (#9556 model), and `_cancel_all_loops_and_runners` all invoke the shared reaper after task cancellation.

**Follow-up (same issue, after #9983 merges):** register `HostRunner.run_simple`/`run_subprocess` children in the same registry — today they are only reaped by their own timeout.

## Tests

Real-subprocess grandchild reap (mocks cannot prove a group died), registry lifecycle through `stream_claude_process`, killpg routing pins for all three kill sites, orchestrator hook pins. Six stale `proc.kill` assertions re-pinned onto `killpg` — MagicMock auto-`.pid` satisfies `__index__`, so the old pins silently exercised the wrong branch. Full `make quality` exit 0.

Relates #9911 (follow-up commit pending #9983)

🤖 Generated with [Claude Code](https://claude.com/claude-code)