### PR TITLE
feat(plan): execution-brief plan contract — prompt is the lever, zero truncation (#9955)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -106,7 +106,8 @@ class ManagedRepo(BaseModel):
 # Each tuple: (field_name, env_var_key, default_value)
 _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
     ("dashboard_port", "HYDRAFLOW_DASHBOARD_PORT", 5555),
-    ("min_plan_words", "HYDRAFLOW_MIN_PLAN_WORDS", 200),
+    ("min_plan_words", "HYDRAFLOW_MIN_PLAN_WORDS", 60),
+    ("max_plan_chars", "HYDRAFLOW_MAX_PLAN_CHARS", 5000),
     (
         "max_pre_quality_review_attempts",
         "HYDRAFLOW_MAX_PRE_QUALITY_REVIEW_ATTEMPTS",
@@ -1552,10 +1553,23 @@ class HydraFlowConfig(BaseModel):
         ),
     )
     min_plan_words: int = Field(
-        default=200,
-        ge=50,
+        default=60,
+        ge=20,
         le=2000,
-        description="Minimum word count for a valid plan",
+        description=(
+            "Minimum word count for a valid plan — a floor that rejects only "
+            "empty/skeletal plans; concise-but-complete briefs pass (#9955)"
+        ),
+    )
+    max_plan_chars: int = Field(
+        default=5000,
+        ge=1000,
+        le=45000,
+        description=(
+            "Hard character budget for a plan (#9955). Kept BELOW "
+            "max_impl_plan_chars so the implement boundary never truncates — "
+            "truncation is information loss the plan phase paid latency for."
+        ),
     )
     max_new_files_warning: int = Field(
         default=5,

--- a/src/plan_constants.py
+++ b/src/plan_constants.py
@@ -10,6 +10,14 @@ PlanScale = Literal["lite", "full"]
 # Each entry is (header, description).  Order matches the desired prompt order.
 PLAN_SECTION_DESCRIPTIONS: tuple[tuple[str, str], ...] = (
     (
+        "## Intent",
+        "1-2 sentences: what outcome this change produces and why (#9955 brief shape)",
+    ),
+    (
+        "## Approach",
+        "one short paragraph: the chosen approach and the key decision(s) behind it",
+    ),
+    (
         "## Files to Modify",
         "list each existing file and what changes are needed "
         "(must reference at least one file path)",
@@ -59,6 +67,8 @@ PLAN_SECTION_DESCRIPTIONS: tuple[tuple[str, str], ...] = (
 )
 
 REQUIRED_SECTIONS: tuple[str, ...] = (
+    "## Intent",
+    "## Approach",
     "## Files to Modify",
     "## New Files",
     "## File Delta",
@@ -69,6 +79,7 @@ REQUIRED_SECTIONS: tuple[str, ...] = (
 )
 
 LITE_REQUIRED_SECTIONS: tuple[str, ...] = (
+    "## Intent",
     "## Files to Modify",
     "## Implementation Steps",
     "## Testing Strategy",

--- a/src/plan_council_prompts.py
+++ b/src/plan_council_prompts.py
@@ -20,6 +20,8 @@ Flag anything that prevents that:
 
 You do NOT critique scope or test coverage; other voters handle those. You critique buildability from the plan as written.
 
+The plan is a SHORT execution brief by design (#9955): task-granularity steps + checkable acceptance criteria, inside a hard character budget. Brevity is NOT a finding — flag a step only when you would have to GUESS to begin, never because you would have to read code you were going to read anyway. "Add more detail" is not a valid concern; "criterion X is not checkable" or "step Y has no concrete target" is.
+
 Output strict JSON: {"findings": [{"severity": "CRITICAL|HIGH|MEDIUM|LOW", "concern": "..."}]}
 """
 

--- a/src/plan_validation.py
+++ b/src/plan_validation.py
@@ -189,6 +189,20 @@ def validate_plan(
         if word_count < min_words:
             errors.append(f"Plan has {word_count} words, minimum is {min_words}")
 
+    # --- Hard character budget (#9955) ---
+    # Effective budget never exceeds the implement boundary: anything past
+    # max_impl_plan_chars is TRUNCATED before the implementer sees it, so
+    # detail beyond the budget is paid-for-then-discarded information loss.
+    max_chars = min(config.max_plan_chars, config.max_impl_plan_chars)
+    if len(plan) > max_chars:
+        errors.append(
+            f"Plan is {len(plan)} chars, budget is {max_chars} — condense to "
+            "the execution-brief shape (intent / approach / touched areas / "
+            "task-granularity steps / checkable acceptance criteria). "
+            "Line-by-line detail is re-derived in-context by the implementer; "
+            "past the budget it is truncated and wasted."
+        )
+
     # --- [NEEDS CLARIFICATION] marker count ---
     clarification_markers = re.findall(
         r"\[NEEDS CLARIFICATION(?::\s*[^\]]+)?\]", plan, re.IGNORECASE

--- a/src/planner.py
+++ b/src/planner.py
@@ -537,10 +537,11 @@ Use semantic tools first (before grep):
 ## Required Output
 
 Your plan is a SHORT EXECUTION BRIEF: reviewed-and-ready-to-execute, with
-criteria to check — NOT a specification. Shape: ## Intent (1-2 sentences),
-## Approach (one short paragraph), the file sections, a task-granularity
-## Task Graph, and CHECKABLE ## Acceptance Criteria (each item something
-the implement and review phases can verify true/false).
+criteria to check — NOT a specification. Lead with intent (1-2 sentences)
+and approach (one short paragraph), keep steps at task granularity, and
+make every acceptance criterion CHECKABLE — something the implement and
+review phases can verify true/false. The required sections for this plan
+scale are listed below.
 
 HARD BUDGET: the entire plan must fit in {max_plan_chars} characters.
 Plans over budget are rejected; detail beyond the budget would be truncated

--- a/src/planner.py
+++ b/src/planner.py
@@ -455,6 +455,12 @@ class PlannerRunner(BaseRunner):
         if section_chars_saved:
             self._last_context_stats["section_dedup_chars_saved"] = section_chars_saved
 
+        # #9955: the budget shown to the agent is the ENFORCED one — never
+        # above the implement boundary, so nothing written is ever truncated.
+        max_plan_chars = min(
+            self._config.max_plan_chars, self._config.max_impl_plan_chars
+        )
+
         prompt = f"""You are a planning agent for GitHub issue #{issue.id}.
 
 ## Issue: {issue.title}
@@ -497,11 +503,18 @@ Use semantic tools first (before grep):
 3. Map the code topology — trace call graphs, data flows, and component boundaries.
    Write LikeC4 diagram files (.likec4) to `/tmp/hydraflow-diagrams/issue-{issue.id}/`
    capturing the C4 model (specification, model, views) for the change area.
-4. Identify concrete file-level deltas.
-5. Build a Task Graph with dependency-ordered phases (full plans only).
-6. Write behavioral test specs for each phase — describe observable outcomes, not test code.
+4. Identify concrete file-level deltas (paths and what changes — not diffs).
+5. Build a Task Graph with dependency-ordered phases at TASK granularity
+   (full plans only). One phase = one coherent task an implementer executes
+   in-context with the actual code open. Do NOT write line-by-line
+   instructions or code snippets — the implementer re-derives that detail
+   from the live code, so it costs plan latency twice and goes stale once
+   (upstream drift). A code fragment belongs in a plan only when it is
+   itself load-bearing (an exact signature, wire format, or invariant).
+6. Write behavioral test specs for each phase — one line each, observable
+   outcomes, not test code.
 7. For UI work, call out reusable components/shared modules (`constants.js`, `types.js`, `theme.js`).
-8. **Principles (ADR-0044).** Before declaring the plan done, check each item. Missing any of these in the plan is cheaper to fix now than at review:
+8. **Principles (ADR-0044).** Before declaring the plan done, VERIFY the brief against each item — fix by adjusting steps/criteria, not by expanding prose. Missing any of these in the plan is cheaper to fix now than at review:
    - **MockWorld scenario coverage:** if the change crosses phases or touches orchestrator/runner behaviour, add a release-gating scenario under `tests/scenarios/` that uses `MockWorld` fakes (no real subprocess / GitHub / git). Name the scenario after the behaviour, not the code.
    - **TDD + behavioral test names:** every phase's **Tests:** entries must describe observable behaviour (given/when/then-style), not function names. "POST /widgets with missing name returns 400" — good. "Test create_widget" — bad.
    - **Hexagonal Ports:** new GitHub / git / worktree / subprocess calls must go through `PRPort`, `IssueStorePort`, or `WorkspacePort`. If your plan introduces a direct `subprocess.run`, `gh`, or `git` call in a non-adapter file, route it through the existing Port (or extend the Port) instead.
@@ -511,9 +524,9 @@ Use semantic tools first (before grep):
      `BaseBackgroundLoop` subclass or subprocess-spawning runner MUST include the
      ADR-0049 kill-switch (`HYDRAFLOW_DISABLE_<WORKER>_LOOP` env + in-body
      `enabled_cb` gate); `run_phase_gates` rejects plans that omit it.
-9. **Audit the plan against `docs/wiki/gotchas.md`.** Every code snippet,
-   test fixture, and cross-module import in your plan must avoid the anti-patterns
-   listed there. Specifically check: symbols imported across modules do not start
+9. **Audit the plan against `docs/wiki/gotchas.md`.** Anything your plan
+   directs (fixtures, imports, logging idioms) must avoid the anti-patterns
+   listed there — note a violation risk as one line under Key Considerations. Specifically check: symbols imported across modules do not start
    with `_`; test helpers do not duplicate ones in `tests/conftest.py` (grep first);
    `logger.error` / `logger.warning` calls pass a literal format string, not a bare
    variable; hardcoded path lists that mirror filesystem or Dockerfile state are
@@ -523,10 +536,21 @@ Use semantic tools first (before grep):
 
 ## Required Output
 
+Your plan is a SHORT EXECUTION BRIEF: reviewed-and-ready-to-execute, with
+criteria to check — NOT a specification. Shape: ## Intent (1-2 sentences),
+## Approach (one short paragraph), the file sections, a task-granularity
+## Task Graph, and CHECKABLE ## Acceptance Criteria (each item something
+the implement and review phases can verify true/false).
+
+HARD BUDGET: the entire plan must fit in {max_plan_chars} characters.
+Plans over budget are rejected; detail beyond the budget would be truncated
+before the implementer ever saw it. Spend the budget on decisions and
+criteria, not restated code.
+
 Output your plan between these exact markers:
 
 PLAN_START
-<your detailed implementation plan here>
+<your execution brief here — required sections, within budget>
 PLAN_END
 
 Then provide a one-line summary:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -251,7 +251,7 @@ class ConfigFactory:
         triage_model: str = "haiku",
         triage_max_turns: int = 3,
         auditor_finding_max_age_days: int = 14,
-        min_plan_words: int = 200,
+        min_plan_words: int = 60,
         max_new_files_warning: int = 5,
         lite_plan_labels: list[str] | None = None,
         repo: str = "test-org/test-repo",

--- a/tests/regressions/test_issue_9955_plan_brief.py
+++ b/tests/regressions/test_issue_9955_plan_brief.py
@@ -1,0 +1,157 @@
+"""Regression: plan phase over-produced detail that the pipeline discarded (#9955).
+
+min_plan_words=200 FORCED verbosity while max_impl_plan_chars=6000 truncated
+the plan before the implementer saw it — the pipeline required detail and
+then threw it away (paid-for information loss). The prompt itself
+manufactured the verbosity ("<your detailed implementation plan here>", a
+9-point write-this rubric).
+
+Pins (operator steering: prompt tuning is the lever, NO information loss):
+- The enforced plan budget is ALWAYS at or below the implement boundary —
+  nothing a planner writes is ever truncated away.
+- Over-budget plans are rejected with condense guidance (retry feedback).
+- A concise-but-complete execution brief passes validation.
+- The planner prompt demands the brief shape + states the budget; the
+  "detailed implementation plan" phrasing is gone.
+- The Builder council voter carries the anti-verbosity guard — brevity is
+  never a finding.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from config import HydraFlowConfig
+from plan_council_prompts import BUILDER_PROMPT
+from plan_validation import validate_plan
+from tests.conftest import TaskFactory
+from tests.helpers import ConfigFactory
+
+CONCISE_BRIEF = (
+    "## Intent\n\n"
+    "Cap the Pipeline Flow dot row so large queues cannot push later stages "
+    "off-screen.\n\n"
+    "## Approach\n\n"
+    "Slice the issue list at a constant cap in StreamView and render the "
+    "remainder as one +N overflow badge, mirroring the existing queued-count "
+    "badge pattern.\n\n"
+    "## Files to Modify\n\n"
+    "- src/ui/src/components/StreamView.jsx — cap dots, add badge\n\n"
+    "## New Files\n\n"
+    "None\n\n"
+    "## File Delta\n\n"
+    "MODIFIED: src/ui/src/components/StreamView.jsx\n\n"
+    "## Task Graph\n\n"
+    "### P1 — Cap and badge\n"
+    "**Files:** src/ui/src/components/StreamView.jsx\n"
+    "**Tests:**\n"
+    "- 67 queued issues render exactly 10 dots and a +57 badge\n"
+    "- 10 or fewer issues render no badge\n"
+    "**Depends on:** (none)\n\n"
+    "## Implementation Steps\n\n"
+    "1. Add FLOW_DOT_CAP constant and slice in StreamView.jsx\n"
+    "2. Render overflow badge with data-testid per stage\n\n"
+    "## Testing Strategy\n\n"
+    "- Extend src/ui/src/components/__tests__/StreamView.test.jsx\n\n"
+    "## Acceptance Criteria\n\n"
+    "- No stage row ever renders more than 10 dots\n"
+    "- Overflow count equals total minus rendered dots\n\n"
+    "## Key Considerations\n\n"
+    "- Keep the queued-count badge testids stable\n"
+)
+
+
+class TestBudgetInvariant:
+    def test_default_budget_is_below_the_implement_boundary(self) -> None:
+        """Nothing a planner writes within budget can ever be truncated."""
+        config = HydraFlowConfig()
+        assert config.max_plan_chars < config.max_impl_plan_chars
+
+    def test_enforced_budget_clamps_to_implement_boundary(self, tmp_path) -> None:
+        """Even a misconfigured max_plan_chars cannot re-enable truncation."""
+        config = ConfigFactory.create(repo_root=tmp_path)
+        object.__setattr__(config, "max_plan_chars", 40_000)
+        object.__setattr__(config, "max_impl_plan_chars", 6_000)
+        task = TaskFactory.create(id=1, title="Overlong plan")
+        plan = CONCISE_BRIEF + ("x" * 7_000)
+
+        errors = validate_plan(task, plan, "full", config=config)
+
+        assert any("budget is 6000" in e for e in errors)
+
+    def test_over_budget_plan_rejected_with_condense_guidance(self, tmp_path) -> None:
+        config = ConfigFactory.create(repo_root=tmp_path)
+        task = TaskFactory.create(id=1, title="Overlong plan")
+        plan = CONCISE_BRIEF + ("padding word " * 2_000)
+
+        errors = validate_plan(task, plan, "full", config=config)
+
+        assert any("condense" in e and "execution-brief" in e for e in errors)
+
+
+class TestConciseBriefPasses:
+    def test_real_short_plan_passes_full_validation(self, tmp_path) -> None:
+        """A ~180-word complete brief clears every gate (min words is a floor
+        against EMPTY plans, not a verbosity mandate)."""
+        config = ConfigFactory.create(repo_root=tmp_path)
+        task = TaskFactory.create(
+            id=9863, title="Cap pipeline flow dots with overflow badge"
+        )
+
+        errors = validate_plan(task, CONCISE_BRIEF, "full", config=config)
+
+        assert errors == []
+
+    def test_min_words_floor_rejects_skeletal_plans(self, tmp_path) -> None:
+        config = ConfigFactory.create(repo_root=tmp_path)
+        task = TaskFactory.create(id=1, title="Skeletal")
+        skeletal = "\n\n".join(
+            f"{s}\nx"
+            for s in (
+                "## Intent",
+                "## Approach",
+                "## Files to Modify",
+                "## New Files",
+                "## File Delta",
+                "## Task Graph",
+                "## Testing Strategy",
+                "## Acceptance Criteria",
+                "## Key Considerations",
+            )
+        )
+
+        errors = validate_plan(task, skeletal, "full", config=config)
+
+        assert any("words" in e for e in errors)
+
+
+class TestPromptShape:
+    @pytest.mark.asyncio
+    async def test_planner_prompt_states_budget_and_brief_shape(
+        self, config, event_bus
+    ) -> None:
+        from planner import PlannerRunner
+
+        runner = PlannerRunner(config, event_bus)
+        task = TaskFactory.create(id=7, title="Some feature", body="Do the thing")
+        prompt, _stats = await runner._build_prompt_with_stats(task)
+
+        assert "SHORT EXECUTION BRIEF" in prompt
+        assert "HARD BUDGET" in prompt
+        assert str(min(config.max_plan_chars, config.max_impl_plan_chars)) in prompt
+        assert "<your detailed implementation plan here>" not in prompt
+        assert "TASK granularity" in prompt
+
+    def test_builder_voter_carries_anti_verbosity_guard(self) -> None:
+        assert "Brevity is NOT a finding" in BUILDER_PROMPT
+        assert '"Add more detail" is not a valid concern' in BUILDER_PROMPT
+
+
+class TestKnobDefaults:
+    def test_min_plan_words_default_is_a_floor_not_a_mandate(self) -> None:
+        assert HydraFlowConfig().min_plan_words == 60

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -29,7 +29,7 @@ _BOUNDED_INT_FIELDS = [
     ("max_review_fix_attempts", 0, 5, 2),
     ("max_pre_quality_review_attempts", 0, 5, 3),
     ("min_review_findings", 0, 20, 3),
-    ("min_plan_words", 50, 2000, 200),
+    ("min_plan_words", 20, 2000, 60),
     ("max_merge_conflict_fix_attempts", 0, 5, 3),
     ("max_new_files_warning", 1, 20, 5),
     ("rc_cadence_hours", 1, 168, 4),
@@ -451,7 +451,7 @@ class TestHydraFlowConfigMinPlanWords:
             workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
-        assert cfg.min_plan_words == 200
+        assert cfg.min_plan_words == 60
 
     def test_min_plan_words_env_var_override(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_plan_validation.py
+++ b/tests/test_plan_validation.py
@@ -20,6 +20,10 @@ def _valid_plan(*, word_pad: int = 200) -> str:
     """Return a plan with all required sections that passes validation."""
     padding = " ".join(["word"] * max(0, word_pad - 80))
     return (
+        "## Intent\n\n"
+        "Add the new data model plus its config knob so downstream consumers can rely on validated settings.\n\n"
+        "## Approach\n\n"
+        "Extend models.py with the model and config.py with the field; wire both through the orchestrator with validation at the boundary.\n\n"
         "## Files to Modify\n\n"
         "- src/models.py \u2014 add new data model\n"
         "- src/config.py \u2014 add configuration field\n\n"

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -51,6 +51,10 @@ def _valid_plan(*, word_pad: int = 200) -> str:
     """Return a plan with all required sections that passes validation."""
     padding = " ".join(["word"] * max(0, word_pad - 80))
     return (
+        "## Intent\n\n"
+        "Add the new data model plus its config knob so downstream consumers can rely on validated settings.\n\n"
+        "## Approach\n\n"
+        "Extend models.py with the model and config.py with the field; wire both through the orchestrator with validation at the boundary.\n\n"
         "## Files to Modify\n\n"
         "- src/models.py — add new data model\n"
         "- src/config.py — add configuration field\n\n"
@@ -1709,8 +1713,10 @@ async def test_build_prompt_warns_about_rejection(config, event_bus, issue):
 
 
 def test_required_sections_has_seven_entries(config, event_bus):
-    """PlannerRunner.REQUIRED_SECTIONS should have 7 entries (including Task Graph)."""
-    assert len(PlannerRunner.REQUIRED_SECTIONS) == 7
+    """PlannerRunner.REQUIRED_SECTIONS has 9 entries (#9955 adds Intent/Approach)."""
+    assert len(PlannerRunner.REQUIRED_SECTIONS) == 9
+    assert "## Intent" in PlannerRunner.REQUIRED_SECTIONS
+    assert "## Approach" in PlannerRunner.REQUIRED_SECTIONS
     assert "## Files to Modify" in PlannerRunner.REQUIRED_SECTIONS
     assert "## New Files" in PlannerRunner.REQUIRED_SECTIONS
     assert "## File Delta" in PlannerRunner.REQUIRED_SECTIONS
@@ -1861,6 +1867,8 @@ def test_detect_plan_scale_custom_lite_labels(event_bus, tmp_path):
 def _lite_plan() -> str:
     """Return a plan with only lite-required sections."""
     return (
+        "## Intent\n\n"
+        "Fix the crash in app.py so the affected flow completes.\n\n"
         "## Files to Modify\n\n"
         "- src/app.py — fix the crash\n\n"
         "## Implementation Steps\n\n"
@@ -1873,7 +1881,7 @@ def _lite_plan() -> str:
 
 
 def test_validate_lite_plan_accepts_three_sections(config, event_bus):
-    """A lite plan with only 3 sections passes validation."""
+    """A lite plan with only the lite-required sections passes validation."""
     runner = _make_runner(config, event_bus)
     task = TaskFactory.create(id=1, title="Fix crash")
     errors = runner._validate_plan(task, _lite_plan(), scale="lite")


### PR DESCRIPTION
## Problem (#9955)

Operator report: plan phase too slow, too detailed, and the detail gets discarded. The pipeline REQUIRED verbosity (`min_plan_words=200`) and then THREW IT AWAY (`max_impl_plan_chars=6000` truncation before the implementer saw it) — and the prompt itself manufactured the verbosity ('<your detailed implementation plan here>', a 9-point write-this rubric).

## Change (operator-steered: prompt tuning is the lever, NO information loss)

- **Prompt**: required output is a SHORT EXECUTION BRIEF — `## Intent` + `## Approach` lead the section contract; Task Graph phases at TASK granularity with an explicit no-line-by-line/no-snippets rule; the ADR-0044 rubric and gotchas audit become verify-the-brief checks; the hard budget is stated inline. Scale-aware section lists stay owned by the schema section (lite prompts never see full-scale section names — pinned by the prompt evals).
- **Contract**: `min_plan_words` 200→60 (floor against skeletal plans; env row + ConfigFactory + validation pins synced); new `max_plan_chars=5000` enforced in `validate_plan` and CLAMPED to `max_impl_plan_chars` — even a misconfigured knob cannot re-enable truncation. Over-budget plans reject with condense guidance (planner retry feedback).
- **Council**: Builder voter carries the anti-verbosity guard — brevity is never a finding; 'criterion not checkable' / 'step has no concrete target' are.

## Tests

Regression file pins the never-truncated invariant (default + clamp), condense rejection, a real ~150-word brief passing full validation, the skeletal floor, prompt shape, and the council guard. Full `make quality` exit 0.

plan_durations in lifetime_stats provides the before/after latency comparison as post-merge factory runs accumulate.

Closes #9955

🤖 Generated with [Claude Code](https://claude.com/claude-code)