### PR TITLE
fix(audit): split P10.3 enforcement from measurement — per-PR gate + telemetry scan (#9902)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,6 +358,10 @@ jobs:
         run: |
           git fetch --no-tags origin main:refs/remotes/origin/main
           git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
+          # P10.6 diffs the PR against its base; make the base ref resolvable.
+          if [ -n "${{ github.base_ref }}" ]; then
+            git fetch --no-tags origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}" || true
+          fi
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
@@ -369,6 +373,9 @@ jobs:
       - name: Run principles audit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # P10.6 per-PR regression gate: empty on push builds, so the gate
+          # is NA there and only the telemetry history scan runs (#9902).
+          HYDRAFLOW_AUDIT_PR_BASE: ${{ github.base_ref }}
         run: make audit
 
   ui-build:

--- a/docs/adr/0044-hydraflow-principles.md
+++ b/docs/adr/0044-hydraflow-principles.md
@@ -386,6 +386,7 @@ but every bug fix from today forward lands with a regression test.
 | P10.3 | CULTURAL | docs/wiki/testing.md | Bug-fix commits land with a regression test in `tests/regressions/` | Audit scans last 50 merged PRs tagged `bug`/`fix`; reports PRs missing a regression-test delta as a warning |
 | P10.4 | STRUCTURAL | docs/wiki/testing.md | Test names describe behaviour, not implementation (e.g. `test_merges_when_all_checks_pass` not `test_merge_function`) | Enforce via a test-name linter or review rubric; audit samples names and flags ones matching `test_<funcname>$` |
 | P10.5 | BEHAVIORAL | docs/wiki/testing.md | Test files use the Arrange / Act / Assert structure visibly | Prefer factories + one assertion per test; multi-assert tests are a smell |
+| P10.6 | BEHAVIORAL | docs/wiki/testing.md | A `fix(...)` PR carries a regression-test delta in its own diff — `tests/regressions/`, or a `src/ui` test delta for UI-only fixes; a `Skip-Regression: <justification>` commit trailer opts out with a greppable reason | Per-PR audit gate diffs the PR against its merge base and fails only the offending PR; the P10.3 history scan stays telemetry |
 
 ## Consequences
 

--- a/scripts/hydraflow_audit/checks/p10_tdd.py
+++ b/scripts/hydraflow_audit/checks/p10_tdd.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -209,8 +210,9 @@ def _bug_fixes_land_with_regression_tests(ctx: CheckContext) -> Finding:  # noqa
         "P10.3",
         Status.WARN,
         f"{len(missing)}/{len(fix_commits)} fix commits {scope} without a regression test ({sample}) — "
-        "set .hydraflow-audit-baseline to a post-adoption commit or ISO date "
-        "to exclude historical drift",
+        "telemetry only (#9902): this scans MERGED history, so it cannot "
+        "blame the PR under test and never fails PR CI; per-PR enforcement "
+        "is P10.6",
     )
 
 
@@ -277,6 +279,160 @@ def _touched_regressions(root: Path, sha: str) -> bool:
     except (subprocess.TimeoutExpired, OSError):
         return True  # don't false-alarm on errors
     return "tests/regressions/" in result.stdout
+
+
+_SKIP_REGRESSION_RE = re.compile(r"^Skip-Regression:\s*(\S.*)$", re.MULTILINE)
+# UI regression coverage: a test delta under src/ui counts for UI-only fixes.
+_UI_TEST_RE = re.compile(r"^src/ui/.*(?:__tests__/|\.test\.[jt]sx?$)")
+_PR_BASE_ENV = "HYDRAFLOW_AUDIT_PR_BASE"
+
+
+def _resolve_merge_base(root: Path, base: str) -> str | None:
+    """Return the merge-base sha of HEAD and *base* (trying origin/ first)."""
+    for candidate in (f"origin/{base}", base):
+        try:
+            result = subprocess.run(
+                ["git", "merge-base", candidate, "HEAD"],
+                check=False,
+                cwd=root,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            return None
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    return None
+
+
+def _pr_fix_shas(root: Path, merge_base: str) -> list[str] | None:
+    """Fix-prefixed, non-test-only commit shas in the PR's own range."""
+    try:
+        result = subprocess.run(
+            ["git", "log", "--no-merges", "--format=%H%x09%s", f"{merge_base}..HEAD"],
+            check=False,
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    shas = [
+        line.split("\t", 1)[0]
+        for line in result.stdout.splitlines()
+        if "\t" in line and _FIX_COMMIT_RE.match(line.split("\t", 1)[1])
+    ]
+    return [sha for sha in shas if not _is_test_only_commit(root, sha)]
+
+
+def _skip_regression_reason(root: Path, merge_base: str) -> str | None:
+    """Return the first Skip-Regression: trailer justification in the range."""
+    try:
+        result = subprocess.run(
+            ["git", "log", "--no-merges", "--format=%B", f"{merge_base}..HEAD"],
+            check=False,
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    match = _SKIP_REGRESSION_RE.search(result.stdout)
+    return match.group(1).strip() if match else None
+
+
+def _evaluate_pr_regression_delta(root: Path, merge_base: str) -> Finding:
+    """Judge the PR's own diff for regression coverage (P10.6 core)."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", f"{merge_base}..HEAD"],
+            check=False,
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return finding("P10.6", Status.NA, "git diff failed")
+    paths = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    if any(path.startswith("tests/regressions/") for path in paths):
+        return finding(
+            "P10.6", Status.PASS, "fix PR carries a tests/regressions/ delta"
+        )
+    product = [
+        path
+        for path in paths
+        if not path.startswith(("tests/", "docs/")) and not _UI_TEST_RE.match(path)
+    ]
+    ui_only = bool(product) and all(path.startswith("src/ui/") for path in product)
+    if ui_only and any(_UI_TEST_RE.match(path) for path in paths):
+        return finding(
+            "P10.6",
+            Status.PASS,
+            "UI-only fix carries a UI test delta (accepted as regression "
+            "coverage — no token Python test required)",
+        )
+    return finding(
+        "P10.6",
+        Status.WARN,
+        "fix(...) commits in THIS PR have no regression-test delta — add a "
+        "test under tests/regressions/ (or a src/ui test delta for UI-only "
+        "fixes), or opt out with a `Skip-Regression: <justification>` "
+        "commit trailer when coverage legitimately lives elsewhere",
+    )
+
+
+def _pr_gate_preflight(root: Path) -> tuple[str | None, Finding | None]:
+    """Resolve the PR merge base, or the NA finding explaining why not."""
+    if not (root / ".git").exists():
+        return None, finding("P10.6", Status.NA, "not a git repo")
+    base = os.environ.get(_PR_BASE_ENV, "").strip()
+    if not base:
+        return None, finding(
+            "P10.6", Status.NA, f"not a PR context ({_PR_BASE_ENV} unset)"
+        )
+    merge_base = _resolve_merge_base(root, base)
+    if merge_base is None:
+        return None, finding("P10.6", Status.NA, f"base ref {base!r} not resolvable")
+    return merge_base, None
+
+
+@register("P10.6")
+def _fix_prs_carry_regression_delta(ctx: CheckContext) -> Finding:
+    """Per-PR enforcement of the regression-test principle (#9902).
+
+    Unlike P10.3 (a history-scan TELEMETRY metric that cannot blame the PR
+    under test), this gate reads the PR's OWN merge-base diff and fails
+    only the offending PR. Off-PR contexts (local audits, push builds) are
+    NA — the branch-history metric covers them. The base branch arrives
+    via ``HYDRAFLOW_AUDIT_PR_BASE`` (the CI workflow passes
+    ``github.base_ref``).
+    """
+    merge_base, na = _pr_gate_preflight(ctx.root)
+    if na is not None:
+        return na
+    assert merge_base is not None
+    fix_shas = _pr_fix_shas(ctx.root, merge_base)
+    if fix_shas is None:
+        return finding("P10.6", Status.NA, "git log failed")
+    if not fix_shas:
+        return finding("P10.6", Status.PASS, "no product fix(...) commits in this PR")
+    reason = _skip_regression_reason(ctx.root, merge_base)
+    if reason:
+        return finding(
+            "P10.6",
+            Status.PASS,
+            f"Skip-Regression trailer present: {reason} (justification "
+            "survives into the squash body)",
+        )
+    return _evaluate_pr_regression_delta(ctx.root, merge_base)
 
 
 @register("P10.4")

--- a/scripts/hydraflow_audit/runner.py
+++ b/scripts/hydraflow_audit/runner.py
@@ -51,7 +51,23 @@ def _run_one(spec: CheckSpec, ctx: CheckContext) -> Finding:
     return result
 
 
+# Telemetry checks measure the CODEBASE, not the change under test —
+# ADR-0044 words P10.3 as "reports ... as a warning", and its history scan
+# runs in every open PR's CI, so its WARN blamed unrelated PRs and forced
+# consent-gated baseline advances for compliant work (#9902). Their WARN is
+# reported but never flips the exit code; per-PR enforcement is P10.6.
+TELEMETRY_CHECKS = frozenset({"P10.3"})
+
+
 def overall_exit_code(findings: list[Finding]) -> int:
-    """0 if every finding is PASS or NA; 1 otherwise."""
+    """0 if every finding is PASS/NA (or a telemetry WARN); 1 otherwise."""
     bad = {Status.FAIL, Status.WARN, Status.NOT_IMPLEMENTED}
-    return 1 if any(f.status in bad for f in findings) else 0
+    return (
+        1
+        if any(
+            f.status in bad
+            and not (f.check_id in TELEMETRY_CHECKS and f.status is Status.WARN)
+            for f in findings
+        )
+        else 0
+    )

--- a/tests/regressions/test_issue_9902_p103_per_pr_gate.py
+++ b/tests/regressions/test_issue_9902_p103_per_pr_gate.py
@@ -1,0 +1,227 @@
+"""Regression: P10.3's history scan blamed the wrong PRs (#9902).
+
+The check scanned MERGED history but ran in every open PR's CI, so one
+fix landing without a regression test turned every unrelated PR red —
+forcing two consent-gated manual baseline advances within three hours
+(#9892 at 19:00Z, #9901 at 20:08Z describing the same already-covered
+change). An instrument that demands manual exemptions for compliant work
+is miscalibrated.
+
+Pins (the enforcement/measurement split):
+- P10.3's WARN is telemetry: reported, never flips the audit exit code —
+  the "unrelated PR goes red" scenario is structurally dead.
+- P10.6 gates the PR's OWN merge-base diff: fix commits without a
+  regression delta fail THAT PR only, with an actionable message.
+- `Skip-Regression: <why>` trailer opts out (greppable justification).
+- A UI-only fix with a src/ui test delta passes without a token Python
+  test.
+- No `.hydraflow-audit-baseline` edit is required for any of the above.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from scripts.hydraflow_audit.checks._helpers import finding
+from scripts.hydraflow_audit.checks.p10_tdd import (
+    _bug_fixes_land_with_regression_tests,
+    _fix_prs_carry_regression_delta,
+)
+from scripts.hydraflow_audit.models import CheckContext, Status
+from scripts.hydraflow_audit.runner import TELEMETRY_CHECKS, overall_exit_code
+
+
+def _git_env() -> dict[str, str]:
+    return {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t",
+    }
+
+
+def _git(tmp_path: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=tmp_path, check=True, env=_git_env())
+
+
+def _commit(tmp_path: Path, subject: str, files: dict[str, str]) -> None:
+    for rel, content in files.items():
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-q", "-m", subject)
+
+
+def _pr_repo(tmp_path: Path, *, fix_files: dict[str, str], subject: str) -> None:
+    """main with one base commit; a fix branch with *fix_files* committed."""
+    _git(tmp_path, "init", "-q", "-b", "main")
+    _commit(tmp_path, "chore: base", {"src/app.py": "x = 1\n"})
+    _git(tmp_path, "checkout", "-q", "-b", "fix/thing")
+    _commit(tmp_path, subject, fix_files)
+
+
+def _ctx(tmp_path: Path) -> CheckContext:
+    return CheckContext(root=tmp_path)
+
+
+class TestTelemetryNeverBlocks:
+    def test_p103_warn_does_not_flip_exit_code(self) -> None:
+        """The 'unrelated PR goes red' scenario: telemetry WARN exits 0."""
+        assert "P10.3" in TELEMETRY_CHECKS
+        findings = [
+            finding("P10.3", Status.WARN, "3/10 fix commits without a test"),
+            finding("P10.2", Status.PASS, ""),
+        ]
+        assert overall_exit_code(findings) == 0
+
+    def test_p106_warn_still_blocks(self) -> None:
+        """Enforcement lives in the per-PR gate — its WARN fails CI."""
+        findings = [finding("P10.6", Status.WARN, "no regression delta")]
+        assert overall_exit_code(findings) == 1
+
+    def test_p103_message_names_the_split(self, tmp_path: Path) -> None:
+        _git(tmp_path, "init", "-q", "-b", "main")
+        _commit(tmp_path, "fix(app): repair crash", {"src/app.py": "x = 2\n"})
+        result = _bug_fixes_land_with_regression_tests(_ctx(tmp_path))
+        assert result.status is Status.WARN
+        assert "telemetry" in (result.message or "")
+        assert "P10.6" in (result.message or "")
+
+
+class TestPerPrGate:
+    def test_fix_pr_without_regression_delta_fails_that_pr(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _pr_repo(
+            tmp_path,
+            subject="fix(app): repair crash",
+            fix_files={"src/app.py": "x = 2\n"},
+        )
+        monkeypatch.setenv("HYDRAFLOW_AUDIT_PR_BASE", "main")
+
+        result = _fix_prs_carry_regression_delta(_ctx(tmp_path))
+
+        assert result.status is Status.WARN
+        assert "tests/regressions/" in (result.message or "")
+        assert "Skip-Regression" in (result.message or "")
+
+    def test_fix_pr_with_regression_delta_passes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _pr_repo(
+            tmp_path,
+            subject="fix(app): repair crash",
+            fix_files={
+                "src/app.py": "x = 2\n",
+                "tests/regressions/test_issue_1_crash.py": "def test_x(): pass\n",
+            },
+        )
+        monkeypatch.setenv("HYDRAFLOW_AUDIT_PR_BASE", "main")
+
+        result = _fix_prs_carry_regression_delta(_ctx(tmp_path))
+
+        assert result.status is Status.PASS
+
+    def test_skip_regression_trailer_opts_out_with_reason(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _pr_repo(
+            tmp_path,
+            subject=(
+                "fix(app): repair crash\n\n"
+                "Coverage lives in tests/test_app.py::test_crash_path.\n\n"
+                "Skip-Regression: covered by existing test_crash_path pins"
+            ),
+            fix_files={"src/app.py": "x = 2\n"},
+        )
+        monkeypatch.setenv("HYDRAFLOW_AUDIT_PR_BASE", "main")
+
+        result = _fix_prs_carry_regression_delta(_ctx(tmp_path))
+
+        assert result.status is Status.PASS
+        assert "covered by existing test_crash_path pins" in (result.message or "")
+
+    def test_ui_only_fix_with_ui_test_delta_passes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _pr_repo(
+            tmp_path,
+            subject="fix(ui): cap dots",
+            fix_files={
+                "src/ui/src/components/StreamView.jsx": "cap\n",
+                "src/ui/src/components/__tests__/StreamView.test.jsx": "t\n",
+            },
+        )
+        monkeypatch.setenv("HYDRAFLOW_AUDIT_PR_BASE", "main")
+
+        result = _fix_prs_carry_regression_delta(_ctx(tmp_path))
+
+        assert result.status is Status.PASS
+        assert "UI" in (result.message or "")
+
+    def test_ui_only_fix_without_ui_test_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _pr_repo(
+            tmp_path,
+            subject="fix(ui): cap dots",
+            fix_files={"src/ui/src/components/StreamView.jsx": "cap\n"},
+        )
+        monkeypatch.setenv("HYDRAFLOW_AUDIT_PR_BASE", "main")
+
+        result = _fix_prs_carry_regression_delta(_ctx(tmp_path))
+
+        assert result.status is Status.WARN
+
+    def test_off_pr_context_is_na(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Local audits and push builds never trip the gate."""
+        _pr_repo(
+            tmp_path,
+            subject="fix(app): repair crash",
+            fix_files={"src/app.py": "x = 2\n"},
+        )
+        monkeypatch.delenv("HYDRAFLOW_AUDIT_PR_BASE", raising=False)
+
+        result = _fix_prs_carry_regression_delta(_ctx(tmp_path))
+
+        assert result.status is Status.NA
+
+    def test_non_fix_pr_passes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _pr_repo(
+            tmp_path,
+            subject="feat(app): add feature",
+            fix_files={"src/app.py": "x = 2\n"},
+        )
+        monkeypatch.setenv("HYDRAFLOW_AUDIT_PR_BASE", "main")
+
+        result = _fix_prs_carry_regression_delta(_ctx(tmp_path))
+
+        assert result.status is Status.PASS
+
+    def test_test_only_fix_commit_is_not_gated(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test-maintenance fixes need no ADDITIONAL regression test."""
+        _pr_repo(
+            tmp_path,
+            subject="fix(tests): stabilize flaky pin",
+            fix_files={"tests/test_app.py": "def test_x(): pass\n"},
+        )
+        monkeypatch.setenv("HYDRAFLOW_AUDIT_PR_BASE", "main")
+
+        result = _fix_prs_carry_regression_delta(_ctx(tmp_path))
+
+        assert result.status is Status.PASS


### PR DESCRIPTION
## Problem (#9902)

The P10.3 history scan runs in every open PR's CI but scans MERGED history — one fix landing without a regression test turned every unrelated PR red, forcing two consent-gated manual baseline advances inside three hours (#9892, #9901) for already-covered work.

## The split

- **P10.3 → telemetry.** Its WARN is still computed and reported, but the runner's `TELEMETRY_CHECKS` mapping never lets it flip the exit code. ADR-0044's own wording — 'reports … as a warning' — never demanded CI-blocking; the exit mapping was the miscalibration. The 'unrelated PR goes red' scenario is pinned dead.
- **NEW P10.6 → per-PR enforcement (blocking).** Diffs the PR against its merge base via `HYDRAFLOW_AUDIT_PR_BASE` (`github.base_ref` in CI; NA locally and on push builds). `fix(...)` commits without a `tests/regressions/` delta fail THAT PR only, with an actionable message. (P10.5 was already taken by the AAA principle — the issue's proposed ID shifted by one.)
- **`Skip-Regression: <justification>`** commit trailer opts out (mirrors `Skip-ADR:`); the reason survives into the squash body, greppable.
- **UI-only fixes**: a `src/ui` test delta (`__tests__/` or `*.test.jsx/tsx`) counts as regression coverage — no token Python test.
- **`.hydraflow-audit-baseline` untouched** — no compliant scenario requires advancing it again; it stays for historical exclusion only.

ADR-0044 gains the P10.6 row (table extension; P10.3's row and semantics unchanged). The audit CI job passes and fetches the base ref.

## Tests

Regression file pins the telemetry exit mapping, the per-PR gate trigger, trailer opt-out with reason, UI recognition both ways, off-PR NA, non-fix and test-only passes. Full `make quality` exit 0.

Closes #9902

🤖 Generated with [Claude Code](https://claude.com/claude-code)