### PR TITLE
feat(shepherd): human-prefix branches get the CI-green merge path (#9889 class 5)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -630,6 +630,11 @@ _ENV_BOOL_OVERRIDES: list[tuple[str, str, bool]] = [
     ),
     ("stale_issue_gc_loop_enabled", "HYDRAFLOW_STALE_ISSUE_GC_LOOP_ENABLED", True),
     ("gate_health_loop_enabled", "HYDRAFLOW_GATE_HEALTH_LOOP_ENABLED", True),
+    (
+        "human_branch_shepherd_enabled",
+        "HYDRAFLOW_HUMAN_BRANCH_SHEPHERD_ENABLED",
+        True,
+    ),
     ("stale_issue_loop_enabled", "HYDRAFLOW_STALE_ISSUE_LOOP_ENABLED", True),
     ("triage_retry_loop_enabled", "HYDRAFLOW_TRIAGE_RETRY_LOOP_ENABLED", True),
     (
@@ -2013,6 +2018,15 @@ class HydraFlowConfig(BaseModel):
             "Bounded update-branch heals per CI-failed bot PR (#9889): a "
             "behind-base PR gets a fresh merge ref + full CI re-run before "
             "the failure strategy applies. 0 disables."
+        ),
+    )
+    human_branch_shepherd_enabled: bool = Field(
+        default=True,
+        description=(
+            "Class 5 (#9889): DependabotMergeLoop shepherds human-prefix "
+            "branches (fix/, feat/, docs/, test/, chore/, refactor/) to merge "
+            "once CI is green — same path as factory branches. Per-PR opt-out: "
+            "the no-auto-merge label."
         ),
     )
     review_orphan_strike_threshold: int = Field(

--- a/src/dependabot_merge_loop.py
+++ b/src/dependabot_merge_loop.py
@@ -12,8 +12,9 @@ from merge_policy import (
     ROLE_ORCHESTRATOR_REVIEWER,
     MergeApproval,
     enforce_merge_policy,
+    fetch_pr_labels,
 )
-from models import ReviewVerdict, SystemAlertPayload
+from models import PRListItem, ReviewVerdict, SystemAlertPayload
 
 if TYPE_CHECKING:
     from github_cache_loop import GitHubDataCache
@@ -40,6 +41,24 @@ _AUTO_AGENT_BRANCH_PREFIX = "agent/auto-agent-"
 # unmerged (#9843). Matching on these exact factory-owned prefixes is safe: no
 # human or normal-pipeline branch uses them. Once selected, the CI-green merge
 # and the stale-arch self-heal path below handle the rest.
+# Class 5 (#9889, operator-approved 2026-07-19): human-prefix branches get
+# the same CI-green shepherd-to-merge path as factory branches. Before this,
+# a human fix/ PR had NO merge path at all — the review→merge pipeline keys
+# on agent/issue-N and this loop selected only bots/factory prefixes, so
+# every green human PR sat until someone hand-merged it. Guardrails: the
+# deploy-time kill-switch below, the existing draft exclusion, the CH-3
+# merge policy (which reads fresh PR labels, so policy-override:*/deny
+# still apply), and a per-PR ``no-auto-merge`` label opt-out.
+_HUMAN_SHEPHERD_BRANCH_PREFIXES = (
+    "fix/",
+    "feat/",
+    "docs/",
+    "test/",
+    "chore/",
+    "refactor/",
+)
+_HUMAN_SHEPHERD_OPT_OUT_LABEL = "no-auto-merge"
+
 _FACTORY_MAINTENANCE_BRANCH_PREFIXES = (
     "ul-proposer/",  # term_proposer_loop
     "ul-evidence/",  # entry_evidence_loop
@@ -119,6 +138,14 @@ class DependabotMergeLoop(BaseBackgroundLoop):
     def _get_default_interval(self) -> int:
         return self._config.dependabot_merge_interval
 
+    def _is_human_shepherd_pr(self, pr: PRListItem) -> bool:
+        """Class 5 (#9889): human-prefix branch eligible for shepherding."""
+        return (
+            self._config.human_branch_shepherd_enabled
+            and not pr.is_bot
+            and pr.branch.startswith(_HUMAN_SHEPHERD_BRANCH_PREFIXES)
+        )
+
     async def _do_work(self) -> dict[str, Any] | None:
         """Check bot PRs and auto-merge if CI passes."""
         if not self._enabled_cb(self._worker_name):
@@ -151,6 +178,8 @@ class DependabotMergeLoop(BaseBackgroundLoop):
                 # auto-agent preflight + the UL/pricing/wiki maintenance loops.
                 or pr.branch.startswith(_AUTO_AGENT_BRANCH_PREFIX)
                 or pr.branch.startswith(_FACTORY_MAINTENANCE_BRANCH_PREFIXES)
+                # Class 5 (#9889): human-prefix branches, kill-switch gated.
+                or self._is_human_shepherd_pr(pr)
             )
         ]
 
@@ -170,6 +199,22 @@ class DependabotMergeLoop(BaseBackgroundLoop):
                 break
 
             if passed:
+                # Class 5 opt-out: a fresh label read (not the cache — the
+                # author may attach it at any time) so ``no-auto-merge``
+                # reliably leaves the PR to its author.
+                # Guarded by merge_policy_enabled: the label read is a raw
+                # gh subprocess (#9754 — the sandbox air-gaps it by disabling
+                # the policy, and this opt-out must not reopen that escape).
+                if self._is_human_shepherd_pr(pr) and self._config.merge_policy_enabled:
+                    labels = await fetch_pr_labels(self._config, pr.pr)
+                    if _HUMAN_SHEPHERD_OPT_OUT_LABEL in labels:
+                        skipped += 1
+                        logger.info(
+                            "Human PR #%d carries %s — leaving it to its author",
+                            pr.pr,
+                            _HUMAN_SHEPHERD_OPT_OUT_LABEL,
+                        )
+                        continue
                 # CH-3 (#9731): consult the factory-autonomy policy before
                 # approving+merging. This lane's approval evidence is its own
                 # CI-green auto-approval (the submit_review below); a deny
@@ -184,7 +229,11 @@ class DependabotMergeLoop(BaseBackgroundLoop):
                         MergeApproval(
                             actor="dependabot_merge_loop",
                             role=ROLE_ORCHESTRATOR_REVIEWER,
-                            source="ci_green_bot_pr_auto_approval",
+                            source=(
+                                "ci_green_human_shepherd_auto_approval"
+                                if self._is_human_shepherd_pr(pr)
+                                else "ci_green_bot_pr_auto_approval"
+                            ),
                         )
                     ],
                     lane="dependabot_merge_loop",
@@ -212,7 +261,14 @@ class DependabotMergeLoop(BaseBackgroundLoop):
 
                 # CI green — approve and merge
                 await self._prs.submit_review(
-                    pr.pr, ReviewVerdict.APPROVE, "CI passed — auto-merging bot PR."
+                    pr.pr,
+                    ReviewVerdict.APPROVE,
+                    (
+                        "CI passed — auto-merging shepherded human-prefix PR "
+                        "(#9889 class 5; add the no-auto-merge label to opt out)."
+                        if self._is_human_shepherd_pr(pr)
+                        else "CI passed — auto-merging bot PR."
+                    ),
                 )
                 merge_ok = await self._prs.merge_pr(pr.pr, auto_rebase=True)
                 if merge_ok:

--- a/src/merge_policy.py
+++ b/src/merge_policy.py
@@ -516,7 +516,7 @@ def find_break_glass_label(labels: Sequence[str], prefix: str) -> str:
     return ""
 
 
-async def _fetch_pr_labels(config: HydraFlowConfig, pr_number: int) -> list[str]:
+async def fetch_pr_labels(config: HydraFlowConfig, pr_number: int) -> list[str]:
     """Fresh PR-label read at the gh subprocess boundary.
 
     Raw gh rather than a new PRPort method (same call and rationale as the
@@ -605,7 +605,7 @@ async def enforce_merge_policy(
         paths: list[str] = []
         if policy.has_change_matchers:
             paths = await prs.get_pr_diff_names(pr_number)
-            labels = await _fetch_pr_labels(config, pr_number)
+            labels = await fetch_pr_labels(config, pr_number)
         decision = policy.classify_change(paths, labels or [])
         verdict = policy.check_merge_allowed(decision, actor=actor, approvals=approvals)
 
@@ -613,7 +613,7 @@ async def enforce_merge_policy(
         return verdict
 
     if labels is None:
-        labels = await _fetch_pr_labels(config, pr_number)
+        labels = await fetch_pr_labels(config, pr_number)
     label = find_break_glass_label(labels, prefix)
     if label:
         record = _break_glass_record(

--- a/tests/scenarios/test_loops.py
+++ b/tests/scenarios/test_loops.py
@@ -425,6 +425,77 @@ class TestL7bAutoAgentPrMerges:
 
 
 # ---------------------------------------------------------------------------
+# L7d: human-prefix branches get the shepherd-to-merge path (#9889 class 5)
+# ---------------------------------------------------------------------------
+
+
+class TestL7dHumanBranchShepherd:
+    """L7d: a CI-green human fix/ PR merges via the shepherd lane; the
+    no-auto-merge label leaves it to its author (operator-approved #9889)."""
+
+    async def test_green_human_fix_pr_merges(self, tmp_path):
+        world = MockWorld(tmp_path)
+
+        from unittest.mock import AsyncMock, patch
+
+        from mockworld.fakes.fake_github import FakePR
+        from models import PRListItem
+
+        human_pr = PRListItem(
+            pr=800,
+            title="fix(ui): cap dots",
+            author="T-rav",
+            branch="fix/pipeline-dots-cap",
+        )
+        world.github._prs[800] = FakePR(
+            number=800, issue_number=0, branch="fix/pipeline-dots-cap"
+        )
+
+        await world.run_with_loops(["dependabot_merge"], cycles=1)
+        world._dependabot_cache.get_open_prs.return_value = [human_pr]
+        world._dependabot_cache.get_all_open_prs.return_value = [human_pr]
+
+        # The opt-out label read is a raw gh subprocess (#9754 seam) — fake
+        # it at the loop boundary; the FakeGitHub port handles the rest.
+        with patch("dependabot_merge_loop.fetch_pr_labels", AsyncMock(return_value=[])):
+            stats = await world.run_with_loops(["dependabot_merge"], cycles=1)
+
+        assert stats["dependabot_merge"]["merged"] == 1
+        assert world.github.pr(800).merged is True
+
+    async def test_no_auto_merge_label_respected(self, tmp_path):
+        world = MockWorld(tmp_path)
+
+        from unittest.mock import AsyncMock, patch
+
+        from mockworld.fakes.fake_github import FakePR
+        from models import PRListItem
+
+        human_pr = PRListItem(
+            pr=801,
+            title="feat(x): risky",
+            author="T-rav",
+            branch="feat/risky-change",
+        )
+        world.github._prs[801] = FakePR(
+            number=801, issue_number=0, branch="feat/risky-change"
+        )
+
+        await world.run_with_loops(["dependabot_merge"], cycles=1)
+        world._dependabot_cache.get_open_prs.return_value = [human_pr]
+        world._dependabot_cache.get_all_open_prs.return_value = [human_pr]
+
+        with patch(
+            "dependabot_merge_loop.fetch_pr_labels",
+            AsyncMock(return_value=["no-auto-merge"]),
+        ):
+            stats = await world.run_with_loops(["dependabot_merge"], cycles=1)
+
+        assert stats["dependabot_merge"]["skipped"] == 1
+        assert world.github.pr(801).merged is False
+
+
+# ---------------------------------------------------------------------------
 # L7c: Dependabot Merge self-heals a bot PR stuck on stale arch artifacts
 # ---------------------------------------------------------------------------
 

--- a/tests/test_dependabot_merge_loop.py
+++ b/tests/test_dependabot_merge_loop.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import sys
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -404,10 +404,14 @@ class TestDependabotMergeLoopAutoAgentBranch:
 
     @pytest.mark.asyncio
     async def test_does_not_merge_arbitrary_owner_branch(self, tmp_path: Path) -> None:
-        """A hand-authored owner PR on an arbitrary branch must not auto-merge."""
+        """A hand-authored PR on a NON-shepherd-prefix branch must not auto-merge.
+
+        (#9889 class 5 made human fix/-style prefixes shepherdable by design,
+        so the arbitrary-branch pin uses a prefix outside that set.)
+        """
         loop, _, _, prs, _ = _make_loop(
             tmp_path,
-            open_prs=[_make_pr(42, author="T-rav", branch="fix/manual-thing")],
+            open_prs=[_make_pr(42, author="T-rav", branch="spike-manual-thing")],
         )
 
         result = await loop._do_work()
@@ -836,3 +840,97 @@ class TestMergePolicyGate:
 
         assert result["merged"] == 1
         prs.merge_pr.assert_awaited_once_with(10, auto_rebase=True)
+
+
+# ---------------------------------------------------------------------------
+# Class 5 (#9889): human-prefix branch shepherding
+# ---------------------------------------------------------------------------
+
+
+class TestHumanBranchShepherd:
+    @pytest.mark.asyncio
+    async def test_green_human_fix_branch_is_merged(self, tmp_path: Path) -> None:
+        """Operator-approved contract: CI-green human fix/ PRs merge."""
+        loop, _, _, prs, _ = _make_loop(
+            tmp_path,
+            open_prs=[_make_pr(42, author="T-rav", branch="fix/manual-thing")],
+        )
+
+        with patch("dependabot_merge_loop.fetch_pr_labels", AsyncMock(return_value=[])):
+            result = await loop._do_work()
+
+        assert result["merged"] == 1
+        prs.merge_pr.assert_awaited_once_with(42, auto_rebase=True)
+
+    @pytest.mark.asyncio
+    async def test_kill_switch_restores_no_merge_path(self, tmp_path: Path) -> None:
+        loop, _, _, prs, _ = _make_loop(
+            tmp_path,
+            open_prs=[_make_pr(42, author="T-rav", branch="fix/manual-thing")],
+        )
+        object.__setattr__(loop._config, "human_branch_shepherd_enabled", False)
+
+        result = await loop._do_work()
+
+        assert result == {"merged": 0, "skipped": 0, "failed": 0}
+        prs.wait_for_ci.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_auto_merge_label_leaves_pr_to_author(
+        self, tmp_path: Path
+    ) -> None:
+        loop, _, _, prs, _ = _make_loop(
+            tmp_path,
+            open_prs=[_make_pr(42, author="T-rav", branch="feat/my-feature")],
+        )
+
+        with patch(
+            "dependabot_merge_loop.fetch_pr_labels",
+            AsyncMock(return_value=["no-auto-merge"]),
+        ):
+            result = await loop._do_work()
+
+        assert result["skipped"] == 1
+        prs.merge_pr.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_bot_prs_never_pay_the_label_fetch(self, tmp_path: Path) -> None:
+        """The opt-out read is a raw gh subprocess — bot lane must skip it."""
+        loop, _, _, prs, _ = _make_loop(
+            tmp_path,
+            open_prs=[_make_pr(7, author="dependabot[bot]", is_bot=True)],
+        )
+
+        with patch("dependabot_merge_loop.fetch_pr_labels", AsyncMock()) as fetch:
+            result = await loop._do_work()
+
+        fetch.assert_not_awaited()
+        assert result["merged"] == 1
+
+    @pytest.mark.asyncio
+    async def test_airgap_skips_label_fetch_when_policy_disabled(
+        self, tmp_path: Path
+    ) -> None:
+        """#9754: with merge_policy_enabled=False (sandbox) no raw gh runs."""
+        loop, _, _, prs, _ = _make_loop(
+            tmp_path,
+            open_prs=[_make_pr(42, author="T-rav", branch="fix/manual-thing")],
+        )
+        object.__setattr__(loop._config, "merge_policy_enabled", False)
+
+        with patch("dependabot_merge_loop.fetch_pr_labels", AsyncMock()) as fetch:
+            result = await loop._do_work()
+
+        fetch.assert_not_awaited()
+        assert result["merged"] == 1
+
+    @pytest.mark.asyncio
+    async def test_draft_human_pr_excluded(self, tmp_path: Path) -> None:
+        pr = _make_pr(42, author="T-rav", branch="fix/manual-thing")
+        pr = pr.model_copy(update={"draft": True})
+        loop, _, _, prs, _ = _make_loop(tmp_path, open_prs=[pr])
+
+        result = await loop._do_work()
+
+        assert result == {"merged": 0, "skipped": 0, "failed": 0}
+        prs.wait_for_ci.assert_not_awaited()


### PR DESCRIPTION
## Problem (#9889 item 3 / class 5, operator-approved)

A human `fix/` PR had NO merge path at all: the review→merge pipeline keys on `agent/issue-N`, and `DependabotMergeLoop` selected only bots + factory prefixes. Every green human PR sat until someone hand-merged it — all of tonight's were.

## Change

`DependabotMergeLoop` now also selects human-prefix branches (`fix/`, `feat/`, `docs/`, `test/`, `chore/`, `refactor/`) through the SAME lane: CI green → CH-3 merge policy (fresh label read; `policy-override:*`/deny intact) → approve → merge.

**Guardrails:**
- `human_branch_shepherd_enabled` deploy-time kill-switch (default on, per sign-off)
- draft exclusion (existing)
- per-PR `no-auto-merge` label opt-out, read FRESH at merge time — and gated on `merge_policy_enabled` so the raw-gh read cannot reopen the #9754 sandbox air-gap escape
- lane-tagged approval source (`ci_green_human_shepherd_auto_approval`) so audit trails distinguish lanes

`merge_policy._fetch_pr_labels` goes public (`fetch_pr_labels`) — same deliberate raw-gh boundary, importable without a cross-module underscore reference.

## Tests

Unit: merge / kill-switch / opt-out / bot-lane-never-pays-the-fetch / air-gap / draft; the arbitrary-branch pin re-anchored on a non-shepherd prefix (a `fix/` branch merging is now the intended behavior). MockWorld L7d scenarios: green merge + label opt-out. Full `make quality` exit 0.

Item 2 of #9889 (bot-PR content-conflict heal) remains open.

Relates #9889

🤖 Generated with [Claude Code](https://claude.com/claude-code)