### PR TITLE
fix(diagnostic): Stage 1 no longer starves the event loop — gate off-thread + bounded prompt (#9879)

### DIFF
--- a/src/base_runner.py
+++ b/src/base_runner.py
@@ -20,7 +20,7 @@ from config import Credentials, HydraFlowConfig
 from events import EventBus
 from execution import get_default_runner
 from models import LoopResult, TranscriptEventData
-from prompt_gate import gate_prompt
+from prompt_gate import GateResult, gate_prompt
 from prompt_telemetry import PromptTelemetry, parse_command_tool_model
 from runner_utils import (
     AuthenticationRetryError,
@@ -181,14 +181,23 @@ class BaseRunner:
         # escalation machinery routes to HITL. No-op for internal/public-code.
         gate_tool, _gate_model = parse_command_tool_model(cmd)
         raw_issue = event_data.get("issue")
-        gated = gate_prompt(
-            prompt,
-            config=self._config,
-            source=str(event_data.get("source", "unknown")),
-            tool=gate_tool,
-            issue_number=raw_issue if isinstance(raw_issue, int) else None,
-            issue_labels=issue_labels or (),
-        )
+
+        # #9879: the gate regex-redacts the WHOLE prompt — pure CPU. On a
+        # large prompt (diagnostic prompts embed CI logs/diffs) running it
+        # inline starved the event loop for ~15s per Stage-1 run, freezing
+        # the dashboard and every other coroutine. Offload to a thread;
+        # regex matching over an immutable str is thread-safe.
+        def _run_gate() -> GateResult:
+            return gate_prompt(
+                prompt,
+                config=self._config,
+                source=str(event_data.get("source", "unknown")),
+                tool=gate_tool,
+                issue_number=raw_issue if isinstance(raw_issue, int) else None,
+                issue_labels=issue_labels or (),
+            )
+
+        gated = await asyncio.to_thread(_run_gate)
         prompt = gated.prompt
 
         start = time.monotonic()

--- a/src/diagnostic_runner.py
+++ b/src/diagnostic_runner.py
@@ -45,7 +45,11 @@ def _build_diagnosis_prompt(
         f"**Origin phase:** {context.origin_phase}\n",
     ]
     if context.ci_logs:
-        sections.append(f"**CI Logs:**\n```\n{context.ci_logs}\n```\n")
+        # Tail, not head: the failure evidence lives at the end of a CI log,
+        # and an unbounded log (a full pytest run can be tens of MB) made the
+        # prompt so large that gating/streaming it froze the event loop
+        # (#9879) and burned tokens the model never needed.
+        sections.append(f"**CI Logs (tail):**\n```\n{context.ci_logs[-8000:]}\n```\n")
     if context.review_comments:
         sections.append(
             "**Review Feedback:**\n"
@@ -53,7 +57,7 @@ def _build_diagnosis_prompt(
             + "\n"
         )
     if context.pr_diff:
-        sections.append(f"**PR Diff:**\n```diff\n{context.pr_diff}\n```\n")
+        sections.append(f"**PR Diff:**\n```diff\n{context.pr_diff[:12000]}\n```\n")
     if context.code_scanning_alerts:
         sections.append(
             "**Code Scanning Alerts:**\n"

--- a/tests/regressions/test_issue_9879_stage1_event_loop.py
+++ b/tests/regressions/test_issue_9879_stage1_event_loop.py
@@ -1,0 +1,107 @@
+"""Regression: DiagnosticLoop Stage 1 froze the event loop ~15s (#9879).
+
+The CH-6 gate regex-redacts the ENTIRE prompt synchronously, and the
+diagnosis prompt embedded UNBOUNDED CI logs and PR diffs (a full pytest
+log is tens of MB). Running that pure-CPU scan inline on the event loop
+starved every other coroutine — the dashboard HTTP layer timed out >12s
+while the factory kept working, masquerading as a hang and causing
+unnecessary restarts. The diagnostic loop was kill-switched (#9898)
+partly on this.
+
+Pins (mechanism, not timing — timing pins flake in CI):
+- BaseRunner._execute runs gate_prompt OFF the event-loop thread
+  (asyncio.to_thread), for every runner.
+- The gated (possibly redacted) prompt is still what reaches the stream.
+- The diagnosis prompt bounds ci_logs (TAIL — failure evidence lives at
+  the end) and pr_diff, so a flood-era context cannot rebuild the
+  multi-MB prompt.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from diagnostic_runner import DiagnosticRunner, _build_diagnosis_prompt
+from models import EscalationContext
+from prompt_gate import GateDecision, GateResult
+
+
+def _context(**overrides) -> EscalationContext:
+    fields = {
+        "cause": "review exhausted",
+        "origin_phase": "review",
+        **overrides,
+    }
+    return EscalationContext(**fields)
+
+
+class TestGateRunsOffTheEventLoop:
+    @pytest.mark.asyncio
+    async def test_gate_prompt_executes_in_a_worker_thread(
+        self, config, event_bus
+    ) -> None:
+        runner = DiagnosticRunner(config=config, event_bus=event_bus)
+        seen: dict[str, object] = {}
+
+        def recording_gate(prompt: str, **kwargs) -> GateResult:
+            seen["on_main_thread"] = (
+                threading.current_thread() is threading.main_thread()
+            )
+            decision = GateDecision(data_class="internal", action="allow")
+            return GateResult(prompt=prompt + "\n<gated>", decision=decision)
+
+        async def fake_stream(**kwargs):
+            seen["streamed_prompt"] = kwargs["prompt"]
+            return "ok"
+
+        with (
+            patch("base_runner.gate_prompt", side_effect=recording_gate),
+            patch("base_runner.stream_claude_process", side_effect=fake_stream),
+        ):
+            await runner._execute(
+                ["claude", "-p"],
+                "diagnose this",
+                config.repo_root,
+                {"issue": 1, "source": "diagnostic"},
+            )
+
+        assert seen["on_main_thread"] is False, (
+            "gate_prompt ran ON the event-loop thread — a large prompt "
+            "starves every coroutine for the duration of the regex scan"
+        )
+        assert str(seen["streamed_prompt"]).endswith("<gated>"), (
+            "the gated prompt must still be what reaches the subprocess"
+        )
+
+
+class TestDiagnosisPromptBounded:
+    def test_huge_ci_logs_are_tail_capped(self) -> None:
+        logs = "HEAD-MARKER " + ("x" * 1_000_000) + " TAIL-MARKER"
+        prompt = _build_diagnosis_prompt(1, "t", "b", _context(ci_logs=logs))
+
+        assert "TAIL-MARKER" in prompt  # failure evidence lives at the end
+        assert "HEAD-MARKER" not in prompt
+        assert len(prompt) < 40_000
+
+    def test_huge_pr_diff_is_capped(self) -> None:
+        diff = "+" + ("y" * 1_000_000)
+        prompt = _build_diagnosis_prompt(1, "t", "b", _context(pr_diff=diff))
+
+        assert len(prompt) < 40_000
+
+    def test_flood_era_context_stays_bounded_end_to_end(self) -> None:
+        ctx = _context(
+            ci_logs="l" * 2_000_000,
+            pr_diff="d" * 2_000_000,
+            agent_transcript="t" * 2_000_000,
+        )
+        prompt = _build_diagnosis_prompt(1, "t", "b", ctx)
+
+        assert len(prompt) < 60_000


### PR DESCRIPTION
## Problem (#9879)

During any Stage-1 diagnose run the whole HTTP layer froze ~15s (status timeouts >12s) — the event loop was blocked, masquerading as a hang and causing unnecessary restarts. Deterministic: disable diagnostic → 0.0s latency.

## Two compounding causes, both fixed

1. **CH-6 `gate_prompt` ran inline on the event loop** — a pure-CPU regex redaction over the ENTIRE prompt, in `BaseRunner._execute` (every runner). Now offloaded via `asyncio.to_thread`, in closure form so the gate-seam completeness AST pin still sees the direct call (it caught the first version).
2. **The diagnosis prompt embedded UNBOUNDED `ci_logs` + `pr_diff`** (a full pytest log is tens of MB) — the input that made the scan pathological, and tokens the model never needed. `ci_logs` is now TAIL-capped (failure evidence lives at the end; mirrors the transcript `[:4000]` discipline), `pr_diff` head-capped.

## Re-enable status

With #9888 (flood cooldown) and #10001 (credit-prose scan + comment dedup) merged, this was the LAST blocker on the #9895 checklist — `diagnostic_loop_enabled` can flip back on after this bakes in.

## Tests

Mechanism pins (timing pins flake): gate executes off the main thread and the gated prompt still reaches the stream; 1–2 MB ci_logs/pr_diff/transcript contexts produce a bounded prompt retaining the log TAIL. Full `make quality` exit 0.

Closes #9879

🤖 Generated with [Claude Code](https://claude.com/claude-code)