### PR TITLE
fix(reap): run_simple children join the runtime-wide reap registry (#9911 follow-up)

### DIFF
--- a/src/execution.py
+++ b/src/execution.py
@@ -8,7 +8,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
-from process_group import kill_process_group
+from process_group import kill_process_group, track, untrack
 
 
 @dataclass
@@ -140,10 +140,17 @@ class HostRunner:
             # pytest, agent CLIs) fork their own grandchildren. (#9648)
             start_new_session=True,
         )
+        # #9911 follow-up: register with the runtime-wide reap registry so
+        # a stop/shutdown mid-flight reaps this child too (previously only
+        # this method's own timeout could).
+        track(proc)
         try:
-            stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                proc.communicate(input=input), timeout=timeout
-            )
+            try:
+                stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                    proc.communicate(input=input), timeout=timeout
+                )
+            finally:
+                untrack(proc)
         except TimeoutError:
             # Reap the whole process group, not just the direct child. Without
             # this, sub-make / pytest / agent grandchildren are re-parented to

--- a/src/process_group.py
+++ b/src/process_group.py
@@ -50,3 +50,35 @@ def kill_process_group(proc: object, sig: signal.Signals = signal.SIGKILL) -> No
             kill = getattr(proc, "kill", None)
             if callable(kill):
                 kill()
+
+
+# ---------------------------------------------------------------------------
+# Runtime-wide registry of live children (#9911 follow-up).
+#
+# stream_claude_process registers its spawns via runner_utils (which aliases
+# this set), and HostRunner.run_simple registers here directly — so the
+# stop/shutdown reaper sees EVERY live child regardless of spawn path. It
+# lives in this module because execution.py cannot import runner_utils
+# (runner_utils imports execution) and this is the shared stdlib-only home.
+# ---------------------------------------------------------------------------
+
+_TRACKED: set[object] = set()
+
+
+def track(proc: object) -> None:
+    """Register a live child for stop-path reaping."""
+    _TRACKED.add(proc)
+
+
+def untrack(proc: object) -> None:
+    """Deregister a child (its spawn path finished normally)."""
+    _TRACKED.discard(proc)
+
+
+def reap_all_tracked(sig: signal.Signals = signal.SIGKILL) -> int:
+    """Group-kill every tracked live child; returns how many were reaped."""
+    live = [proc for proc in list(_TRACKED) if getattr(proc, "returncode", 0) is None]
+    for proc in live:
+        kill_process_group(proc, sig)
+    _TRACKED.clear()
+    return len(live)

--- a/src/process_group.py
+++ b/src/process_group.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import contextlib
 import os
 import signal
-from typing import TypeGuard
+from typing import Any, TypeGuard
 
 
 def is_real_pid(pid: object) -> TypeGuard[int]:
@@ -62,7 +62,7 @@ def kill_process_group(proc: object, sig: signal.Signals = signal.SIGKILL) -> No
 # (runner_utils imports execution) and this is the shared stdlib-only home.
 # ---------------------------------------------------------------------------
 
-_TRACKED: set[object] = set()
+_TRACKED: set[Any] = set()
 
 
 def track(proc: object) -> None:

--- a/src/runner_utils.py
+++ b/src/runner_utils.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
+import process_group
 from activity_parser import ActivityParser, get_activity_parser
 from events import EventBus, EventType, HydraFlowEvent
 from execution import SubprocessRunner, get_default_runner
@@ -406,20 +407,16 @@ def terminate_processes(active_procs: set[asyncio.subprocess.Process]) -> None:
 # terminate() at all), so stopping the runtime orphaned their children to
 # launchd for the length of a pytest/make run. stream_claude_process
 # registers every spawn here; the stop/shutdown path reaps the union.
-_ALL_TRACKED_PROCS: set[asyncio.subprocess.Process] = set()
+_ALL_TRACKED_PROCS: set[asyncio.subprocess.Process] = process_group._TRACKED  # type: ignore[assignment]
 
 
 def reap_all_tracked_processes() -> int:
     """SIGKILL the process group of every tracked live subprocess (#9911).
 
-    Returns the number of process groups reaped. Idempotent: group kills
-    are best-effort and already-dead groups are suppressed.
+    Delegates to the shared registry in :mod:`process_group` — run_simple
+    children register there too, so the stop path sees every spawn path.
     """
-    live = [proc for proc in list(_ALL_TRACKED_PROCS) if proc.returncode is None]
-    for proc in live:
-        _kill_proc_group(proc)
-    _ALL_TRACKED_PROCS.clear()
-    return len(live)
+    return process_group.reap_all_tracked()
 
 
 # ---------------------------------------------------------------------------

--- a/src/runner_utils.py
+++ b/src/runner_utils.py
@@ -407,7 +407,7 @@ def terminate_processes(active_procs: set[asyncio.subprocess.Process]) -> None:
 # terminate() at all), so stopping the runtime orphaned their children to
 # launchd for the length of a pytest/make run. stream_claude_process
 # registers every spawn here; the stop/shutdown path reaps the union.
-_ALL_TRACKED_PROCS: set[asyncio.subprocess.Process] = process_group._TRACKED  # type: ignore[assignment]
+_ALL_TRACKED_PROCS: set[asyncio.subprocess.Process] = process_group._TRACKED
 
 
 def reap_all_tracked_processes() -> int:

--- a/tests/regressions/test_issue_9911_stop_path_reap.py
+++ b/tests/regressions/test_issue_9911_stop_path_reap.py
@@ -198,3 +198,54 @@ class TestOrchestratorHooksInvokeReaper:
 
         reap.assert_called_once()
 
+
+
+class TestRunSimpleChildrenAreStopReapable:
+    """#9911 follow-up: run_simple children register in the shared registry,
+    so a stop/shutdown mid-flight reaps them — previously only run_simple's
+    own timeout could, and a Stop during a long make/pytest left the tree
+    running at PPID=1."""
+
+    @pytest.mark.asyncio
+    async def test_in_flight_run_simple_child_is_reaped_by_stop_path(
+        self, tmp_path: Path
+    ) -> None:
+        import process_group
+        from execution import HostRunner
+
+        pidfile = tmp_path / "grandchild.pid"
+        runner_task = asyncio.create_task(
+            HostRunner().run_simple(
+                ["bash", "-c", f"sleep 300 & echo $! > {pidfile}; wait"],
+                timeout=60,
+            )
+        )
+        try:
+            deadline = time.monotonic() + 5
+            while not pidfile.exists() and time.monotonic() < deadline:
+                await asyncio.sleep(0.05)
+            grandchild = int(pidfile.read_text().strip())
+            assert _pid_alive(grandchild)
+
+            reaped = reap_all_tracked_processes()
+
+            assert reaped >= 1
+            deadline = time.monotonic() + 5
+            while _pid_alive(grandchild) and time.monotonic() < deadline:
+                await asyncio.sleep(0.05)
+            assert not _pid_alive(grandchild), (
+                "run_simple grandchild survived the stop-path reap"
+            )
+        finally:
+            runner_task.cancel()
+            await asyncio.gather(runner_task, return_exceptions=True)
+            assert not process_group._TRACKED
+
+    @pytest.mark.asyncio
+    async def test_completed_run_simple_child_is_deregistered(self) -> None:
+        import process_group
+        from execution import HostRunner
+
+        await HostRunner().run_simple(["true"], timeout=10)
+
+        assert not process_group._TRACKED


### PR DESCRIPTION
## Problem

The stop-path reaper (#10002) covered `stream_claude_process` spawns only — `HostRunner.run_simple` children (every `gh`/`git`/`make`/`pytest` via `run_subprocess`) were reapable solely by their own timeout. A Stop during a long make/pytest left the tree at PPID=1 — the original #9911 evidence was exactly this (52-minute orphaned pytest).

## Change

The registry moves to `process_group.py` (execution.py cannot import runner_utils; process_group is the shared stdlib-only home beside the #10017 kill primitive). `runner_utils` keeps its public names as delegates/aliases — orchestrator call sites unchanged. `run_simple` registers after spawn, deregisters in a `finally` around communicate; its own timeout/cancel reaps untouched.

## Tests

Real-subprocess pin: an in-flight run_simple grandchild dies on `reap_all_tracked_processes`; completed children deregister; registry empty after cancel. Full `make quality` exit 0.

Relates #9911

🤖 Generated with [Claude Code](https://claude.com/claude-code)