### PR TITLE
fix(gate): derive the CH-6 runner pin from BaseRunner subclasses — 12 unguarded _execute sites threaded (#10000)

### DIFF
--- a/src/bug_reproducer.py
+++ b/src/bug_reproducer.py
@@ -169,6 +169,7 @@ class BugReproducer(BaseRunner):
             self._config.repo_root,
             {"issue": task.id, "source": "bug_reproducer"},
             on_output=_check_repro_complete,
+            issue_labels=task.tags,
         )
 
     def _build_command(self, _worktree_path: Path | None = None) -> list[str]:

--- a/src/diagnostic_loop.py
+++ b/src/diagnostic_loop.py
@@ -15,6 +15,7 @@ from exception_classify import reraise_on_credit_or_bug
 from models import AttemptRecord, Severity
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
 
     from diagnostic_runner import DiagnosisResult, DiagnosticRunner
@@ -128,7 +129,18 @@ class DiagnosticLoop(BaseBackgroundLoop):
                 continue
             issue_title = raw_issue.get("title", "")
             issue_body = raw_issue.get("body", "") or ""
-            outcome = await self._process_issue(issue_number, issue_title, issue_body)
+            # CH-6 (#10000): thread the issue's labels down to the runner so
+            # a data-class:<class> label elevates the prompt gate for the
+            # diagnose/fix spawns. Labels ride the gh wire shape
+            # ([{"name": ...}]) on the OPEN listing (#9943).
+            issue_labels = tuple(
+                label["name"]
+                for label in raw_issue.get("labels") or []
+                if isinstance(label, dict) and label.get("name")
+            )
+            outcome = await self._process_issue(
+                issue_number, issue_title, issue_body, issue_labels
+            )
             processed += 1
             if outcome == "fixed":
                 fixed += 1
@@ -149,6 +161,7 @@ class DiagnosticLoop(BaseBackgroundLoop):
         issue_number: int,
         issue_title: str,
         issue_body: str,
+        issue_labels: Sequence[str] = (),
     ) -> str:
         """Run the full diagnostic pipeline for a single issue.
 
@@ -172,7 +185,9 @@ class DiagnosticLoop(BaseBackgroundLoop):
             context = context.model_copy(update={"previous_attempts": attempts})
 
         # --- Stage 1: Diagnose ---
-        diagnosis = await self._diagnose(issue_number, issue_title, issue_body, context)
+        diagnosis = await self._diagnose(
+            issue_number, issue_title, issue_body, context, issue_labels
+        )
         diagnosis_comment = _format_diagnosis_comment(diagnosis)
 
         # --- Gates: not-fixable / attempts exhausted both escalate ---
@@ -190,6 +205,7 @@ class DiagnosticLoop(BaseBackgroundLoop):
             diagnosis,
             attempts,
             diagnosis_comment,
+            issue_labels,
         )
 
     async def _escalate_missing_context(self, issue_number: int) -> None:
@@ -217,6 +233,7 @@ class DiagnosticLoop(BaseBackgroundLoop):
         issue_title: str,
         issue_body: str,
         context: EscalationContext,
+        issue_labels: Sequence[str] = (),
     ) -> DiagnosisResult:
         """Stage 1: run the diagnose agent and persist the severity."""
         logger.info(
@@ -224,7 +241,7 @@ class DiagnosticLoop(BaseBackgroundLoop):
         )
         await self._publish_update(issue_number, "diagnosing")
         diagnosis = await self._runner.diagnose(
-            issue_number, issue_title, issue_body, context
+            issue_number, issue_title, issue_body, context, issue_labels=issue_labels
         )
         self._state.set_diagnosis_severity(issue_number, diagnosis.severity)
         return diagnosis
@@ -269,6 +286,7 @@ class DiagnosticLoop(BaseBackgroundLoop):
         diagnosis: DiagnosisResult,
         attempts: list[AttemptRecord],
         diagnosis_comment: str,
+        issue_labels: Sequence[str] = (),
     ) -> str:
         """Stage 2: provision a workspace, run the fix, and finalize the outcome.
 
@@ -287,7 +305,7 @@ class DiagnosticLoop(BaseBackgroundLoop):
             return "escalated"
 
         success, transcript = await self._run_fix(
-            issue_number, issue_title, issue_body, diagnosis, wt_path
+            issue_number, issue_title, issue_body, diagnosis, wt_path, issue_labels
         )
         self._record_attempt(issue_number, attempts, success, transcript)
         return await self._finalize_fix_outcome(
@@ -323,6 +341,7 @@ class DiagnosticLoop(BaseBackgroundLoop):
         issue_body: str,
         diagnosis: DiagnosisResult,
         wt_path: Path,
+        issue_labels: Sequence[str] = (),
     ) -> tuple[bool, str]:
         """Run the fix agent and clean up the workspace on failure.
 
@@ -331,7 +350,12 @@ class DiagnosticLoop(BaseBackgroundLoop):
         """
         try:
             success, transcript = await self._runner.fix(
-                issue_number, issue_title, issue_body, diagnosis, str(wt_path)
+                issue_number,
+                issue_title,
+                issue_body,
+                diagnosis,
+                str(wt_path),
+                issue_labels=issue_labels,
             )
         except Exception as exc:
             # Infra-level failures (auth, credit, OS permission/IO) propagate

--- a/src/diagnostic_runner.py
+++ b/src/diagnostic_runner.py
@@ -13,6 +13,8 @@ from base_runner import BaseRunner
 from exception_classify import reraise_on_credit_or_bug
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from models import EscalationContext
 
 from models import DiagnosisResult, Severity
@@ -137,8 +139,15 @@ class DiagnosticRunner(BaseRunner):
         issue_title: str,
         issue_body: str,
         context: EscalationContext,
+        *,
+        issue_labels: Sequence[str] = (),
     ) -> DiagnosisResult:
-        """Stage 1: Read-only diagnosis against repo root. Returns structured result."""
+        """Stage 1: Read-only diagnosis against repo root. Returns structured result.
+
+        *issue_labels* is threaded from the diagnostic loop's issue listing
+        so the CH-6 gate's upward-only ``data-class:`` label elevation
+        applies to the diagnosis spawn (#10000).
+        """
         bypass = self._mockworld_diagnosis()
         if bypass is not None:
             return bypass
@@ -150,6 +159,7 @@ class DiagnosticRunner(BaseRunner):
                 prompt,
                 self._config.repo_root,
                 {"issue": issue_number, "source": "diagnostic"},
+                issue_labels=issue_labels,
             )
         except (PermissionError, KeyboardInterrupt, SystemExit, MemoryError):
             raise
@@ -204,8 +214,15 @@ class DiagnosticRunner(BaseRunner):
         issue_body: str,
         diagnosis: DiagnosisResult,
         wt_path: str,
+        *,
+        issue_labels: Sequence[str] = (),
     ) -> tuple[bool, str]:
-        """Stage 2: Attempt fix in worktree. Returns (success, transcript)."""
+        """Stage 2: Attempt fix in worktree. Returns (success, transcript).
+
+        *issue_labels* is threaded from the diagnostic loop's issue listing
+        so the CH-6 gate's upward-only ``data-class:`` label elevation
+        applies to the fix spawn (#10000).
+        """
         prompt = (
             f"# Fix Issue #{issue_number}: {issue_title}\n\n"
             f"**Root Cause:** {diagnosis.root_cause}\n\n"
@@ -223,6 +240,7 @@ class DiagnosticRunner(BaseRunner):
                 prompt,
                 wt,
                 {"issue": issue_number, "source": "diagnostic_fix"},
+                issue_labels=issue_labels,
             )
             verify = await self._verify_quality(wt)
             return verify.passed, transcript

--- a/src/discover_runner.py
+++ b/src/discover_runner.py
@@ -339,6 +339,7 @@ class DiscoverRunner(BaseRunner):
                 self._config.repo_root,
                 {"issue": task.id, "source": f"discover:attempt-{attempt}"},
                 on_output=_check_complete,
+                issue_labels=task.tags,
             )
 
             parsed = self._extract_result(transcript, task.id)
@@ -425,6 +426,7 @@ class DiscoverRunner(BaseRunner):
                 prompt,
                 self._config.repo_root,
                 {"issue": task.id, "source": "discover:evaluator"},
+                issue_labels=task.tags,
             )
         except Exception as exc:
             reraise_on_credit_or_bug(exc)

--- a/src/expert_council.py
+++ b/src/expert_council.py
@@ -375,6 +375,7 @@ The experts will read this before revoting.
                 self._config.repo_root,
                 {"issue": task.id, "source": "council-mediator"},
                 on_output=_check,
+                issue_labels=task.tags,
             )
             # Extract the useful content (strip stream wrappers)
             from triage import TriageRunner  # noqa: PLC0415
@@ -408,6 +409,7 @@ The experts will read this before revoting.
                 "source": f"council-{expert['name'].lower().replace(' ', '-')}",
             },
             on_output=_check_complete,
+            issue_labels=task.tags,
         )
 
         return self._parse_vote(transcript, expert["name"])

--- a/src/plan_reviewer.py
+++ b/src/plan_reviewer.py
@@ -240,6 +240,7 @@ class PlanReviewer(BaseRunner):
             self._config.repo_root,
             {"issue": task.id, "source": "plan_reviewer"},
             on_output=_check_review_complete,
+            issue_labels=task.tags,
         )
 
     def _build_command(self, _worktree_path: Path | None = None) -> list[str]:

--- a/src/shape_runner.py
+++ b/src/shape_runner.py
@@ -181,6 +181,7 @@ class ShapeRunner(BaseRunner):
                 self._config.repo_root,
                 {"issue": task.id, "source": f"shape:attempt-{attempt}"},
                 on_output=_check_complete,
+                issue_labels=task.tags,
             )
             result.transcript = transcript
 
@@ -260,6 +261,7 @@ class ShapeRunner(BaseRunner):
                 prompt,
                 self._config.repo_root,
                 {"issue": task.id, "source": "shape:evaluator"},
+                issue_labels=task.tags,
             )
         except Exception as exc:
             reraise_on_credit_or_bug(exc)

--- a/src/triage.py
+++ b/src/triage.py
@@ -421,6 +421,7 @@ or for a claim that is demonstrably false / already implemented (the described p
             self._config.repo_root,
             {"issue": issue.id, "source": "triage"},
             telemetry_stats=prompt_stats,
+            issue_labels=issue.tags,
         )
         self._save_transcript("triage-issue", issue.id, transcript)
 
@@ -676,6 +677,7 @@ or for a claim that is demonstrably false / already implemented (the described p
                 prompt,
                 self._config.repo_root,
                 {"issue": task.id, "source": "decomposition"},
+                issue_labels=task.tags,
             )
         except Exception as exc:
             reraise_on_credit_or_bug(exc)

--- a/tests/regressions/test_issue_10000_ch6_derived_runner_list.py
+++ b/tests/regressions/test_issue_10000_ch6_derived_runner_list.py
@@ -1,0 +1,180 @@
+"""Regression: CH-6 gate pin covered 5 of 12 runner modules (#10000).
+
+``_RUNNER_EXECUTE_MODULES`` was a hand-maintained tuple listing only
+``agent.py, planner.py, research_runner.py, reviewer.py, hitl_runner.py`` —
+seven other BaseRunner subclass modules (diagnostic_runner, discover_runner,
+expert_council, shape_runner, bug_reproducer, plan_reviewer, triage) bypassed
+the ``issue_labels=`` pin entirely, so a ``data-class:regulated-*`` issue
+label did NOT elevate the prompt gate for their spawns — exactly the omission
+the pin was written to make "structurally impossible to reintroduce" (#9734
+review finding 1).
+
+Pins:
+- The runner-module list is DERIVED from the BaseRunner subclass set via AST,
+  so it can never rot again — a synthetic new subclass module with an
+  unlabeled ``self._execute`` call is flagged the moment it exists.
+- Every previously-bypassed module is in the derived list.
+- DiagnosticRunner threads ``issue_labels`` all the way to
+  ``base_runner.gate_prompt`` for both the diagnose and fix spawns.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from models import EscalationContext
+from tests.helpers import ConfigFactory
+from tests.test_prompt_gate_completeness import (
+    _base_runner_modules,
+    _unlabeled_execute_calls,
+)
+
+# Every BaseRunner subclass module at the time of the fix. The seven entries
+# after hitl_runner.py are the ones the hand-maintained tuple missed.
+_ALL_RUNNER_MODULES = {
+    "agent.py",
+    "planner.py",
+    "research_runner.py",
+    "reviewer.py",
+    "hitl_runner.py",
+    "diagnostic_runner.py",
+    "discover_runner.py",
+    "expert_council.py",
+    "shape_runner.py",
+    "bug_reproducer.py",
+    "plan_reviewer.py",
+    "triage.py",
+}
+
+_SYNTHETIC_UNLABELED = """\
+from base_runner import BaseRunner
+
+
+class SneakyRunner(BaseRunner):
+    async def run(self, cmd, prompt, cwd):
+        return await self._execute(cmd, prompt, cwd, {"issue": 1})
+"""
+
+_SYNTHETIC_LABELED = """\
+from base_runner import BaseRunner
+
+
+class PoliteRunner(BaseRunner):
+    async def run(self, cmd, prompt, cwd, task):
+        return await self._execute(
+            cmd, prompt, cwd, {"issue": task.id}, issue_labels=task.tags
+        )
+"""
+
+
+class TestDerivedRunnerList:
+    def test_derived_list_covers_every_baserunner_subclass_module(self) -> None:
+        """All 12 runner modules — including the 7 the old tuple missed."""
+        assert set(_base_runner_modules()) >= _ALL_RUNNER_MODULES
+
+    def test_synthetic_runner_omitting_kwarg_is_flagged(self, tmp_path: Path) -> None:
+        """A brand-new BaseRunner subclass module cannot dodge the pin."""
+        module = tmp_path / "sneaky_runner.py"
+        module.write_text(_SYNTHETIC_UNLABELED)
+
+        derived = _base_runner_modules(tmp_path)
+        assert "sneaky_runner.py" in derived, (
+            "AST derivation failed to pick up a new BaseRunner subclass "
+            "module — the completeness pin would silently skip it."
+        )
+        offenders = _unlabeled_execute_calls(module, "sneaky_runner.py")
+        assert offenders == ["sneaky_runner.py:6"], (
+            "The unlabeled self._execute call in a new runner module must be "
+            f"flagged; got {offenders}."
+        )
+
+    def test_synthetic_runner_passing_kwarg_is_clean(self, tmp_path: Path) -> None:
+        module = tmp_path / "polite_runner.py"
+        module.write_text(_SYNTHETIC_LABELED)
+
+        assert "polite_runner.py" in _base_runner_modules(tmp_path)
+        assert _unlabeled_execute_calls(module, "polite_runner.py") == []
+
+    def test_non_runner_module_is_not_in_derived_list(self, tmp_path: Path) -> None:
+        """Only BaseRunner subclass modules are pinned — no false positives."""
+        module = tmp_path / "plain_helper.py"
+        module.write_text("class Helper:\n    pass\n")
+
+        assert "plain_helper.py" not in _base_runner_modules(tmp_path)
+
+
+_LABELS = ("data-class:regulated-phi", "bug")
+
+
+def _make_runner(tmp_path: Path):
+    from diagnostic_runner import DiagnosticRunner
+
+    config = ConfigFactory.create(repo_root=tmp_path)
+    bus = MagicMock()
+    bus.current_session_id = "sess-test"
+    return DiagnosticRunner(config, bus)
+
+
+class TestDiagnosticRunnerLabelThreading:
+    @pytest.mark.asyncio
+    async def test_diagnose_threads_issue_labels_to_gate_prompt(
+        self, tmp_path: Path
+    ) -> None:
+        runner = _make_runner(tmp_path)
+        ctx = EscalationContext(cause="CI failed", origin_phase="review")
+        gated = MagicMock()
+        gated.prompt = "gated prompt"
+
+        with (
+            patch("base_runner.gate_prompt", return_value=gated) as gate,
+            patch(
+                "base_runner.stream_claude_process",
+                new_callable=AsyncMock,
+                return_value="out",
+            ),
+        ):
+            await runner.diagnose(42, "Bug", "Fix it", ctx, issue_labels=_LABELS)
+
+        assert gate.call_args is not None, "gate_prompt was never consulted"
+        assert tuple(gate.call_args.kwargs["issue_labels"]) == _LABELS
+
+    @pytest.mark.asyncio
+    async def test_fix_threads_issue_labels_to_gate_prompt(
+        self, tmp_path: Path
+    ) -> None:
+        from models import DiagnosisResult, Severity
+
+        runner = _make_runner(tmp_path)
+        diagnosis = DiagnosisResult(
+            root_cause="Missing import",
+            severity=Severity.P2_FUNCTIONAL,
+            fixable=True,
+            fix_plan="Add the import",
+            human_guidance="Trivial",
+        )
+        gated = MagicMock()
+        gated.prompt = "gated prompt"
+        verify = MagicMock()
+        verify.passed = True
+        runner._verify_quality = AsyncMock(return_value=verify)  # type: ignore[method-assign]
+
+        with (
+            patch("base_runner.gate_prompt", return_value=gated) as gate,
+            patch(
+                "base_runner.stream_claude_process",
+                new_callable=AsyncMock,
+                return_value="out",
+            ),
+        ):
+            await runner.fix(
+                42, "Bug", "Fix it", diagnosis, str(tmp_path), issue_labels=_LABELS
+            )
+
+        assert gate.call_args is not None, "gate_prompt was never consulted"
+        assert tuple(gate.call_args.kwargs["issue_labels"]) == _LABELS

--- a/tests/scenarios/test_product_phase_trust_scenario.py
+++ b/tests/scenarios/test_product_phase_trust_scenario.py
@@ -123,8 +123,9 @@ def _build_execute_stub(
         event_data: dict[str, Any],
         *,
         on_output: Any = None,
+        **kwargs: Any,
     ) -> str:
-        _ = on_output
+        _ = on_output, kwargs  # issue_labels et al (#10000) — stub ignores
         source = str(event_data.get("source", ""))
         call_log.append(source)
         # Pick the queue whose key is a prefix of the source tag. Sources

--- a/tests/test_diagnostic_loop.py
+++ b/tests/test_diagnostic_loop.py
@@ -743,3 +743,45 @@ class TestDiagnosticEscalationRoutesToAutoAgent:
         prs.add_labels.assert_awaited_once_with(
             42, ["hitl-escalation", "diagnose-failed"]
         )
+
+
+class TestIssueLabelsThreading:
+    """CH-6 (#10000): labels from the issue listing reach diagnose AND fix."""
+
+    @pytest.mark.asyncio
+    async def test_do_work_threads_wire_shape_labels_to_runner(
+        self, tmp_path: Path
+    ) -> None:
+        """gh wire-shape labels ([{"name": ...}]) flow to both runner stages."""
+        loop, runner, prs, _, _ = _make_loop(tmp_path)
+        prs.list_issues_by_label.return_value = [
+            {
+                "number": 42,
+                "title": "Bug",
+                "body": "It's broken",
+                "labels": [
+                    {"name": "data-class:regulated-phi"},
+                    {"name": "hydraflow-diagnose"},
+                ],
+            }
+        ]
+
+        await loop._do_work()
+
+        expected = ("data-class:regulated-phi", "hydraflow-diagnose")
+        assert runner.diagnose.call_args.kwargs["issue_labels"] == expected
+        assert runner.fix.call_args.kwargs["issue_labels"] == expected
+
+    @pytest.mark.asyncio
+    async def test_do_work_tolerates_missing_labels_key(self, tmp_path: Path) -> None:
+        """Issues without a labels key still process (empty elevation)."""
+        loop, runner, prs, _, _ = _make_loop(tmp_path)
+        prs.list_issues_by_label.return_value = [
+            {"number": 42, "title": "Bug", "body": "It's broken"}
+        ]
+
+        result = await loop._do_work()
+
+        assert result is not None
+        assert result["processed"] == 1
+        assert runner.diagnose.call_args.kwargs["issue_labels"] == ()

--- a/tests/test_diagnostic_runner.py
+++ b/tests/test_diagnostic_runner.py
@@ -489,3 +489,86 @@ class TestDiagnosticRunner:
         )
         assert result.fixable is False
         assert result.root_cause == "No output"
+
+
+class TestIssueLabelsThreading:
+    """CH-6 (#10000): diagnose/fix thread issue_labels to gate_prompt.
+
+    The gate call lives inside ``BaseRunner._execute``; patching
+    ``base_runner.gate_prompt`` intercepts it regardless of how _execute
+    wraps the call internally. Without the threading, a
+    ``data-class:regulated-*`` label on the escalated issue would not
+    elevate the gate for the diagnose/fix spawns.
+    """
+
+    _LABELS = ("data-class:regulated-phi", "bug")
+
+    def _real_runner(self, tmp_path):
+        from unittest.mock import MagicMock
+
+        from diagnostic_runner import DiagnosticRunner
+        from tests.helpers import ConfigFactory
+
+        bus = MagicMock()
+        bus.current_session_id = "sess-test"
+        return DiagnosticRunner(ConfigFactory.create(repo_root=tmp_path), bus)
+
+    @pytest.mark.asyncio
+    async def test_diagnose_labels_reach_gate_prompt(self, tmp_path) -> None:
+        from unittest.mock import AsyncMock, patch
+
+        runner = self._real_runner(tmp_path)
+        ctx = EscalationContext(cause="CI failed", origin_phase="review")
+        gated = MagicMock()
+        gated.prompt = "gated prompt"
+
+        with (
+            patch("base_runner.gate_prompt", return_value=gated) as gate,
+            patch(
+                "base_runner.stream_claude_process",
+                new_callable=AsyncMock,
+                return_value="out",
+            ),
+        ):
+            await runner.diagnose(42, "Bug", "Fix it", ctx, issue_labels=self._LABELS)
+
+        assert gate.call_args is not None
+        assert tuple(gate.call_args.kwargs["issue_labels"]) == self._LABELS
+
+    @pytest.mark.asyncio
+    async def test_fix_labels_reach_gate_prompt(self, tmp_path) -> None:
+        from unittest.mock import AsyncMock, patch
+
+        runner = self._real_runner(tmp_path)
+        diagnosis = DiagnosisResult(
+            root_cause="Missing import",
+            severity=Severity.P2_FUNCTIONAL,
+            fixable=True,
+            fix_plan="Add the import",
+            human_guidance="Trivial",
+        )
+        gated = MagicMock()
+        gated.prompt = "gated prompt"
+        verify = MagicMock()
+        verify.passed = True
+        runner._verify_quality = AsyncMock(return_value=verify)
+
+        with (
+            patch("base_runner.gate_prompt", return_value=gated) as gate,
+            patch(
+                "base_runner.stream_claude_process",
+                new_callable=AsyncMock,
+                return_value="out",
+            ),
+        ):
+            await runner.fix(
+                42,
+                "Bug",
+                "Fix it",
+                diagnosis,
+                str(tmp_path),
+                issue_labels=self._LABELS,
+            )
+
+        assert gate.call_args is not None
+        assert tuple(gate.call_args.kwargs["issue_labels"]) == self._LABELS

--- a/tests/test_prompt_gate_completeness.py
+++ b/tests/test_prompt_gate_completeness.py
@@ -21,6 +21,7 @@ NOT grow.
 from __future__ import annotations
 
 import ast
+from pathlib import Path
 
 from tests._spawn_audit import SRC, iter_module_facts
 
@@ -100,17 +101,64 @@ def test_no_spawner_bypasses_the_gated_seams() -> None:
     )
 
 
-# Runner modules whose ``self._execute(...)`` call sites all have a task/issue
-# (or threaded label context) in scope. Every call MUST pass ``issue_labels=``
-# so the CH-6 upward-only ``data-class:`` label elevation reaches the gate —
-# omitting it silently disables label-based elevation for that spawn.
-_RUNNER_EXECUTE_MODULES = (
-    "agent.py",
-    "planner.py",
-    "research_runner.py",
-    "reviewer.py",
-    "hitl_runner.py",
-)
+# Runner modules are DERIVED from the BaseRunner subclass set (#10000): the
+# old hand-maintained tuple listed 5 of 12 subclass modules, so more than
+# half the runner surface silently bypassed the pin. Every ``self._execute``
+# call in a derived module MUST pass ``issue_labels=`` so the CH-6
+# upward-only ``data-class:`` label elevation reaches the gate — omitting it
+# silently disables label-based elevation for that spawn.
+
+# Interface-gap exemptions from the runner pin below. Mirrors the
+# implement_spec_reviewer.py precedent for _AGENTPORT_CALLER_FOLLOWUPS: an
+# entry means the module's enclosing interfaces verifiably carry no issue
+# context, and threading labels is an interface change tracked as a named
+# follow-up issue — never a silent skip. Currently empty: every BaseRunner
+# subclass has (or is threaded) label context at its _execute call sites.
+_RUNNER_EXECUTE_EXEMPT: tuple[str, ...] = ()
+
+
+def _base_runner_modules(src_dir: Path = SRC) -> tuple[str, ...]:
+    """Enumerate top-level ``*.py`` in *src_dir* defining a BaseRunner subclass.
+
+    AST-derived (``class X(BaseRunner)`` / ``class X(mod.BaseRunner)``) so the
+    module list can never rot the way the hand-maintained tuple did (#10000).
+    """
+    modules: list[str] = []
+    for path in sorted(src_dir.glob("*.py")):
+        tree = ast.parse(path.read_text(), filename=path.name)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            bases = {
+                getattr(base, "id", None) or getattr(base, "attr", None)
+                for base in node.bases
+            }
+            if "BaseRunner" in bases:
+                modules.append(path.name)
+                break
+    return tuple(modules)
+
+
+def _unlabeled_execute_calls(path: Path, rel: str) -> list[str]:
+    """Return ``rel:lineno`` for every ``self._execute(...)`` in *path* that
+    omits the ``issue_labels=`` kwarg."""
+    offenders: list[str] = []
+    tree = ast.parse(path.read_text(), filename=rel)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        is_self_execute = (
+            isinstance(func, ast.Attribute)
+            and func.attr == "_execute"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "self"
+        )
+        if not is_self_execute:
+            continue
+        if not any(kw.arg == "issue_labels" for kw in node.keywords):
+            offenders.append(f"{rel}:{node.lineno}")
+    return offenders
 
 
 def test_every_runner_execute_call_passes_issue_labels() -> None:
@@ -121,33 +169,34 @@ def test_every_runner_execute_call_passes_issue_labels() -> None:
     the gate see only the repo-declared class, so a ``data-class:regulated-*``
     issue label on an internal repo would NOT redact/block that spawn. This
     pin makes the omission structurally impossible to reintroduce (#9734
-    review finding 1).
+    review finding 1) — and the module list is derived from the BaseRunner
+    subclass set so a new runner is covered the moment it exists (#10000).
     """
+    modules = _base_runner_modules()
+    # Sanity floor: if derivation ever breaks the pin must not pass vacuously.
+    core = {"agent.py", "planner.py", "reviewer.py", "triage.py"}
+    assert core <= set(modules), (
+        f"BaseRunner subclass derivation lost core runner modules: "
+        f"{sorted(core - set(modules))} — _base_runner_modules is broken."
+    )
+    stale_exempt = sorted(set(_RUNNER_EXECUTE_EXEMPT) - set(modules))
+    assert not stale_exempt, (
+        f"_RUNNER_EXECUTE_EXEMPT has stale entries that are no longer "
+        f"BaseRunner subclass modules: {stale_exempt}. Remove them."
+    )
     offenders: list[str] = []
-    for rel in _RUNNER_EXECUTE_MODULES:
-        path = SRC / rel
-        assert path.exists(), f"runner module {rel} not found in src/"
-        tree = ast.parse(path.read_text(), filename=rel)
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-            func = node.func
-            is_self_execute = (
-                isinstance(func, ast.Attribute)
-                and func.attr == "_execute"
-                and isinstance(func.value, ast.Name)
-                and func.value.id == "self"
-            )
-            if not is_self_execute:
-                continue
-            if not any(kw.arg == "issue_labels" for kw in node.keywords):
-                offenders.append(f"{rel}:{node.lineno}")
+    for rel in modules:
+        if rel in _RUNNER_EXECUTE_EXEMPT:
+            continue
+        offenders.extend(_unlabeled_execute_calls(SRC / rel, rel))
     assert not offenders, (
         f"These self._execute(...) call sites omit issue_labels=: {offenders}. "
         "Without it the CH-6 gate cannot apply the upward-only "
         "data-class:<class> label elevation for that spawn — pass "
         "issue_labels=task.tags / issue.tags / issue.labels (or thread the "
-        "labels into the enclosing method) at every call."
+        "labels into the enclosing method) at every call. If the enclosing "
+        "interface truly carries no issue context, add the module to "
+        "_RUNNER_EXECUTE_EXEMPT with a comment naming the follow-up issue."
     )
 
 


### PR DESCRIPTION
## Problem (#10000)

The issue_labels completeness pin hand-listed 5 runner modules while the codebase has MORE BaseRunner subclasses — every unlisted module's `self._execute` calls silently skipped CH-6 data-class label elevation. The AST derivation found the issue's own inventory short too: **12** subclass modules (the issue missed `triage.py`, 2 more unguarded sites).

## Change

- `_RUNNER_EXECUTE_MODULES` is DERIVED (AST scan for `class X(BaseRunner)`) with a documented-exemption tuple (empty) and a core-module sanity floor so the pin can't pass vacuously.
- All 12 unguarded call sites thread `issue_labels=` from context the caller already had (`task.tags`/`issue.tags`; the diagnostic loop threads gh wire-shape labels from the #9943 projection down both stages). Zero empty-tuple compromises.

## Tests

Regression file pins the derived list (synthetic unlabeled subclass flagged at exact line, labeled clean, non-runner excluded, all 12 covered) and diagnose/fix labels reaching `gate_prompt` through the #9879 to_thread closure. 290 touched-suite tests green; full `make quality` exit 0.

Closes #10000

🤖 Generated with [Claude Code](https://claude.com/claude-code)