### PR TITLE
fix(merge-heal): DIRTY content-conflict auto-heal for bot/factory PRs (#9889 item 2)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -647,6 +647,11 @@ _ENV_BOOL_OVERRIDES: list[tuple[str, str, bool]] = [
         "HYDRAFLOW_HUMAN_BRANCH_SHEPHERD_ENABLED",
         True,
     ),
+    (
+        "dependabot_conflict_heal_enabled",
+        "HYDRAFLOW_DEPENDABOT_CONFLICT_HEAL_ENABLED",
+        True,
+    ),
     ("stale_issue_loop_enabled", "HYDRAFLOW_STALE_ISSUE_LOOP_ENABLED", True),
     ("triage_retry_loop_enabled", "HYDRAFLOW_TRIAGE_RETRY_LOOP_ENABLED", True),
     (
@@ -2052,6 +2057,19 @@ class HydraFlowConfig(BaseModel):
             "branches (fix/, feat/, docs/, test/, chore/, refactor/) to merge "
             "once CI is green — same path as factory branches. Per-PR opt-out: "
             "the no-auto-merge label."
+        ),
+    )
+    dependabot_conflict_heal_enabled: bool = Field(
+        default=True,
+        description=(
+            "Item 2 (#9889): DependabotMergeLoop heals CI-green PRs whose "
+            "merge fails on a genuine content conflict (mergeable=False). "
+            "Factory-maintenance PRs are closed-superseded (their loop "
+            "regenerates a fresh one, single-flight #9939); other bot PRs get "
+            "one bounded update-branch before the failure strategy; human "
+            "shepherd-prefix PRs get one dedup-bounded conflict comment and "
+            "are otherwise left to their author. False restores the legacy "
+            "log-and-give-up path."
         ),
     )
     review_orphan_strike_threshold: int = Field(

--- a/src/dependabot_merge_loop.py
+++ b/src/dependabot_merge_loop.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import HydraFlowConfig
+from dedup_store import DedupStore
 from events import EventType, HydraFlowEvent
 from merge_policy import (
     ROLE_ORCHESTRATOR_REVIEWER,
@@ -14,10 +15,15 @@ from merge_policy import (
     enforce_merge_policy,
     fetch_pr_labels,
 )
-from models import PRListItem, ReviewVerdict, SystemAlertPayload
+from models import (
+    PRListItem,
+    ReviewVerdict,
+    SystemAlertPayload,
+)
 
 if TYPE_CHECKING:
     from github_cache_loop import GitHubDataCache
+    from models import DependabotMergeSettings
     from ports import PRPort
     from state import StateTracker
 
@@ -134,6 +140,13 @@ class DependabotMergeLoop(BaseBackgroundLoop):
         self._cache = cache
         self._prs = prs
         self._state = state
+        # #9889 item 2: at most ONE conflict comment per human-shepherd PR,
+        # ever — persisted so restarts don't re-comment (the
+        # runs_gc_chain_alerts DedupStore precedent).
+        self._conflict_comment_dedup = DedupStore(
+            "dependabot_conflict_comments",
+            config.data_root / "dedup" / "dependabot_conflict_comments.json",
+        )
 
     def _get_default_interval(self) -> int:
         return self._config.dependabot_merge_interval
@@ -144,6 +157,125 @@ class DependabotMergeLoop(BaseBackgroundLoop):
             self._config.human_branch_shepherd_enabled
             and not pr.is_bot
             and pr.branch.startswith(_HUMAN_SHEPHERD_BRANCH_PREFIXES)
+        )
+
+    async def _apply_failure_strategy(
+        self, pr: PRListItem, strategy: str, cause: str, detail: str
+    ) -> str:
+        """Apply the configured ``failure_strategy`` to *pr*.
+
+        Returns the counter the caller should bump: ``"skipped"`` for
+        ``skip`` (PR left open, re-polled next cycle) or ``"failed"`` for
+        ``hitl``/``close`` (PR escalated/closed and marked processed).
+        """
+        if strategy == "hitl":
+            await self._prs.add_labels(pr.pr, self._config.hitl_label)
+            await self._prs.post_comment(
+                pr.pr, f"{cause} — escalating to HITL.\n\n{detail}"
+            )
+            self._state.add_dependabot_merge_processed(pr.pr)
+            logger.info("Bot PR #%d: %s — escalated to HITL", pr.pr, cause)
+            return "failed"
+        if strategy == "close":
+            await self._prs.post_comment(
+                pr.pr, f"{cause} — closing per configured strategy.\n\n{detail}"
+            )
+            await self._prs.close_issue(pr.pr)
+            self._state.add_dependabot_merge_processed(pr.pr)
+            logger.info("Bot PR #%d: %s — closed", pr.pr, cause)
+            return "failed"
+        # "skip" (the default) and any unknown value: leave open.
+        logger.info("Bot PR #%d: %s (strategy=skip) — leaving open", pr.pr, cause)
+        return "skipped"
+
+    async def _maybe_heal_merge_conflict(
+        self, pr: PRListItem, settings: DependabotMergeSettings
+    ) -> str | None:
+        """Item 2 (#9889): DIRTY content-conflict auto-heal.
+
+        Called after ``merge_pr`` returned False on a CI-green PR. The
+        mergeable-state read (``get_pr_mergeable``) corroborates that the
+        failure is a genuine content conflict — ``False`` maps to GitHub's
+        CONFLICTING; ``True``/``None`` means transient/unknown, for which the
+        caller keeps the legacy log-and-give-up path. Heal by PR class:
+
+        * human shepherd-prefix → the author's to fix: one DedupStore-bounded
+          conflict comment, never closed, never update-branched;
+        * factory-maintenance prefix → close-supersede: the owning loop
+          regenerates a fresh PR (single-flight #9939 prevents pile-up), so
+          rebasing generated content is wasted work;
+        * dependabot/other bot → one bounded update-branch (the #9884
+          fresh-merge-ref lesson, sharing the class-2 attempt counter), then
+          the configured ``failure_strategy``.
+
+        Everything is bounded and idempotent: the dedup file caps comments at
+        one per PR, close-supersede marks the PR processed, and update-branch
+        rides ``dependabot_update_branch_max_attempts``. Returns the caller's
+        counter to bump ("skipped"/"failed"), or None when no heal applies.
+        """
+        if not self._config.dependabot_conflict_heal_enabled:
+            return None
+        if await self._prs.get_pr_mergeable(pr.pr) is not False:
+            return None
+
+        if self._is_human_shepherd_pr(pr):
+            dedup_key = str(pr.pr)
+            if dedup_key not in self._conflict_comment_dedup.get():
+                await self._prs.post_comment(
+                    pr.pr,
+                    "This PR has a merge conflict with its base branch, so "
+                    "auto-merge is on hold. Please resolve the conflict — "
+                    "the factory shepherds human-prefix PRs to merge once "
+                    "they are conflict-free and CI-green (#9889).",
+                )
+                self._conflict_comment_dedup.add(dedup_key)
+            logger.info("Human PR #%d is conflicting — left to its author", pr.pr)
+            return "skipped"
+
+        if pr.branch.startswith(_FACTORY_MAINTENANCE_BRANCH_PREFIXES):
+            await self._prs.post_comment(
+                pr.pr,
+                "Closing: this factory-maintenance PR has a merge conflict "
+                "with its base branch. Its generated content is cheap to "
+                "rebuild, so the owning loop will regenerate and open a "
+                "fresh conflict-free PR on its next cycle (single-flight "
+                "#9939 guarantees no pile-up). No action needed (#9889).",
+            )
+            await self._prs.close_pr(pr.pr)
+            self._state.add_dependabot_merge_processed(pr.pr)
+            logger.info(
+                "Factory-maintenance PR #%d (%s) conflicting — "
+                "closed-superseded; owning loop will regenerate",
+                pr.pr,
+                pr.branch,
+            )
+            return "failed"
+
+        # Dependabot / configured-bot / auto-agent PRs: one bounded
+        # update-branch may clear a conflict against state the base already
+        # fixed. Shares the class-2 counter so a PR never exceeds
+        # ``dependabot_update_branch_max_attempts`` across both paths.
+        ub_cap = self._config.dependabot_update_branch_max_attempts
+        if (
+            ub_cap > 0
+            and self._state.get_dependabot_update_branch_attempts(pr.pr) < ub_cap
+            and await self._prs.update_pr_branch(pr.pr, method="merge")
+        ):
+            self._state.bump_dependabot_update_branch_attempts(pr.pr)
+            logger.info(
+                "Bot PR #%d conflicting — updated branch for a fresh merge "
+                "ref; re-evaluating next cycle (attempt %d/%d)",
+                pr.pr,
+                self._state.get_dependabot_update_branch_attempts(pr.pr),
+                ub_cap,
+            )
+            return "skipped"
+        return await self._apply_failure_strategy(
+            pr,
+            settings.failure_strategy,
+            "Merge conflict on bot PR",
+            "The PR is CONFLICTING with its base branch and the bounded "
+            "update-branch heal did not clear it (#9889).",
         )
 
     async def _do_work(self) -> dict[str, Any] | None:
@@ -275,7 +407,18 @@ class DependabotMergeLoop(BaseBackgroundLoop):
                     merged += 1
                     self._state.add_dependabot_merge_processed(pr.pr)
                     logger.info("Auto-merged bot PR #%d (%s)", pr.pr, pr.title)
-                else:
+                    continue
+                # #9889 item 2: the merge failed — when the PR's mergeable
+                # state corroborates a genuine content conflict (DIRTY), heal
+                # it per PR class instead of log-and-give-up (the arch
+                # self-heal below only fires on arch-staleness CI text, never
+                # on mergeable-state conflicts, so it can't help here).
+                heal_outcome = await self._maybe_heal_merge_conflict(pr, settings)
+                if heal_outcome == "skipped":
+                    skipped += 1
+                elif heal_outcome == "failed":
+                    failed += 1
+                else:  # not a content conflict — legacy give-up
                     failed += 1
                     logger.warning("Failed to merge bot PR #%d", pr.pr)
                 continue
@@ -350,29 +493,12 @@ class DependabotMergeLoop(BaseBackgroundLoop):
                 continue
 
             # CI truly failed — apply failure strategy
-            strategy = settings.failure_strategy
-            if strategy == "skip":
+            strategy_outcome = await self._apply_failure_strategy(
+                pr, settings.failure_strategy, "CI failed on bot PR", summary
+            )
+            if strategy_outcome == "skipped":
                 skipped += 1
-                logger.info(
-                    "Bot PR #%d CI failed (strategy=skip) — leaving open", pr.pr
-                )
-            elif strategy == "hitl":
-                await self._prs.add_labels(pr.pr, self._config.hitl_label)
-                await self._prs.post_comment(
-                    pr.pr,
-                    f"CI failed on bot PR — escalating to HITL.\n\n{summary}",
-                )
-                self._state.add_dependabot_merge_processed(pr.pr)
+            else:
                 failed += 1
-                logger.info("Bot PR #%d CI failed — escalated to HITL", pr.pr)
-            elif strategy == "close":
-                await self._prs.post_comment(
-                    pr.pr,
-                    f"CI failed on bot PR — closing per configured strategy.\n\n{summary}",
-                )
-                await self._prs.close_issue(pr.pr)
-                self._state.add_dependabot_merge_processed(pr.pr)
-                failed += 1
-                logger.info("Bot PR #%d CI failed — closed", pr.pr)
 
         return {"merged": merged, "skipped": skipped, "failed": failed}

--- a/tests/regressions/test_issue_9889_conflict_heal.py
+++ b/tests/regressions/test_issue_9889_conflict_heal.py
@@ -1,0 +1,70 @@
+"""Item 2 (#9889): DIRTY content-conflict auto-heal for bot/factory PRs.
+
+Before this fix, a CI-green bot PR whose merge failed on a genuine content
+conflict hit ``merge_pr`` → False and the loop just logged and gave up — the
+arch self-heal only fires on arch-staleness CI text, never on mergeable-state
+conflicts — so conflicting factory PRs sat DIRTY forever. Pinned contracts:
+
+1. Close-supersede: a conflicting factory-maintenance PR (ul-*/pricing/wiki)
+   is closed with an explanatory comment — its loop regenerates a fresh PR
+   (single-flight #9939), so rebasing generated content is wasted work.
+2. Human PRs stay untouched: a conflicting shepherd-prefix (fix/ etc.) PR is
+   never closed, never update-branched, never marked processed — one
+   DedupStore-bounded comment tells the author, and that is all.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tests.test_dependabot_merge_loop import _make_loop, _make_pr
+
+
+@pytest.mark.asyncio
+async def test_conflicting_factory_maintenance_pr_is_closed_superseded(
+    tmp_path: Path,
+) -> None:
+    loop, _, _, prs, state = _make_loop(
+        tmp_path,
+        open_prs=[_make_pr(9889, author="HydraOps-T-rav", branch="ul-proposer/abc123")],
+        merge_result=False,
+        mergeable=False,  # GitHub: CONFLICTING
+    )
+
+    result = await loop._do_work()
+
+    # Close-supersede, not log-and-give-up: comment + close_pr + processed.
+    prs.post_comment.assert_awaited_once()
+    assert "conflict" in prs.post_comment.await_args.args[1].lower()
+    prs.close_pr.assert_awaited_once_with(9889)
+    state.add_dependabot_merge_processed.assert_called_once_with(9889)
+    # Never a rebase of generated content, never the issue-close surface.
+    prs.update_pr_branch.assert_not_awaited()
+    prs.close_issue.assert_not_awaited()
+    assert result["failed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_conflicting_human_pr_is_never_closed_or_update_branched(
+    tmp_path: Path,
+) -> None:
+    loop, _, _, prs, state = _make_loop(
+        tmp_path,
+        open_prs=[_make_pr(9890, author="T-rav", branch="fix/human-owned")],
+        merge_result=False,
+        mergeable=False,
+    )
+
+    with patch("dependabot_merge_loop.fetch_pr_labels", AsyncMock(return_value=[])):
+        await loop._do_work()
+        await loop._do_work()  # still open + conflicting next cycle
+
+    # One comment ever (DedupStore), and the PR remains fully the author's:
+    prs.post_comment.assert_awaited_once()
+    prs.close_pr.assert_not_awaited()
+    prs.close_issue.assert_not_awaited()
+    prs.update_pr_branch.assert_not_awaited()
+    state.add_dependabot_merge_processed.assert_not_called()

--- a/tests/test_dependabot_merge_loop.py
+++ b/tests/test_dependabot_merge_loop.py
@@ -99,14 +99,23 @@ def _make_loop(
     arch_autoheal_max_attempts: int | None = None,
     update_branch_max_attempts: int | None = None,
     update_branch_result: bool = True,
+    mergeable: bool | None = None,
 ) -> tuple[DependabotMergeLoop, asyncio.Event, MagicMock, MagicMock, MagicMock]:
     """Build a DependabotMergeLoop with test-friendly defaults.
 
     Returns (loop, stop_event, cache_mock, prs_mock, state_mock).
+
+    ``mergeable`` feeds ``get_pr_mergeable`` (the #9889 item-2 conflict
+    corroboration read). The harness default ``None`` (= unknown) keeps the
+    legacy merge-failure path in every pre-existing test; conflict-heal tests
+    opt in with ``mergeable=False``.
     """
     deps = make_bg_loop_deps(
         tmp_path, enabled=enabled, dependabot_merge_interval=interval
     )
+    # Isolate the conflict-comment DedupStore under tmp_path (the factory
+    # config's data_root defaults to CWD, which would leak between tests).
+    object.__setattr__(deps.config, "data_root", tmp_path / "data")
     if arch_autoheal_max_attempts is not None:
         object.__setattr__(
             deps.config,
@@ -135,6 +144,8 @@ def _make_loop(
     prs.add_labels = AsyncMock()
     prs.post_comment = AsyncMock()
     prs.close_issue = AsyncMock()
+    prs.close_pr = AsyncMock(return_value=True)
+    prs.get_pr_mergeable = AsyncMock(return_value=mergeable)
     prs.refresh_pr_branch_with_arch_regen = AsyncMock(return_value=arch_refresh_result)
 
     state = _make_state(
@@ -934,3 +945,224 @@ class TestHumanBranchShepherd:
 
         assert result == {"merged": 0, "skipped": 0, "failed": 0}
         prs.wait_for_ci.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Item 2 (#9889): DIRTY content-conflict auto-heal
+# ---------------------------------------------------------------------------
+
+
+class TestConflictHeal:
+    """A CI-green PR whose merge fails on a genuine content conflict
+    (``get_pr_mergeable`` reads False = CONFLICTING) is healed by class:
+    factory-maintenance → close-supersede (the regenerating loop reopens a
+    fresh PR, single-flight #9939); dependabot/bot → one bounded
+    update-branch then the failure strategy; human shepherd-prefix → one
+    dedup-bounded comment, otherwise the author's to fix."""
+
+    @pytest.mark.asyncio
+    async def test_ul_pr_conflict_closed_with_supersede_comment(
+        self, tmp_path: Path
+    ) -> None:
+        loop, _, _, prs, state = _make_loop(
+            tmp_path,
+            open_prs=[
+                _make_pr(50, author="HydraOps-T-rav", branch="ul-proposer/4e3d7b2b")
+            ],
+            merge_result=False,
+            mergeable=False,
+        )
+
+        result = await loop._do_work()
+
+        prs.post_comment.assert_awaited_once()
+        comment = prs.post_comment.await_args.args[1]
+        assert "conflict" in comment.lower()
+        assert "fresh" in comment.lower() or "supersed" in comment.lower()
+        prs.close_pr.assert_awaited_once_with(50)
+        state.add_dependabot_merge_processed.assert_called_once_with(50)
+        prs.update_pr_branch.assert_not_awaited()
+        prs.close_issue.assert_not_awaited()
+        assert result["failed"] == 1
+        assert result["merged"] == 0
+
+    @pytest.mark.parametrize(
+        "branch",
+        [
+            "ul-evidence/5ebff585",
+            "ul-edges/0afc892d",
+            "ul-pruner/9f1c2d3e",
+            "pricing-refresh-auto",
+            "hydraflow/wiki-maint-20260719-0400",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_all_factory_maintenance_prefixes_close_supersede(
+        self, tmp_path: Path, branch: str
+    ) -> None:
+        loop, _, _, prs, state = _make_loop(
+            tmp_path,
+            open_prs=[_make_pr(51, author="HydraOps-T-rav", branch=branch)],
+            merge_result=False,
+            mergeable=False,
+        )
+
+        await loop._do_work()
+
+        prs.close_pr.assert_awaited_once_with(51)
+        state.add_dependabot_merge_processed.assert_called_once_with(51)
+
+    @pytest.mark.asyncio
+    async def test_dependabot_conflict_update_branch_once_then_retry(
+        self, tmp_path: Path
+    ) -> None:
+        loop, _, _, prs, state = _make_loop(
+            tmp_path,
+            open_prs=[
+                _make_pr(
+                    52, author="app/dependabot", branch="dependabot/uv/foo", is_bot=True
+                )
+            ],
+            merge_result=False,
+            mergeable=False,
+            update_branch_max_attempts=1,
+            update_branch_result=True,
+        )
+
+        result = await loop._do_work()
+
+        prs.update_pr_branch.assert_awaited_once_with(52, method="merge")
+        state.bump_dependabot_update_branch_attempts.assert_called_once_with(52)
+        prs.close_pr.assert_not_awaited()
+        prs.post_comment.assert_not_awaited()
+        state.add_dependabot_merge_processed.assert_not_called()
+        assert result["skipped"] == 1
+        assert result["failed"] == 0
+
+    @pytest.mark.asyncio
+    async def test_dependabot_conflict_cap_exhausted_applies_failure_strategy(
+        self, tmp_path: Path
+    ) -> None:
+        loop, _, _, prs, state = _make_loop(
+            tmp_path,
+            open_prs=[
+                _make_pr(
+                    53, author="app/dependabot", branch="dependabot/uv/bar", is_bot=True
+                )
+            ],
+            merge_result=False,
+            mergeable=False,
+            update_branch_max_attempts=1,
+            failure_strategy="hitl",
+        )
+        state.get_dependabot_update_branch_attempts.side_effect = lambda _n: 1
+
+        result = await loop._do_work()
+
+        prs.update_pr_branch.assert_not_awaited()
+        prs.add_labels.assert_awaited_once()
+        prs.post_comment.assert_awaited_once()
+        state.add_dependabot_merge_processed.assert_called_once_with(53)
+        prs.close_pr.assert_not_awaited()
+        assert result["failed"] == 1
+
+    @pytest.mark.asyncio
+    async def test_dependabot_conflict_update_branch_refused_falls_to_strategy(
+        self, tmp_path: Path
+    ) -> None:
+        """update_pr_branch=False (GitHub can't rebase a real conflict) must
+        not burn the attempt budget and must fall through to the strategy."""
+        loop, _, _, prs, state = _make_loop(
+            tmp_path,
+            open_prs=[
+                _make_pr(
+                    54, author="app/dependabot", branch="dependabot/uv/baz", is_bot=True
+                )
+            ],
+            merge_result=False,
+            mergeable=False,
+            update_branch_max_attempts=1,
+            update_branch_result=False,
+            failure_strategy="skip",
+        )
+
+        result = await loop._do_work()
+
+        prs.update_pr_branch.assert_awaited_once_with(54, method="merge")
+        state.bump_dependabot_update_branch_attempts.assert_not_called()
+        assert result["skipped"] == 1  # strategy=skip leaves it open
+        state.add_dependabot_merge_processed.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_human_pr_conflict_single_comment_never_closed(
+        self, tmp_path: Path
+    ) -> None:
+        loop, _, _, prs, state = _make_loop(
+            tmp_path,
+            open_prs=[_make_pr(55, author="T-rav", branch="fix/manual-thing")],
+            merge_result=False,
+            mergeable=False,
+        )
+
+        with patch("dependabot_merge_loop.fetch_pr_labels", AsyncMock(return_value=[])):
+            first = await loop._do_work()
+            second = await loop._do_work()  # PR still open + conflicting
+
+        # Exactly ONE conflict comment across both cycles (DedupStore-bounded).
+        prs.post_comment.assert_awaited_once()
+        comment = prs.post_comment.await_args.args[1]
+        assert "conflict" in comment.lower()
+        # Never closed, never update-branched, never marked processed —
+        # the author keeps full ownership.
+        prs.close_pr.assert_not_awaited()
+        prs.close_issue.assert_not_awaited()
+        prs.update_pr_branch.assert_not_awaited()
+        state.add_dependabot_merge_processed.assert_not_called()
+        assert first["skipped"] == 1
+        assert second["skipped"] == 1
+
+    @pytest.mark.asyncio
+    async def test_kill_switch_off_restores_legacy_give_up(
+        self, tmp_path: Path
+    ) -> None:
+        loop, _, _, prs, state = _make_loop(
+            tmp_path,
+            open_prs=[
+                _make_pr(56, author="HydraOps-T-rav", branch="ul-proposer/deadbeef")
+            ],
+            merge_result=False,
+            mergeable=False,
+        )
+        object.__setattr__(loop._config, "dependabot_conflict_heal_enabled", False)
+
+        result = await loop._do_work()
+
+        prs.get_pr_mergeable.assert_not_awaited()
+        prs.close_pr.assert_not_awaited()
+        prs.post_comment.assert_not_awaited()
+        prs.update_pr_branch.assert_not_awaited()
+        state.add_dependabot_merge_processed.assert_not_called()
+        assert result["failed"] == 1
+
+    @pytest.mark.asyncio
+    async def test_transient_merge_failure_is_not_treated_as_conflict(
+        self, tmp_path: Path
+    ) -> None:
+        """mergeable=None (unknown) and True (clean) both mean the merge
+        failure was NOT a content conflict — legacy give-up, no heal."""
+        for status in (None, True):
+            loop, _, _, prs, state = _make_loop(
+                tmp_path,
+                open_prs=[
+                    _make_pr(57, author="HydraOps-T-rav", branch="ul-edges/cafe")
+                ],
+                merge_result=False,
+                mergeable=status,
+            )
+
+            result = await loop._do_work()
+
+            prs.get_pr_mergeable.assert_awaited_once_with(57)
+            prs.close_pr.assert_not_awaited()
+            prs.post_comment.assert_not_awaited()
+            assert result["failed"] == 1


### PR DESCRIPTION
## Problem (#9889, last residual item)

On a mergeable-state conflict, `merge_pr` returns False and the loop logged-and-gave-up — no rebase, no close-supersede. Conflicted bot/UL PRs piled up until a human intervened (the arch self-heal only fires on arch-staleness CI text, not content conflicts).

## Change

When a CI-green selected PR fails to merge, corroborate via tri-state `get_pr_mergeable` (False = CONFLICTING → heal; True/None = transient → exact legacy path), then route by class:
- **Factory-maintenance prefixes** (ul-*/pricing/wiki-maint): comment + close-supersede — the regenerating loop reopens fresh (single-flight #9939 prevents pile-up); rebasing generated content is wasted work.
- **Dependabot/bots/auto-agent**: ONE update-branch reusing the existing `dependabot_update_branch_max_attempts` budget, then the normal `failure_strategy`.
- **Human-shepherd prefixes**: one DedupStore-bounded comment; never closed, never update-branched.

Kill-switch `dependabot_conflict_heal_enabled` (default on). `_apply_failure_strategy` extracted and shared with the CI-fail path (all pre-existing strategy tests pass unmodified). No new port surface.

## Tests

8 new unit tests (5-way prefix parametrize, dedup across cycles, kill-switch, transient non-heal) + regression file pinning close-supersede and human-untouched contracts + L7 scenarios green. Full `make quality` exit 0.

Relates #9889

🤖 Generated with [Claude Code](https://claude.com/claude-code)