### PR TITLE
fix(escalation): streak escalations auto-close on recovery (#10015)

### DIFF
--- a/src/contract_refresh_loop.py
+++ b/src/contract_refresh_loop.py
@@ -180,6 +180,24 @@ class ContractRefreshLoop(BaseBackgroundLoop):
             labels=["hydraflow-find", "fake-drift"],
         )
 
+    def _escalation_rollup(self) -> RollupIssueManager:
+        """One rolling ``fake-repair-stuck`` escalation per adapter (#10015).
+
+        Subjects are adapter names under a namespace SEPARATE from
+        ``contract_refresh`` (which tracks the ``fake_drift`` rollup), so
+        the per-tick ``resolve_all_except`` sweep can close every recovered
+        adapter's escalation without touching the fake-drift issue.
+        Previously escalations were bare ``create_issue`` calls: a clean
+        tick cleared the attempt counter and dedup but left the
+        hitl-escalation issue open forever (the #9867 dead-letter shape).
+        """
+        return RollupIssueManager(
+            pr=self._prs,
+            state=self._state,
+            namespace="contract_refresh_escalations",
+            labels=["hitl-escalation", "fake-repair-stuck"],
+        )
+
     # ------------------------------------------------------------------
     # Recording
     # ------------------------------------------------------------------
@@ -628,12 +646,12 @@ class ContractRefreshLoop(BaseBackgroundLoop):
         ``config.max_fake_repair_attempts``. The HITL operator uses the
         adapter name in the label + title to jump straight to the stuck
         fake.
+
+        #10015: tracked per adapter via :meth:`_escalation_rollup` so the
+        adapter's next clean tick auto-closes the issue. The title is
+        STABLE (rollup contract) — the attempt count lives in the body.
         """
-        labels = ["hitl-escalation", "fake-repair-stuck", f"adapter-{adapter}"]
-        title = (
-            f"Contract refresh stuck: {adapter} has drifted "
-            f"{attempts} consecutive ticks"
-        )
+        title = f"Contract refresh stuck: {adapter} fake repair not converging"
         body = (
             f"`ContractRefreshLoop` has detected drift on the **{adapter}** "
             f"adapter for {attempts} consecutive ticks without the drift "
@@ -645,14 +663,15 @@ class ContractRefreshLoop(BaseBackgroundLoop):
             f"repair the fake in `src/mockworld/fakes/` or adjust the "
             f"cassette normalizers.\n\n"
             f"This issue dedups on the adapter name — the next clean tick "
-            f"for `{adapter}` will clear both the attempt counter and the "
-            f"escalation dedup entry, so a future stuck streak can "
-            f"re-escalate."
+            f"for `{adapter}` clears the attempt counter and the escalation "
+            f"dedup entry and auto-closes this issue (#10015), so a future "
+            f"stuck streak escalates fresh."
         )
-        return await self._prs.create_issue(
+        return await self._escalation_rollup().ensure(
+            adapter,
             title=title,
             body=body,
-            labels=labels,
+            extra_labels=[f"adapter-{adapter}"],
         )
 
     async def _maybe_escalate(self, drifted_adapters: set[str]) -> dict[str, int]:
@@ -831,6 +850,21 @@ class ContractRefreshLoop(BaseBackgroundLoop):
         # per-adapter escalation dedup.
         drifted_adapters: set[str] = {r.adapter for r in fleet.reports}
         self._update_attempt_counters(drifted_adapters)
+
+        # #10015 — auto-close open fake-repair-stuck escalations for every
+        # adapter NOT drifting this tick, mirroring the attempt-counter reset
+        # semantics directly above (a no-signal recorder already resets the
+        # counter, so it closes the escalation too; a genuine re-occurrence
+        # re-escalates fresh once the streak rebuilds). No-op when nothing
+        # is tracked.
+        await self._escalation_rollup().resolve_all_except(
+            drifted_adapters,
+            comment=(
+                "This adapter is no longer drifting — the fake is back in "
+                "sync with its committed cassettes; auto-closing (#10015). "
+                "A future stuck streak escalates fresh."
+            ),
+        )
 
         if not fleet.has_drift:
             return await self._on_clean_tick()

--- a/src/staging_promotion_loop.py
+++ b/src/staging_promotion_loop.py
@@ -84,18 +84,26 @@ class StagingPromotionLoop(BaseBackgroundLoop):
     def _get_default_interval(self) -> int:
         return self._config.staging_promotion_interval
 
-    def _rollups(self) -> RollupIssueManager | None:
-        """One rolling "promotion CI is failing" issue, auto-closed on a green
-        promotion — replaces the per-PR ``RC promotion #N failed CI`` pile-up
-        (#9219..#9342). ``None`` when state is absent (unit tests fall back to
-        create_issue's stable-title dedup)."""
+    def _rollups(self, labels: list[str] | None = None) -> RollupIssueManager | None:
+        """One rolling issue per subject under the ``staging_promotion``
+        namespace — ``rc_ci`` ("promotion CI is failing", #9359) and
+        ``rc_promotion_stuck`` (the streak escalation, #10015) — auto-closed
+        on a green promotion. Replaces the per-PR ``RC promotion #N failed
+        CI`` pile-up (#9219..#9342). ``None`` when state is absent (unit
+        tests fall back to create_issue's stable-title dedup). *labels*
+        overrides the default find-label set at create time; ``resolve`` is
+        label-independent, so any instance can close any tracked subject."""
         if self._state is None:
             return None
         return RollupIssueManager(
             pr=self._prs,
             state=self._state,
             namespace="staging_promotion",
-            labels=list(self._config.find_label or ["hydraflow-find"]),
+            labels=(
+                labels
+                if labels is not None
+                else list(self._config.find_label or ["hydraflow-find"])
+            ),
         )
 
     async def _do_work(self) -> dict[str, Any] | None:
@@ -227,6 +235,19 @@ class StagingPromotionLoop(BaseBackgroundLoop):
                             comment=(
                                 f"RC promotion to {self._config.main_branch} "
                                 "succeeded — auto-closing."
+                            ),
+                        )
+                        # #10015: the streak escalation gets the same green-path
+                        # resolve as rc_ci — before this it was a dead letter
+                        # (a green promotion only reset the counter; #9867
+                        # closed only via an unrelated PR body). Idempotent
+                        # no-op when no escalation is tracked.
+                        await rollups.resolve(
+                            "rc_promotion_stuck",
+                            comment=(
+                                f"RC promotion to {self._config.main_branch} "
+                                "succeeded — the consecutive-failure streak is "
+                                "broken; auto-closing this escalation."
                             ),
                         )
                 # CH-4 (#9732): the promotion succeeded — compile its release
@@ -516,12 +537,20 @@ class StagingPromotionLoop(BaseBackgroundLoop):
         ``rc_consecutive_failure_escalation_threshold`` consecutive failures we
         file ONE ``hitl-escalation`` issue so a human looks at the pipeline, not
         just the latest red PR.
+
+        #10015: tracked as the ``rc_promotion_stuck`` rollup subject so the
+        next green promotion auto-closes it (mirrors ``rc_ci``). The title is
+        STABLE per the rollup contract — the streak size and latest PR number
+        live in the body.
         """
         labels = list(self._config.hitl_escalation_label or ["hitl-escalation"])
         for lbl in self._config.rc_promotion_stuck_label:
             if lbl not in labels:
                 labels.append(lbl)
-        title = f"staging→main promotion stuck: {failures} consecutive RC failures"
+        title = (
+            f"staging→{self._config.main_branch} promotion stuck: "
+            "repeated consecutive RC failures"
+        )
         body = (
             f"The StagingPromotionLoop has failed to promote `staging` → "
             f"`{self._config.main_branch}` **{failures} times in a row** "
@@ -533,8 +562,13 @@ class StagingPromotionLoop(BaseBackgroundLoop):
             "- a systemic CI/promotion-loop defect (e.g. the #9351 timeout "
             "misclassification that silently force-closed green PRs).\n\n"
             "This fires once per failure streak; the next successful promotion "
-            "clears the counter."
+            "clears the counter and auto-closes this escalation (#10015)."
         )
+        rollups = self._rollups(labels=labels)
+        if rollups is not None:
+            return await rollups.ensure("rc_promotion_stuck", title=title, body=body)
+        # State-less fallback (unit tests): create_issue's exact-title dedup on
+        # the now-stable title still prevents per-streak pile-up.
         try:
             return await self._prs.create_issue(title, body, labels)
         except Exception:  # noqa: BLE001

--- a/tests/regressions/test_issue_10015_streak_escalation_autoclose.py
+++ b/tests/regressions/test_issue_10015_streak_escalation_autoclose.py
@@ -1,0 +1,161 @@
+"""Regression: streak escalations had no auto-close path (#10015).
+
+StagingPromotionLoop's rc-promotion-stuck escalation (#9867 class) was filed
+via bare ``create_issue`` with no resolve path — a green promotion only reset
+the consecutive-failure counter, so the HITL escalation stayed open forever
+unless a human (or an unrelated PR body saying "Closes #NNNN") closed it.
+
+Pins (#10015):
+- The escalation is tracked as a rollup subject
+  (``staging_promotion:rc_promotion_stuck``) with a STABLE title.
+- The next green promotion closes the escalation issue and clears its
+  tracking, alongside the existing ``rc_ci`` rolling-issue resolve.
+- A later streak escalates fresh (new issue), not into the dead letter.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import evidence_pack
+import subprocess_util
+from base_background_loop import LoopDeps
+from config import HydraFlowConfig
+from events import EventBus
+from models import PRInfo
+from staging_promotion_loop import StagingPromotionLoop
+from state import StateTracker
+
+RC_CI_ISSUE = 7001
+ESCALATION_ISSUE = 8002
+
+
+@pytest.fixture(autouse=True)
+def _offline_boundaries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the CH-4 evidence compiler and gh reconcile sweep off the network."""
+    monkeypatch.setattr(
+        evidence_pack,
+        "compile_evidence_pack",
+        AsyncMock(return_value=MagicMock(gap_count=0)),
+    )
+
+    async def _empty_list(*cmd: str, **_kwargs: object) -> str:
+        assert cmd[:3] == ("gh", "pr", "list"), cmd
+        return "[]"
+
+    monkeypatch.setattr(subprocess_util, "run_subprocess", _empty_list)
+
+
+def _make_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[StagingPromotionLoop, MagicMock, StateTracker]:
+    monkeypatch.setenv("HYDRAFLOW_STAGING_ENABLED", "true")
+    monkeypatch.setenv("HYDRAFLOW_RC_CONSECUTIVE_FAILURE_ESCALATION_THRESHOLD", "2")
+    cfg = HydraFlowConfig(
+        repo_root=tmp_path,
+        workspace_base=tmp_path / "wt",
+        state_file=tmp_path / "s.json",
+        data_root=tmp_path / "data",
+    )
+
+    async def _sleep(_s: float) -> None:
+        return None
+
+    deps = LoopDeps(
+        event_bus=EventBus(),
+        stop_event=asyncio.Event(),
+        status_cb=MagicMock(),
+        enabled_cb=lambda _n: True,
+        sleep_fn=_sleep,
+    )
+
+    prs = MagicMock()
+    prs.find_open_promotion_pr = AsyncMock(
+        return_value=PRInfo(
+            number=70,
+            issue_number=0,
+            branch="rc/2026-07-18-0400",
+            url="https://github.com/o/r/pull/70",
+            draft=False,
+        )
+    )
+    prs.wait_for_ci = AsyncMock(return_value=(False, "ci failed: scenario tests"))
+    prs.merge_promotion_pr = AsyncMock(return_value=True)
+    prs.post_comment = AsyncMock()
+    prs.close_issue = AsyncMock()
+    prs.update_issue_body = AsyncMock()
+    prs.get_pr_head_sha = AsyncMock(return_value="somesha")
+    prs.list_rc_branches = AsyncMock(return_value=[])
+    prs.delete_branch = AsyncMock(return_value=True)
+
+    async def _create_issue(title: str, body: str, labels: list[str]) -> int:
+        if "rc-promotion-stuck" in labels:
+            return ESCALATION_ISSUE
+        return RC_CI_ISSUE
+
+    prs.create_issue = AsyncMock(side_effect=_create_issue)
+
+    state = StateTracker(state_file=tmp_path / "s.json")
+    loop = StagingPromotionLoop(config=cfg, prs=prs, deps=deps, state=state)
+    return loop, prs, state
+
+
+def _escalation_creates(prs: MagicMock) -> list:
+    out = []
+    for call in prs.create_issue.await_args_list:
+        labels = call.kwargs.get("labels") or (
+            call.args[2] if len(call.args) > 2 else []
+        )
+        if "rc-promotion-stuck" in labels:
+            out.append(call)
+    return out
+
+
+@pytest.mark.asyncio
+async def test_green_promotion_auto_closes_streak_escalation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The exact #9867 shape: red, red (escalates), green → escalation closes."""
+    loop, prs, state = _make_loop(tmp_path, monkeypatch)
+
+    await loop._do_work()  # red 1
+    await loop._do_work()  # red 2 → escalation filed at threshold
+
+    assert len(_escalation_creates(prs)) == 1
+    tracked = state.get_rollup_issue("staging_promotion:rc_promotion_stuck")
+    assert tracked is not None
+    assert tracked["issue_number"] == ESCALATION_ISSUE
+
+    prs.wait_for_ci.return_value = (True, "ok")
+    result = await loop._do_work()  # green → auto-close
+
+    assert result["status"] == "promoted"
+    prs.close_issue.assert_any_await(ESCALATION_ISSUE)
+    assert state.get_rollup_issue("staging_promotion:rc_promotion_stuck") is None
+    assert state.get_consecutive_rc_failures() == 0
+
+
+@pytest.mark.asyncio
+async def test_next_streak_escalates_fresh_after_auto_close(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The dead-letter must not linger: a second stall files a NEW escalation."""
+    loop, prs, _state = _make_loop(tmp_path, monkeypatch)
+
+    await loop._do_work()  # red 1
+    await loop._do_work()  # red 2 → escalation
+    prs.wait_for_ci.return_value = (True, "ok")
+    await loop._do_work()  # green → close + clear
+
+    prs.wait_for_ci.return_value = (False, "ci failed: scenario tests")
+    await loop._do_work()  # red 1 of streak 2
+    await loop._do_work()  # red 2 of streak 2 → fresh escalation
+
+    assert len(_escalation_creates(prs)) == 2

--- a/tests/test_contract_refresh_loop.py
+++ b/tests/test_contract_refresh_loop.py
@@ -765,6 +765,28 @@ async def test_drift_clears_attempts_for_adapters_not_in_this_tick(
     assert state.get_contract_refresh_attempts("docker") == 2
 
 
+def _issue_call_fields(call: Any) -> tuple[str, str, list[str]]:
+    """``(title, body, labels)`` from a create_issue call, positional or kw.
+
+    #10015: escalations now route through ``RollupIssueManager.ensure``,
+    which calls ``create_issue(title, body, labels)`` positionally — the
+    old kwargs-only filters would silently match nothing.
+    """
+    title = call.kwargs.get("title") or (call.args[0] if call.args else "")
+    body = call.kwargs.get("body") or (call.args[1] if len(call.args) > 1 else "")
+    labels = call.kwargs.get("labels") or (call.args[2] if len(call.args) > 2 else [])
+    return title, body, labels
+
+
+def _escalation_issue_calls(prs: Any) -> list:
+    """create_issue calls carrying the ``hitl-escalation`` label."""
+    return [
+        c
+        for c in prs.create_issue.await_args_list
+        if "hitl-escalation" in _issue_call_fields(c)[2]
+    ]
+
+
 @pytest.mark.asyncio
 async def test_third_attempt_files_escalation_issue(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -800,16 +822,16 @@ async def test_third_attempt_files_escalation_issue(
     # The escalation issue was filed.
     assert prs.create_issue.await_count >= 1
     # Find the hitl-escalation call (there may be another for fake-drift).
-    escalation_calls = [
-        call
-        for call in prs.create_issue.await_args_list
-        if "hitl-escalation" in (call.kwargs.get("labels") or [])
-    ]
+    escalation_calls = _escalation_issue_calls(prs)
     assert len(escalation_calls) == 1, prs.create_issue.await_args_list
-    kwargs = escalation_calls[0].kwargs
-    assert "fake-repair-stuck" in kwargs["labels"]
-    assert "adapter-git" in kwargs["labels"]
-    assert "git" in kwargs["title"].lower() or "git" in kwargs["body"].lower()
+    title, body, labels = _issue_call_fields(escalation_calls[0])
+    assert "fake-repair-stuck" in labels
+    assert "adapter-git" in labels
+    assert "git" in title.lower() or "git" in body.lower()
+    # #10015: STABLE title (rollup contract) — the attempt count lives in
+    # the body so the issue dedups/adopts across streaks.
+    assert "3" not in title
+    assert "3 consecutive ticks" in body
 
 
 @pytest.mark.asyncio
@@ -842,21 +864,11 @@ async def test_escalation_is_deduped_across_ticks(
 
     # Tick 3: escalation filed.
     await loop._do_work()
-    first_escalations = [
-        c
-        for c in prs.create_issue.await_args_list
-        if "hitl-escalation" in (c.kwargs.get("labels") or [])
-    ]
-    assert len(first_escalations) == 1
+    assert len(_escalation_issue_calls(prs)) == 1
 
     # Tick 4: same adapter still stuck → dedup hit → no new escalation.
     await loop._do_work()
-    all_escalations = [
-        c
-        for c in prs.create_issue.await_args_list
-        if "hitl-escalation" in (c.kwargs.get("labels") or [])
-    ]
-    assert len(all_escalations) == 1, all_escalations
+    assert len(_escalation_issue_calls(prs)) == 1, prs.create_issue.await_args_list
 
 
 @pytest.mark.asyncio
@@ -896,11 +908,7 @@ async def test_escalation_zero_sentinel_does_not_dedup(
     # Tick 4: still stuck → re-attempts (would be deduped if sentinel had
     # been recorded).
     await loop._do_work()
-    escalations = [
-        c
-        for c in prs.create_issue.await_args_list
-        if "hitl-escalation" in (c.kwargs.get("labels") or [])
-    ]
+    escalations = _escalation_issue_calls(prs)
     assert len(escalations) == 2, escalations
 
 
@@ -955,24 +963,100 @@ async def test_escalation_resets_after_clean_tick(
         "detect_fleet_drift",
         lambda *_a, **_k: _drift_fleet_for("git", rec),
     )
-    pre_count = len(
-        [
-            c
-            for c in prs.create_issue.await_args_list
-            if "hitl-escalation" in (c.kwargs.get("labels") or [])
-        ]
-    )
+    pre_count = len(_escalation_issue_calls(prs))
     await loop._do_work()
-    post_count = len(
-        [
-            c
-            for c in prs.create_issue.await_args_list
-            if "hitl-escalation" in (c.kwargs.get("labels") or [])
-        ]
-    )
+    post_count = len(_escalation_issue_calls(prs))
     assert post_count == pre_count + 1, (
         "Escalation should re-fire after an adapter goes clean then drifts again"
     )
+
+
+@pytest.mark.asyncio
+async def test_clean_tick_auto_closes_open_escalation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#10015: a clean tick CLOSES the open fake-repair-stuck escalation.
+
+    Before this, a clean tick only cleared the attempt counter and the
+    escalation dedup — the hitl-escalation issue itself stayed open forever
+    (the same dead-letter shape as the rc-promotion-stuck escalation)."""
+    _stub_recording(monkeypatch)
+    rec = _seed_recorded_cassette(tmp_path / "rec" / "git", "git", "commit")
+    monkeypatch.setattr(crl_module, "record_git", lambda *_a, **_k: [rec])
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", _FakeAutoPR())
+    _stub_make_trust_contracts_ok(monkeypatch)
+
+    state = _FakeState()
+    state.inc_contract_refresh_attempts("git")
+    state.inc_contract_refresh_attempts("git")
+
+    prs = AsyncMock()
+    prs.create_issue = AsyncMock(return_value=555)
+    loop = _loop(tmp_path, prs=prs, state=state)
+
+    # Tick 3: drift → escalation filed and tracked as a rollup subject.
+    monkeypatch.setattr(
+        crl_module,
+        "detect_fleet_drift",
+        lambda *_a, **_k: _drift_fleet_for("git", rec),
+    )
+    await loop._do_work()
+    tracked = state.get_rollup_issue("contract_refresh_escalations:git")
+    assert tracked is not None
+    assert tracked["issue_number"] == 555
+
+    # Tick 4: clean → the escalation issue auto-closes and tracking clears.
+    monkeypatch.setattr(
+        crl_module,
+        "detect_fleet_drift",
+        lambda *_a, **_k: crl_module.FleetDriftReport(reports=[], has_drift=False),
+    )
+    await loop._do_work()
+
+    prs.close_issue.assert_any_await(555)
+    assert state.get_rollup_issue("contract_refresh_escalations:git") is None
+
+
+@pytest.mark.asyncio
+async def test_recovered_adapter_escalation_closes_while_stuck_one_stays(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#10015: per-adapter close — only the RECOVERED adapter's escalation
+    closes; a still-drifting sibling keeps its open escalation."""
+    _stub_recording(monkeypatch)
+    rec = _seed_recorded_cassette(tmp_path / "rec" / "docker", "docker", "run")
+    monkeypatch.setattr(crl_module, "record_docker", lambda *_a, **_k: [rec])
+    monkeypatch.setattr(
+        crl_module,
+        "detect_fleet_drift",
+        lambda *_a, **_k: _drift_fleet_for("docker", rec),
+    )
+    monkeypatch.setattr(auto_pr, "generate_and_open_pr_async", _FakeAutoPR())
+    _stub_make_trust_contracts_ok(monkeypatch)
+
+    state = _FakeState()
+    # Both adapters escalated on earlier ticks; docker is still drifting.
+    state.set_rollup_issue(
+        "contract_refresh_escalations:git", issue_number=601, content_hash="h1"
+    )
+    state.set_rollup_issue(
+        "contract_refresh_escalations:docker", issue_number=602, content_hash="h2"
+    )
+    state.inc_contract_refresh_attempts("docker")
+
+    prs = AsyncMock()
+    prs.create_issue = AsyncMock(return_value=700)
+    loop = _loop(tmp_path, prs=prs, state=state)
+
+    await loop._do_work()
+
+    prs.close_issue.assert_any_await(601)
+    closed = [c.args[0] for c in prs.close_issue.await_args_list]
+    assert 602 not in closed
+    assert state.get_rollup_issue("contract_refresh_escalations:git") is None
+    tracked = state.get_rollup_issue("contract_refresh_escalations:docker")
+    assert tracked is not None
+    assert tracked["issue_number"] == 602
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_staging_promotion_loop.py
+++ b/tests/test_staging_promotion_loop.py
@@ -593,6 +593,128 @@ class TestRepeatedFailureEscalation:
         assert state.get_consecutive_rc_failures() == 0
 
 
+class TestEscalationAutoClose:
+    """#10015: the rc-promotion-stuck escalation must auto-close on the next
+    green promotion — mirroring the rc_ci rolling-issue pattern. Before this,
+    the escalation was filed via bare ``create_issue`` with no resolve path:
+    a green promotion only reset the failure counter, and #9867 closed only
+    because an unrelated PR body happened to say "Closes #9867"."""
+
+    ESCALATION_ISSUE = 8002
+    RC_CI_ISSUE = 7001
+
+    def _streak_loop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> tuple[StagingPromotionLoop, MagicMock, StateTracker]:
+        monkeypatch.setenv("HYDRAFLOW_RC_CONSECUTIVE_FAILURE_ESCALATION_THRESHOLD", "2")
+        loop, prs = _make_loop(
+            tmp_path,
+            monkeypatch,
+            open_promotion=_make_pr(number=70),
+            ci_result=(False, "ci failed: scenario tests"),
+        )
+
+        async def _create_issue(title: str, body: str, labels: list[str]) -> int:
+            if "rc-promotion-stuck" in labels:
+                return self.ESCALATION_ISSUE
+            return self.RC_CI_ISSUE
+
+        prs.create_issue = AsyncMock(side_effect=_create_issue)
+        prs.update_issue_body = AsyncMock()
+        prs.get_pr_head_sha = AsyncMock(return_value="somesha")
+        state = StateTracker(state_file=tmp_path / "s.json")
+        loop._state = state  # type: ignore[attr-defined]
+        return loop, prs, state
+
+    @pytest.mark.asyncio
+    async def test_escalation_is_tracked_as_rollup_subject(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        loop, prs, state = self._streak_loop(tmp_path, monkeypatch)
+
+        await loop._do_work()  # failure 1 — below threshold
+        assert state.get_rollup_issue("staging_promotion:rc_promotion_stuck") is None
+
+        await loop._do_work()  # failure 2 — escalates, tracked as a rollup
+        tracked = state.get_rollup_issue("staging_promotion:rc_promotion_stuck")
+        assert tracked is not None
+        assert tracked["issue_number"] == self.ESCALATION_ISSUE
+
+    @pytest.mark.asyncio
+    async def test_escalation_title_is_stable_and_count_lives_in_body(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Rollup contract: variable content (streak size, latest PR) goes in
+        the BODY; the title must be stable so re-adoption dedup works."""
+        loop, prs, _state = self._streak_loop(tmp_path, monkeypatch)
+
+        await loop._do_work()
+        await loop._do_work()
+
+        escalations = _escalation_calls(prs)
+        assert len(escalations) == 1
+        title, body, labels = escalations[0].args
+        assert "promotion stuck" in title
+        assert "2" not in title  # streak count must NOT be in the title
+        assert "2 times in a row" in body
+        assert "#70" in body
+        assert "hydraflow-hitl-escalation" in labels
+        assert "rc-promotion-stuck" in labels
+
+    @pytest.mark.asyncio
+    async def test_green_promotion_auto_closes_open_escalation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        loop, prs, state = self._streak_loop(tmp_path, monkeypatch)
+
+        await loop._do_work()
+        await loop._do_work()  # escalation filed + tracked
+
+        prs.wait_for_ci.return_value = (True, "ok")
+        prs.merge_promotion_pr = AsyncMock(return_value=True)
+        result = await loop._do_work()
+
+        assert result["status"] == "promoted"
+        prs.close_issue.assert_any_await(self.ESCALATION_ISSUE)
+        assert state.get_rollup_issue("staging_promotion:rc_promotion_stuck") is None
+        assert state.get_consecutive_rc_failures() == 0
+
+    @pytest.mark.asyncio
+    async def test_green_without_open_escalation_is_a_noop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """resolve() is idempotent — a clean green tick with no tracked
+        escalation must not touch GitHub for the escalation subject."""
+        loop, prs, _state = self._streak_loop(tmp_path, monkeypatch)
+        prs.wait_for_ci.return_value = (True, "ok")
+        prs.merge_promotion_pr = AsyncMock(return_value=True)
+
+        result = await loop._do_work()
+
+        assert result["status"] == "promoted"
+        prs.close_issue.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fresh_streak_after_green_files_new_escalation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        loop, prs, _state = self._streak_loop(tmp_path, monkeypatch)
+
+        await loop._do_work()
+        await loop._do_work()  # streak 1 escalates
+        assert len(_escalation_calls(prs)) == 1
+
+        prs.wait_for_ci.return_value = (True, "ok")
+        prs.merge_promotion_pr = AsyncMock(return_value=True)
+        await loop._do_work()  # green — closes + clears tracking
+
+        prs.wait_for_ci.return_value = (False, "ci failed: scenario tests")
+        await loop._do_work()
+        await loop._do_work()  # streak 2 escalates fresh
+
+        assert len(_escalation_calls(prs)) == 2
+
+
 class TestSentinelFidelity:
     @pytest.mark.asyncio
     async def test_producer_timeout_sentinel_is_pending_not_failure(


### PR DESCRIPTION
## Problem (#10015)

StagingPromotionLoop's rc-promotion-stuck escalation was a bare `create_issue` with no resolve path — a green promotion only reset the failure counter, so #9867-class escalations stayed open forever. Sibling sweep found `contract_refresh_loop` had the identical gap.

## Change

- staging_promotion: the escalation is now a rollup subject (`staging_promotion:rc_promotion_stuck`, stable title, streak/PR in body, same labels); the green path resolves it beside the existing rc_ci resolve.
- contract_refresh: escalations route through a per-adapter `RollupIssueManager` (`contract_refresh_escalations`), auto-closed each clean tick.
- Other streak escalations verified already covered (live_corpus_replay's own resolver, the shared EscalationReconciler, corpus_learning's documented bespoke lifecycle) — no change.

## Tests

TDD red→green; regression file pins red-red-green auto-close + fresh re-escalation. 94 tests green across touched suites; full `make quality` exit 0.

Closes #10015

🤖 Generated with [Claude Code](https://claude.com/claude-code)