### PR TITLE
fix(ci): per-PR concurrency groups — superseded runs cancel, gates never do

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,15 @@ on:
 permissions:
   contents: read
 
+# Superseded PR runs are cancelled (a new push makes the old run's verdict
+# moot); push/schedule runs are never cancelled — rc promotion gates and the
+# nightly must always finish (#10027 flake-class fix at the source: without
+# groups, every PR push left the prior run burning runners, and "cancelled"
+# was ambiguous between superseded and infra-killed).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   changes:
     name: Detect Changes

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -10,6 +10,15 @@ on:
 permissions:
   contents: read
 
+# Superseded PR runs are cancelled (a new push makes the old run's verdict
+# moot); push/schedule runs are never cancelled — rc promotion gates and the
+# nightly must always finish (#10027 flake-class fix at the source: without
+# groups, every PR push left the prior run burning runners, and "cancelled"
+# was ambiguous between superseded and infra-killed).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   changes:
     name: Detect Changes


### PR DESCRIPTION
## Problem

Neither `ci.yml` nor `quality.yml` had a concurrency stanza: every PR push left the prior run burning runners to completion, and `cancelled` was ambiguous between *superseded* and *infra-killed* — tonight's #9983/#10002 rerun archaeology traced straight to this.

## Change

Both workflows gain a group keyed `workflow + PR number (|| ref)` with `cancel-in-progress` **only for pull_request events** — rc/* promotion gates, staging pushes, and the nightly always run to completion.

This is the workstream-first half of #10027: with superseded runs self-cancelling by design, the retrier's cancelled-class shrinks to genuine infra kills.

Workflow-only diff (Skip-Regression trailer in the commit); YAML validated locally.

Relates #10027

🤖 Generated with [Claude Code](https://claude.com/claude-code)