### PR TITLE
fix(reap): heavy-make caretaker loops group-kill their subtrees on timeout (#9579)

### DIFF
--- a/src/contract_refresh_loop.py
+++ b/src/contract_refresh_loop.py
@@ -75,6 +75,7 @@ from contract_recording import (
 )
 from dedup_store import DedupStore
 from models import WorkCycleResult  # noqa: TCH001
+from process_group import kill_process_group
 from rollup_issue_manager import RollupIssueManager
 
 if TYPE_CHECKING:
@@ -523,18 +524,23 @@ class ContractRefreshLoop(BaseBackgroundLoop):
             cwd=str(self._config.repo_root),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            # Group leader (pid == pgid) so the timeout reap kills the whole
+            # make → pytest replay subtree, not just the top-level make
+            # (#9579).
+            start_new_session=True,
         )
         try:
             stdout_b, stderr_b = await asyncio.wait_for(
                 proc.communicate(), timeout=_REPLAY_GATE_TIMEOUT_SECONDS
             )
         except TimeoutError:
-            # proc.kill() itself raises ProcessLookupError when the child
-            # already exited — suppress it (and proc.wait()) so the timeout is
-            # handled as a failure instead of crashing the loop cycle.
-            # (#9794/#9816/#9883)
+            # Group-kill: a child-only proc.kill() orphaned the sub-make /
+            # pytest grandchildren at PPID=1 (#9579). The guarded primitive
+            # never raises — an already-exited child included — so the
+            # timeout is handled as a failure instead of crashing the loop
+            # cycle. (#9794/#9816/#9883)
+            kill_process_group(proc)
             with contextlib.suppress(ProcessLookupError):
-                proc.kill()
                 await proc.wait()
             logger.warning(
                 "Replay gate timed out after %ss; treating as failure",

--- a/src/principles_audit_loop.py
+++ b/src/principles_audit_loop.py
@@ -22,6 +22,7 @@ import trace_collector
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from exception_classify import reraise_on_credit_or_bug
 from models import WorkCycleResult
+from process_group import kill_process_group
 
 if TYPE_CHECKING:
     from config import HydraFlowConfig, ManagedRepo
@@ -43,19 +44,23 @@ async def _communicate_bounded(
 ) -> tuple[bytes, bytes]:
     """``proc.communicate()`` bounded by *timeout* seconds.
 
-    On timeout the wedged child is killed and a ``TimeoutError`` propagates so
-    the caller ends its cycle (and is restarted by the supervisor) rather than
-    hanging indefinitely.
+    On timeout the wedged child's whole PROCESS GROUP is reaped and a
+    ``TimeoutError`` propagates so the caller ends its cycle (and is
+    restarted by the supervisor) rather than hanging indefinitely.
+
+    Callers must spawn with ``start_new_session=True`` (child is its own
+    group leader): ``make audit-json`` fans out sub-make → pytest → LLM
+    grandchildren, and a child-only ``proc.kill()`` re-parented them to
+    init where they kept burning API credits (#9579). The guarded
+    primitive never raises — an already-exited child included — so the
+    TimeoutError (the intended failed-read signal) still propagates
+    (#9794/#9816).
     """
     try:
         return await asyncio.wait_for(proc.communicate(), timeout=timeout)
     except TimeoutError:
-        # proc.kill() itself raises ProcessLookupError when the child already
-        # exited — suppress it too, not just proc.wait() — so the TimeoutError
-        # (the intended failed-read signal) propagates instead of crashing the
-        # caller with ProcessLookupError. (#9794/#9816)
+        kill_process_group(proc)
         with contextlib.suppress(ProcessLookupError):
-            proc.kill()
             await proc.wait()
         raise
 
@@ -234,6 +239,10 @@ class PrinciplesAuditLoop(BaseBackgroundLoop):
             cwd=self._config.repo_root,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            # Group leader (pid == pgid) so the timeout reap in
+            # _communicate_bounded kills the whole make → pytest → LLM
+            # subtree, not just the top-level make (#9579).
+            start_new_session=True,
         )
         try:
             stdout, stderr = await _communicate_bounded(
@@ -296,6 +305,9 @@ class PrinciplesAuditLoop(BaseBackgroundLoop):
             cwd=cwd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
+            # Group leader: _communicate_bounded reaps via killpg, which is
+            # only meaningful when the child owns its group (#9579).
+            start_new_session=True,
         )
         try:
             out, _ = await _communicate_bounded(proc, timeout=_GIT_TIMEOUT_SECONDS)

--- a/src/skill_prompt_eval_loop.py
+++ b/src/skill_prompt_eval_loop.py
@@ -35,6 +35,7 @@ from escalation_reconcile import EscalationReconciler
 from exception_classify import reraise_on_credit_or_bug
 from execution import get_default_runner
 from models import WorkCycleResult
+from process_group import kill_process_group
 from prompt_efficiency import (
     INEFFICIENCY_THRESHOLD,
     SkillEfficiencyRow,
@@ -97,19 +98,23 @@ async def _communicate_bounded(
 ) -> tuple[bytes, bytes]:
     """``proc.communicate()`` bounded by *timeout* seconds.
 
-    On timeout the wedged child is killed and a ``TimeoutError`` propagates so
-    the caller can treat it as a failed read (rather than hanging the loop
-    cycle indefinitely).
+    On timeout the wedged child's whole PROCESS GROUP is reaped and a
+    ``TimeoutError`` propagates so the caller can treat it as a failed read
+    (rather than hanging the loop cycle indefinitely).
+
+    Callers must spawn with ``start_new_session=True`` (child is its own
+    group leader): the corpus/validation spawns fan out sub-make → pytest →
+    LLM-agent grandchildren, and a child-only ``proc.kill()`` re-parented
+    them to init where they kept burning API credits (#9579). The guarded
+    primitive never raises — an already-exited child included — so the
+    TimeoutError (the intended failed-read signal) still propagates
+    (#9794/#9816).
     """
     try:
         return await asyncio.wait_for(proc.communicate(), timeout=timeout)
     except TimeoutError:
-        # proc.kill() itself raises ProcessLookupError when the child already
-        # exited — suppress it too, not just proc.wait() — so the TimeoutError
-        # (the intended failed-read signal) propagates instead of crashing the
-        # caller with ProcessLookupError. (#9794/#9816)
+        kill_process_group(proc)
         with contextlib.suppress(ProcessLookupError):
-            proc.kill()
             await proc.wait()
         raise
 
@@ -351,6 +356,10 @@ class SkillPromptEvalLoop(BaseBackgroundLoop):
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=env,
+                # Group leader (pid == pgid) so the timeout reap in
+                # _communicate_bounded kills the whole make → pytest →
+                # LLM-agent subtree, not just the top-level make (#9579).
+                start_new_session=True,
             )
             stdout, stderr = await _communicate_bounded(
                 proc, timeout=_ADVERSARIAL_TIMEOUT_SECONDS
@@ -936,6 +945,10 @@ class SkillPromptEvalLoop(BaseBackgroundLoop):
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=env,
+                # Group leader (pid == pgid) so the timeout reap in
+                # _communicate_bounded kills the whole corpus-runner →
+                # LLM-agent subtree, not just the direct child (#9579).
+                start_new_session=True,
             )
             stdout, stderr = await _communicate_bounded(
                 proc, timeout=_ADVERSARIAL_TIMEOUT_SECONDS

--- a/src/staging_bisect_loop.py
+++ b/src/staging_bisect_loop.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import HydraFlowConfig
 from dedup_store import DedupStore
+from process_group import kill_process_group
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -182,18 +183,23 @@ class StagingBisectLoop(BaseBackgroundLoop):
                 cwd=str(self._config.repo_root),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
+                # Group leader (pid == pgid) so the timeout reap kills the
+                # whole make → pytest probe subtree, not just the top-level
+                # make (#9579).
+                start_new_session=True,
             )
             try:
                 stdout_b, stderr_b = await asyncio.wait_for(
                     proc.communicate(), timeout=timeout_s
                 )
             except TimeoutError:
-                # proc.kill() itself raises ProcessLookupError when the child
-                # already exited — suppress it (and proc.wait()) so the timeout
-                # surfaces as a probe failure instead of crashing the loop.
-                # (#9794/#9816/#9883)
+                # Group-kill: a child-only proc.kill() orphaned the sub-make /
+                # pytest grandchildren at PPID=1 (#9579). The guarded
+                # primitive never raises — an already-exited child included —
+                # so the timeout surfaces as a probe failure instead of
+                # crashing the loop. (#9794/#9816/#9883)
+                kill_process_group(proc)
                 with contextlib.suppress(ProcessLookupError):
-                    proc.kill()
                     await proc.wait()
                 exit_code = 124  # bash convention
                 stderr_excerpt = f"timeout after {timeout_s}s"
@@ -488,17 +494,22 @@ class StagingBisectLoop(BaseBackgroundLoop):
             cwd=cwd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            # Group leader (pid == pgid): `git bisect run make bisect-probe`
+            # fans out a make → pytest subtree per step; the reaps below must
+            # kill the whole group, not just the top-level git (#9579).
+            start_new_session=True,
         )
         comm_task = asyncio.create_task(proc.communicate())
         deadline = asyncio.get_event_loop().time() + timeout
         while True:
             remaining = deadline - asyncio.get_event_loop().time()
             if remaining <= 0:
-                # proc.kill() raises ProcessLookupError if the child already
-                # exited — suppress it so the intended TimeoutError propagates
-                # instead of crashing the loop cycle. (#9794/#9816/#9883)
-                with contextlib.suppress(ProcessLookupError):
-                    proc.kill()
+                # Group-kill: a child-only proc.kill() orphaned the per-step
+                # make → pytest grandchildren at PPID=1 (#9579). The guarded
+                # primitive never raises — an already-exited child included —
+                # so the intended TimeoutError propagates instead of crashing
+                # the loop cycle. (#9794/#9816/#9883)
+                kill_process_group(proc)
                 with contextlib.suppress(asyncio.CancelledError):
                     await comm_task
                 raise TimeoutError(f"git command exceeded {timeout}s")
@@ -513,11 +524,10 @@ class StagingBisectLoop(BaseBackgroundLoop):
                     "staging_bisect: kill-switch tripped mid-run — "
                     "terminating git subprocess"
                 )
-                # proc.kill() raises ProcessLookupError if the child already
-                # exited — suppress it so the intended BisectCancelledError
-                # propagates instead of crashing the loop cycle. (#9794/#9816/#9883)
-                with contextlib.suppress(ProcessLookupError):
-                    proc.kill()
+                # Group-kill (#9579) — never raises, so the intended
+                # BisectCancelledError propagates instead of crashing the
+                # loop cycle. (#9794/#9816/#9883)
+                kill_process_group(proc)
                 with contextlib.suppress(asyncio.CancelledError):
                     await comm_task
                 raise BisectCancelledError("kill-switch tripped during git bisect run")

--- a/tests/regressions/test_issue_9579.py
+++ b/tests/regressions/test_issue_9579.py
@@ -1,0 +1,265 @@
+"""Regression #9579: heavy-make caretaker loops orphaned subprocess
+grandchildren on timeout.
+
+The four heavy-make sites (``skill_prompt_eval_loop``,
+``principles_audit_loop``, ``contract_refresh_loop``,
+``staging_bisect_loop``) spawned ``make``/pytest/LLM subtrees WITHOUT
+``start_new_session=True`` and reaped a timeout with a child-only
+``proc.kill()`` — the top-level ``make`` died, its sub-make → pytest →
+LLM-agent grandchildren re-parented to init (PPID=1) and kept burning API
+credits against an abandoned cycle.
+
+Fix shape (#10017's guarded primitive, no local killpg re-derivation):
+
+* every heavy spawn passes ``start_new_session=True`` (child is its own
+  process-group leader, ``pid == pgid``);
+* every timeout/cancel reap routes through
+  ``process_group.kill_process_group`` (guarded: real-int-pid only, mock
+  fakes fall back to child-only ``proc.kill()``, never raises).
+
+Three layers below:
+
+1. AST pin — the spawn sites carry ``start_new_session=True`` and the reap
+   paths call ``kill_process_group`` (no bare ``proc.kill()`` regression);
+2. behavior pin — the shared ``_communicate_bounded`` helpers invoke the
+   primitive on timeout and still surface ``TimeoutError``;
+3. end-to-end — a REAL child that forks a grandchild into its group is
+   reaped grandchild-and-all by a converted helper.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import contextlib
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+SRC_DIR = Path(__file__).resolve().parent.parent.parent / "src"
+sys.path.insert(0, str(SRC_DIR))
+
+# (module, function) → every asyncio.create_subprocess_exec inside must
+# carry start_new_session=True. These are the heavy-make / heavy-subtree
+# spawn sites named by #9579 (staging_bisect._run_git runs
+# `git bisect run make bisect-probe`, a per-step make → pytest subtree).
+_HEAVY_SPAWN_SITES = [
+    ("skill_prompt_eval_loop", "_run_corpus"),
+    ("skill_prompt_eval_loop", "_validate_candidate"),
+    ("principles_audit_loop", "_run_audit"),
+    ("principles_audit_loop", "_run_git"),
+    ("contract_refresh_loop", "_run_replay_gate"),
+    ("staging_bisect_loop", "_run_bisect_probe"),
+    ("staging_bisect_loop", "_run_git"),
+]
+
+# (module, function) → the timeout/cancel reap inside must route through
+# the guarded primitive (a `kill_process_group(...)` call) and must not
+# fall back to a child-only bare `proc.kill()`.
+_GROUP_REAP_SITES = [
+    ("skill_prompt_eval_loop", "_communicate_bounded"),
+    ("principles_audit_loop", "_communicate_bounded"),
+    ("contract_refresh_loop", "_run_replay_gate"),
+    ("staging_bisect_loop", "_run_bisect_probe"),
+    ("staging_bisect_loop", "_run_git"),
+]
+
+
+def _find_function(tree: ast.AST, name: str) -> ast.AST:
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+            and node.name == name
+        ):
+            return node
+    raise AssertionError(f"function {name!r} not found — site renamed? Update pins.")
+
+
+def _module_tree(module_name: str) -> ast.AST:
+    path = SRC_DIR / f"{module_name}.py"
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+@pytest.mark.parametrize(("module_name", "func_name"), _HEAVY_SPAWN_SITES)
+def test_heavy_spawn_sites_start_a_new_session(
+    module_name: str, func_name: str
+) -> None:
+    func = _find_function(_module_tree(module_name), func_name)
+    spawns = [
+        node
+        for node in ast.walk(func)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "create_subprocess_exec"
+    ]
+    assert spawns, (
+        f"{module_name}.{func_name} no longer spawns via create_subprocess_exec "
+        "— update the #9579 pins to the new spawn path."
+    )
+    for call in spawns:
+        kwargs = {k.arg: k.value for k in call.keywords if k.arg is not None}
+        sns = kwargs.get("start_new_session")
+        assert isinstance(sns, ast.Constant) and sns.value is True, (
+            f"{module_name}.{func_name}:{call.lineno} spawns without "
+            "start_new_session=True — the child is not a process-group "
+            "leader, so the timeout reap kills only the direct child and "
+            "orphans the make/pytest/LLM grandchildren at PPID=1 where they "
+            "burn API credits (#9579)."
+        )
+
+
+@pytest.mark.parametrize(("module_name", "func_name"), _GROUP_REAP_SITES)
+def test_heavy_reap_sites_use_the_guarded_group_primitive(
+    module_name: str, func_name: str
+) -> None:
+    func = _find_function(_module_tree(module_name), func_name)
+    calls_primitive = any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "kill_process_group"
+        for node in ast.walk(func)
+    )
+    assert calls_primitive, (
+        f"{module_name}.{func_name} no longer reaps via "
+        "process_group.kill_process_group — a child-only proc.kill() "
+        "re-introduces the #9579 orphaned-grandchildren leak. Do NOT inline "
+        "os.killpg either: the guard in the primitive is load-bearing "
+        "(see tests/architecture/test_process_group_kill_guard.py)."
+    )
+    bare_kills = [
+        node.lineno
+        for node in ast.walk(func)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "kill"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "proc"
+    ]
+    assert not bare_kills, (
+        f"{module_name}.{func_name} lines {bare_kills}: bare proc.kill() "
+        "alongside the group primitive — the child-only path is exactly the "
+        "#9579 regression."
+    )
+
+
+class _HangingProc:
+    """communicate() outlives any test timeout; pid=None keeps the guarded
+    primitive on its child-only fallback if it is ever reached for real
+    (never signal a fabricated pid — mock .pid → killpg(1) kills CI)."""
+
+    returncode: int | None = None
+    pid: None = None
+
+    def __init__(self) -> None:
+        self.killed = False
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        await asyncio.sleep(30)
+        return (b"", b"")
+
+    def kill(self) -> None:
+        self.killed = True
+
+    async def wait(self) -> int:
+        return -9
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "module_name", ["skill_prompt_eval_loop", "principles_audit_loop"]
+)
+async def test_communicate_bounded_reaps_the_group_on_timeout(
+    monkeypatch: pytest.MonkeyPatch, module_name: str
+) -> None:
+    """On timeout the shared helper must invoke the GROUP primitive exactly
+    once and still surface TimeoutError (the intended failed-read signal)."""
+    module = __import__(module_name)
+    reaped: list[object] = []
+
+    def _record_reap(proc: object) -> None:
+        reaped.append(proc)
+
+    monkeypatch.setattr(module, "kill_process_group", _record_reap)
+    proc = _HangingProc()
+    with pytest.raises(TimeoutError):
+        await module._communicate_bounded(proc, timeout=0.01)
+    assert reaped == [proc], (
+        "timeout must route through process_group.kill_process_group "
+        "(group reap), not a child-only proc.kill()"
+    )
+    assert not proc.killed, (
+        "child-only proc.kill() was called from the loop helper — the group "
+        "primitive owns the fallback decision (#9579)"
+    )
+
+
+_CHILD_SCRIPT = """
+import subprocess, sys, time
+
+# Grandchild joins THIS child's (new) session/process group — the exact
+# shape of make -> pytest under a caretaker loop.
+grandchild = subprocess.Popen(["sleep", "300"])
+with open(sys.argv[1], "w") as fh:
+    fh.write(str(grandchild.pid))
+time.sleep(300)
+"""
+
+
+@pytest.mark.asyncio
+async def test_timed_out_heavy_subtree_reaps_grandchildren(
+    tmp_path: Path,
+) -> None:
+    """End-to-end #9579: a converted helper must kill the GRANDCHILD, not
+    just the direct child, when the heavy subtree times out."""
+    from principles_audit_loop import _communicate_bounded
+
+    pid_file = tmp_path / "grandchild.pid"
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        _CHILD_SCRIPT,
+        str(pid_file),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        start_new_session=True,  # as the production spawn sites now do
+    )
+    grandchild_pid: int | None = None
+    try:
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            if pid_file.exists() and pid_file.read_text().strip():
+                grandchild_pid = int(pid_file.read_text().strip())
+                break
+            await asyncio.sleep(0.05)
+        assert grandchild_pid is not None, "child never reported its grandchild pid"
+
+        with pytest.raises(TimeoutError):
+            await _communicate_bounded(proc, timeout=0.2)
+
+        # SIGKILL delivery + init reaping are asynchronous — poll briefly.
+        deadline = time.monotonic() + 5.0
+        grandchild_dead = False
+        while time.monotonic() < deadline:
+            try:
+                os.kill(grandchild_pid, 0)
+            except ProcessLookupError:
+                grandchild_dead = True
+                break
+            await asyncio.sleep(0.1)
+        assert grandchild_dead, (
+            f"grandchild sleep(300) [pid {grandchild_pid}] survived the "
+            "timeout reap — the #9579 orphaned-subtree leak is back"
+        )
+    finally:
+        # Belt-and-braces: never leak the subtree out of the test run.
+        from process_group import kill_process_group
+
+        kill_process_group(proc)
+        if grandchild_pid is not None:
+            with contextlib.suppress(ProcessLookupError, OSError):
+                os.kill(grandchild_pid, 9)
+        with contextlib.suppress(ProcessLookupError, OSError):
+            await proc.wait()

--- a/tests/regressions/test_reap_processlookuperror.py
+++ b/tests/regressions/test_reap_processlookuperror.py
@@ -81,6 +81,18 @@ async def test_communicate_bounded_surfaces_timeout_not_processlookup(
     monkeypatch, module_name, timeout_attr
 ):
     module = __import__(module_name)
+
+    # #9579 moved the heavy-make loops (skill_prompt_eval, principles_audit)
+    # onto process_group.kill_process_group, which group-kills a REAL int pid
+    # via os.killpg. _DeadProc models an already-reaped child, so patch killpg
+    # to raise ProcessLookupError (group already gone) — and never signal a
+    # live pgid that happens to match the fake pid. Harmless for the loops
+    # still on guarded proc.kill(): they never call killpg.
+    def _dead_killpg(_pgid: int, _sig: int) -> None:
+        raise ProcessLookupError()
+
+    monkeypatch.setattr(os, "killpg", _dead_killpg)
+
     if timeout_attr is None:
         # ``_communicate_bounded(proc, timeout)`` — timeout is a call arg.
         coro = module._communicate_bounded(_DeadProc(), timeout=0.01)
@@ -88,7 +100,7 @@ async def test_communicate_bounded_surfaces_timeout_not_processlookup(
         monkeypatch.setattr(module, timeout_attr, 0.01)
         coro = module._communicate_bounded(_DeadProc())
     # Must raise TimeoutError (caller treats as failed read), never the
-    # ProcessLookupError from the already-dead child's proc.kill().
+    # ProcessLookupError from the already-dead child's reap.
     with pytest.raises(TimeoutError):
         await coro
 


### PR DESCRIPTION
Closes #9579

## Problem

The four heavy-make caretaker loops spawned `make`/pytest/LLM subtrees WITHOUT `start_new_session=True` and reaped a timeout with a child-only `proc.kill()`. The top-level `make` died; its sub-make → pytest → LLM-agent grandchildren re-parented to init (PPID=1) and kept burning API credits against an abandoned cycle.

The recent sweeps did NOT cover these sites: #9983/#10019 fixed the central `HostRunner.run_simple` path, #10017 landed the guarded `process_group.kill_process_group` primitive + the `os.killpg`-only-in-`process_group.py` structural gate, and #9993 only guarded the bare kills against `ProcessLookupError` — the four loops' spawns stayed non-leader + child-only kill.

## Fix (minimal, on the #10017 primitive — no killpg re-derivation)

| Site | Change |
|---|---|
| `skill_prompt_eval_loop._run_corpus` / `._validate_candidate` | `start_new_session=True`; shared `_communicate_bounded` reaps via `kill_process_group` |
| `principles_audit_loop._run_audit` / `._run_git` | same (both route through the module's `_communicate_bounded`, so both spawns must be group leaders — killpg on a non-leader real pid silently no-ops) |
| `contract_refresh_loop._run_replay_gate` | `start_new_session=True`; timeout reap via `kill_process_group` (rc=124 synthesis unchanged) |
| `staging_bisect_loop._run_bisect_probe` and the polled `._run_git` (drives `git bisect run make bisect-probe`) | `start_new_session=True`; timeout AND kill-switch reaps via `kill_process_group` |

## Tests

- `tests/regressions/test_issue_9579.py` (new): AST pin on the 7 spawn sites (+`start_new_session=True`) and 5 reap paths (`kill_process_group`, no bare `proc.kill()`); behavior pin that the shared helpers invoke the primitive exactly once on timeout and still surface `TimeoutError`; real end-to-end proof that a timed-out child's **grandchild** dies with it.
- `tests/regressions/test_reap_processlookuperror.py`: the parametrized pin now patches `os.killpg` for the converted helpers so the fake pid 424242 can never signal a live group (mock-pid → killpg CI hazard).
- Green: the 4 loop test files (118), `tests/regressions/test_issue_9579.py` (15), `test_reap_processlookuperror.py`, `test_issue_9508.py`, `tests/architecture/` killpg gate; ruff + pyright clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)