### PR TITLE
test(regressions): drop forbidden skipif from the 9553 reap pins — staging is red on the active-tests guard

### DIFF
--- a/tests/regressions/test_issue_9553.py
+++ b/tests/regressions/test_issue_9553.py
@@ -161,7 +161,6 @@ def _make_probe_loop(
     )
 
 
-@pytest.mark.skipif(os.name != "posix", reason="POSIX process groups only")
 class TestWatchdogCancelReapsProcessTree:
     """A watchdog-cancelled cycle reaps the whole OS process group — leader AND
     grandchild — and leaves the tracked registry clean, for both spawn paths."""


### PR DESCRIPTION
**Staging hotfix.** #10031 merged carrying a `@pytest.mark.skipif(os.name != 'posix')` that `test_no_ignored_active_tests` forbids (the same guard that stripped the win32 skipif from the #9648 pins) — its PR ran the fast subset, so every FULL quality run since is red. One-line marker removal; all supported platforms are POSIX. Guard + reap pins green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)