### PR TITLE
fix(credit): per-backend credit pause — a Claude cap no longer halts z.ai/kimi workers (#9807)

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -2828,6 +2828,10 @@ class OrchestratorStatusPayload(TypedDict, total=False):
     status: str
     reset: bool
     credits_paused_until: str
+    # Which backend the active credit pause is scoped to — "anthropic" or a
+    # one-shot backend ("zai"/"kimi"/"openrouter"). Absent for a global/legacy
+    # pause. Lets the UI show which provider is paused (#9807).
+    credits_paused_provider: str
 
 
 class SessionStartPayload(TypedDict):
@@ -2894,6 +2898,9 @@ class SystemAlertPayload(TypedDict, total=False):
     hook_name: str
     issue: int
     resume_at: str
+    # The billing provider a credit pause/false-positive alert refers to —
+    # "anthropic" or a one-shot backend ("zai"/"kimi"/"openrouter") (#9807).
+    provider: str
 
 
 class TranscriptSummaryPayload(TypedDict, total=False):

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable, Coroutine, Iterable
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, cast
 
@@ -40,7 +40,11 @@ from phase_utils import (
     log_exception_with_bug_classification,
     release_batch_in_flight,
 )
-from runner_utils import reap_all_tracked_processes
+from runner_utils import (
+    backend_probe_endpoint,
+    normalize_provider,
+    reap_all_tracked_processes,
+)
 from service_registry import (
     ServiceRegistry,
     WorkerRegistryCallbacks,
@@ -50,6 +54,7 @@ from service_registry import (
 from state import StateTracker
 from state_restorer import StateRestorer
 from subprocess_util import (
+    PROVIDER_ANTHROPIC,
     AuthenticationError,
     CreditExhaustedError,
     probe_auth_availability,
@@ -90,6 +95,24 @@ _POST_MERGE_DELAY: int = 5
 # guarded against on the credit false-positive path. The delay lives inside the
 # recreated task, so it never blocks supervision of the other loops (#9621).
 _AUTH_TRANSIENT_RESTART_DELAY_S: float = 30.0
+
+# Loops whose primary LLM work routes through a per-role provider dial (the
+# one-shot OpenAI-compatible backends — z.ai / kimi / openrouter). Maps each
+# such loop to the ``HydraFlowConfig`` field holding its dial. EVERY other loop
+# runs on the Claude harness and bills against Anthropic; only these can route
+# elsewhere, so only these can survive an Anthropic credit pause (or be the sole
+# casualty of a backend cap). See :meth:`HydraFlowOrchestrator._loop_providers`.
+# A loop that does MIXED work (dial'd one-shot + some harness spawns, e.g.
+# pr_unsticker's HITL analysis) self-heals: while it survives an Anthropic pause
+# its harness sub-call re-raises an ``anthropic`` signal that the already-active
+# pause absorbs. Keep in sync with the ``*_provider`` dials in config.py.
+_BACKEND_WORKER_LOOPS: dict[str, str] = {
+    "repo_wiki": "wiki_compilation_provider",
+    "adr_reviewer": "adr_review_provider",
+    "pr_unsticker": "pr_unstick_provider",
+    "term_proposer": "term_proposer_provider",
+    "entry_evidence": "term_proposer_provider",
+}
 
 
 class HydraFlowOrchestrator:
@@ -132,6 +155,13 @@ class HydraFlowOrchestrator:
         self._auth_failed = False
         # Credit pause — set when API credits are exhausted
         self._credits_paused_until: datetime | None = None
+        # Which billing provider the active pause is scoped to (#9807): a backend
+        # name ("zai"/"kimi"/"openrouter") pauses only loops routed there;
+        # "anthropic" pauses everything except surviving backend workers; ``None``
+        # is the global fallback (unknown provider → pause all). Purely for
+        # status/UI + observability; the affected-loop set is computed at pause
+        # time and threaded through resume.
+        self._credit_paused_provider: str | None = None
         # Per-source last false-positive suppression (#9888 throttle).
         self._credit_fp_last: dict[str, datetime] = {}
         self._credit_pause_lock = asyncio.Lock()
@@ -400,9 +430,19 @@ class HydraFlowOrchestrator:
             return self._credits_paused_until
         return None
 
+    @property
+    def credits_paused_provider(self) -> str | None:
+        """The billing provider the ACTIVE credit pause is scoped to, or ``None``
+        (no active pause, or a global/legacy pause). Surfaced in the status
+        payload so the UI can show *which* backend is paused (#9807)."""
+        if self.credits_paused_until is not None:
+            return self._credit_paused_provider
+        return None
+
     def clear_credit_pause(self) -> None:
         """Clear a credit pause early, waking ``_sleep_until_resume``."""
         self._credits_paused_until = None
+        self._credit_paused_provider = None
         self._credit_resume_event.set()
 
     @property
@@ -540,6 +580,7 @@ class HydraFlowOrchestrator:
         self._running = False
         self._auth_failed = False
         self._credits_paused_until = None
+        self._credit_paused_provider = None
         # ``clear_active`` is orchestrator-only — not on IssueStorePort.
         cast("IssueStore", self._svc.store).clear_active()
         self._svc.implementer.active_issues.clear()
@@ -764,6 +805,8 @@ class HydraFlowOrchestrator:
         data: OrchestratorStatusPayload = {"status": self.run_status}
         if self.credits_paused_until:
             data["credits_paused_until"] = self.credits_paused_until.isoformat()
+            if self.credits_paused_provider is not None:
+                data["credits_paused_provider"] = self.credits_paused_provider
         await self._bus.publish(
             HydraFlowEvent(
                 type=EventType.ORCHESTRATOR_STATUS,
@@ -1885,6 +1928,45 @@ class HydraFlowOrchestrator:
         with contextlib.suppress(TimeoutError):
             await asyncio.wait_for(self._stop_event.wait(), timeout=seconds)
 
+    def _loop_providers(self, loop_names: Iterable[str]) -> dict[str, str]:
+        """Map each loop name to the billing provider its LLM work routes to.
+
+        Loops in ``_BACKEND_WORKER_LOOPS`` read their configured ``*_provider``
+        dial (normalized: the harness dial ``"claude"`` → ``"anthropic"``); every
+        other loop runs on the Claude harness → ``"anthropic"``. Read from live
+        config so an operator's dial change takes effect on the next pause."""
+        providers: dict[str, str] = {}
+        for name in loop_names:
+            dial_field = _BACKEND_WORKER_LOOPS.get(name)
+            if dial_field is None:
+                providers[name] = PROVIDER_ANTHROPIC
+            else:
+                providers[name] = normalize_provider(getattr(self._config, dial_field))
+        return providers
+
+    def _affected_loops(
+        self, provider: str, loop_names: Iterable[str], source: str
+    ) -> tuple[set[str], bool]:
+        """Which loops a *provider* exhaustion must pause, + whether to terminate
+        the shared Claude-harness runner pools.
+
+        - Unknown provider (``normalize_provider`` changes it) → GLOBAL fallback:
+          pause every loop and terminate the runner pools (today's behavior).
+        - ``"anthropic"`` → pause every anthropic-routed loop (all but the
+          surviving backend workers) and terminate the harness pools.
+        - A backend (``"zai"``/``"kimi"``/``"openrouter"``) → pause only loops
+          routed there (always including *source*, which demonstrably routes to
+          it since it raised the signal) and leave the harness pools running."""
+        names = list(loop_names)
+        provider_map = self._loop_providers(names)
+        if normalize_provider(provider) != provider:
+            # Provider the registry doesn't recognize — fail safe to a global pause.
+            return set(names), True
+        affected = {n for n, p in provider_map.items() if p == provider}
+        if provider != PROVIDER_ANTHROPIC and source in provider_map:
+            affected.add(source)
+        return affected, provider == PROVIDER_ANTHROPIC
+
     def _compute_resume_time(self, exc: CreditExhaustedError) -> datetime:
         """Compute the UTC datetime at which credit pause should end."""
         buffer = timedelta(minutes=self._config.credit_pause_buffer_minutes)
@@ -1894,17 +1976,32 @@ class HydraFlowOrchestrator:
         return now + timedelta(hours=5) + buffer
 
     async def _cancel_all_loops_and_runners(
-        self, tasks: dict[str, asyncio.Task[None]]
+        self,
+        tasks: dict[str, asyncio.Task[None]],
+        affected: set[str] | None = None,
+        *,
+        terminate_runners: bool = True,
     ) -> None:
-        """Cancel all loop tasks and terminate active subprocesses."""
-        for task in tasks.values():
+        """Cancel the *affected* loop tasks and (optionally) terminate the
+        Claude-harness subprocess pools.
+
+        *affected* ``None`` means every loop (the global / Anthropic pause).
+        A backend-scoped pause (z.ai/kimi/openrouter) passes only the loops
+        routed to that backend and ``terminate_runners=False`` so the shared
+        harness runner pools — which bill against Anthropic and belong to the
+        surviving loops — are left untouched (#9807)."""
+        to_cancel = (
+            tasks if affected is None else {n: tasks[n] for n in affected if n in tasks}
+        )
+        for task in to_cancel.values():
             task.cancel()
-        await asyncio.gather(*tasks.values(), return_exceptions=True)
-        self._svc.planners.terminate()
-        self._svc.agents.terminate()
-        self._svc.reviewers.terminate()
-        self._svc.hitl_runner.terminate()
-        reap_all_tracked_processes()
+        await asyncio.gather(*to_cancel.values(), return_exceptions=True)
+        if terminate_runners:
+            self._svc.planners.terminate()
+            self._svc.agents.terminate()
+            self._svc.reviewers.terminate()
+            self._svc.hitl_runner.terminate()
+            reap_all_tracked_processes()
 
     async def _sleep_until_resume(self, resume_at: datetime) -> None:
         """Sleep until *resume_at* (interruptible by stop or credit-resume event)."""
@@ -1948,6 +2045,13 @@ class HydraFlowOrchestrator:
             ):
                 return True
 
+            # Which backend hit the limit (#9807). Default "anthropic" — the
+            # Claude harness — so every legacy raise site stays global-scoped;
+            # the one-shot backends (z.ai/kimi/openrouter) tag their own signal.
+            provider = (
+                getattr(exc, "provider", PROVIDER_ANTHROPIC) or PROVIDER_ANTHROPIC
+            )
+
             # Corroborate the text-detected signal with a live API probe before
             # committing a GLOBAL pause. ``is_credit_exhaustion`` matches
             # credit-error PROSE, so a diagnostic/reviewer run that merely quotes
@@ -1976,16 +2080,26 @@ class HydraFlowOrchestrator:
                 )
                 return False
 
+            # Probe the AFFECTED backend, not always Anthropic (#9807): a z.ai
+            # 429 is corroborated against z.ai's endpoint, a Claude cap against
+            # Anthropic. Endpoint (base_url/api_key) resolves from the provider
+            # registry; anthropic → ("","") which the probe ignores.
+            probe_base_url, probe_api_key = backend_probe_endpoint(
+                provider, self._config
+            )
             if (
                 self._config.credit_pause_require_probe
-                and await probe_credit_availability()
+                and await probe_credit_availability(
+                    provider, base_url=probe_base_url, api_key=probe_api_key
+                )
             ):
                 self._credit_fp_last[source] = datetime.now(UTC)
                 logger.warning(
-                    "Credit-exhaustion signal from %r NOT corroborated by live "
-                    "API probe — treating as a false positive (likely quoted "
-                    "credit-error prose); not pausing.",
+                    "Credit-exhaustion signal from %r (provider=%s) NOT "
+                    "corroborated by live API probe — treating as a false "
+                    "positive (likely quoted credit-error prose); not pausing.",
                     source,
+                    provider,
                 )
                 await self._bus.publish(
                     HydraFlowEvent(
@@ -1996,6 +2110,7 @@ class HydraFlowOrchestrator:
                                 "— ignoring as a false positive."
                             ),
                             "source": source,
+                            "provider": provider,
                             # Benign: a false positive was suppressed, nothing
                             # paused. Render yellow, not the red critical banner.
                             "severity": "warning",
@@ -2006,19 +2121,32 @@ class HydraFlowOrchestrator:
 
             resume_at = self._compute_resume_time(exc)
             self._credits_paused_until = resume_at
+            self._credit_paused_provider = provider
             pause_seconds = max((resume_at - datetime.now(UTC)).total_seconds(), 0)
 
+            # Scope the pause to the loops routed to this backend. Anthropic (or
+            # an unrecognized provider) still pauses the whole factory except the
+            # surviving backend workers; a z.ai/kimi cap pauses only its own
+            # loops and leaves Claude work running (#9807).
+            affected, terminate_runners = self._affected_loops(
+                provider, tasks.keys(), source
+            )
+            scope = "all loops" if terminate_runners else f"{provider} loops"
+
             logger.warning(
-                "Credit limit reached (detected in %r). "
-                "Pausing all loops until %s (%.0f minutes).",
+                "Credit limit reached (detected in %r, provider=%s). "
+                "Pausing %s until %s (%.0f minutes).",
                 source,
+                provider,
+                scope,
                 resume_at.isoformat(),
                 pause_seconds / 60,
             )
 
             data: SystemAlertPayload = {
-                "message": "Credit limit reached. Pausing all loops.",
+                "message": f"Credit limit reached ({provider}). Pausing {scope}.",
                 "source": source,
+                "provider": provider,
                 "resume_at": resume_at.isoformat(),
             }
             await self._bus.publish(
@@ -2028,16 +2156,21 @@ class HydraFlowOrchestrator:
                 )
             )
 
-            await self._cancel_all_loops_and_runners(tasks)
+            await self._cancel_all_loops_and_runners(
+                tasks, affected, terminate_runners=terminate_runners
+            )
 
         await self._sleep_until_resume(resume_at)
 
         if self._stop_event.is_set():
             self._credits_paused_until = None
+            self._credit_paused_provider = None
             self._credit_resume_event.clear()
             return True
 
-        await self._resume_loops_after_credit_pause(tasks, loop_factories, source)
+        await self._resume_loops_after_credit_pause(
+            tasks, loop_factories, source, affected
+        )
         return True
 
     async def _resume_loops_after_credit_pause(
@@ -2045,15 +2178,25 @@ class HydraFlowOrchestrator:
         tasks: dict[str, asyncio.Task[None]],
         loop_factories: list[tuple[str, Callable[[], Coroutine[Any, Any, None]]]],
         source: str,
+        affected: set[str] | None = None,
     ) -> None:
-        """Clear pause state and restart all loops after credit pause."""
+        """Clear pause state and restart the loops paused for this credit pause.
+
+        *affected* ``None`` restarts every loop (global/legacy). A scoped pause
+        passes the same set it cancelled so only those loops are recreated —
+        the surviving backend/harness loops were never touched (#9807)."""
+        provider = self._credit_paused_provider
         self._credits_paused_until = None
+        self._credit_paused_provider = None
         self._credit_resume_event.clear()
-        logger.info("Credit pause ended — restarting all loops")
+        scope = "all loops" if affected is None else f"{len(affected)} loop(s)"
+        logger.info("Credit pause ended — restarting %s", scope)
         data: SystemAlertPayload = {
-            "message": "Credit pause ended. Resuming all loops.",
+            "message": "Credit pause ended. Resuming loops.",
             "source": source,
         }
+        if provider is not None:
+            data["provider"] = provider
         await self._bus.publish(
             HydraFlowEvent(
                 type=EventType.SYSTEM_ALERT,
@@ -2061,6 +2204,8 @@ class HydraFlowOrchestrator:
             )
         )
         for loop_name, factory in loop_factories:
+            if affected is not None and loop_name not in affected:
+                continue
             tasks[loop_name] = asyncio.create_task(
                 factory(), name=f"hydraflow-{loop_name}"
             )

--- a/src/runner_utils.py
+++ b/src/runner_utils.py
@@ -23,6 +23,7 @@ from prompt_gate import PromptGateBlockedError, gate_prompt
 from prompt_telemetry import parse_command_tool_model
 from stream_parser import StreamParser
 from subprocess_util import (
+    PROVIDER_ANTHROPIC,
     CreditExhaustedError,
     is_credit_exhaustion,
     make_clean_env,
@@ -676,6 +677,35 @@ def provider_key_presence() -> dict[str, bool]:
     }
 
 
+def normalize_provider(dial: str) -> str:
+    """Map a per-role provider *dial* value to its billing-provider identity.
+
+    The CLI-harness dial (``"claude"``) and anything unrecognized bill against
+    Anthropic (``"anthropic"``); the OpenAI-compatible one-shot dials
+    (``"openrouter"``/``"zai"``/``"kimi"``) are already their own billing
+    identity and map to themselves. This is the single point that reconciles the
+    config's ``*_provider`` Literal namespace (which spells the harness
+    ``"claude"``) with ``CreditExhaustedError.provider`` (which spells it
+    ``"anthropic"``), so the orchestrator can compare a signal's provider
+    against each loop's routed backend."""
+    if dial in _OPENAI_COMPAT_BACKENDS:
+        return dial
+    return PROVIDER_ANTHROPIC
+
+
+def backend_probe_endpoint(provider: str, config: HydraFlowConfig) -> tuple[str, str]:
+    """Resolve ``(base_url, api_key)`` for a one-shot backend's credit probe.
+
+    Returns ``("", "")`` when *provider* is not a known OpenAI-compatible
+    backend (e.g. ``"anthropic"``), which the probe treats as "cannot probe →
+    fail-open". Reuses the registry's own ``base_url``/``api_key`` resolution so
+    the probe hits exactly the endpoint + key a real spawn would use."""
+    backend = _OPENAI_COMPAT_BACKENDS.get(provider)
+    if backend is None:
+        return "", ""
+    return backend.base_url(config), backend.api_key()
+
+
 def _telemetry_cmd(provider: str, tool: str, model: str) -> list[str]:
     """The ``cmd``-shaped descriptor ``_record_inference`` parses into
     ``(tool, model)``. For an OpenAI-compatible backend the 'tool' is the
@@ -768,11 +798,16 @@ async def _openai_compatible_complete(
         raise TimeoutError(str(exc)) from exc
 
     if resp.status_code in (402, 429):
-        raise CreditExhaustedError(f"{provider} {resp.status_code}: {resp.text[:200]}")
+        # Tag the signal with THIS backend so the orchestrator scopes the pause
+        # to loops routed here — a z.ai/kimi cap must not halt Claude work, and
+        # vice-versa (#9807).
+        raise CreditExhaustedError(
+            f"{provider} {resp.status_code}: {resp.text[:200]}", provider=provider
+        )
     if resp.status_code >= 400:
         body = resp.text or ""
         if is_credit_exhaustion(body):
-            raise CreditExhaustedError(f"{provider}: {body[:200]}")
+            raise CreditExhaustedError(f"{provider}: {body[:200]}", provider=provider)
         return SimpleResult(
             stderr=f"{provider} http {resp.status_code}: {body[:300]}",
             returncode=resp.status_code,

--- a/src/subprocess_util.py
+++ b/src/subprocess_util.py
@@ -312,6 +312,14 @@ class CircuitBreakerOpenError(RuntimeError):
     """
 
 
+#: The billing-provider identity of the default (Claude CLI / harness) backend.
+#: One-shot OpenAI-compatible backends carry their own registry name
+#: ("openrouter"/"zai"/"kimi"); everything routed through the harness bills
+#: against Anthropic. Used as ``CreditExhaustedError.provider``'s default so a
+#: signal is scoped to Anthropic unless a backend classifies itself otherwise.
+PROVIDER_ANTHROPIC = "anthropic"
+
+
 class CreditExhaustedError(RuntimeError):
     """Raised when a subprocess fails because API credits are exhausted.
 
@@ -320,11 +328,26 @@ class CreditExhaustedError(RuntimeError):
     resume_at:
         The datetime (UTC) when credits are expected to reset, or ``None``
         if no reset time could be parsed from the error output.
+    provider:
+        The billing-provider identity that hit the limit — ``"anthropic"``
+        (the Claude CLI / harness, the default) or a one-shot OpenAI-compatible
+        backend name (``"openrouter"``/``"zai"``/``"kimi"``). The orchestrator
+        scopes the credit pause to loops routed to this provider so a Claude cap
+        never halts z.ai/kimi background workers, and vice-versa (#9807). Kept
+        defaulting to ``"anthropic"`` so every existing raise site — all of
+        which are harness paths — stays Anthropic-scoped without change.
     """
 
-    def __init__(self, message: str = "", *, resume_at: datetime | None = None) -> None:
+    def __init__(
+        self,
+        message: str = "",
+        *,
+        resume_at: datetime | None = None,
+        provider: str = PROVIDER_ANTHROPIC,
+    ) -> None:
         super().__init__(message)
         self.resume_at = resume_at
+        self.provider = provider
 
 
 _AUTH_PATTERNS = ("401", "not logged in", "authentication required", "auth token")
@@ -554,12 +577,8 @@ def _parse_weekly_resume_time(text: str) -> datetime | None:
     return _parse_weekly_month_day(text) or _parse_weekly_weekday(text)
 
 
-async def probe_credit_availability() -> bool:
-    """Make a lightweight Anthropic API call to check if credits are available.
-
-    Returns ``True`` if credits appear available (or if the check cannot be
-    performed), ``False`` if the API responds with a credit-exhaustion error.
-    """
+async def _probe_anthropic() -> bool:
+    """Lightweight Anthropic API call — the ground-truth credit probe."""
     import os
 
     import httpx
@@ -595,6 +614,63 @@ async def probe_credit_availability() -> bool:
         # here — they propagate so they surface in logs instead of silently
         # returning False.
         return True
+
+
+async def probe_openai_compatible_availability(base_url: str, api_key: str) -> bool:
+    """Cheap credit probe for an OpenAI-compatible one-shot backend (z.ai / kimi
+    / openrouter). A ``GET {base_url}/models`` costs no tokens and reflects the
+    same key/billing the real spawn uses.
+
+    Mirrors :func:`_probe_anthropic`'s contract exactly: returns ``True`` when
+    credits appear available OR the probe cannot be performed (no key/base_url,
+    transient network error — fail-open per #6381/#9869 so a flaky probe delays
+    a real pause by at most one detection cycle rather than masking it), and
+    ``False`` only when the backend confirms exhaustion (HTTP 402/429 or a
+    credit-exhaustion body).
+    """
+    import httpx
+
+    if not api_key or not base_url:
+        # Cannot probe (backend not wired) — assume available; scoping falls
+        # back to pausing on the text signal alone.
+        return True
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(
+                f"{base_url.rstrip('/')}/models",
+                headers={"Authorization": f"Bearer {api_key}"},
+            )
+            if resp.status_code == 200:
+                return True
+            if resp.status_code in (402, 429):
+                return False
+            # Any other status: only a credit-exhaustion body counts as exhausted
+            # (a 401/404 is an auth/routing problem, not a spent balance).
+            return not is_credit_exhaustion(resp.text)
+    except (httpx.HTTPError, OSError):
+        return True
+
+
+async def probe_credit_availability(
+    provider: str = PROVIDER_ANTHROPIC,
+    *,
+    base_url: str = "",
+    api_key: str = "",
+) -> bool:
+    """Corroborate a credit-exhaustion signal against the AFFECTED backend.
+
+    ``provider`` selects which backend to probe: the default ``"anthropic"``
+    hits the Anthropic API; a one-shot OpenAI-compatible backend name
+    (``"openrouter"``/``"zai"``/``"kimi"``) probes ``{base_url}/models`` with
+    ``base_url``/``api_key`` (resolved by the caller from the provider registry).
+
+    Returns ``True`` if credits appear available (or the check cannot be
+    performed — fail-open), ``False`` only when the backend confirms exhaustion.
+    Back-compat: called with no args it probes Anthropic exactly as before.
+    """
+    if provider == PROVIDER_ANTHROPIC:
+        return await _probe_anthropic()
+    return await probe_openai_compatible_availability(base_url, api_key)
 
 
 # Ground-truth auth-rejection phrases in ``gh auth status`` output. These

--- a/tests/regressions/test_issue_9807_per_backend_credit_isolation.py
+++ b/tests/regressions/test_issue_9807_per_backend_credit_isolation.py
@@ -1,0 +1,124 @@
+"""Regression: a Claude credit cap globally halted z.ai/kimi background workers,
+and a backend cap globally halted Claude work (#9807).
+
+Before per-backend isolation, ``_pause_for_credits`` cancelled EVERY loop on any
+corroborated ``CreditExhaustedError``, regardless of which backend hit the
+limit. A single spurious/real Claude cap therefore idled the whole factory —
+including loops whose operator had deliberately routed them to z.ai/kimi to
+survive exactly that.
+
+The fix classifies the signal's ``provider`` and scopes the pause to loops
+routed there:
+  * an Anthropic cap pauses the harness loops but SPARES backend-routed loops;
+  * a z.ai/kimi cap pauses only its own loops and leaves Claude work + the
+    shared harness runner pools running.
+
+These tests pin both directions through the real ``_pause_for_credits``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from orchestrator import HydraFlowOrchestrator
+from subprocess_util import CreditExhaustedError
+from tests.helpers import ConfigFactory
+
+
+async def _noop_loop() -> None:
+    await asyncio.sleep(0)
+
+
+def _make_orch(**dials):
+    """Orchestrator with the pause machinery below the classifier stubbed so the
+    test exercises only the scoping decision. *dials* set ``*_provider`` fields."""
+    config = ConfigFactory.create().model_copy(update=dials)
+    orch = HydraFlowOrchestrator(config)
+    orch._cancel_all_loops_and_runners = AsyncMock()  # type: ignore[method-assign]
+    orch._sleep_until_resume = AsyncMock()  # type: ignore[method-assign]
+    orch._resume_loops_after_credit_pause = AsyncMock()  # type: ignore[method-assign]
+    return orch
+
+
+_TASKS = {"plan": None, "review": None, "repo_wiki": None, "store": None}
+_FACTORIES = [(name, _noop_loop) for name in _TASKS]
+
+
+@pytest.mark.asyncio
+async def test_anthropic_cap_spares_kimi_routed_worker() -> None:
+    """A Claude cap must NOT cancel the kimi-routed wiki loop (the reported bug)."""
+    orch = _make_orch(wiki_compilation_provider="kimi")
+    exc = CreditExhaustedError("usage limit reached")  # provider defaults anthropic
+
+    with patch("orchestrator.probe_credit_availability", AsyncMock(return_value=False)):
+        paused = await orch._pause_for_credits(exc, "plan", dict(_TASKS), _FACTORIES)
+
+    assert paused is True
+    assert orch._credit_paused_provider == "anthropic"
+    affected, kwargs = _cancel_call(orch)
+    assert "repo_wiki" not in affected  # kimi worker survives the Claude cap
+    assert {"plan", "review", "store"} <= affected
+    assert kwargs["terminate_runners"] is True
+
+
+@pytest.mark.asyncio
+async def test_backend_cap_scopes_to_backend_and_spares_harness() -> None:
+    """A kimi cap pauses only kimi loops; Claude loops + harness pools survive."""
+    orch = _make_orch(wiki_compilation_provider="kimi")
+    exc = CreditExhaustedError("kimi 429: rate limit", provider="kimi")
+
+    with patch("orchestrator.probe_credit_availability", AsyncMock(return_value=False)):
+        paused = await orch._pause_for_credits(
+            exc, "repo_wiki", dict(_TASKS), _FACTORIES
+        )
+
+    assert paused is True
+    assert orch._credit_paused_provider == "kimi"
+    affected, kwargs = _cancel_call(orch)
+    assert affected == {"repo_wiki"}
+    assert kwargs["terminate_runners"] is False  # Anthropic runner pools untouched
+    # Resume is scoped to the same set.
+    resume_args = orch._resume_loops_after_credit_pause.await_args
+    assert resume_args.args[3] == {"repo_wiki"}
+
+
+@pytest.mark.asyncio
+async def test_backend_probe_targets_the_affected_backend() -> None:
+    """The corroborating probe hits the AFFECTED backend, not always Anthropic."""
+    orch = _make_orch(wiki_compilation_provider="zai")
+    exc = CreditExhaustedError("zai 402", provider="zai")
+
+    probe = AsyncMock(return_value=False)
+    with patch("orchestrator.probe_credit_availability", probe):
+        await orch._pause_for_credits(exc, "repo_wiki", dict(_TASKS), _FACTORIES)
+
+    # Probed with provider="zai" (positional) rather than the Anthropic default.
+    assert probe.await_args.args[0] == "zai"
+
+
+@pytest.mark.asyncio
+async def test_backend_false_positive_does_not_pause_claude() -> None:
+    """A refuted backend signal pauses nothing (and reports not-paused for the
+    caller to restart the crashed loop) — Claude work is never touched."""
+    orch = _make_orch(wiki_compilation_provider="zai")
+    exc = CreditExhaustedError("zai quoted prose", provider="zai")
+
+    with patch("orchestrator.probe_credit_availability", AsyncMock(return_value=True)):
+        paused = await orch._pause_for_credits(
+            exc, "repo_wiki", dict(_TASKS), _FACTORIES
+        )
+
+    assert paused is False
+    assert orch._credits_paused_until is None
+    orch._cancel_all_loops_and_runners.assert_not_awaited()
+
+
+def _cancel_call(orch) -> tuple[set[str], dict]:
+    """Extract (affected, kwargs) from the recorded _cancel_all_loops_and_runners call."""
+    call = orch._cancel_all_loops_and_runners.await_args
+    # Signature: (tasks, affected, *, terminate_runners=...)
+    affected = call.args[1] if len(call.args) > 1 else call.kwargs["affected"]
+    return affected, call.kwargs

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -300,6 +300,35 @@ class TestOpenAICompatibleComplete:
                 _FakeResp(status_code=400, text="You've hit your usage limit"),
             )
 
+    async def test_429_tags_signal_with_this_backend(self, monkeypatch):
+        # #9807: the raised signal carries THIS backend so the orchestrator can
+        # scope the pause to z.ai/kimi loops instead of halting Claude work.
+        with pytest.raises(CreditExhaustedError) as exc_info:
+            await self._run(
+                monkeypatch,
+                _FakeResp(status_code=429, text="rate limit"),
+                provider="zai",
+            )
+        assert exc_info.value.provider == "zai"
+
+    async def test_402_tags_signal_with_this_backend(self, monkeypatch):
+        with pytest.raises(CreditExhaustedError) as exc_info:
+            await self._run(
+                monkeypatch,
+                _FakeResp(status_code=402, text="insufficient credits"),
+                provider="kimi",
+            )
+        assert exc_info.value.provider == "kimi"
+
+    async def test_400_credit_body_tags_signal_with_this_backend(self, monkeypatch):
+        with pytest.raises(CreditExhaustedError) as exc_info:
+            await self._run(
+                monkeypatch,
+                _FakeResp(status_code=400, text="You've hit your usage limit"),
+                provider="openrouter",
+            )
+        assert exc_info.value.provider == "openrouter"
+
     async def test_other_http_error_soft_fails_labeled_by_provider(self, monkeypatch):
         result = await self._run(
             monkeypatch, _FakeResp(status_code=500, text="server boom"), provider="zai"

--- a/tests/test_per_backend_credit_pause.py
+++ b/tests/test_per_backend_credit_pause.py
@@ -1,0 +1,219 @@
+"""Per-backend credit-pause isolation (#9807).
+
+A Claude (Anthropic) credit cap must not halt z.ai/kimi background workers, and
+a z.ai/kimi cap must not halt Claude work. These tests pin the three seams that
+make that true:
+
+  1. classification  — ``CreditExhaustedError.provider`` + ``normalize_provider``
+  2. scoping         — ``_loop_providers`` / ``_affected_loops`` on the orchestrator
+  3. probe-lift      — per-provider ``probe_credit_availability`` + endpoint resolution
+
+The end-to-end classification-at-the-raise-site is pinned in test_llm_provider.py
+(``_openai_compatible_complete`` tags the signal with its backend).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import httpx
+
+from orchestrator import HydraFlowOrchestrator
+from runner_utils import backend_probe_endpoint, normalize_provider
+from subprocess_util import (
+    PROVIDER_ANTHROPIC,
+    CreditExhaustedError,
+    probe_credit_availability,
+)
+from tests.helpers import ConfigFactory
+
+# ---------------------------------------------------------------------------
+# 1. Classification
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeProvider:
+    def test_claude_dial_maps_to_anthropic(self) -> None:
+        # The config dial spells the harness "claude"; the billing identity is
+        # "anthropic" — this is the single reconciliation point.
+        assert normalize_provider("claude") == "anthropic"
+
+    @pytest.mark.parametrize("backend", ["zai", "kimi", "openrouter"])
+    def test_backend_dials_map_to_themselves(self, backend: str) -> None:
+        assert normalize_provider(backend) == backend
+
+    def test_unknown_dial_falls_back_to_anthropic(self) -> None:
+        # An unrecognized dial is treated as harness so it participates in the
+        # (safe) global Anthropic pause rather than being silently exempted.
+        assert normalize_provider("gemini") == "anthropic"
+        assert normalize_provider("") == "anthropic"
+
+
+class TestCreditExhaustedProvider:
+    def test_defaults_to_anthropic(self) -> None:
+        # Back-compat: every legacy raise site stays Anthropic-scoped.
+        assert CreditExhaustedError("out").provider == PROVIDER_ANTHROPIC
+
+    def test_carries_explicit_provider(self) -> None:
+        assert CreditExhaustedError("out", provider="zai").provider == "zai"
+
+
+class TestBackendProbeEndpoint:
+    def test_known_backend_resolves_base_url_and_key(self, monkeypatch) -> None:
+        monkeypatch.setenv("ZAI_API_KEY", "sk-zai-test")
+        config = ConfigFactory.create()
+        base_url, api_key = backend_probe_endpoint("zai", config)
+        assert base_url == config.zai_base_url
+        assert api_key == "sk-zai-test"
+
+    def test_anthropic_returns_empty(self) -> None:
+        config = ConfigFactory.create()
+        assert backend_probe_endpoint("anthropic", config) == ("", "")
+
+    def test_unknown_provider_returns_empty(self) -> None:
+        config = ConfigFactory.create()
+        assert backend_probe_endpoint("gemini", config) == ("", "")
+
+
+# ---------------------------------------------------------------------------
+# 2. Scoping — _loop_providers / _affected_loops
+# ---------------------------------------------------------------------------
+
+_LOOPS = ["triage", "plan", "review", "repo_wiki", "pr_unsticker", "store"]
+
+
+class TestLoopProviders:
+    def test_all_anthropic_by_default(self) -> None:
+        orch = HydraFlowOrchestrator(ConfigFactory.create())
+        providers = orch._loop_providers(_LOOPS)
+        assert set(providers.values()) == {PROVIDER_ANTHROPIC}
+
+    def test_dialed_loop_maps_to_its_backend(self) -> None:
+        orch = HydraFlowOrchestrator(
+            ConfigFactory.create().model_copy(
+                update={"wiki_compilation_provider": "kimi"}
+            )
+        )
+        providers = orch._loop_providers(_LOOPS)
+        assert providers["repo_wiki"] == "kimi"
+        # A non-dialed loop is unaffected.
+        assert providers["plan"] == PROVIDER_ANTHROPIC
+
+
+class TestAffectedLoops:
+    def test_anthropic_cap_spares_backend_routed_loop(self) -> None:
+        # THE core #9807 invariant: an Anthropic cap pauses the harness loops but
+        # NOT the kimi-routed wiki loop, which keeps ticking.
+        orch = HydraFlowOrchestrator(
+            ConfigFactory.create().model_copy(
+                update={"wiki_compilation_provider": "kimi"}
+            )
+        )
+        affected, terminate = orch._affected_loops("anthropic", _LOOPS, "plan")
+        assert "repo_wiki" not in affected
+        assert {"triage", "plan", "review", "store"} <= affected
+        assert terminate is True  # harness pools are torn down for an Anthropic cap
+
+    def test_backend_cap_scopes_to_that_backend_only(self) -> None:
+        orch = HydraFlowOrchestrator(
+            ConfigFactory.create().model_copy(
+                update={"wiki_compilation_provider": "kimi"}
+            )
+        )
+        affected, terminate = orch._affected_loops("kimi", _LOOPS, "repo_wiki")
+        assert affected == {"repo_wiki"}
+        assert terminate is False  # harness pools (Anthropic) left running
+
+    def test_backend_cap_always_includes_source(self) -> None:
+        # A backend signal raised by a loop the table doesn't map (e.g. a shared
+        # sub-step) still pauses+restarts that loop rather than orphaning it.
+        orch = HydraFlowOrchestrator(ConfigFactory.create())
+        affected, terminate = orch._affected_loops("zai", _LOOPS, "review")
+        assert "review" in affected
+        assert terminate is False
+
+    def test_unknown_provider_falls_back_to_global(self) -> None:
+        orch = HydraFlowOrchestrator(ConfigFactory.create())
+        affected, terminate = orch._affected_loops("gemini", _LOOPS, "plan")
+        assert affected == set(_LOOPS)
+        assert terminate is True
+
+
+# ---------------------------------------------------------------------------
+# 3. Probe-lift per provider
+# ---------------------------------------------------------------------------
+
+
+def _fake_get_client(resp_or_exc):
+    client = AsyncMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    if isinstance(resp_or_exc, Exception):
+        client.get = AsyncMock(side_effect=resp_or_exc)
+    else:
+        client.get = AsyncMock(return_value=resp_or_exc)
+    return client
+
+
+@pytest.mark.asyncio
+class TestPerProviderProbe:
+    async def test_anthropic_provider_delegates_to_anthropic_probe(self) -> None:
+        # No key configured → Anthropic probe assumes available (fail-open).
+        with patch.dict("os.environ", {}, clear=True):
+            assert await probe_credit_availability("anthropic") is True
+
+    async def test_backend_200_means_available(self) -> None:
+        resp = MagicMock(status_code=200, text="ok")
+        with patch("httpx.AsyncClient", return_value=_fake_get_client(resp)):
+            result = await probe_credit_availability(
+                "zai", base_url="https://api.z.ai", api_key="sk-zai"
+            )
+        assert result is True
+
+    @pytest.mark.parametrize("code", [402, 429])
+    async def test_backend_402_429_means_exhausted(self, code: int) -> None:
+        resp = MagicMock(status_code=code, text="insufficient credits")
+        with patch("httpx.AsyncClient", return_value=_fake_get_client(resp)):
+            result = await probe_credit_availability(
+                "kimi", base_url="https://api.moonshot.ai", api_key="sk-kimi"
+            )
+        assert result is False
+
+    async def test_backend_credit_body_means_exhausted(self) -> None:
+        resp = MagicMock(status_code=400, text="your credit balance is too low")
+        with patch("httpx.AsyncClient", return_value=_fake_get_client(resp)):
+            result = await probe_credit_availability(
+                "zai", base_url="https://api.z.ai", api_key="sk-zai"
+            )
+        assert result is False
+
+    async def test_backend_no_key_fails_open(self) -> None:
+        # Cannot probe an unwired backend — assume available so scoping falls
+        # back to the text signal rather than masking a real cap.
+        result = await probe_credit_availability(
+            "zai", base_url="https://x", api_key=""
+        )
+        assert result is True
+
+    async def test_backend_network_error_fails_open(self) -> None:
+        client = _fake_get_client(httpx.ConnectError("boom"))
+        with patch("httpx.AsyncClient", return_value=client):
+            result = await probe_credit_availability(
+                "zai", base_url="https://api.z.ai", api_key="sk-zai"
+            )
+        assert result is True
+
+    async def test_backend_non_credit_error_fails_open(self) -> None:
+        # A 401/404 is auth/routing, not a spent balance — do not pause.
+        resp = MagicMock(status_code=404, text="model not found")
+        with patch("httpx.AsyncClient", return_value=_fake_get_client(resp)):
+            result = await probe_credit_availability(
+                "zai", base_url="https://api.z.ai", api_key="sk-zai"
+            )
+        assert result is True


### PR DESCRIPTION
## Summary
Isolates the credit pause per backend so a Claude (Anthropic) credit limit no longer halts z.ai/kimi background workers, and a z.ai/kimi limit no longer globally halts Claude work. Builds on the landed detection hardening (#9869 probe corroboration, #9927 probe-refuted restart, #9888 FP throttle, #9924 false-positive return) without regressing any of it.

Closes #9807

## Design
**1. Classify the exhausted backend at the signal source** (bounded to the raise sites in `runner_utils.py`, not every spawn site):
- `CreditExhaustedError` gains a `provider` attribute, default `"anthropic"` — every existing harness raise site stays Anthropic-scoped unchanged.
- The OpenAI-compatible one-shot path tags its 402/429/credit-body raises with its backend (`"zai"`/`"kimi"`/`"openrouter"`).
- `normalize_provider()` reconciles the config dial namespace (`"claude"`) with the billing identity (`"anthropic"`).

**2. Scope the pause** (orchestrator):
- `_loop_providers`/`_affected_loops` map each loop to the backend it routes to (`_BACKEND_WORKER_LOOPS`: the 5 dial'd loops → their `*_provider`; everything else → `anthropic`).
- `_pause_for_credits(exc)` reads `exc.provider` and pauses only the affected loops. A backend-only cap leaves the shared Claude-harness runner pools running; an Anthropic cap pauses everything **except** the surviving backend workers. Resume is scoped to the same set. Mixed loops self-heal (a surviving loop's harness sub-call re-raises `anthropic`, absorbed by the active pause).

**3. Probe-lift per provider**: `probe_credit_availability(provider, base_url=, api_key=)` corroborates against the AFFECTED backend — the Anthropic messages API, or a cheap token-free `GET /models` for the one-shot backends — fail-open on infra errors like #9869. `backend_probe_endpoint()` resolves the endpoint from the provider registry.

**4. Global fallback** preserved for an unrecognized provider; per-provider pause state surfaced on the status + `SYSTEM_ALERT` payloads (mirrors the existing UI contract).

## Tests
- `tests/test_per_backend_credit_pause.py` — classification, `normalize_provider`, endpoint resolution, `_loop_providers`/`_affected_loops` scoping, per-provider probe-lift.
- `tests/test_llm_provider.py` — one-shot raises tag their backend.
- `tests/regressions/test_issue_9807_per_backend_credit_isolation.py` — end-to-end through the real `_pause_for_credits`: anthropic cap spares kimi worker; backend cap scopes + spares harness; probe targets the affected backend; false-positive pauses nothing.
- 262 focused tests green; existing credit-pause + #9807/#9924 regressions unchanged. `ruff`/`pyright` clean, no new `noqa`/`type: ignore` in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)