### PR TITLE
fix(fake-coverage): auto-close rollups on full recovery (#9541)

### DIFF
--- a/src/fake_coverage_auditor_loop.py
+++ b/src/fake_coverage_auditor_loop.py
@@ -619,6 +619,7 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
 
         filed = 0
         updated = 0
+        rollups_closed = 0
         escalated = 0
         dedup = self._dedup.get()
         all_known: dict[str, list[str]] = {}
@@ -693,7 +694,7 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
             else:
                 # Gap closed — clear attempts + drop the rollup mapping so
                 # the next regression re-files cleanly.
-                await self._clear_rollup_state(
+                rollups_closed += await self._clear_rollup_state(
                     fake, "adapter-surface", dedup, recovered=recovered_surface
                 )
 
@@ -715,7 +716,7 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
                 elif action == "updated":
                     updated += 1
             else:
-                await self._clear_rollup_state(
+                rollups_closed += await self._clear_rollup_state(
                     fake, "test-helper", dedup, recovered=recovered_helpers
                 )
 
@@ -747,6 +748,7 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
             "status": "ok",
             "filed": filed,
             "updated": updated,
+            "rollups_closed": rollups_closed,
             "escalated": escalated,
             "autoclosed": autoclosed,
             "fakes_seen": len(catalog),
@@ -842,31 +844,43 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
         kind: str,
         dedup: set[str],
         recovered: list[str] | None = None,
-    ) -> None:
+    ) -> int:
         """Reset rollup tracking when the gap closes (no uncovered methods).
 
         Drops the attempt counter, dedup key, and rollup-issue mapping so
-        a future regression re-files cleanly. When the previous tick had
-        an actual gap (``recovered`` is non-empty) AND a rollup issue is
-        tracked, repaint the body with the "all covered" view first so
-        humans looking at the open issue see the resolution rather than
-        a stale list of methods. The issue itself is left open for humans
-        to close.
+        a future regression re-files cleanly (fresh number, fresh
+        3-strikes clock). When the previous tick had an actual gap
+        (``recovered`` non-empty) AND a rollup issue is tracked, repaint
+        the body with the recovery trajectory, comment, and CLOSE the
+        issue (#9541) — leaving it open for a human was the #9183
+        dead-letter shape every other caretaker rollup has since dropped
+        (#9359, #10015/#10022 precedents). Returns 1 when a rollup was
+        auto-closed, else 0.
         """
         key = f"{fake}:{kind}"  # shared key for attempts + rollup mapping
         dedup_key = f"fake_coverage_auditor:{fake}:{kind}"
         tracked_number = self._state.get_fake_coverage_rollup_issue(key)
+        closed = 0
         if tracked_number and recovered:
             if kind == "adapter-surface":
                 body = self._render_surface_body(fake, [], recovered)
             else:
                 body = self._render_helper_body(fake, [], recovered)
             await self._pr.update_issue_body(tracked_number, body)
+            await self._pr.post_comment(
+                tracked_number,
+                f"All {len(recovered)} {kind} method(s) recovered — coverage "
+                "restored, auto-closing (#9541). A future regression files a "
+                "FRESH rollup with a fresh escalation clock.",
+            )
+            await self._pr.close_issue(tracked_number)
+            closed = 1
         self._state.clear_fake_coverage_attempts(key)
         self._state.clear_fake_coverage_rollup_issue(key)
         if dedup_key in dedup:
             dedup.discard(dedup_key)
             self._dedup.set_all(dedup)
+        return closed
 
     async def _audit_retirement(self, cassette_root: Path) -> int:
         """Find baseline_only cassettes covered by live dispatchers; file

--- a/tests/regressions/test_issue_9541_fake_coverage_rollup_autoclose.py
+++ b/tests/regressions/test_issue_9541_fake_coverage_rollup_autoclose.py
@@ -1,0 +1,152 @@
+"""Regression: fake-coverage rollups had no auto-close path (#9541).
+
+When the last uncovered adapter-surface method gained a cassette,
+``_clear_rollup_state`` in ``src/fake_coverage_auditor_loop.py`` repainted the
+rollup body to the "all covered" view and cleared dedup/attempt state but left
+the GitHub issue OPEN, relying on a human to close it — the #9183 dead-letter
+shape. Other caretaker loops auto-close their find-issues on recovery (#9359
+rollup rollout; #10015 streak-escalation precedent).
+
+Pins (#9541):
+- red → red → recovery: the tracked rollup issue is repainted (strikethrough
+  trajectory), commented, and CLOSED on the recovery tick; attempts, the
+  rollup mapping, and the dedup key are all cleared.
+- a later regression re-files a FRESH rollup issue (new number, attempt
+  counter restarted) rather than resurrecting the closed one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from base_background_loop import LoopDeps
+from config import HydraFlowConfig
+from dedup_store import DedupStore
+from events import EventBus
+from fake_coverage_auditor_loop import FakeCoverageAuditorLoop
+from state import StateTracker
+
+ROLLUP_ISSUE = 4242
+REFILED_ISSUE = 5000
+KEY = "FakeGitHub:adapter-surface"
+DEDUP_KEY = "fake_coverage_auditor:FakeGitHub:adapter-surface"
+
+
+@pytest.fixture
+def world(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Auditor wired to a REAL StateTracker/DedupStore over a tiny repo tree.
+
+    The memory-pinned harness shape: ``repo_root`` must point at the seeded
+    tree or the catalog scan finds nothing. ``_list_open_rollup_titles`` is
+    replaced by a mutable set the test drives (it is a raw ``gh`` read), and
+    escalation reconciles run against empty AsyncMock port listings.
+    """
+    cfg = HydraFlowConfig(
+        data_root=tmp_path / "data", repo="hydra/hydraflow", repo_root=tmp_path
+    )
+    state = StateTracker(tmp_path / "state.json")
+    dedup = DedupStore("fake_coverage", tmp_path / "dedup.json")
+    pr = AsyncMock()
+    pr.create_issue = AsyncMock(side_effect=[ROLLUP_ISSUE, REFILED_ISSUE])
+    pr.close_issue = AsyncMock(return_value=True)
+    pr.list_issues_by_label = AsyncMock(return_value=[])
+    pr.list_closed_issues_by_label = AsyncMock(return_value=[])
+    deps = LoopDeps(
+        event_bus=EventBus(),
+        stop_event=asyncio.Event(),
+        status_cb=lambda *a, **k: None,
+        enabled_cb=lambda _name: True,
+    )
+    loop = FakeCoverageAuditorLoop(
+        config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=deps
+    )
+
+    open_titles: set[str] = set()
+
+    async def fake_list_titles() -> set[str]:
+        return set(open_titles)
+
+    monkeypatch.setattr(loop, "_list_open_rollup_titles", fake_list_titles)
+
+    fake_dir = tmp_path / "src" / "mockworld" / "fakes"
+    fake_dir.mkdir(parents=True)
+    (fake_dir / "fake_github.py").write_text(
+        "class FakeGitHub:\n    async def missing(self): ...\n"
+    )
+    cassettes = tmp_path / "tests" / "trust" / "contracts" / "cassettes" / "github"
+    cassettes.mkdir(parents=True)
+
+    return loop, pr, state, dedup, open_titles, cassettes
+
+
+def _record_cassette(cassettes: Path) -> None:
+    (cassettes / "missing.yaml").write_text(
+        yaml.safe_dump({"input": {"command": "missing"}, "output": {}})
+    )
+
+
+async def _drive_red_red_recovery(world) -> dict:
+    """Tick 1 red (file), tick 2 red (update), tick 3 recovered. Returns
+    the recovery tick's stats."""
+    loop, pr, state, dedup, open_titles, cassettes = world
+
+    stats1 = await loop._do_work()
+    assert stats1["filed"] == 1
+    assert state.get_fake_coverage_rollup_issue(KEY) == ROLLUP_ISSUE
+    open_titles.add(pr.create_issue.await_args.args[0])
+
+    stats2 = await loop._do_work()
+    assert stats2["updated"] == 1
+    assert pr.create_issue.await_count == 1  # updated in place, not re-filed
+
+    _record_cassette(cassettes)
+    return await loop._do_work()
+
+
+async def test_red_red_recovery_autocloses_rollup(world) -> None:
+    loop, pr, state, dedup, open_titles, cassettes = world
+
+    stats3 = await _drive_red_red_recovery(world)
+
+    # The rollup issue was commented and closed on the recovery tick.
+    assert stats3["rollups_closed"] == 1
+    pr.close_issue.assert_awaited_once_with(ROLLUP_ISSUE)
+    assert pr.post_comment.await_args.args[0] == ROLLUP_ISSUE
+    # Final body records the recovery trajectory, not a stale gap list.
+    final_body = pr.update_issue_body.await_args.args[1]
+    assert pr.update_issue_body.await_args.args[0] == ROLLUP_ISSUE
+    assert "~~`missing`~~" in final_body
+    # Tracking fully cleared: mapping, attempt counter, dedup key.
+    assert state.get_fake_coverage_rollup_issue(KEY) is None
+    assert state.get_fake_coverage_attempts(KEY) == 0
+    assert DEDUP_KEY not in dedup.get()
+
+
+async def test_regression_after_autoclose_refiles_fresh(world) -> None:
+    loop, pr, state, dedup, open_titles, cassettes = world
+
+    await _drive_red_red_recovery(world)
+    open_titles.clear()  # the rollup was auto-closed
+
+    # The regression returns: the cassette disappears again.
+    (cassettes / "missing.yaml").unlink()
+
+    stats4 = await loop._do_work()
+
+    # A FRESH rollup was filed (new number), not the closed one resurrected.
+    assert stats4["filed"] == 1
+    assert pr.create_issue.await_count == 2
+    assert state.get_fake_coverage_rollup_issue(KEY) == REFILED_ISSUE
+    # Attempt counter restarted from scratch (1 of 3), so the 3-strikes
+    # escalation clock is fresh for the new streak.
+    assert state.get_fake_coverage_attempts(KEY) == 1
+    # And only the original close happened — the fresh issue stays open.
+    pr.close_issue.assert_awaited_once_with(ROLLUP_ISSUE)

--- a/tests/scenarios/test_fake_coverage_auditor_scenario.py
+++ b/tests/scenarios/test_fake_coverage_auditor_scenario.py
@@ -33,6 +33,8 @@ from unittest.mock import AsyncMock
 import pytest
 import yaml
 
+from dedup_store import DedupStore
+from state import StateTracker
 from tests.scenarios.fakes.mock_world import MockWorld
 from tests.scenarios.helpers.loop_port_seeding import seed_ports as _seed_ports
 
@@ -158,3 +160,60 @@ class TestFakeCoverageAuditor:
         assert (
             await world.github.list_issues_by_label("hydraflow-fake-coverage-gap") == []
         )
+
+    async def test_recovered_surface_gap_autocloses_rollup(self, tmp_path) -> None:
+        """#9541: when the last uncovered method gains a cassette, the loop
+        closes its OWN rollup issue on the recovery tick instead of leaving
+        it open for a human (mirrors the #10015 resolve-on-clean-tick shape).
+
+        Needs a REAL StateTracker/DedupStore seeded as the auditor's state
+        ports so tick 2 sees tick 1's rollup tracking — the catalog default
+        is a clean-slate MagicMock that forgets the filed issue number.
+        """
+        world = MockWorld(tmp_path)
+
+        repo = tmp_path / "repo"
+        fake_dir = repo / "src" / "mockworld" / "fakes"
+        fake_dir.mkdir(parents=True)
+        (fake_dir / "fake_github.py").write_text(
+            "class FakeGitHub:\n    async def close_issue(self, num): ...\n"
+        )
+        cassettes = repo / "tests" / "trust" / "contracts" / "cassettes" / "github"
+        cassettes.mkdir(parents=True)
+
+        _seed_ports(
+            world,
+            fake_coverage_reconcile_closed=AsyncMock(return_value=None),
+            fake_coverage_grep=AsyncMock(return_value=True),
+            fake_coverage_state=StateTracker(tmp_path / "auditor-state.json"),
+            fake_coverage_dedup=DedupStore(
+                "fake_coverage", tmp_path / "auditor-dedup.json"
+            ),
+        )
+
+        # Tick 1 — close_issue has no cassette → one rollup filed, OPEN.
+        await world.run_with_loops(["fake_coverage_auditor"], cycles=1)
+        open_issues = await world.github.list_issues_by_label(
+            "hydraflow-adapter-surface"
+        )
+        assert len(open_issues) == 1
+        number = open_issues[0]["number"]
+
+        # The gap recovers: the missing cassette lands between ticks.
+        (cassettes / "close_issue.yaml").write_text(
+            yaml.safe_dump({"input": {"command": "close_issue"}, "output": {}})
+        )
+
+        # Tick 2 — full recovery auto-closes the rollup (#9541).
+        stats = await world.run_with_loops(["fake_coverage_auditor"], cycles=1)
+
+        assert stats["fake_coverage_auditor"]["rollups_closed"] == 1
+        assert (
+            await world.github.list_issues_by_label("hydraflow-adapter-surface") == []
+        )
+        issue = world.github.issue(number)
+        assert issue.state == "closed"
+        # Final body records the recovery trajectory, not a stale gap list.
+        assert "~~`close_issue`~~" in issue.body
+        # The resolution comment landed before the close.
+        assert any("auto-clos" in c for c in issue.comments)

--- a/tests/test_fake_coverage_auditor_loop.py
+++ b/tests/test_fake_coverage_auditor_loop.py
@@ -394,7 +394,12 @@ async def test_do_work_keeps_escalation_for_live_gap(
     )
     stuck_key = "fake_coverage_auditor:FakeGitHub:adapter-surface"
     dedup.get.return_value = {stuck_key}
-    state.get_fake_coverage_rollup_issue.return_value = 42
+    # Per-kind tracking — only adapter-surface has a tracked rollup; the
+    # test-helper kind (no gap in this fake) must not alias to it now that
+    # _clear_rollup_state auto-closes tracked rollups on recovery (#9541).
+    state.get_fake_coverage_rollup_issue.side_effect = lambda k: (
+        42 if k == "FakeGitHub:adapter-surface" else None
+    )
     pr.list_issues_by_label.return_value = [
         {
             "number": 9618,
@@ -908,6 +913,103 @@ async def test_rollup_body_updated_when_gap_fully_closes(
     assert "missing" in body
     # State was cleared after the body update.
     state.clear_fake_coverage_rollup_issue.assert_any_call("FakeGitHub:adapter-surface")
+
+
+async def test_rollup_autocloses_when_gap_fully_recovers(
+    loop_env, monkeypatch, tmp_path
+) -> None:
+    """#9541: full recovery closes the tracked rollup issue, not just the body.
+
+    Before this, ``_clear_rollup_state`` repainted the body to the
+    "all covered" view and cleared tracking but left the GitHub issue OPEN
+    forever (the #9183 dead-letter shape) — mirror the #10015
+    resolve-on-clean-tick precedent instead.
+    """
+    cfg, state, pr, dedup = loop_env
+    state.get_fake_coverage_rollup_issue.side_effect = lambda k: (
+        5050 if k == "FakeGitHub:adapter-surface" else None
+    )
+    state.get_fake_coverage_last_known.return_value = {
+        "FakeGitHub": ["missing"],
+        "__uncovered__:FakeGitHub:adapter-surface": ["missing"],
+    }
+    fake_dir = tmp_path / "src" / "mockworld" / "fakes"
+    fake_dir.mkdir(parents=True)
+    (fake_dir / "fake_github.py").write_text(
+        "class FakeGitHub:\n    async def missing(self): ...\n"
+    )
+    cassette_dir = tmp_path / "tests" / "trust" / "contracts" / "cassettes" / "github"
+    cassette_dir.mkdir(parents=True)
+    (cassette_dir / "missing.yaml").write_text(
+        yaml.safe_dump({"input": {"command": "missing"}, "output": {}})
+    )
+
+    stop = asyncio.Event()
+    loop = FakeCoverageAuditorLoop(
+        config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=_deps(stop)
+    )
+
+    async def fake_reconcile():
+        return None
+
+    async def fake_list_titles():
+        return set()
+
+    monkeypatch.setattr(loop, "_reconcile_closed_escalations", fake_reconcile)
+    monkeypatch.setattr(loop, "_list_open_rollup_titles", fake_list_titles)
+
+    stats = await loop._do_work()
+
+    # The rollup issue was commented and closed — no more human-only close.
+    pr.close_issue.assert_awaited_once_with(5050)
+    pr.post_comment.assert_awaited_once()
+    assert pr.post_comment.await_args.args[0] == 5050
+    assert stats["rollups_closed"] == 1
+    # Body repaint (the "all covered" view) still lands before the close.
+    assert pr.update_issue_body.await_args_list[0].args[0] == 5050
+    # Tracking fully cleared so a future regression re-files fresh.
+    state.clear_fake_coverage_rollup_issue.assert_any_call("FakeGitHub:adapter-surface")
+    state.clear_fake_coverage_attempts.assert_any_call("FakeGitHub:adapter-surface")
+
+
+async def test_rollup_autoclose_noop_when_untracked(
+    loop_env, monkeypatch, tmp_path
+) -> None:
+    """#9541: a clean tick with no tracked rollup must not close anything —
+    the auto-close is keyed strictly on the tracked rollup-issue number, so
+    operator-owned issues (e.g. HITL escalations) are never swept up."""
+    cfg, state, pr, dedup = loop_env
+    state.get_fake_coverage_rollup_issue.return_value = None
+    fake_dir = tmp_path / "src" / "mockworld" / "fakes"
+    fake_dir.mkdir(parents=True)
+    (fake_dir / "fake_github.py").write_text(
+        "class FakeGitHub:\n    async def covered(self): ...\n"
+    )
+    cassette_dir = tmp_path / "tests" / "trust" / "contracts" / "cassettes" / "github"
+    cassette_dir.mkdir(parents=True)
+    (cassette_dir / "covered.yaml").write_text(
+        yaml.safe_dump({"input": {"command": "covered"}, "output": {}})
+    )
+
+    stop = asyncio.Event()
+    loop = FakeCoverageAuditorLoop(
+        config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=_deps(stop)
+    )
+
+    async def fake_reconcile():
+        return None
+
+    async def fake_list_titles():
+        return set()
+
+    monkeypatch.setattr(loop, "_reconcile_closed_escalations", fake_reconcile)
+    monkeypatch.setattr(loop, "_list_open_rollup_titles", fake_list_titles)
+
+    stats = await loop._do_work()
+
+    pr.close_issue.assert_not_awaited()
+    pr.post_comment.assert_not_awaited()
+    assert stats["rollups_closed"] == 0
 
 
 async def test_helper_rollup_same_shape(loop_env, monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Problem (#9541)

`_clear_rollup_state` repainted the recovery trajectory and cleared tracking but left the GitHub issue OPEN for a human — the #9183 dead-letter shape every other caretaker rollup has since dropped (#9359, #10015/#10022 precedents).

## Change

On the recovery tick the tracked rollup is repainted (strikethrough trajectory), commented, and CLOSED; mapping/attempts/dedup fully cleared so a later regression files a FRESH rollup with a fresh 3-strikes clock. Stats gain `rollups_closed`.

## Tests

Red-phase contract implemented green: unit + scenario + regression + ratchet; `make quality` exit 0.

Closes #9541

🤖 Generated with [Claude Code](https://claude.com/claude-code)