### PR TITLE
fix(quality): make quality runs the UI vitest suite — local/CI parity (#9875)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ RESET := \033[0m
 DOCKER_IMAGE ?= ghcr.io/t-rav/hydraflow-agent:latest
 DOCKER_BASE_IMAGE ?= ghcr.io/t-rav/hydraflow-agent-base:latest
 
-.PHONY: help run dev factory dry-run clean clean-assets compact coverage cover smoke test test-fast test-cov lint lint-check lint-fix lint-ul typecheck security quality quality-lite install install-plugins setup status ui ui-dev ui-clean ensure-labels ensure-hooks prep scaffold hot docker-build docker-ensure docker-test deps integration soak check-node-ui trust trust-adversarial auto-agent-adversarial
+.PHONY: help run dev factory dry-run clean clean-assets compact coverage cover smoke test test-fast test-cov test-ui lint lint-check lint-fix lint-ul typecheck security quality quality-lite install install-plugins setup status ui ui-dev ui-clean ensure-labels ensure-hooks prep scaffold hot docker-build docker-ensure docker-test deps integration soak check-node-ui trust trust-adversarial auto-agent-adversarial
 
 check-node-ui:
 	@cd $(HYDRAFLOW_DIR)src/ui && $(HYDRAFLOW_DIR)scripts/ui-npm.sh --version >/dev/null
@@ -61,8 +61,9 @@ help:
 	@echo "  make lint-fix       Auto-repair formatting/lint issues"
 	@echo "  make typecheck      Run Pyright type checks"
 	@echo "  make security       Run Bandit security scan"
+	@echo "  make test-ui        Run UI vitest suite (skips with warning if node/node_modules missing)"
 	@echo "  make quality-lite   Lint + typecheck + security (parallel)"
-	@echo "  make quality        quality-lite + test (parallel)"
+	@echo "  make quality        quality-lite + test + UI vitest (parallel)"
 	@echo "  make ensure-labels  Create HydraFlow labels in GitHub repo (API with offline fallback)"
 	@echo "  make prep           Sync agent assets then run full prep (API with offline fallback)"
 	@echo "  make scaffold       Generate baseline tests and CI configuration (API with offline fallback)"
@@ -354,9 +355,31 @@ init:
 		$(ARGS)
 
 
+# UI vitest stage (#9875): CI's "Dashboard Build" job runs the src/ui vitest
+# suite, but `make quality` historically did not — a stale UI test could pass
+# every local gate and only go red at the PR check (the UNSTABLE merge behind
+# #9617). Parity fix: quality runs the same suite through the same entry point
+# CI uses (`npm test` -> src/ui/scripts/run-vitest.cjs; NOT raw `npx vitest`,
+# which skips the wrapper's jsdom patch + encoding shim). Node is an optional
+# local tool, so machines without node or an installed src/ui/node_modules
+# degrade LOUDLY-but-green: the stage prints a SKIPPED warning instead of
+# failing quality — CI's Dashboard Build job still gates the merge either way.
+# Single definition shared by `make test-ui` and the quality parallel block.
+# Kept inline (no $(MAKE) recursion) so `make -n quality` stays a pure dry-run:
+# recipe lines containing $(MAKE) execute even under -n.
+UI_TEST_CMD = if command -v node >/dev/null 2>&1 && [ -d $(HYDRAFLOW_DIR)src/ui/node_modules ]; then \
+		(cd $(HYDRAFLOW_DIR)src/ui && node ./scripts/run-vitest.cjs run) && echo "[ui-tests OK]"; \
+	else \
+		echo "$(YELLOW)[ui-tests SKIPPED] node or src/ui/node_modules missing — UI vitest suite NOT run locally; CI Dashboard Build still runs it. Fix: install Node 20.19+/22.12+ then run npm ci in src/ui$(RESET)"; \
+	fi
+
+test-ui:
+	@$(UI_TEST_CMD)
+
 # Lint runs first, serially — ensures a failing lint aborts quality before
 # spending time on tests, and guarantees the same verdict as `make lint-check`.
-# pyright, bandit, and pytest are parallelised after lint passes.
+# pyright, bandit, pytest, and the UI vitest suite are parallelised after lint
+# passes.
 quality: deps lint-ul
 	@echo "$(BLUE)Running quality checks in parallel...$(RESET)"
 	@cd $(HYDRAFLOW_DIR) && $(UV) ruff check . && $(UV) ruff format . --check && echo "[lint OK]"
@@ -365,12 +388,17 @@ quality: deps lint-ul
 		$(UV) bandit -c pyproject.toml -r . --severity-level medium && echo "[security OK]" & \
 		PYTHONPATH=src $(UV) pytest tests/ && echo "[tests OK]" & \
 		PYTHONPATH=src $(UV) pytest tests/scenarios/ -m scenario_loops -q && echo "[scenarios OK]" & \
+		( $(UI_TEST_CMD) ) & \
 		wait_result=0; \
 		for job in $$(jobs -p); do wait $$job || wait_result=1; done; \
 		exit $$wait_result; \
 	)
 	@echo "$(GREEN)HydraFlow quality pipeline passed$(RESET)"
 
+# The UI vitest stage (#9875) is deliberately NOT part of quality-lite: this is
+# the pre-push gate and must stay fast (lint + typecheck + security only, no
+# test suites of any kind). UI drift is still caught by `make quality` locally
+# and by CI's Dashboard Build job on every PR.
 quality-lite: deps
 	@echo "$(BLUE)Running lightweight quality checks...$(RESET)"
 	@cd $(HYDRAFLOW_DIR) && ( \

--- a/tests/regressions/test_issue_9875_quality_ui_vitest.py
+++ b/tests/regressions/test_issue_9875_quality_ui_vitest.py
@@ -1,0 +1,124 @@
+"""Regression guard for issue #9875: `make quality` must plan the UI vitest stage.
+
+CI's "Dashboard Build" job runs the src/ui vitest suite (``npm test`` ->
+``src/ui/scripts/run-vitest.cjs``), but ``make quality`` historically did not,
+so a stale UI test (a ``Header.test.jsx`` asserting an old rendered arrow
+count) passed every local gate and only went red at the PR check — the
+``mergeStateStatus=UNSTABLE`` merge behind #9617. The merge-state gate is the
+symptom backstop; this pin guards the prevention:
+
+- ``make -n quality`` must include the UI vitest stage, run through the same
+  entry point CI uses (``run-vitest.cjs`` — not raw ``npx vitest``, which
+  skips the wrapper's jsdom patch and encoding shim);
+- node is an optional local tool, so the stage must degrade loudly-but-green
+  when node or an installed ``src/ui/node_modules`` is missing (skip with a
+  visible warning, never fail quality on a node-less machine);
+- the gating command must not be piped to ``tail`` — pipes mask the exit code
+  (the known ``make | tail`` footgun);
+- ``quality-lite`` (the pre-push gate) deliberately stays vitest-free so
+  pre-push stays fast.
+
+Asserted against ``make -n`` output — the real execution plan, after variable
+expansion — rather than raw Makefile text, so a refactor of the recipe wiring
+cannot silently drop the stage while a text pin still matches. ``make -n``
+executes nothing here: the quality chain intentionally contains no ``$(MAKE)``
+recipe lines (those run even under ``-n``).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from functools import cache
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+@cache
+def _dry_run_plan(target: str) -> str:
+    """Return the `make -n <target>` execution plan from the repo root."""
+    # Strip inherited make state: when this test itself runs under `make
+    # quality`, MAKEFLAGS/MFLAGS would otherwise leak into the child make.
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if k not in {"MAKEFLAGS", "MFLAGS", "MAKELEVEL"}
+    }
+    proc = subprocess.run(  # noqa: S603 — fixed argv, repo-root cwd
+        ["make", "-n", target],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        f"`make -n {target}` failed (rc={proc.returncode}):\n{proc.stderr}"
+    )
+    return proc.stdout
+
+
+def test_quality_plan_includes_ui_vitest_stage() -> None:
+    plan = _dry_run_plan("quality")
+
+    assert "run-vitest.cjs" in plan, (
+        "make quality no longer plans the UI vitest stage — src/ui changes "
+        "would pass local quality while CI's Dashboard Build goes red "
+        "(issue #9875)"
+    )
+
+
+def test_ui_stage_uses_ci_entry_point() -> None:
+    # CI runs `npm test` -> `node ./scripts/run-vitest.cjs run`. Parity means
+    # the same wrapper (it patches vitest's jsdom chunk and injects the
+    # encoding shim); raw `npx vitest run` can fail where CI passes.
+    plan = _dry_run_plan("quality")
+
+    assert "node ./scripts/run-vitest.cjs run" in plan
+
+
+def test_ui_stage_degrades_loudly_but_green_without_node() -> None:
+    plan = _dry_run_plan("quality")
+
+    assert "command -v node" in plan, (
+        "the UI vitest stage must guard on node availability so quality "
+        "stays green (but warns) on machines without node"
+    )
+    assert "src/ui/node_modules" in plan, (
+        "the UI vitest stage must guard on an installed src/ui/node_modules "
+        "(npm ci) so quality stays green (but warns) on fresh clones"
+    )
+    assert "[ui-tests SKIPPED]" in plan, (
+        "the skip branch must warn visibly — silent skips hide the parity gap"
+    )
+
+
+def test_ui_stage_exit_code_is_not_masked_by_tail_pipe() -> None:
+    plan = _dry_run_plan("quality")
+
+    offending = [
+        line
+        for line in plan.splitlines()
+        if "run-vitest.cjs" in line and "| tail" in line
+    ]
+    assert offending == [], (
+        "the UI vitest command must not be piped to tail — the pipe masks "
+        f"the exit code (known make-quality footgun): {offending}"
+    )
+
+
+def test_quality_lite_plan_stays_vitest_free() -> None:
+    # Deliberate: quality-lite is the pre-push gate and must stay fast.
+    # See the comment above the quality-lite target in the Makefile.
+    plan = _dry_run_plan("quality-lite")
+
+    assert "run-vitest.cjs" not in plan
+
+
+def test_standalone_test_ui_target_runs_same_stage() -> None:
+    plan = _dry_run_plan("test-ui")
+
+    assert "node ./scripts/run-vitest.cjs run" in plan
+    assert "[ui-tests SKIPPED]" in plan

--- a/tests/test_makefile_quality_order.py
+++ b/tests/test_makefile_quality_order.py
@@ -23,3 +23,46 @@ def test_lint_runs_before_parallel_block() -> None:
     assert not lint_line.rstrip().endswith("&"), (
         "make quality: lint preamble line must not be a background job"
     )
+
+
+def _quality_recipe() -> str:
+    text = MAKEFILE.read_text()
+    quality_start = text.index("quality: deps lint-ul")
+    quality_end = text.index("\nquality-lite:", quality_start)
+    return text[quality_start:quality_end]
+
+
+def test_ui_vitest_stage_is_parallel_job_in_quality() -> None:
+    """#9875: quality must run the UI vitest stage inside the parallel block."""
+    recipe = _quality_recipe()
+
+    ui_line = next((ln for ln in recipe.splitlines() if "UI_TEST_CMD" in ln), None)
+    assert ui_line is not None, (
+        "make quality: the UI vitest stage ($(UI_TEST_CMD)) is missing — "
+        "src/ui changes would pass local quality while CI Dashboard Build "
+        "goes red (issue #9875)"
+    )
+
+    # Background job (parallelised alongside pyright/bandit/pytest), placed
+    # before the wait loop so its exit code is collected by wait_result.
+    assert ui_line.rstrip().endswith("& \\"), (
+        "make quality: the UI vitest stage must be a background job "
+        "('& \\') inside the parallel block"
+    )
+    assert recipe.index("UI_TEST_CMD") < recipe.index("wait_result=0"), (
+        "make quality: the UI vitest stage must start before the wait loop "
+        "so its exit code propagates into wait_result"
+    )
+
+
+def test_ui_vitest_stage_not_in_quality_lite() -> None:
+    """#9875: quality-lite is the pre-push gate — it must stay vitest-free."""
+    text = MAKEFILE.read_text()
+    lite_start = text.index("\nquality-lite:")
+    lite_end = text.index("\ninstall:", lite_start)
+    recipe = text[lite_start:lite_end]
+
+    assert "UI_TEST_CMD" not in recipe and "vitest" not in recipe, (
+        "quality-lite must not run the UI vitest suite: pre-push stays fast "
+        "by design (see the comment above quality-lite; issue #9875)"
+    )


### PR DESCRIPTION
## Problem (#9875)

src/ui changes could pass every local gate and only go red at the PR check (the UNSTABLE-merge shape behind #9617): CI's Dashboard Build runs the vitest suite, `make quality` never did.

## Change

quality gains a `test-ui` stage running the SAME entry point CI uses (`npm test` → run-vitest.cjs — not raw `npx vitest`, which skips the wrapper's jsdom patch and encoding shim). No-node machines degrade loudly-but-green (SKIPPED warning; CI still gates); the stage stays inline so `make -n` remains a pure dry-run; quality-lite deliberately excludes it to keep pre-push fast.

## Tests

Makefile-plan pin + regression file; the stage ran the full UI suite green in-worktree; `make quality` exit 0 including the new stage.

Closes #9875

🤖 Generated with [Claude Code](https://claude.com/claude-code)