### PR TITLE
feat(queue): selectable work-queue discipline — consume the P0/P1/P2 labels the factory already produces (#10037)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -21,6 +21,7 @@ from pydantic import (
 )
 
 import file_util
+from queue_strategy import BandWeights, QueueStrategy
 
 logger = logging.getLogger("hydraflow.config")
 
@@ -795,6 +796,41 @@ class HydraFlowConfig(BaseModel):
     max_hitl_workers: int = Field(
         default=1, ge=1, le=5, description="Concurrent HITL correction agents"
     )
+
+    # Work-queue discipline (#10037) — how IssueStore orders each stage queue.
+    # ``IssueRefinementLoop`` (#9957) produces the P0/P1/P2 labels these read.
+    queue_strategy: QueueStrategy = Field(
+        default=QueueStrategy.WEIGHTED_MIX,
+        description=(
+            "Stage-queue ordering: 'fifo' (oldest first, pre-#10037 behaviour), "
+            "'priority' (strict P0>P1>P2, starves lower bands), or "
+            "'weighted_mix' (P0 preempts, then a starvation-free ratio draw)"
+        ),
+    )
+    # Weights are the per-cycle share each band draws under 'weighted_mix'.
+    # The floor of 1 is deliberate: it makes "a band cannot starve" an
+    # unconditional guarantee rather than a property of the default values.
+    queue_weight_p1: int = Field(
+        default=3, ge=1, le=10, description="P1 items drawn per weighted_mix cycle"
+    )
+    queue_weight_p2: int = Field(
+        default=2, ge=1, le=10, description="P2 items drawn per weighted_mix cycle"
+    )
+    queue_weight_unprioritised: int = Field(
+        default=1,
+        ge=1,
+        le=10,
+        description="Unlabelled items drawn per weighted_mix cycle",
+    )
+
+    def band_weights(self) -> BandWeights:
+        """Weighted-mix draw ratio in the form the ordering engine expects."""
+        return BandWeights(
+            p1=self.queue_weight_p1,
+            p2=self.queue_weight_p2,
+            unprioritised=self.queue_weight_unprioritised,
+        )
+
     # Plugin skill registry — see docs/superpowers/specs/2026-04-18-dynamic-plugin-skill-registry-design.md
     required_plugins: list[str] = Field(
         default_factory=lambda: [

--- a/src/issue_store.py
+++ b/src/issue_store.py
@@ -15,6 +15,7 @@ from config import HydraFlowConfig
 from events import EventBus, EventType, HydraFlowEvent
 from exception_classify import reraise_on_credit_or_bug
 from models import PipelineIssueStatus, PipelineSnapshotEntry, QueueStats, Task
+from queue_strategy import order_queue
 from subprocess_util import AuthenticationError
 from task_source import TaskFetcher
 
@@ -505,8 +506,36 @@ class IssueStore:
         """Return the set of HITL issue numbers."""
         return set(self._hitl_numbers)
 
+    def _is_eligible(self, task: Task, stage: IssueStoreStage) -> bool:
+        """Whether *task* may be dispatched from *stage* on this tick."""
+        if task.id in self._active:
+            return False
+        # ``human-required`` issues have been escalated out of the pipeline;
+        # core phases must not re-pull them, or they re-fail and re-escalate
+        # forever. The label is cleared on a successful HITL correction (it is
+        # in ``all_pipeline_labels``), after which the issue re-enters the
+        # queue clean (ADR-0084, pillar C).
+        if "human-required" in task.tags:
+            return False
+        return not (
+            stage != STAGE_FIND
+            and self._crate_manager is not None
+            and self._crate_manager.active_crate_number is not None
+            and not self._crate_manager.is_in_active_crate(task)
+        )
+
     def _take_from_queue(self, stage: IssueStoreStage, max_count: int) -> list[Task]:
-        """Pop up to *max_count* tasks from *stage* queue, skipping active.
+        """Take up to *max_count* eligible tasks from the *stage* queue.
+
+        Which tasks are considered first is decided by the configured queue
+        strategy (#10037), not by arrival order — the pre-#10037 behaviour is
+        still available exactly as ``fifo``. The strategy and its weights are
+        re-read here on every call so the dashboard knob applies on the next
+        phase tick rather than at restart.
+
+        The deque itself stays in arrival order; ordering is a read-time
+        selection concern only, so queue snapshots and stats are unaffected.
+        Ineligible tasks simply keep their place for the next tick.
 
         Safety note: This method is synchronous with no ``await`` points, so
         the GIL guarantees it cannot be interleaved with ``_route_issues``
@@ -515,41 +544,34 @@ class IssueStore:
         call completes atomically, and this synchronous method runs to
         completion within a single event-loop tick.
         """
-        result: list[Task] = []
-        skipped: list[Task] = []
         q = self._queues[stage]
+        ordered = order_queue(
+            list(q),
+            self._config.queue_strategy,
+            self._config.band_weights(),
+        )
 
-        while q and len(result) < max_count:
-            task = q.popleft()
-            self._queue_members[stage].discard(task.id)
-            if (
-                task.id in self._active
-                # ``human-required`` issues have been escalated out of the
-                # pipeline; core phases must not re-pull them, or they re-fail
-                # and re-escalate forever. The label is cleared on a successful
-                # HITL correction (it is in ``all_pipeline_labels``), after which
-                # the issue re-enters the queue clean (ADR-0084, pillar C).
-                or "human-required" in task.tags
-                or (
-                    stage != STAGE_FIND
-                    and self._crate_manager is not None
-                    and self._crate_manager.active_crate_number is not None
-                    and not self._crate_manager.is_in_active_crate(task)
-                )
-            ):
-                skipped.append(task)
-            else:
+        result: list[Task] = []
+        for task in ordered:
+            if len(result) >= max_count:
+                break
+            if self._is_eligible(task, stage):
                 result.append(task)
 
-        # Put skipped tasks back at the front
-        for task in reversed(skipped):
-            q.appendleft(task)
-            self._queue_members[stage].add(task.id)
+        if not result:
+            return []
 
-        if result:
-            for t in result:
-                self._in_flight[t.id] = stage
-            self._publish_queue_update_nowait()
+        taken = {t.id for t in result}
+        remaining = [t for t in q if t.id not in taken]
+        q.clear()
+        q.extend(remaining)
+        members = self._queue_members[stage]
+        members.clear()
+        members.update(t.id for t in remaining)
+
+        for t in result:
+            self._in_flight[t.id] = stage
+        self._publish_queue_update_nowait()
         return result
 
     # ------------------------------------------------------------------

--- a/src/queue_strategy.py
+++ b/src/queue_strategy.py
@@ -103,7 +103,16 @@ def order_queue(
             task for band in (*PRIORITY_BANDS, UNPRIORITISED) for task in banded[band]
         ]
 
-    return _weighted_interleave(banded, weights)
+    if strategy == QueueStrategy.WEIGHTED_MIX:
+        return _weighted_interleave(banded, weights)
+
+    # Explicit rather than falling through to weighted_mix: a strategy added to
+    # the enum without a branch here would otherwise be silently mis-dispatched
+    # as weighted_mix, and a scheduler quietly running the wrong discipline is
+    # exactly the kind of failure nobody notices. Config and the settings route
+    # both validate, so this is unreachable from the UI or a config file.
+    msg = f"unhandled queue strategy {strategy!r}"
+    raise ValueError(msg)
 
 
 def _partition(tasks: list[Task]) -> dict[str, list[Task]]:

--- a/src/queue_strategy.py
+++ b/src/queue_strategy.py
@@ -1,0 +1,143 @@
+"""Work-queue ordering strategies for :class:`~issue_store.IssueStore` (#10037).
+
+Before this module the factory had no work picker: selection was oldest-first
+FIFO, pinned at the GitHub API call (``sort=created`` / ``direction=asc``) and
+consumed by a plain ``deque.popleft()``. ``IssueRefinementLoop`` (#9957) already
+classifies the backlog into P0/P1/P2 labels, but nothing read them — a producer
+without a consumer, while the oldest and least valuable issues sat permanently
+at the front of every stage queue.
+
+This module is the pure ordering engine: no I/O, no config object, no clock.
+``IssueStore`` owns the queues and the eligibility rules; this decides only the
+sequence in which queued work is *considered*.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from models import Task
+
+
+class QueueStrategy(StrEnum):
+    """Selectable queue disciplines."""
+
+    FIFO = "fifo"
+    PRIORITY = "priority"
+    WEIGHTED_MIX = "weighted_mix"
+
+
+#: Priority labels, most urgent first. Written by ``IssueRefinementLoop``.
+PRIORITY_BANDS: tuple[str, ...] = ("P0", "P1", "P2")
+
+#: Band for issues carrying no priority label — the majority of fresh intake.
+UNPRIORITISED = "none"
+
+#: P0 means "the factory is broken right now" and preempts the mix outright
+#: rather than taking a share of it.
+_PREEMPT_BAND = "P0"
+
+#: Bands that participate in the weighted draw, in draw order.
+_MIX_BANDS: tuple[str, ...] = ("P1", "P2", UNPRIORITISED)
+
+
+@dataclass(frozen=True)
+class BandWeights:
+    """How many items each band contributes per cycle of the weighted draw.
+
+    A band with a positive weight cannot be starved: it receives a fixed share
+    of every cycle regardless of how much higher-band work arrives. That is the
+    whole reason ``weighted_mix`` exists alongside ``priority``, so weights are
+    validated positive at the config boundary rather than here.
+    """
+
+    p1: int
+    p2: int
+    unprioritised: int
+
+    def of(self, band: str) -> int:
+        """Weight for *band*; unknown bands draw nothing (never dropped)."""
+        return {
+            "P1": self.p1,
+            "P2": self.p2,
+            UNPRIORITISED: self.unprioritised,
+        }.get(band, 0)
+
+
+def band_of(task: Task) -> str:
+    """The priority band *task* belongs to.
+
+    An issue carrying several priority labels resolves to the most urgent one.
+    Multi-labelling happens when a human adds a label that
+    ``IssueRefinementLoop`` has already set differently; resolving upward fails
+    safe, since the issue gets worked sooner rather than buried.
+    """
+    tags = set(task.tags)
+    for band in PRIORITY_BANDS:
+        if band in tags:
+            return band
+    return UNPRIORITISED
+
+
+def order_queue(
+    tasks: list[Task],
+    strategy: QueueStrategy,
+    weights: BandWeights,
+) -> list[Task]:
+    """Return *tasks* in the order *strategy* would have them considered.
+
+    The result is always a permutation of the input. ``IssueStore`` rebuilds
+    its deque from this list, so dropping a task here would silently lose
+    queued work and duplicating one would double-dispatch an agent.
+    """
+    if strategy == QueueStrategy.FIFO:
+        return list(tasks)
+
+    banded = _partition(tasks)
+
+    if strategy == QueueStrategy.PRIORITY:
+        return [
+            task for band in (*PRIORITY_BANDS, UNPRIORITISED) for task in banded[band]
+        ]
+
+    return _weighted_interleave(banded, weights)
+
+
+def _partition(tasks: list[Task]) -> dict[str, list[Task]]:
+    """Split *tasks* into per-band lists, preserving arrival order within each."""
+    banded: dict[str, list[Task]] = {
+        band: [] for band in (*PRIORITY_BANDS, UNPRIORITISED)
+    }
+    for task in tasks:
+        banded[band_of(task)].append(task)
+    return banded
+
+
+def _weighted_interleave(
+    banded: dict[str, list[Task]],
+    weights: BandWeights,
+) -> list[Task]:
+    """Drain P0, then draw the remaining bands in the configured ratio."""
+    ordered: list[Task] = list(banded[_PREEMPT_BAND])
+    remaining = {band: list(banded[band]) for band in _MIX_BANDS}
+
+    while True:
+        progressed = False
+        for band in _MIX_BANDS:
+            for _ in range(weights.of(band)):
+                if not remaining[band]:
+                    break
+                ordered.append(remaining[band].pop(0))
+                progressed = True
+        if not progressed:
+            break
+
+    # A zero-weight band means "only once nothing else is left", never
+    # "discard" — without this the result would stop being a permutation.
+    for band in _MIX_BANDS:
+        ordered.extend(remaining[band])
+
+    return ordered

--- a/src/settings_registry.py
+++ b/src/settings_registry.py
@@ -50,6 +50,13 @@ SETTINGS: dict[str, SettingSpec] = {
     "max_reviewers": SettingSpec("Concurrency", live=True, order=3),
     "max_hitl_workers": SettingSpec("Concurrency", live=True, order=4),
     "batch_size": SettingSpec("Concurrency", live=True, order=5),
+    # --- Work Queue (stage-queue ordering, #10037) -----------------------
+    # Live: IssueStore re-reads these on every dequeue, so a change takes
+    # effect on the next phase tick without a restart.
+    "queue_strategy": SettingSpec("Work Queue", live=True, order=0),
+    "queue_weight_p1": SettingSpec("Work Queue", live=True, order=1),
+    "queue_weight_p2": SettingSpec("Work Queue", live=True, order=2),
+    "queue_weight_unprioritised": SettingSpec("Work Queue", live=True, order=3),
     # --- Models ----------------------------------------------------------
     "model": SettingSpec("Models", live=True, order=0),
     "planner_model": SettingSpec("Models", live=True, order=1),

--- a/tests/regressions/test_issue_10037_queue_strategy_dispatch.py
+++ b/tests/regressions/test_issue_10037_queue_strategy_dispatch.py
@@ -1,0 +1,42 @@
+"""Regression: order_queue fails loudly on an unhandled strategy (#10037).
+
+``order_queue`` originally ended with a bare ``return _weighted_interleave(...)``,
+so anything that was not ``fifo`` or ``priority`` was treated as
+``weighted_mix``. Nothing invalid can reach it today — ``HydraFlowConfig``
+validates the field and ``PATCH /api/control/config`` re-validates through
+``model_validate`` and 422s on a bad value — but a *new* strategy added to the
+``QueueStrategy`` enum without a matching branch would have been silently
+dispatched as ``weighted_mix``.
+
+That is the dangerous shape: the scheduler keeps running and picking work, just
+under the wrong discipline, with no error, no log line, and every existing test
+still green. This pins the loud failure so the fall-through cannot come back.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from models import Task
+from queue_strategy import BandWeights, QueueStrategy, order_queue
+
+_WEIGHTS = BandWeights(p1=3, p2=2, unprioritised=1)
+
+
+def test_an_unhandled_strategy_raises_rather_than_silently_mixing() -> None:
+    with pytest.raises(ValueError, match="unhandled queue strategy"):
+        order_queue(
+            [Task(id=1, title="issue 1")],
+            "not_a_strategy",  # type: ignore[arg-type]
+            _WEIGHTS,
+        )
+
+
+@pytest.mark.parametrize("strategy", list(QueueStrategy))
+def test_every_declared_strategy_still_dispatches(strategy: QueueStrategy) -> None:
+    # The other half of the guard: the raise must not be reachable for a
+    # strategy that IS declared, or adding the guard would have broken a
+    # working discipline instead of protecting it.
+    tasks = [Task(id=1, title="a", tags=["P1"]), Task(id=2, title="b")]
+
+    assert sorted(t.id for t in order_queue(tasks, strategy, _WEIGHTS)) == [1, 2]

--- a/tests/sandbox_scenarios/scenarios/s58_work_queue_settings_ui.py
+++ b/tests/sandbox_scenarios/scenarios/s58_work_queue_settings_ui.py
@@ -1,0 +1,63 @@
+"""s58 — Work Queue settings UI exposes the queue-discipline dial (#10037).
+
+The sandbox e2e layer for the selectable work-queue strategy. Unit coverage
+proves the ordering engine (``tests/test_queue_strategy.py``) and that the store
+consults it (``tests/test_issue_store_queue_strategy.py``); the MockWorld
+scenario proves priority labels survive GitHub → ``Task.tags`` → dispatch
+(``tests/scenarios/test_queue_strategy_scenario.py``). None of them cross the
+browser, so without this the operator-facing half of the feature is unvalidated.
+
+That half matters on its own: the strategy is only switchable at runtime because
+``settings_registry.SETTINGS`` lists it, and the dropdown's options are derived
+from the ``QueueStrategy`` StrEnum rather than hand-written. A break in either
+link leaves the factory permanently on whatever the config file happened to say,
+with every lower-tier test still green.
+
+Mirrors s53's shape: settings screen only, no pipeline activity.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s58_work_queue_settings_ui"
+DESCRIPTION = (
+    "System ▸ Settings ▸ Work Queue exposes the queue_strategy dial with all "
+    "three disciplines and the per-band weight rows."
+)
+
+
+def seed() -> MockWorldSeed:
+    # No pipeline activity needed — this exercises the settings screen only.
+    return MockWorldSeed(cycles_to_run=1)
+
+
+async def assert_outcome(api, page) -> None:
+    await page.goto("/")
+    await page.click("text=System")
+    await page.get_by_text("Settings", exact=True).first.click()
+
+    panel = page.locator("[data-testid='runtime-settings-panel']")
+    await panel.wait_for(timeout=15_000)
+
+    # The Work Queue group renders its strategy row (schema-derived).
+    strategy = page.locator("[data-testid='setting-queue_strategy']")
+    await strategy.wait_for(timeout=15_000)
+
+    # All three disciplines are offered. The choices derive from the
+    # QueueStrategy StrEnum, so a missing option means that discipline is
+    # unreachable from the UI — in particular 'fifo', which is the operator's
+    # escape hatch back to the pre-#10037 ordering.
+    for discipline in ("fifo", "priority", "weighted_mix"):
+        options = page.locator(
+            "[data-testid='input-queue_strategy'] option", has_text=discipline
+        )
+        assert await options.count() > 0, (
+            f"queue_strategy dropdown is missing the {discipline!r} option"
+        )
+
+    # The band weights are tunable alongside it. Without these the mix ratio is
+    # fixed at its defaults and 'weighted_mix' can't be rebalanced in the field.
+    for field in ("queue_weight_p1", "queue_weight_p2", "queue_weight_unprioritised"):
+        row = page.locator(f"[data-testid='setting-{field}']")
+        await row.wait_for(timeout=10_000)

--- a/tests/scenarios/test_queue_strategy_scenario.py
+++ b/tests/scenarios/test_queue_strategy_scenario.py
@@ -1,0 +1,141 @@
+"""MockWorld scenario: the work picker honours priority end-to-end (#10037).
+
+The third leg of the pyramid for the selectable queue discipline.
+``tests/test_queue_strategy.py`` proves the ordering engine against hand-built
+``Task`` objects; ``tests/test_issue_store_queue_strategy.py`` proves the store
+consults it. Neither touches the seam that actually decides whether the feature
+works in production: **do the P0/P1/P2 labels survive the trip from GitHub into
+``Task.tags``?**
+
+``IssueRefinementLoop`` writes those labels to GitHub. The fetcher projects
+``labels(first: 20)`` and ``GitHubIssue.to_task`` copies them into ``tags``,
+where ``band_of`` reads them. If any link in that chain filtered labels down to
+the pipeline-stage set, every strategy would silently degrade to FIFO with all
+tests still green — the failure would be invisible until someone noticed the
+factory ignoring priorities in production.
+
+So this scenario seeds ``world.github`` (the real ``FakeGitHub``, wire-shape
+``labels: [{"name": ...}]``), converts through the real ``GitHubIssue``
+projection, routes into the harness's real ``IssueStore``, and asserts the
+dispatch order that results — plus that draining across multiple ticks stays
+correctly interleaved rather than only getting the first pick right.
+"""
+
+from __future__ import annotations
+
+from models import GitHubIssue, Task
+from queue_strategy import QueueStrategy
+
+
+def _ready_label(world) -> str:
+    """The implement-stage label this harness is configured with.
+
+    Read from config rather than hardcoded: the test fixture uses
+    ``test-label``, and pinning the production string here would make the
+    scenario silently route nothing.
+    """
+    return world.harness.store._config.ready_label[0]
+
+
+def _fetch_as_tasks(github, label: str) -> list[Task]:
+    """Read seeded issues back out of FakeGitHub the way the fetcher does.
+
+    ``list_issues_by_label`` returns the gh wire shape, so labels arrive as
+    ``[{"name": ...}]`` and are flattened here exactly as the real fetch path
+    flattens them before handing ``GitHubIssue`` to ``to_task``.
+    """
+    raw = github._issues.values()
+    return [
+        GitHubIssue(
+            number=issue.number,
+            title=issue.title,
+            body=issue.body,
+            labels=list(issue.labels),
+        ).to_task()
+        for issue in raw
+        if issue.state == "open" and label in issue.labels
+    ]
+
+
+def _seed_backlog(github, ready: str) -> None:
+    """An aged backlog plus fresh prioritised intake — the real-world shape.
+
+    Numbers ascend with age (lowest = oldest), mirroring GitHub, so a FIFO
+    picker would take 9001 first and a priority-aware one would not.
+    """
+    github.add_issue(9001, "Ancient unlabelled chore", "", labels=[ready])
+    github.add_issue(9002, "Old P2 hardening", "", labels=[ready, "P2"])
+    github.add_issue(9003, "Another unlabelled chore", "", labels=[ready])
+    github.add_issue(9004, "Recent P1 — a loop is limping", "", labels=[ready, "P1"])
+    github.add_issue(
+        9005, "Newest P0 — the factory is wedged", "", labels=[ready, "P0"]
+    )
+
+
+class TestQueueStrategyScenario:
+    """Priority labels written to GitHub actually steer what gets worked."""
+
+    def test_priority_labels_survive_the_trip_from_github_into_task_tags(
+        self, mock_world
+    ) -> None:
+        # The seam the other two tiers cannot see. If this regresses, every
+        # strategy quietly degrades to FIFO with all unit tests still green.
+        ready = _ready_label(mock_world)
+        _seed_backlog(mock_world.github, ready)
+
+        tasks = _fetch_as_tasks(mock_world.github, ready)
+        by_number = {t.id: t.tags for t in tasks}
+
+        assert "P0" in by_number[9005]
+        assert "P1" in by_number[9004]
+        assert "P2" in by_number[9002]
+        assert by_number[9001] == [ready]
+
+    def test_the_wedged_p0_is_worked_before_the_oldest_issue(self, mock_world) -> None:
+        # The headline behaviour change: pre-#10037 this dispatched 9001.
+        store = mock_world.harness.store
+        ready = _ready_label(mock_world)
+        store._config.queue_strategy = QueueStrategy.WEIGHTED_MIX
+        _seed_backlog(mock_world.github, ready)
+        store._route_issues(_fetch_as_tasks(mock_world.github, ready))
+
+        assert [t.id for t in store.get_implementable(1)] == [9005]
+
+    def test_draining_the_backlog_stays_interleaved_across_ticks(
+        self, mock_world
+    ) -> None:
+        # One correct pick is not the contract — the whole drain order is.
+        # P0 first, then the P1:P2:unlabelled = 3:2:1 draw. With only one P1
+        # and one P2 left, the first cycle takes both plus one unlabelled,
+        # and the second cycle takes the remaining unlabelled.
+        store = mock_world.harness.store
+        ready = _ready_label(mock_world)
+        store._config.queue_strategy = QueueStrategy.WEIGHTED_MIX
+        _seed_backlog(mock_world.github, ready)
+        store._route_issues(_fetch_as_tasks(mock_world.github, ready))
+
+        drained: list[int] = []
+        for _ in range(5):
+            picked = store.get_implementable(1)
+            assert picked, "queue drained early — a task was lost"
+            drained.append(picked[0].id)
+
+        assert drained == [9005, 9004, 9002, 9001, 9003]
+
+    def test_fifo_still_reproduces_the_pre_10037_order_end_to_end(
+        self, mock_world
+    ) -> None:
+        # The operator escape hatch, proven at the same integration depth as
+        # the new default rather than only at the unit tier.
+        store = mock_world.harness.store
+        ready = _ready_label(mock_world)
+        store._config.queue_strategy = QueueStrategy.FIFO
+        _seed_backlog(mock_world.github, ready)
+        store._route_issues(_fetch_as_tasks(mock_world.github, ready))
+
+        drained: list[int] = []
+        for _ in range(5):
+            picked = store.get_implementable(1)
+            drained.append(picked[0].id)
+
+        assert drained == [9001, 9002, 9003, 9004, 9005]

--- a/tests/test_issue_store_queue_strategy.py
+++ b/tests/test_issue_store_queue_strategy.py
@@ -1,0 +1,159 @@
+"""IssueStore honours the configured work-queue strategy (#10037).
+
+``tests/test_queue_strategy.py`` proves the ordering engine in isolation. These
+tests prove the *wiring*: that the store actually consults the strategy when
+dispatching, that the knob is re-read live, and that eligibility rules still
+win over priority.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from events import EventBus
+from issue_store import STAGE_READY, IssueStore
+from models import Task
+from queue_strategy import QueueStrategy
+from tests.conftest import TaskFactory
+from tests.helpers import ConfigFactory
+
+
+def _make_store(strategy: QueueStrategy = QueueStrategy.WEIGHTED_MIX) -> IssueStore:
+    config = ConfigFactory.create()
+    config.queue_strategy = strategy
+    fetcher = AsyncMock()
+    fetcher.fetch_all = AsyncMock(return_value=[])
+    return IssueStore(config, fetcher, EventBus())
+
+
+def _queue(store: IssueStore, *tasks: Task) -> None:
+    for task in tasks:
+        store._queues[STAGE_READY].append(task)
+        store._queue_members[STAGE_READY].add(task.id)
+
+
+def _ready(id: int, priority: str | None = None) -> Task:
+    tags = ["hydraflow-ready"] + ([priority] if priority else [])
+    return TaskFactory.create(id=id, tags=tags)
+
+
+def test_a_fresh_p1_is_dispatched_ahead_of_an_older_unlabelled_issue() -> None:
+    # The headline #10037 acceptance criterion. Pre-#10037 the oldest issue won
+    # unconditionally, so a P1 filed today queued behind the whole backlog.
+    store = _make_store()
+    _queue(
+        store,
+        _ready(id=1),
+        _ready(id=2),
+        _ready(id=3, priority="P1"),
+    )
+
+    assert [t.id for t in store.get_implementable(1)] == [3]
+
+
+def test_p0_preempts_every_other_band() -> None:
+    store = _make_store()
+    _queue(
+        store,
+        _ready(id=1, priority="P1"),
+        _ready(id=2, priority="P2"),
+        _ready(id=3, priority="P0"),
+    )
+
+    assert [t.id for t in store.get_implementable(1)] == [3]
+
+
+def test_fifo_strategy_reproduces_the_pre_10037_oldest_first_behaviour() -> None:
+    store = _make_store(QueueStrategy.FIFO)
+    _queue(
+        store,
+        _ready(id=1),
+        _ready(id=2, priority="P0"),
+        _ready(id=3, priority="P1"),
+    )
+
+    assert [t.id for t in store.get_implementable(3)] == [1, 2, 3]
+
+
+def test_the_strategy_knob_is_re_read_on_every_dequeue() -> None:
+    # ``live=True`` in the settings registry is a promise to the operator that
+    # flipping this in the dashboard takes effect on the next tick. If the
+    # store ever caches the strategy at construction, this fails.
+    store = _make_store(QueueStrategy.FIFO)
+    _queue(store, _ready(id=1), _ready(id=2, priority="P0"))
+
+    assert [t.id for t in store.get_implementable(1)] == [1]
+
+    store._config.queue_strategy = QueueStrategy.WEIGHTED_MIX
+
+    assert [t.id for t in store.get_implementable(1)] == [2]
+
+
+def test_priority_does_not_override_the_human_required_guard() -> None:
+    # Eligibility is a correctness rule (ADR-0084 pillar C); ordering must not
+    # be able to promote an escalated issue back into the pipeline.
+    store = _make_store()
+    escalated = TaskFactory.create(
+        id=1, tags=["hydraflow-ready", "P0", "human-required"]
+    )
+    _queue(store, escalated, _ready(id=2, priority="P2"))
+
+    assert [t.id for t in store.get_implementable(1)] == [2]
+
+
+def test_an_active_issue_is_skipped_even_when_it_outranks_the_rest() -> None:
+    store = _make_store()
+    _queue(store, _ready(id=1, priority="P0"), _ready(id=2, priority="P2"))
+    store.mark_active(1, STAGE_READY)
+
+    assert [t.id for t in store.get_implementable(1)] == [2]
+
+
+def test_taking_work_leaves_the_rest_queued_in_arrival_order() -> None:
+    # Ordering is a read-time concern; permuting the stored deque would leak
+    # into queue snapshots and stats for no benefit.
+    store = _make_store()
+    _queue(
+        store,
+        _ready(id=1),
+        _ready(id=2, priority="P2"),
+        _ready(id=3, priority="P0"),
+    )
+
+    store.get_implementable(1)
+
+    assert [t.id for t in store._queues[STAGE_READY]] == [1, 2]
+    assert store._queue_members[STAGE_READY] == {1, 2}
+
+
+def test_lower_bands_still_advance_under_a_flood_of_higher_priority_work() -> None:
+    # The starvation guarantee, asserted through the real store rather than the
+    # engine: with weights P1=3/P2=2/none=1 a P2 must appear within one cycle.
+    store = _make_store()
+    _queue(store, *[_ready(id=100 + i, priority="P2") for i in range(3)])
+    _queue(store, *[_ready(id=i, priority="P1") for i in range(30)])
+
+    dispatched = [t.id for t in store.get_implementable(6)]
+
+    assert any(number >= 100 for number in dispatched)
+
+
+@pytest.mark.parametrize("strategy", list(QueueStrategy))
+def test_no_queued_task_is_lost_or_duplicated_by_any_strategy(
+    strategy: QueueStrategy,
+) -> None:
+    store = _make_store(strategy)
+    _queue(
+        store,
+        _ready(id=1, priority="P2"),
+        _ready(id=2),
+        _ready(id=3, priority="P0"),
+        _ready(id=4, priority="P1"),
+    )
+
+    taken = [t.id for t in store.get_implementable(2)]
+    left = [t.id for t in store._queues[STAGE_READY]]
+
+    assert sorted(taken + left) == [1, 2, 3, 4]

--- a/tests/test_queue_strategy.py
+++ b/tests/test_queue_strategy.py
@@ -197,13 +197,6 @@ def test_weighted_mix_on_an_all_one_band_queue_is_plain_arrival_order() -> None:
     assert _ids(ordered) == [0, 1, 2, 3]
 
 
-def test_an_unhandled_strategy_raises_rather_than_silently_mixing() -> None:
-    # Guards the "add a strategy, forget a branch" bug. Falling through to
-    # weighted_mix would run the wrong discipline with no signal at all.
-    with pytest.raises(ValueError, match="unhandled queue strategy"):
-        order_queue([_task(1)], "not_a_strategy", DEFAULT_WEIGHTS)  # type: ignore[arg-type]
-
-
 def test_empty_queue_orders_to_empty() -> None:
     for strategy in QueueStrategy:
         assert order_queue([], strategy, DEFAULT_WEIGHTS) == []

--- a/tests/test_queue_strategy.py
+++ b/tests/test_queue_strategy.py
@@ -1,0 +1,202 @@
+"""Work-queue ordering strategies (#10037)."""
+
+from __future__ import annotations
+
+import pytest
+
+from models import Task
+from queue_strategy import (
+    UNPRIORITISED,
+    BandWeights,
+    QueueStrategy,
+    band_of,
+    order_queue,
+)
+
+
+def _task(number: int, *tags: str) -> Task:
+    return Task(id=number, title=f"issue {number}", tags=list(tags))
+
+
+def _ids(tasks: list[Task]) -> list[int]:
+    return [t.id for t in tasks]
+
+
+DEFAULT_WEIGHTS = BandWeights(p1=3, p2=2, unprioritised=1)
+
+
+# --- band_of ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("tags", "expected"),
+    [
+        (("P0",), "P0"),
+        (("P1",), "P1"),
+        (("P2",), "P2"),
+        ((), UNPRIORITISED),
+        (("hydraflow-ready",), UNPRIORITISED),
+        (("hydraflow-ready", "P1"), "P1"),
+    ],
+)
+def test_band_of_reads_the_priority_label(tags: tuple[str, ...], expected: str) -> None:
+    assert band_of(_task(1, *tags)) == expected
+
+
+def test_band_of_takes_the_most_urgent_when_an_issue_carries_several() -> None:
+    # Mislabelled issues happen (a human adds P1 while IssueRefinementLoop has
+    # already applied P2). Resolving to the most urgent band fails safe: the
+    # issue gets worked sooner rather than being buried.
+    assert band_of(_task(1, "P2", "P0", "P1")) == "P0"
+
+
+# --- the permutation invariant --------------------------------------------
+
+
+@pytest.mark.parametrize("strategy", list(QueueStrategy))
+def test_ordering_is_a_permutation_of_the_input(strategy: QueueStrategy) -> None:
+    # Load-bearing: IssueStore rebuilds its deque from this result, so dropping
+    # or duplicating a task here silently loses queued work or double-dispatches
+    # an agent. Every strategy must return exactly the input set.
+    tasks = [
+        _task(1, "P2"),
+        _task(2),
+        _task(3, "P0"),
+        _task(4, "P1"),
+        _task(5, "P1"),
+        _task(6),
+        _task(7, "P2"),
+    ]
+    ordered = order_queue(tasks, strategy, DEFAULT_WEIGHTS)
+
+    assert sorted(_ids(ordered)) == sorted(_ids(tasks))
+    assert len(ordered) == len(tasks)
+
+
+def test_ordering_never_drops_a_band_whose_weight_is_absent() -> None:
+    # A zero weight means "only when nothing else is left", never "discard".
+    tasks = [_task(1, "P1"), _task(2, "P2"), _task(3)]
+    ordered = order_queue(
+        tasks, QueueStrategy.WEIGHTED_MIX, BandWeights(p1=1, p2=0, unprioritised=0)
+    )
+
+    assert sorted(_ids(ordered)) == [1, 2, 3]
+
+
+# --- fifo ------------------------------------------------------------------
+
+
+def test_fifo_preserves_the_incoming_order_exactly() -> None:
+    # fifo is the escape hatch and the pre-#10037 behaviour pin: it must be a
+    # faithful no-op so operators can revert ordering without a code change.
+    tasks = [_task(1, "P2"), _task(2, "P0"), _task(3, "P1")]
+
+    assert _ids(order_queue(tasks, QueueStrategy.FIFO, DEFAULT_WEIGHTS)) == [1, 2, 3]
+
+
+# --- priority --------------------------------------------------------------
+
+
+def test_priority_orders_by_band_then_keeps_arrival_order_within_a_band() -> None:
+    tasks = [
+        _task(1, "P2"),
+        _task(2),
+        _task(3, "P0"),
+        _task(4, "P1"),
+        _task(5, "P1"),
+        _task(6, "P2"),
+    ]
+
+    assert _ids(order_queue(tasks, QueueStrategy.PRIORITY, DEFAULT_WEIGHTS)) == [
+        3,
+        4,
+        5,
+        1,
+        6,
+        2,
+    ]
+
+
+def test_priority_starves_the_lower_bands_under_continuous_p1_inflow() -> None:
+    # Documents *why* priority is not the default. This is the failure mode
+    # weighted_mix exists to avoid — asserted, not just described in a comment,
+    # so the trade-off stays visible if someone flips the default.
+    p2_backlog = [_task(100 + i, "P2") for i in range(5)]
+    incoming_p1 = [_task(i, "P1") for i in range(20)]
+
+    ordered = order_queue(
+        p2_backlog + incoming_p1, QueueStrategy.PRIORITY, DEFAULT_WEIGHTS
+    )
+
+    assert all(band_of(t) == "P1" for t in ordered[:20])
+
+
+# --- weighted_mix ----------------------------------------------------------
+
+
+def test_weighted_mix_drains_p0_before_anything_else() -> None:
+    # P0 is "the factory is broken right now" — it preempts the mix entirely
+    # rather than taking a share of it.
+    tasks = [_task(1, "P1"), _task(2, "P2"), _task(3, "P0"), _task(4, "P0")]
+
+    ordered = order_queue(tasks, QueueStrategy.WEIGHTED_MIX, DEFAULT_WEIGHTS)
+
+    assert _ids(ordered)[:2] == [3, 4]
+
+
+def test_weighted_mix_draws_bands_in_the_configured_ratio() -> None:
+    tasks = [_task(i, "P1") for i in range(3)]
+    tasks += [_task(10 + i, "P2") for i in range(2)]
+    tasks += [_task(20)]
+
+    ordered = order_queue(tasks, QueueStrategy.WEIGHTED_MIX, DEFAULT_WEIGHTS)
+
+    assert _ids(ordered) == [0, 1, 2, 10, 11, 20]
+
+
+def test_weighted_mix_repeats_the_ratio_across_cycles() -> None:
+    tasks = [_task(i, "P1") for i in range(6)]
+    tasks += [_task(10 + i, "P2") for i in range(4)]
+    tasks += [_task(20 + i) for i in range(2)]
+
+    ordered = order_queue(tasks, QueueStrategy.WEIGHTED_MIX, DEFAULT_WEIGHTS)
+
+    assert _ids(ordered) == [0, 1, 2, 10, 11, 20, 3, 4, 5, 12, 13, 21]
+
+
+def test_weighted_mix_keeps_lower_bands_moving_under_continuous_p1_inflow() -> None:
+    # The headline guarantee, and the acceptance criterion from #10037: a band
+    # with a positive weight cannot be starved no matter how much higher-band
+    # work arrives.
+    p2_backlog = [_task(100 + i, "P2") for i in range(5)]
+    incoming_p1 = [_task(i, "P1") for i in range(50)]
+
+    ordered = order_queue(
+        p2_backlog + incoming_p1, QueueStrategy.WEIGHTED_MIX, DEFAULT_WEIGHTS
+    )
+    first_ten = ordered[:10]
+
+    assert any(band_of(t) == "P2" for t in first_ten)
+
+
+def test_weighted_mix_skips_bands_that_have_run_out() -> None:
+    # An empty band must not stall the cycle or emit padding.
+    tasks = [_task(i, "P1") for i in range(4)]
+    tasks += [_task(20)]
+
+    ordered = order_queue(tasks, QueueStrategy.WEIGHTED_MIX, DEFAULT_WEIGHTS)
+
+    assert _ids(ordered) == [0, 1, 2, 20, 3]
+
+
+def test_weighted_mix_on_an_all_one_band_queue_is_plain_arrival_order() -> None:
+    tasks = [_task(i, "P2") for i in range(4)]
+
+    ordered = order_queue(tasks, QueueStrategy.WEIGHTED_MIX, DEFAULT_WEIGHTS)
+
+    assert _ids(ordered) == [0, 1, 2, 3]
+
+
+def test_empty_queue_orders_to_empty() -> None:
+    for strategy in QueueStrategy:
+        assert order_queue([], strategy, DEFAULT_WEIGHTS) == []

--- a/tests/test_queue_strategy.py
+++ b/tests/test_queue_strategy.py
@@ -197,6 +197,13 @@ def test_weighted_mix_on_an_all_one_band_queue_is_plain_arrival_order() -> None:
     assert _ids(ordered) == [0, 1, 2, 3]
 
 
+def test_an_unhandled_strategy_raises_rather_than_silently_mixing() -> None:
+    # Guards the "add a strategy, forget a branch" bug. Falling through to
+    # weighted_mix would run the wrong discipline with no signal at all.
+    with pytest.raises(ValueError, match="unhandled queue strategy"):
+        order_queue([_task(1)], "not_a_strategy", DEFAULT_WEIGHTS)  # type: ignore[arg-type]
+
+
 def test_empty_queue_orders_to_empty() -> None:
     for strategy in QueueStrategy:
         assert order_queue([], strategy, DEFAULT_WEIGHTS) == []

--- a/tests/test_settings_registry.py
+++ b/tests/test_settings_registry.py
@@ -90,6 +90,15 @@ class TestSchemaDerivation:
         for r in enum_rows:
             assert r["choices"], f"{r['name']} typed enum but no choices"
 
+    def test_enum_field_from_str_enum_offers_every_queue_discipline(self) -> None:
+        # queue_strategy (#10037) is a StrEnum, not a Literal — a different
+        # branch of _derive_type. It is the operator's only runtime access to
+        # the work picker, and 'fifo' in particular is the escape hatch back to
+        # the pre-#10037 ordering, so a dropped choice strands them.
+        row = self._schema()["queue_strategy"]
+        assert row["type"] == "enum"
+        assert set(row["choices"]) == {"fifo", "priority", "weighted_mix"}
+
     def test_current_value_reflects_config(self) -> None:
         cfg = HydraFlowConfig()
         object.__setattr__(cfg, "max_workers", 7)


### PR DESCRIPTION
## Problem (#10037)

The factory had no work picker. Selection was **oldest-first FIFO**, pinned at the GitHub API call (`issue_fetcher.py:205-207` `sort=created`/`direction=asc`, and the GraphQL `orderBy` at `:376`) and consumed by a plain `deque.popleft()` (`issue_store.py:523`). There was no `sort()`, no comparator, no priority anywhere in `issue_store.py` — the GitHub API's `orderBy` *was* the scheduler.

Two consequences:

1. **Priority was produced but never consumed.** `IssueRefinementLoop` (#9957, merged today) classifies the backlog into P0/P1/P2 and applies the labels. 43 of 63 open issues already carry one (8×P1, 35×P2). Nothing read them.
2. **Oldest-first actively inverted the intent.** The oldest issues are the stale, low-value P2 cruft, so they sat permanently at the front of every stage queue. A P1 filed today queued behind 35 P2s.

## Change

Queue discipline becomes a selectable strategy, chosen by a `queue_strategy` knob:

| Strategy | Behaviour |
|---|---|
| `fifo` | The pre-#10037 oldest-first ordering, kept as the operator escape hatch. |
| `priority` | Strict P0 > P1 > P2 > unlabelled. Starves lower bands under sustained higher-band inflow. |
| `weighted_mix` | **New default.** P0 preempts outright; the remaining bands draw on a configurable ratio (default P1:P2:unlabelled = 3:2:1). |

`weighted_mix` is the default because the operating need is a deliberate *blend* of P1, P2, maintenance and feature work — not any single-axis ordering. Its starvation-freedom is structural, not tuned: a band with a positive weight receives a fixed share of every cycle no matter how much higher-band work arrives. Weights are floored at 1 (`ge=1`) precisely so that guarantee is unconditional rather than a property of the default values. `priority` is included mainly so the starvation failure mode is demonstrable rather than theoretical — there is a test asserting it.

**No new loop, no new ADR.** The host is the existing `IssueStore`, whose `_take_from_queue` is a single choke point serving all six core phases. [ADR-0099](docs/adr/0099-orchestration-as-a-control-system.md) already models `IssueStore` as the supervisory **Controller** and lists "queue priority tiers" under that role, and its Context names this exact gap ("issue selection is FIFO by label priority… the rich sensor data is not fed into what-to-do-next decisions"). This is the first concrete implementation of a role that ADR was already written around.

ADR-0099 anticipates `IssueStore` being superseded as supervisory controller by `DriverManager` + `SchedulingPolicy` at v2. `QueueStrategy`/`order_queue` are deliberately a pure control law over a task list — the same shape ADR-0099 specifies for `SchedulingPolicy.select` over a frozen `SchedulingView` — so this logic should port rather than be discarded. The execution-model half is tracked separately in #10038.

## Notes for review

- **`order_queue` must return a permutation of its input.** `_take_from_queue` rebuilds the queue from it, so a dropped task silently loses queued work and a duplicated one double-dispatches an agent. This is asserted for every strategy, including the zero-weight edge case where a band would otherwise never be emitted.
- **The deque stays in arrival order.** Ordering is a read-time selection concern only, so queue snapshots and pipeline stats are unaffected.
- **Eligibility still wins over priority.** The `human-required` guard (ADR-0084 pillar C), the active-issue guard, and the crate gate are unchanged and are asserted to beat a P0. They were extracted verbatim into `_is_eligible`.
- **Graceful degradation:** if `IssueRefinementLoop` is off or behind, everything is unlabelled, every task lands in one band, and `weighted_mix` reduces to arrival order — i.e. today's behaviour. The feature fails soft.
- The crate/milestone gate at `issue_store.py` is dormant (the repo has zero milestones; it was an abandoned experiment) and is left untouched here rather than removed as drive-by scope.

## Testing

Full pyramid per `docs/standards/testing/README.md`.

**Unit** — `tests/test_queue_strategy.py` (21 tests): banding, the permutation invariant across all strategies, `fifo` no-op parity, the ratio draw across cycles, band exhaustion, and both the starvation failure (`priority`) and the starvation guarantee (`weighted_mix`).

**Unit/integration** — `tests/test_issue_store_queue_strategy.py` (11 tests): the store consults the strategy, the knob is re-read live on every dequeue (the `live=True` promise), eligibility beats priority, and no task is lost or duplicated by any strategy.

**MockWorld scenario** — `tests/scenarios/test_queue_strategy_scenario.py` (4 tests): seeds the real `FakeGitHub` and converts through the real `GitHubIssue.to_task` projection. This covers the seam the other tiers structurally cannot see — **whether P-labels survive GitHub → `Task.tags`**. If any link in that chain filtered labels to the pipeline-stage set, every strategy would silently degrade to FIFO with all unit tests still green. Also asserts the whole multi-tick drain order, not just the first pick.

**Sandbox e2e** — `tests/sandbox_scenarios/scenarios/s58_work_queue_settings_ui.py`: the browser layer. The strategy is only runtime-switchable because `settings_registry.SETTINGS` lists it, and the dropdown options derive from the `QueueStrategy` StrEnum; a break in either link strands the operator on whatever the config file said, with every lower tier green. Mirrors s53's settings-only shape.

Deliberately **not** added to the ci.yml fast subset: s53 already exercises the settings-screen mechanism on every PR, so s58's marginal PR-time value doesn't justify the added gate. It runs in the collective suite.

`make quality`: lint, typecheck, security, scenario-loops, test-sludge and arch-check all green. Suite detail below.

Closes #10037

## Suite status

Full `tests/` suite: 18,792 passed. One failure, `tests/architecture/test_mkdocs_strict.py::test_mkdocs_build_strict_succeeds`, which reproduces identically on the **unmodified base commit** (`67cc3ce0`) with none of these changes — pre-existing, not introduced here.

An earlier run also showed 3 failures in `test_review_phase_term_proposer_routing.py` (`inspect.getsource(ReviewPhase.review_prs)` returning a different method's body). They did not reproduce on a clean re-run, did not reproduce on the base commit, and pass both in isolation and alongside the new test files. They coincided with a second full-suite run executing concurrently in another worktree.
