### PR TITLE
fix(gate-health): suspected-hang classifier for cancelled-at-timeout CI jobs (#10010)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -207,6 +207,11 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
     ("gate_health_interval", "HYDRAFLOW_GATE_HEALTH_INTERVAL", 604800),
     ("gate_health_run_window", "HYDRAFLOW_GATE_HEALTH_RUN_WINDOW", 50),
     ("gate_health_min_attempts", "HYDRAFLOW_GATE_HEALTH_MIN_ATTEMPTS", 3),
+    (
+        "gate_health_hang_tolerance_seconds",
+        "HYDRAFLOW_GATE_HEALTH_HANG_TOLERANCE_SECONDS",
+        90,
+    ),
     ("adr_review_interval", "HYDRAFLOW_ADR_REVIEW_INTERVAL", 86400),
     ("adr_review_approval_threshold", "HYDRAFLOW_ADR_REVIEW_APPROVAL_THRESHOLD", 2),
     ("adr_review_max_rounds", "HYDRAFLOW_ADR_REVIEW_MAX_ROUNDS", 3),
@@ -1332,6 +1337,17 @@ class HydraFlowConfig(BaseModel):
         description=(
             "Minimum failures before GateHealthLoop flags a check: "
             "born-broken needs N, blame-correlation N-1"
+        ),
+    )
+    gate_health_hang_tolerance_seconds: int = Field(
+        default=90,
+        ge=10,
+        le=600,
+        description=(
+            "GateHealthLoop suspected-hang classifier (#10010): a CANCELLED "
+            "job whose duration lands within this many seconds of its "
+            "workflow's configured timeout-minutes is a candidate hang, "
+            "not a generic cancellation"
         ),
     )
 

--- a/src/gate_health_loop.py
+++ b/src/gate_health_loop.py
@@ -20,8 +20,11 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+import yaml
 
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import HydraFlowConfig
@@ -46,6 +49,124 @@ _DOCS_ONLY_RE = re.compile(r"^docs/|\.md$|^\.github/ISSUE_TEMPLATE/")
 _CODE_CHECK_FRAGMENTS = ("test", "quality", "lint", "type", "sandbox", "scenario")
 
 _QUARANTINE_RE = re.compile(r'^QUARANTINED\s*=\s*["\']#(\d+)["\']', re.MULTILINE)
+
+# A step's conclusion once it has actually finished running one way or
+# another (#10010). Anything else (``None``/``"cancelled"``) at the moment
+# the job dies means that step was still executing — the hang signal.
+_TERMINAL_STEP_CONCLUSIONS = frozenset({"success", "failure", "skipped"})
+
+
+def _duration_seconds(started_at: object, completed_at: object) -> float | None:
+    """Wall-clock seconds between two ISO-8601 timestamps, or ``None``."""
+    if not started_at or not completed_at:
+        return None
+    try:
+        start = datetime.fromisoformat(str(started_at).replace("Z", "+00:00"))
+        end = datetime.fromisoformat(str(completed_at).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return (end - start).total_seconds()
+
+
+def _find_unfinished_test_step(steps: list[dict[str, Any]]) -> str | None:
+    """Name of a test-labeled step that never reached a terminal conclusion.
+
+    A job's own ``conclusion`` becomes ``cancelled`` the instant the runner
+    is killed, whether or not any given step actually finished. The signal
+    that distinguishes a genuine in-flight hang from a clean/early
+    cancellation is a *step* named for tests still sitting at a
+    non-terminal conclusion (``None``/``"cancelled"``) when the job died.
+    """
+    for step in steps:
+        name = str(step.get("name", ""))
+        if "test" not in name.lower():
+            continue
+        conclusion = str(step.get("conclusion") or "").lower()
+        if conclusion not in _TERMINAL_STEP_CONCLUSIONS:
+            return name
+    return None
+
+
+def _load_workflow_job_timeouts(repo_root: Path) -> dict[str, int]:
+    """Map job display name -> configured ``timeout-minutes`` (best-effort).
+
+    Parsed directly from ``.github/workflows/*.yml`` — the GitHub Actions
+    jobs API surfaces a job's actual start/end times but never its
+    *configured* timeout, so the reference value has to come from the repo
+    itself (same local-file-read pattern as ``_find_stale_quarantines``).
+    """
+    timeouts: dict[str, int] = {}
+    workflows_dir = repo_root / ".github" / "workflows"
+    if not workflows_dir.is_dir():
+        return timeouts
+    paths = sorted(workflows_dir.glob("*.yml")) + sorted(workflows_dir.glob("*.yaml"))
+    for path in paths:
+        try:
+            doc = yaml.safe_load(path.read_text())
+        except (OSError, yaml.YAMLError):
+            continue
+        if not isinstance(doc, dict):
+            continue
+        jobs = doc.get("jobs")
+        if not isinstance(jobs, dict):
+            continue
+        for job_id, spec in jobs.items():
+            if not isinstance(spec, dict):
+                continue
+            minutes = spec.get("timeout-minutes")
+            if not isinstance(minutes, int) or minutes <= 0:
+                continue
+            display_name = str(spec.get("name") or job_id)
+            timeouts[display_name] = minutes
+    return timeouts
+
+
+def find_suspected_hangs(
+    job_records: list[dict[str, Any]],
+    *,
+    timeout_minutes_by_job: dict[str, int],
+    tolerance_seconds: int,
+) -> list[dict[str, Any]]:
+    """Cancelled-at-timeout jobs with an unfinished test step (#10010).
+
+    A job cancelled by GitHub's own timeout enforcement is invisible to
+    ``tally_job_stats`` (cancelled is filtered out there) and looks nothing
+    like a normal red: zero FAILED lines, conclusion CANCELLED. That
+    combination — duration landing within *tolerance_seconds* of the job's
+    configured ``timeout-minutes`` AND a test step that never reached a
+    terminal conclusion — is the signature a blind retry burns attempt
+    budget against instead of fixing (PRs #9983, #10002: a mocked ``.pid``
+    fed a real ``os.killpg``, which reached the CI container's own PID 1).
+    """
+    findings: list[dict[str, Any]] = []
+    for rec in job_records:
+        if str(rec.get("conclusion", "")).lower() != "cancelled":
+            continue
+        name = str(rec.get("name", "")).strip()
+        timeout_minutes = timeout_minutes_by_job.get(name)
+        if not timeout_minutes:
+            continue
+        duration = _duration_seconds(rec.get("started_at"), rec.get("completed_at"))
+        if duration is None:
+            continue
+        if abs(duration - timeout_minutes * 60) > tolerance_seconds:
+            continue
+        unfinished_step = _find_unfinished_test_step(rec.get("steps") or [])
+        if unfinished_step is None:
+            continue
+        findings.append(
+            {
+                "kind": "suspected_hang",
+                "check": name,
+                "run_id": int(rec.get("run_id", 0) or 0),
+                "pr_number": int(rec.get("pr_number", 0) or 0),
+                "duration_seconds": round(duration),
+                "timeout_minutes": timeout_minutes,
+                "unfinished_step": unfinished_step,
+                "tolerance_seconds": tolerance_seconds,
+            }
+        )
+    return findings
 
 
 @dataclass
@@ -163,20 +284,33 @@ def is_docs_only(paths: list[str]) -> bool:
 
 
 def finding_fingerprint(finding: dict[str, Any]) -> str:
-    """Stable dedup key: kind + subject (NOT counts, which grow every cycle)."""
+    """Stable dedup key: kind + subject (NOT counts, which grow every cycle).
+
+    ``suspected_hang`` also folds in the run id: unlike the structural
+    findings below (one standing defect, filed once and then deduped
+    forever), each hang is a distinct incident on a distinct commit/PR —
+    fingerprinting on check name alone would silently swallow every hang
+    after the first one on a given check.
+    """
     subject = finding.get("check") or finding.get("workflow") or finding.get("scenario")
+    if finding["kind"] == "suspected_hang":
+        return f"{finding['kind']}:{subject}:{finding.get('run_id')}"
     return f"{finding['kind']}:{subject}"
 
 
 class GateHealthLoop(BaseBackgroundLoop):
     """Weekly read-only auditor of CI gate health distributions (#9974).
 
-    Four analyses per cycle: born-broken checks, blame-correlation
+    Five analyses per cycle: born-broken checks, blame-correlation
     (code checks failing docs-only diffs), missing failure artifacts,
-    and quarantine markers whose tracking issue is closed. Findings file
-    as ``hydraflow-find`` issues with the stats table in the body and a
-    consent package for anything human-gated. Deduped by finding
-    fingerprint so a standing defect files once, not weekly.
+    quarantine markers whose tracking issue is closed, and suspected CI
+    hangs — a cancelled-at-timeout job with an unfinished test step
+    (#10010). Findings file as ``hydraflow-find`` issues with the stats
+    table in the body and a consent package for anything human-gated.
+    Deduped by finding fingerprint so a standing defect files once, not
+    weekly (suspected-hang findings are the one exception: each is a
+    distinct incident, fingerprinted per run so a second, unrelated hang
+    on the same check still gets its own issue).
     """
 
     def __init__(
@@ -225,6 +359,9 @@ class GateHealthLoop(BaseBackgroundLoop):
 
         job_records, failed_run_artifacts = await self._collect(runs)
         stats = tally_job_stats(job_records)
+        timeout_minutes_by_job = _load_workflow_job_timeouts(
+            Path(self._config.repo_root)
+        )
 
         findings = [
             *find_born_broken(
@@ -235,6 +372,11 @@ class GateHealthLoop(BaseBackgroundLoop):
             ),
             *find_missing_artifacts(failed_run_artifacts),
             *await self._find_stale_quarantines(),
+            *find_suspected_hangs(
+                job_records,
+                timeout_minutes_by_job=timeout_minutes_by_job,
+                tolerance_seconds=self._config.gate_health_hang_tolerance_seconds,
+            ),
         ]
 
         filed = await self._file_findings(findings)
@@ -289,6 +431,12 @@ class GateHealthLoop(BaseBackgroundLoop):
                         "created_at": run.get("created_at", ""),
                         "docs_only": docs_only,
                         "pr_number": pr_number,
+                        # Only consumed by find_suspected_hangs (#10010);
+                        # tally_job_stats ignores unknown keys.
+                        "run_id": run_id,
+                        "started_at": job.get("started_at", ""),
+                        "completed_at": job.get("completed_at", ""),
+                        "steps": job.get("steps", []),
                     }
                 )
 
@@ -417,7 +565,7 @@ def _render_finding(finding: dict[str, Any]) -> tuple[str, str]:
             "reds; an upload path that produces nothing on failure makes "
             "every red an archaeology session.\n"
         )
-    else:  # stale_quarantine
+    elif kind == "stale_quarantine":
         title = (
             f"Gate health: quarantine on {finding['scenario']} references "
             f"closed #{finding['issue']}"
@@ -439,5 +587,61 @@ def _render_finding(finding: dict[str, Any]) -> tuple[str, str]:
             f"sed -i '' '/^QUARANTINED/d' {finding['path']}\n"
             "```\n"
             "Human-gated: GateHealthLoop will NOT execute this.\n"
+        )
+    else:  # suspected_hang
+        pr_number = finding.get("pr_number") or 0
+        pr_note = f" (PR #{pr_number})" if pr_number else ""
+        tolerance = finding.get("tolerance_seconds", 90)
+        title = f"Gate health: {finding['check']} suspected CI hang, not a normal red"
+        body = (
+            f"## Evidence (GateHealthLoop, automated)\n\n"
+            f"| metric | value |\n|---|---|\n"
+            f"| check | `{finding['check']}` |\n"
+            f"| run | {finding['run_id']}{pr_note} |\n"
+            f"| conclusion | CANCELLED |\n"
+            f"| duration | {finding['duration_seconds']}s |\n"
+            f"| configured timeout-minutes | {finding['timeout_minutes']} |\n"
+            f"| unfinished step | `{finding['unfinished_step']}` |\n\n"
+            f"**This is not a normal red.** The job was CANCELLED within "
+            f"~{tolerance}s of its own configured timeout, with a test "
+            "step that never reached success/failure/skipped — the job "
+            "was still running the test suite when GitHub Actions killed "
+            "it. There are zero FAILED lines to read because nothing "
+            "failed; the run just never finished.\n\n"
+            "## Why this needs its own playbook — do NOT blind-retry\n\n"
+            "PRs #9983 and #10002 hit exactly this signature: Tests "
+            "cancelled at the workflow timeout with zero FAILED lines. "
+            "Root cause both times was a real `os.killpg` reaching the "
+            "CI runner's own process tree because a test mocked a "
+            "subprocess's `.pid` (a `MagicMock`/default `.pid` resolves "
+            "to `1`), and the code under test fed that value straight "
+            'into `os.killpg`, so the "kill the child" call killed the '
+            "container's own PID 1 instead. Retrying into the same "
+            "wedge just re-burns the attempt budget — the fix is a code "
+            "change, not a re-run.\n\n"
+            "**Diagnosis REQUIRED a Linux container both times.** macOS "
+            "gives a benign `EPERM` on the same `killpg` call (no "
+            "permission to signal PID 1 as a non-root user), so every "
+            "local run on a Mac passed clean. That divergence — clean "
+            "on macOS, hangs/kills the container on Linux — IS the "
+            "signal, not noise to explain away.\n\n"
+            "## Recommended repro playbook\n\n"
+            "1. **Bounded local repro first.** Re-run the failing test(s) "
+            "locally with a hard wall-clock timeout close to the CI "
+            "value above, so a real hang still shows up as a timeout "
+            "instead of hanging your shell too.\n"
+            "2. **If the diff touches subprocess/signal code** "
+            "(`execution.py`, `runner_utils.py`, `subprocess_util.py`, "
+            "`process_group.py`) and the local repro comes back clean "
+            "or throws a benign `EPERM`, do NOT trust that as a pass — "
+            "reproduce inside a Linux container instead (e.g. "
+            '`docker run --rm -v "$PWD:/repo" -w /repo python:3.11 '
+            "...`). A clean macOS run and a wedged Linux run are the "
+            "same test; the platform IS the differentiator.\n"
+            "3. Check for any mock standing in for a real subprocess/"
+            "process-group object whose `.pid` (or similar identity "
+            "attribute) could resolve to a real, sensitive PID (1, or "
+            "the test runner's own PID) before it reaches a real "
+            "`kill`/`killpg`/`terminate` call.\n"
         )
     return title, body

--- a/src/ports.py
+++ b/src/ports.py
@@ -474,7 +474,12 @@ class PRPort(Protocol):
         ...
 
     async def get_workflow_run_jobs(self, run_id: int) -> list[dict[str, Any]]:
-        """Return jobs for one run: ``{"name", "conclusion"}`` each (#9974)."""
+        """Return jobs for one run (#9974, enriched #10010).
+
+        Each dict: ``{"name", "conclusion", "started_at", "completed_at",
+        "steps"}`` — the last three feed GateHealthLoop's suspected-hang
+        classifier.
+        """
         ...
 
     async def count_workflow_run_artifacts(self, run_id: int) -> int:

--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -1632,14 +1632,28 @@ class PRManager:
         )
 
     async def get_workflow_run_jobs(self, run_id: int) -> list[dict[str, Any]]:
-        """Return jobs for one workflow run: name + conclusion (#9974)."""
+        """Return jobs for one workflow run (#9974, enriched #10010).
+
+        Each dict: ``{"name", "conclusion", "started_at", "completed_at",
+        "steps"}``. ``started_at``/``completed_at``/``steps`` feed
+        GateHealthLoop's suspected-hang classifier (duration vs. the
+        workflow's configured timeout-minutes, plus whether a test step
+        ever reached a terminal conclusion) — the jobs API is the only
+        source for a job's *actual* timing and step-level outcomes.
+        """
         self._assert_repo()
         output = await self._run_gh(
             "gh",
             "api",
             f"repos/{self._repo}/actions/runs/{int(run_id)}/jobs?per_page=100",
             "--jq",
-            '[.jobs[] | {name: .name, conclusion: (.conclusion // "")}]',
+            (
+                '[.jobs[] | {name: .name, conclusion: (.conclusion // ""), '
+                'started_at: (.started_at // ""), '
+                'completed_at: (.completed_at // ""), '
+                "steps: [.steps[]? | {name: .name, "
+                'conclusion: (.conclusion // "")}]}]'
+            ),
         )
         try:
             rows = json.loads(output or "[]")

--- a/tests/regressions/test_gate_health_suspected_hang_10010.py
+++ b/tests/regressions/test_gate_health_suspected_hang_10010.py
@@ -1,0 +1,88 @@
+"""Regression (#10010): cancelled-at-timeout CI jobs were invisible to
+GateHealthLoop, so the factory blindly retried into repeat hangs.
+
+2026-07-19: PRs #9983 and #10002 hung the CI ``Tests`` job — CANCELLED at
+~the workflow's ``timeout-minutes`` with ZERO FAILED lines. That is not a
+red-check distribution (``tally_job_stats`` explicitly drops ``cancelled``
+conclusions), so nothing in GateHealthLoop (#9974) ever flagged it; the
+factory just retried into the same wedge. Root cause both times: a test
+mocked a subprocess's ``.pid`` (defaulting to ``1``), and the code under
+test fed that straight into a real ``os.killpg`` — which reached the CI
+container's own PID 1. Diagnosis REQUIRED a Linux container: macOS raises a
+benign ``EPERM`` on the same call, so every local repro passed clean.
+
+``find_suspected_hangs`` must classify exactly this shape — job conclusion
+CANCELLED, duration within tolerance of the job's configured
+``timeout-minutes``, a test-named step that never reached a terminal
+conclusion — as a distinct ``suspected_hang`` verdict, separate from every
+other GateHealthLoop finding kind, so the rendered issue carries the
+bounded-local/Linux-container repro playbook instead of nothing at all.
+"""
+
+from __future__ import annotations
+
+from gate_health_loop import (
+    find_suspected_hangs,
+    finding_fingerprint,
+    tally_job_stats,
+)
+
+_HANGING_TESTS_JOB = {
+    "name": "Tests",
+    "conclusion": "cancelled",
+    "run_id": 9983,
+    "pr_number": 9983,
+    "started_at": "2026-07-18T00:00:00Z",
+    "completed_at": "2026-07-18T00:30:02Z",  # 1802s vs. a 30m (1800s) timeout
+    "steps": [
+        {"name": "Install dependencies", "conclusion": "success"},
+        # The step never reached success/failure/skipped: the runner was
+        # killed mid-test, not after it — zero FAILED lines to read.
+        {"name": "Run tests with coverage", "conclusion": None},
+    ],
+}
+
+
+def test_cancelled_at_timeout_job_is_invisible_to_the_distribution_tally() -> None:
+    # Confirms the ORIGINAL bug premise still holds: this job shape
+    # contributes nothing to born-broken/blame-correlation stats. The fix
+    # is an ADDITIONAL classifier, not a change to this exclusion.
+    stats = tally_job_stats([_HANGING_TESTS_JOB])
+    assert stats == {}
+
+
+def test_cancelled_at_timeout_with_unfinished_step_is_suspected_hang() -> None:
+    findings = find_suspected_hangs(
+        [_HANGING_TESTS_JOB],
+        timeout_minutes_by_job={"Tests": 30},
+        tolerance_seconds=90,
+    )
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding["kind"] == "suspected_hang"
+    assert finding["check"] == "Tests"
+    assert finding["unfinished_step"] == "Run tests with coverage"
+
+
+def test_a_second_unrelated_hang_on_the_same_check_still_gets_its_own_issue() -> None:
+    # #9983 and #10002 are two DISTINCT incidents on the same "Tests" job.
+    # A fingerprint keyed on check name alone (like the structural findings)
+    # would silently drop the second one after the first was filed.
+    first = finding_fingerprint(
+        {"kind": "suspected_hang", "check": "Tests", "run_id": 9983}
+    )
+    second = finding_fingerprint(
+        {"kind": "suspected_hang", "check": "Tests", "run_id": 10002}
+    )
+    assert first != second
+
+
+def test_duration_far_from_timeout_is_a_normal_cancellation_not_a_hang() -> None:
+    early_cancel = dict(_HANGING_TESTS_JOB, completed_at="2026-07-18T00:01:30Z")
+    findings = find_suspected_hangs(
+        [early_cancel],
+        timeout_minutes_by_job={"Tests": 30},
+        tolerance_seconds=90,
+    )
+    assert findings == []

--- a/tests/scenarios/test_caretaker_loops_part2.py
+++ b/tests/scenarios/test_caretaker_loops_part2.py
@@ -507,6 +507,43 @@ class TestL20bGateHealthLoop:
         assert stats["gate_health"]["findings"] == 0
         assert len(world.github._issues) == before
 
+    async def test_suspected_hang_scenario_files_playbook_issue(self, tmp_path):
+        """#10010: cancelled-at-timeout job -> suspected-hang, not a retry."""
+        world = MockWorld(tmp_path)
+        workflows_dir = tmp_path / "repo" / ".github" / "workflows"
+        workflows_dir.mkdir(parents=True, exist_ok=True)
+        (workflows_dir / "ci.yml").write_text(
+            "jobs:\n  test:\n    name: Tests\n    timeout-minutes: 30\n"
+        )
+        world.github.add_workflow_run(
+            555,
+            workflow="CI",
+            conclusion="cancelled",
+            created_at="2026-07-19T00:00:00Z",
+            pr_number=42,
+            jobs=[
+                {
+                    "name": "Tests",
+                    "conclusion": "cancelled",
+                    "started_at": "2026-07-19T00:00:00Z",
+                    "completed_at": "2026-07-19T00:30:05Z",
+                    "steps": [
+                        {"name": "Install dependencies", "conclusion": "success"},
+                        {"name": "Run tests with coverage", "conclusion": None},
+                    ],
+                }
+            ],
+        )
+
+        stats = await world.run_with_loops(["gate_health"], cycles=1)
+
+        assert stats["gate_health"]["filed"] == 1
+        filed = self._issues_titled(world, "suspected CI hang")
+        assert len(filed) == 1
+        assert "#9983" in filed[0].body
+        assert "#10002" in filed[0].body
+        assert "Linux container" in filed[0].body
+
 
 # ---------------------------------------------------------------------------
 # L21: sentry — no credentials and project polling paths

--- a/tests/test_gate_health_loop.py
+++ b/tests/test_gate_health_loop.py
@@ -14,12 +14,123 @@ from gate_health_loop import (
     GateHealthLoop,
     find_born_broken,
     find_missing_artifacts,
+    find_suspected_hangs,
     find_uncorrelated_blame,
     finding_fingerprint,
     is_docs_only,
     tally_job_stats,
 )
 from tests.helpers import make_bg_loop_deps
+
+
+def _cancelled_job(
+    *,
+    name: str = "Tests",
+    run_id: int = 555,
+    pr_number: int = 42,
+    started_at: str = "2026-07-19T00:00:00Z",
+    completed_at: str = "2026-07-19T00:30:05Z",
+    test_step_conclusion: str | None = None,
+) -> dict:
+    """A cancelled job record shaped like ``_collect``'s enriched output.
+
+    Defaults to the #9983/#10002 signature: ~30m duration (matches the
+    ``Tests`` job's real 30-minute timeout-minutes), test step never
+    reaching a terminal conclusion.
+    """
+    return {
+        "name": name,
+        "conclusion": "cancelled",
+        "run_id": run_id,
+        "pr_number": pr_number,
+        "started_at": started_at,
+        "completed_at": completed_at,
+        "steps": [
+            {"name": "Install dependencies", "conclusion": "success"},
+            {"name": "Run tests with coverage", "conclusion": test_step_conclusion},
+        ],
+    }
+
+
+class TestFindSuspectedHangs:
+    """#10010: cancelled-at-timeout jobs get their own verdict, not a retry."""
+
+    def test_cancelled_at_timeout_with_unfinished_test_step_is_flagged(self) -> None:
+        job = _cancelled_job()  # ~30m05s duration, test step conclusion=None
+
+        findings = find_suspected_hangs(
+            [job], timeout_minutes_by_job={"Tests": 30}, tolerance_seconds=90
+        )
+
+        assert len(findings) == 1
+        finding = findings[0]
+        assert finding["kind"] == "suspected_hang"
+        assert finding["check"] == "Tests"
+        assert finding["run_id"] == 555
+        assert finding["pr_number"] == 42
+        assert finding["unfinished_step"] == "Run tests with coverage"
+        assert finding["timeout_minutes"] == 30
+
+    def test_cancelled_early_is_not_flagged(self) -> None:
+        # Cancelled 2 minutes in (e.g. a manual abort) — nowhere near the
+        # 30-minute timeout, so this is a normal cancellation, not a hang.
+        job = _cancelled_job(completed_at="2026-07-19T00:02:00Z")
+
+        findings = find_suspected_hangs(
+            [job], timeout_minutes_by_job={"Tests": 30}, tolerance_seconds=90
+        )
+
+        assert findings == []
+
+    def test_failed_normally_is_not_flagged(self) -> None:
+        job = _cancelled_job()
+        job["conclusion"] = "failure"
+
+        findings = find_suspected_hangs(
+            [job], timeout_minutes_by_job={"Tests": 30}, tolerance_seconds=90
+        )
+
+        assert findings == []
+
+    def test_cancelled_at_timeout_with_finished_test_step_is_not_flagged(self) -> None:
+        # Killed at ~timeout, but the test step already reached a verdict
+        # (e.g. cancelled during a later upload/cleanup step, or a
+        # fail-fast sibling) — not the in-flight-hang signature.
+        job = _cancelled_job(test_step_conclusion="success")
+
+        findings = find_suspected_hangs(
+            [job], timeout_minutes_by_job={"Tests": 30}, tolerance_seconds=90
+        )
+
+        assert findings == []
+
+    def test_unknown_job_name_is_not_flagged(self) -> None:
+        job = _cancelled_job(name="Some New Job")
+
+        findings = find_suspected_hangs(
+            [job], timeout_minutes_by_job={"Tests": 30}, tolerance_seconds=90
+        )
+
+        assert findings == []
+
+    def test_missing_timestamps_are_not_flagged(self) -> None:
+        job = _cancelled_job(started_at="", completed_at="")
+
+        findings = find_suspected_hangs(
+            [job], timeout_minutes_by_job={"Tests": 30}, tolerance_seconds=90
+        )
+
+        assert findings == []
+
+    def test_fingerprint_distinguishes_hangs_by_run(self) -> None:
+        a = finding_fingerprint(
+            {"kind": "suspected_hang", "check": "Tests", "run_id": 555}
+        )
+        b = finding_fingerprint(
+            {"kind": "suspected_hang", "check": "Tests", "run_id": 999}
+        )
+        assert a != b  # two distinct incidents on the same check both file
+
 
 # ---------------------------------------------------------------------------
 # Pure engine
@@ -235,4 +346,92 @@ class TestGateHealthLoop:
         result = await loop._do_work()
 
         assert result["findings"] == 0
+        prs.create_issue.assert_not_awaited()
+
+
+class TestSuspectedHangLoopWiring:
+    """End-to-end: cancelled-at-timeout job -> filed issue with the
+    bounded-local/Linux-container playbook, distinct from a retry (#10010).
+    """
+
+    def _write_workflow(self, repo_root: Path) -> None:
+        workflows_dir = repo_root / ".github" / "workflows"
+        workflows_dir.mkdir(parents=True)
+        (workflows_dir / "ci.yml").write_text(
+            "jobs:\n  test:\n    name: Tests\n    timeout-minutes: 30\n"
+        )
+
+    def _run_seed(self, run_id: int, pr_number: int, created_at: str) -> dict:
+        return {
+            "id": run_id,
+            "workflow": "CI",
+            "conclusion": "cancelled",
+            "created_at": created_at,
+            "pr_number": pr_number,
+        }
+
+    @pytest.mark.asyncio
+    async def test_suspected_hang_files_playbook_issue(self, tmp_path: Path) -> None:
+        loop, prs = _make_loop(tmp_path)
+        self._write_workflow(Path(loop._config.repo_root))
+        prs.list_workflow_runs.return_value = [
+            self._run_seed(555, 42, "2026-07-19T00:00:00Z")
+        ]
+        prs.get_workflow_run_jobs.return_value = [_cancelled_job()]
+
+        result = await loop._do_work()
+
+        assert result["filed"] == 1
+        title, body = prs.create_issue.await_args.args[0:2]
+        assert "suspected CI hang" in title
+        assert "#9983" in body
+        assert "#10002" in body
+        assert "killpg" in body
+        assert "Linux container" in body
+        assert "do NOT" in body  # explicit anti-blind-retry directive
+        assert prs.create_issue.await_args.kwargs["labels"] == ["hydraflow-find"]
+
+    @pytest.mark.asyncio
+    async def test_recurring_run_dedupes_but_new_incident_still_files(
+        self, tmp_path: Path
+    ) -> None:
+        loop, prs = _make_loop(tmp_path)
+        self._write_workflow(Path(loop._config.repo_root))
+
+        prs.list_workflow_runs.return_value = [
+            self._run_seed(555, 42, "2026-07-19T00:00:00Z")
+        ]
+        prs.get_workflow_run_jobs.return_value = [_cancelled_job()]
+        first = await loop._do_work()
+        second = await loop._do_work()  # same run seen again -> deduped
+
+        # A DIFFERENT run on the SAME check is a distinct incident and
+        # must file its own issue — the fingerprint must not swallow it.
+        prs.list_workflow_runs.return_value = [
+            self._run_seed(777, 43, "2026-07-19T01:00:00Z")
+        ]
+        prs.get_workflow_run_jobs.return_value = [
+            _cancelled_job(run_id=777, pr_number=43)
+        ]
+        third = await loop._do_work()
+
+        assert first["filed"] == 1
+        assert second["filed"] == 0
+        assert third["filed"] == 1
+        assert prs.create_issue.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_no_workflow_file_means_no_finding(self, tmp_path: Path) -> None:
+        # Timeout-minutes lookup fails closed: no .github/workflows means
+        # no reference timeout, so the classifier can't confirm anything
+        # and stays silent instead of guessing.
+        loop, prs = _make_loop(tmp_path)
+        prs.list_workflow_runs.return_value = [
+            self._run_seed(555, 42, "2026-07-19T00:00:00Z")
+        ]
+        prs.get_workflow_run_jobs.return_value = [_cancelled_job()]
+
+        result = await loop._do_work()
+
+        assert result["filed"] == 0
         prs.create_issue.assert_not_awaited()


### PR DESCRIPTION
## Summary

- `GateHealthLoop` couldn't see cancelled-at-timeout CI jobs at all — `tally_job_stats` explicitly drops `cancelled` conclusions, so PRs #9983/#10002 (Tests job cancelled at ~timeout-minutes with zero FAILED lines) were invisible to the auditor and the factory just retried into the same wedge.
- Adds `find_suspected_hangs`: flags a job as `suspected_hang` when its conclusion is CANCELLED, its duration lands within `gate_health_hang_tolerance_seconds` (new knob, default 90s) of the job's configured `timeout-minutes` (parsed from `.github/workflows/*.yml` — the jobs API never surfaces the configured timeout, only actual start/end times), AND a test-named step never reached a terminal conclusion (success/failure/skipped).
- The rendered `hydraflow-find` issue carries its own playbook — bounded local repro first; Linux-container repro when the diff touches subprocess/signal paths, since the platform divergence (benign `EPERM` on macOS vs. real `os.killpg` reaching the CI container's PID 1 on Linux) IS the signal — citing #9983/#10002 and the killpg-mock-pid pattern directly, instead of triggering a blind retry.
- Fingerprinted per `run_id` (not just check name, unlike GateHealthLoop's other findings): each hang is a distinct incident, so a second unrelated hang on the same check still gets its own issue instead of being deduped away.
- `get_workflow_run_jobs` (PRPort + pr_manager + docstrings) enriched with `started_at`/`completed_at`/`steps` — additive, existing consumers (`tally_job_stats`) ignore the new keys.
- New knob `gate_health_hang_tolerance_seconds` triple-registered (env override + `Field` + covered by `test_config_consistency.py`).

**Deferred to #10049**: the optional docker Linux smoke lane. A correctly-scoped version touches the `dorny/paths-filter` block that already caused #9908, and needs real test-design judgment (what should the container mimic) that a foreground pass can't fully validate against a live GitHub Actions run. Filed as a follow-up with the design constraints spelled out.

Part of #10010 (core classifier + playbook ship here; CI lane tracked separately in #10049).

## Test plan

- [x] `tests/test_gate_health_loop.py` — 7 new pure-engine cases for `find_suspected_hangs` (cancelled-at-timeout→flagged, cancelled-early→not, failed-normally→not, finished-test-step→not, unknown-job→not, missing-timestamps→not, fingerprint-per-run) + 3 new loop-wiring cases (playbook issue filed, dedup-vs-new-incident, no-workflow-file-fails-closed) — all passing
- [x] `tests/regressions/test_gate_health_suspected_hang_10010.py` — pins the exact #9983/#10002 shape
- [x] `tests/scenarios/test_caretaker_loops_part2.py::TestL20bGateHealthLoop` — MockWorld scenario for the suspected-hang finding
- [x] `tests/test_disturbance_ratchet.py`, `tests/test_config_consistency.py` — green, no new violations
- [x] `ruff check .`, `ruff format --check .`, `pyright` (full repo) — clean, no new noqa/type-ignore
- [x] `tests/test_pr_manager*.py`, `tests/test_config*.py` — no regressions from the `get_workflow_run_jobs`/config changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)