### PR TITLE
fix(queue): fail loudly on an unhandled queue strategy + gate the dial per-PR (#10037)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,7 +430,7 @@ jobs:
           python-version: "3.11"
       - run: pip install uv && uv pip install --system -e ".[dev]"
       - run: docker compose -f docker-compose.sandbox.yml build hydraflow ui playwright
-      - name: Run fast subset (s01, s06, s53, s54, s55)
+      - name: Run fast subset (s01, s06, s53, s54, s55, s58)
         run: |
           # Run every scenario and aggregate failures — do NOT early-exit on the
           # first red, or a broken leading scenario (e.g. s01, #9754) silently
@@ -438,9 +438,13 @@ jobs:
           # Keep this list in sync with the scenario-file QUARANTINED markers
           # until the loader drives this step's selection too. s55 was
           # quarantined under #9925 and un-quarantined once the #9796
-          # discover/shape wedge fix (#9919) proved to resolve it.
+          # discover/shape wedge fix (#9919) proved to resolve it. s58 gates the
+          # work-queue strategy dial (#10037): the picker decides what the
+          # factory works on next, and the dial is the only runtime access to
+          # it, so a broken dropdown is worth catching per-PR rather than at
+          # the next collective run.
           rc=0
-          for s in s01_happy_single_issue s06_kill_switch_via_ui s53_model_routing_settings_ui s54_decompose_to_converge s55_nested_decompose; do
+          for s in s01_happy_single_issue s06_kill_switch_via_ui s53_model_routing_settings_ui s54_decompose_to_converge s55_nested_decompose s58_work_queue_settings_ui; do
             if python scripts/sandbox_scenario.py run "$s"; then
               echo "::notice::sandbox $s PASSED"
             else

--- a/src/queue_strategy.py
+++ b/src/queue_strategy.py
@@ -136,13 +136,23 @@ def order_queue(
             task for band in (*PRIORITY_BANDS, UNPRIORITISED) for task in banded[band]
         ]
 
-    return _weighted_mix(
-        banded,
-        weights,
-        rng if rng is not None else random.Random(),
-        now,
-        starvation_threshold_hours,
-    )
+    if strategy == QueueStrategy.WEIGHTED_MIX:
+        return _weighted_mix(
+            banded,
+            weights,
+            rng if rng is not None else random.Random(),
+            now,
+            starvation_threshold_hours,
+        )
+
+    # Explicit rather than falling through to weighted_mix: a strategy added to
+    # QueueStrategy without a branch here would otherwise be dispatched silently
+    # as weighted_mix, and a scheduler quietly running the wrong discipline is
+    # the kind of failure nobody notices — the queue keeps draining, just in the
+    # wrong order. Config and PATCH /api/control/config both validate, so this
+    # is unreachable from the UI or a config file.
+    msg = f"unhandled queue strategy {strategy!r}"
+    raise ValueError(msg)
 
 
 def _partition(tasks: list[Task]) -> dict[str, list[Task]]:

--- a/tests/regressions/regression_issue_10037.py
+++ b/tests/regressions/regression_issue_10037.py
@@ -31,12 +31,14 @@ from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import AsyncMock
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "src"))
 
 from events import EventBus
 from issue_store import STAGE_READY, IssueStore
 from models import Task
-from queue_strategy import QueueStrategy
+from queue_strategy import BandWeights, QueueStrategy, order_queue
 from tests.helpers import ConfigFactory
 
 
@@ -116,3 +118,34 @@ def test_activating_a_crate_still_gates_out_unmilestoned_work() -> None:
     _enqueue(store, Task(id=1, title="unmilestoned P0", tags=["P0"]))
 
     assert store.get_implementable(1) == []
+
+
+def test_an_unhandled_queue_strategy_raises_rather_than_silently_mixing() -> None:
+    # ``order_queue`` originally ended with a bare ``return _weighted_mix(...)``,
+    # so anything that was not ``fifo`` or ``priority`` was dispatched as
+    # ``weighted_mix``. Nothing invalid reaches it today — HydraFlowConfig
+    # validates the field and PATCH /api/control/config re-validates through
+    # model_validate and 422s — but a NEW member added to QueueStrategy without
+    # a matching branch would have been silently mis-dispatched.
+    #
+    # That is the dangerous shape for a scheduler: it keeps draining the queue
+    # and picking work, just under the wrong discipline, with no error, no log
+    # line, and every existing test still green.
+    with pytest.raises(ValueError, match="unhandled queue strategy"):
+        order_queue(
+            [Task(id=1, title="issue 1")],
+            "not_a_strategy",  # type: ignore[arg-type]
+            BandWeights(p1=3, p2=2, unprioritised=1),
+        )
+
+
+def test_every_declared_queue_strategy_still_dispatches() -> None:
+    # The converse of the guard: it must not have made a real discipline
+    # unreachable. Every enum member still returns the full task set.
+    tasks = [Task(id=1, title="a", tags=["P1"]), Task(id=2, title="b")]
+    weights = BandWeights(p1=3, p2=2, unprioritised=1)
+
+    for strategy in QueueStrategy:
+        ordered = order_queue(tasks, strategy, weights, rng=random.Random(0))
+
+        assert sorted(t.id for t in ordered) == [1, 2], strategy


### PR DESCRIPTION
Two gaps left by #10045 (which implemented #10037 and has merged).

## 1. `order_queue` silently mis-dispatches an unhandled strategy

On `staging` it ends with a bare `return _weighted_mix(...)`, so anything that is not `fifo` or `priority` is dispatched as `weighted_mix`.

Nothing invalid reaches it today — `HydraFlowConfig` validates the field, and `PATCH /api/control/config` re-validates through `model_validate` and 422s on a bad value. The exposure is a **future** member added to `QueueStrategy` without a matching branch.

That is the dangerous shape for a scheduler specifically: it keeps draining the queue and picking work, just under the wrong discipline — no error, no log line, and every existing test still green. Made explicit so the failure is loud.

## 2. `s58` was not gated per-PR

`s58_work_queue_settings_ui` ran only in the collective suite. The work picker decides what the factory does next, and the settings dial is the operator's only runtime access to it, so a broken dropdown is worth catching on the PR that breaks it.

## Testing

Pins added to the **existing** `tests/regressions/regression_issue_10037.py` rather than a competing file:

- the guard raises on an unhandled strategy
- every declared `QueueStrategy` member still dispatches the full task set — the converse, so the guard is proven to protect a discipline rather than break one

`make quality` green: **19,015 passed**, 0 failed, all five gates OK.

## Note for reviewers — the feature is currently inert

`queue_strategy` defaults to `QueueStrategy.FIFO`, pinned by a regression test as the migration default. So #10037 is merged but changes nothing until an operator flips the knob: the factory still selects oldest-first, which was the original complaint (the stale P2 backlog sits at the front of every stage queue).

That looks like a deliberate ship-dark choice, so this PR does **not** change it — flipping the default is factory-wide blast radius and belongs in its own decision, not smuggled into a guard fix.