### PR TITLE
test(sandbox): seam completeness guard — every spawn path declares its air-gap seam (#10012)

### DIFF
--- a/src/mockworld/sandbox_main.py
+++ b/src/mockworld/sandbox_main.py
@@ -42,6 +42,71 @@ from service_registry import (
 if TYPE_CHECKING:
     from config import HydraFlowConfig
 
+# --- Air-gap seam registry (#10012) ----------------------------------------
+#
+# Every loop/runner module that can lexically spawn an LLM or a subprocess
+# (run_lightweight_agent / get_default_runner / stream_claude_process /
+# create_subprocess_exec / run_subprocess / run_subprocess_result call sites
+# in src/*_loop.py, src/*_runner.py, and src/runners/**) must either declare
+# here HOW the sandbox air-gaps it, or sit in the shrink-only grandfathered
+# baseline of tests/architecture/test_sandbox_seam_completeness.py. That
+# guard AST-enumerates the call sites and reddens when a NEW spawn path
+# appears without a declaration — turning the next s51/s56/s57 wedged-sandbox
+# incident (#9919, #9925, #10006) into a red unit test at PR time.
+#
+# Keys are module stems (the loop/worker's module name); values are one of
+# SEAM_KINDS:
+#
+# - "fake_llm_runner": the runner instance is rebound wholesale via
+#   ``runners=fake_llm`` in ``build_services`` (triage/plan/implement/review);
+#   remaining BaseRunner constructions thread ``runner=subprocess_runner``,
+#   which main() below injects as FakeSubprocessRunner.
+# - "fake_subprocess_runner": the spawn only happens through the injected
+#   SubprocessRunner; main() passes FakeSubprocessRunner so the real docker/
+#   host dispatch is never constructed.
+# - "mockworld_sentinel": subclasses consult ``_mockworld_fake_llm``
+#   (attached by main() below) in their dispatch method and route to FakeLLM
+#   before reaching the real spawn; ShapeRunner is dropped to None outright.
+# - "seed_seam": main() below injects seed-scripted stand-ins onto the loop
+#   instance when the scenario seeds them (and the scenario is crafted to
+#   stay within the seam's coverage — see the per-loop comments in main()).
+# - "config_disable": ``_apply_sandbox_config_overrides`` turns the spawning
+#   code path off wholesale.
+SEAM_KINDS: frozenset[str] = frozenset(
+    {
+        "fake_llm_runner",
+        "fake_subprocess_runner",
+        "mockworld_sentinel",
+        "seed_seam",
+        "config_disable",
+    }
+)
+
+SANDBOX_SEAMS: dict[str, str] = {
+    # The four phase runners (triage/plan/implement/review) are replaced by
+    # ``runners=fake_llm``; every other build_services BaseRunner gets the
+    # injected FakeSubprocessRunner via ``runner=subprocess_runner``.
+    "base_runner": "fake_llm_runner",
+    # ADR-0063 runners (discover/plan-review/council/spec-review/diagnostic/
+    # decompose) consult the ``_mockworld_fake_llm`` sentinel before their
+    # BaseSubprocessRunner.run spawn; sentinels are attached in main().
+    "base_subprocess_runner": "mockworld_sentinel",
+    # ``get_docker_runner`` is the default only when no ``subprocess_runner``
+    # is injected; main() always injects FakeSubprocessRunner.
+    "docker_runner": "fake_subprocess_runner",
+    # External recorders + replay gate path off via
+    # ``contract_refresh_external_enabled=False`` (s30).
+    "contract_refresh_loop": "config_disable",
+    # s56: ``skill_prompt_corpus_cases`` / ``skill_prompt_refine_patch`` seed
+    # seams replace ``_run_corpus`` and ``_refine_llm``; the seeded patch trips
+    # the tripwire so the loop returns before ``_open_refine_pr``'s raw spawns.
+    "skill_prompt_eval_loop": "seed_seam",
+    # s57: ``issue_refinement_backlog`` / ``issue_refinement_verdicts`` seed
+    # seams replace ``_refinement_llm`` so dup/priority judgments never shell
+    # out to a real ``claude``.
+    "issue_refinement_loop": "seed_seam",
+}
+
 
 def _apply_sandbox_config_overrides(config: HydraFlowConfig) -> None:
     """Turn off production code paths that reach services unreachable on the

--- a/tests/architecture/sandbox_seam_scan.py
+++ b/tests/architecture/sandbox_seam_scan.py
@@ -1,0 +1,148 @@
+"""AST enumeration of LLM/subprocess spawn call sites in loop + runner modules.
+
+Support code for the sandbox seam completeness guard (#10012, s51/s56/s57
+wedge class). Pure functions only — no repo mutation, no subprocesses. The
+guard test (``test_sandbox_seam_completeness.py``) and its regression story
+(``tests/regressions/test_sandbox_seam_guard.py``) both import from here.
+
+A "spawn primitive" is one of the call names through which loop/runner code
+reaches a real ``claude`` or a raw subprocess. The scan is lexical (call
+sites by name, per module), deliberately line-number-free so signatures are
+drift-immune, mirroring ``disturbance.models.Finding``.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Collection, Mapping
+from pathlib import Path
+
+# Call names that spawn an LLM or subprocess. ``run_subprocess_result`` is
+# subprocess_util's non-raising twin of ``run_subprocess`` — same spawn class,
+# included so switching a caller between the two cannot dodge the guard.
+SPAWN_PRIMITIVES: frozenset[str] = frozenset(
+    {
+        "run_lightweight_agent",
+        "get_default_runner",
+        "stream_claude_process",
+        "create_subprocess_exec",
+        "run_subprocess",
+        "run_subprocess_result",
+    }
+)
+
+
+def spawn_target_files(repo_root: Path) -> list[Path]:
+    """Enumerate the loop + runner modules the guard scans.
+
+    Scope per #10012: ``src/*_loop.py``, ``src/*_runner.py``, and everything
+    under ``src/runners/``. Non-recursive at the ``src`` top level, so
+    ``src/mockworld/**`` (the Fakes — sandbox-side seam machinery itself)
+    stays out of scope.
+    """
+    src = repo_root / "src"
+    files: set[Path] = set(src.glob("*_loop.py"))
+    files.update(src.glob("*_runner.py"))
+    files.update(p for p in (src / "runners").glob("**/*.py"))
+    return sorted(files)
+
+
+class _SpawnCallVisitor(ast.NodeVisitor):
+    """Collects (enclosing qualname, primitive name) for every spawn call."""
+
+    def __init__(self) -> None:
+        self._stack: list[str] = []
+        self.hits: list[tuple[str, str]] = []
+
+    def _visit_scoped(self, node: ast.AST, name: str) -> None:
+        self._stack.append(name)
+        self.generic_visit(node)
+        self._stack.pop()
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._visit_scoped(node, node.name)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_scoped(node, node.name)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_scoped(node, node.name)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        callee = node.func
+        name: str | None = None
+        if isinstance(callee, ast.Name):
+            name = callee.id
+        elif isinstance(callee, ast.Attribute):
+            name = callee.attr
+        if name in SPAWN_PRIMITIVES:
+            qualname = ".".join(self._stack) or "<module>"
+            self.hits.append((qualname, name))
+        self.generic_visit(node)
+
+
+def scan_spawn_signatures(repo_root: Path) -> dict[str, int]:
+    """Return ``{signature: count}`` for every spawn call site in scope.
+
+    ``signature`` is ``"{posix relpath}::{enclosing qualname}::{primitive}"``
+    — line-number-free so refactors that move code within a function do not
+    churn the baseline; counts catch a second spawn call added to the same
+    function of a grandfathered module.
+    """
+    counts: dict[str, int] = {}
+    stems_seen: dict[str, str] = {}
+    for path in spawn_target_files(repo_root):
+        rel = path.relative_to(repo_root).as_posix()
+        stem = path.stem
+        if stem in stems_seen and stems_seen[stem] != rel:
+            msg = (
+                f"module stem collision: {stems_seen[stem]} vs {rel} — "
+                "SANDBOX_SEAMS keys are module stems and must stay unique"
+            )
+            raise ValueError(msg)
+        stems_seen[stem] = rel
+        visitor = _SpawnCallVisitor()
+        visitor.visit(ast.parse(path.read_text(), filename=rel))
+        for qualname, primitive in visitor.hits:
+            signature = f"{rel}::{qualname}::{primitive}"
+            counts[signature] = counts.get(signature, 0) + 1
+    return counts
+
+
+def signature_module(signature: str) -> str:
+    """Module stem for a signature (the SANDBOX_SEAMS key namespace)."""
+    return Path(signature.split("::", 1)[0]).stem
+
+
+def undeclared_signatures(
+    current: Mapping[str, int], declared_modules: Collection[str]
+) -> dict[str, int]:
+    """Signatures whose module declares no seam in SANDBOX_SEAMS."""
+    return {
+        signature: count
+        for signature, count in current.items()
+        if signature_module(signature) not in declared_modules
+    }
+
+
+def ratchet_diff(
+    current: Mapping[str, int], baseline: Mapping[str, int]
+) -> tuple[dict[str, int], dict[str, int]]:
+    """Compare undeclared spawn counts to the grandfathered baseline.
+
+    Returns ``(new, resolved)`` — mirrors ``disturbance.baseline.diff``:
+    ``new`` maps signature -> excess over baseline (guard reddens);
+    ``resolved`` maps signature -> shortfall under baseline (baseline must
+    be pruned in the same change so the ratchet only shrinks).
+    """
+    new: dict[str, int] = {}
+    resolved: dict[str, int] = {}
+    for signature, count in current.items():
+        allowed = baseline.get(signature, 0)
+        if count > allowed:
+            new[signature] = count - allowed
+    for signature, allowed in baseline.items():
+        count = current.get(signature, 0)
+        if count < allowed:
+            resolved[signature] = allowed - count
+    return new, resolved

--- a/tests/architecture/test_sandbox_seam_completeness.py
+++ b/tests/architecture/test_sandbox_seam_completeness.py
@@ -1,0 +1,152 @@
+"""Sandbox seam completeness guard (#10012) — the s51/s56/s57 wedge class.
+
+A loop/runner path that spawns a real ``claude`` or a raw subprocess inside
+the air-gapped sandbox hangs it: s51 (#9919, DiscoverRunner/ShapeRunner),
+s55 (#9925 family), s56 (SkillPromptEvalLoop refine path, seams added by
+hand in #10006). Each recurrence was a wedged-sandbox incident discovered
+at scenario time.
+
+This guard turns the next one into a red unit test at PR time: it AST-scans
+every loop + runner module for spawn-primitive call sites and asserts each
+module either declares its air-gap seam in
+``mockworld.sandbox_main.SANDBOX_SEAMS`` or sits in the grandfathered
+baseline below. The baseline only shrinks (ratchet, mirroring
+``tests/test_disturbance_ratchet.py``): a NEW spawn path without a seam
+declaration reddens, and covering a grandfathered path requires pruning its
+entry in the same change so the baseline stays honest.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mockworld.sandbox_main import SANDBOX_SEAMS, SEAM_KINDS
+from tests.architecture.sandbox_seam_scan import (
+    ratchet_diff,
+    scan_spawn_signatures,
+    signature_module,
+    undeclared_signatures,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Grandfathered spawn paths with no declared sandbox seam yet, keyed
+# ``{signature: count}`` (see sandbox_seam_scan.scan_spawn_signatures).
+# These predate the guard; under the air-gapped sandbox they fail fast on
+# their subprocess timeout tiers rather than air-gapping cleanly. DO NOT ADD
+# ENTRIES: a new spawn path must declare a seam in SANDBOX_SEAMS (seed seam,
+# sentinel, injected fake, or config-disable) instead. Remove entries as
+# seams are added — the ratchet only shrinks.
+GRANDFATHERED_SPAWN_BASELINE: dict[str, int] = {
+    "src/adr_touchpoint_auditor_loop.py::AdrTouchpointAuditorLoop._fetch_pr_changed_files::create_subprocess_exec": 1,
+    "src/adr_touchpoint_auditor_loop.py::AdrTouchpointAuditorLoop._list_recent_merged_prs::create_subprocess_exec": 1,
+    "src/fake_coverage_auditor_loop.py::FakeCoverageAuditorLoop._grep_scenario_for_helper::create_subprocess_exec": 1,
+    "src/fake_coverage_auditor_loop.py::FakeCoverageAuditorLoop._list_open_rollup_titles::create_subprocess_exec": 1,
+    "src/flake_tracker_loop.py::FlakeTrackerLoop._download_junit::create_subprocess_exec": 1,
+    "src/flake_tracker_loop.py::FlakeTrackerLoop._fetch_recent_runs::create_subprocess_exec": 1,
+    "src/health_monitor_loop.py::HealthMonitorLoop._check_stale_code::run_subprocess": 1,
+    "src/memory_backlog_loop.py::MemoryBacklogLoop._commit_mirror_updates::create_subprocess_exec": 2,
+    "src/principles_audit_loop.py::PrinciplesAuditLoop._run_audit::create_subprocess_exec": 1,
+    "src/principles_audit_loop.py::PrinciplesAuditLoop._run_git::create_subprocess_exec": 1,
+    "src/rc_budget_loop.py::RCBudgetLoop._fetch_job_breakdown::create_subprocess_exec": 1,
+    "src/rc_budget_loop.py::RCBudgetLoop._fetch_junit_tests::create_subprocess_exec": 1,
+    "src/rc_budget_loop.py::RCBudgetLoop._fetch_recent_runs::create_subprocess_exec": 1,
+    "src/repo_wiki_loop.py::RepoWikiLoop._adopt_open_maintenance_pr::run_subprocess": 1,
+    "src/repo_wiki_loop.py::RepoWikiLoop._maintenance_batch_forced_by_age::run_subprocess": 1,
+    "src/repo_wiki_loop.py::RepoWikiLoop._poll_and_merge_open_pr::run_subprocess": 3,
+    "src/staging_bisect_loop.py::StagingBisectLoop._run_bisect_probe::create_subprocess_exec": 1,
+    "src/staging_bisect_loop.py::StagingBisectLoop._run_gh::create_subprocess_exec": 1,
+    "src/staging_bisect_loop.py::StagingBisectLoop._run_git::create_subprocess_exec": 1,
+    "src/staging_promotion_loop.py::StagingPromotionLoop._list_merged_promotion_prs::run_subprocess": 1,
+    "src/trust_fleet_sanity_loop.py::TrustFleetSanityLoop._find_open_escalation::create_subprocess_exec": 1,
+    "src/trust_fleet_sanity_loop.py::TrustFleetSanityLoop._reconcile_closed_escalations::create_subprocess_exec": 1,
+    "src/workspace_gc_loop.py::WorkspaceGCLoop._collect_orphaned_branches::run_subprocess": 2,
+    "src/workspace_gc_loop.py::WorkspaceGCLoop._get_issue_state::run_subprocess": 1,
+}
+
+
+def test_scan_finds_known_spawn_sites() -> None:
+    """Anti-vacuity canary.
+
+    If the scan scope or the primitive set regresses (rename, glob typo),
+    every other assertion here would pass vacuously on an empty scan. Pin
+    two load-bearing sites that exist as long as HydraFlow shells out to
+    ``claude`` at all.
+    """
+    current = scan_spawn_signatures(REPO_ROOT)
+    assert "src/base_runner.py::BaseRunner._execute::stream_claude_process" in current
+    assert any(
+        signature_module(signature) == "base_subprocess_runner" for signature in current
+    )
+
+
+def test_new_spawn_paths_require_seam_declaration() -> None:
+    current = scan_spawn_signatures(REPO_ROOT)
+    undeclared = undeclared_signatures(current, SANDBOX_SEAMS)
+    new, _resolved = ratchet_diff(undeclared, GRANDFATHERED_SPAWN_BASELINE)
+    assert not new, (
+        f"Spawn paths with no declared sandbox seam (beyond baseline): {new}. "
+        "This is the s51/s56 wedge class — a real claude/subprocess spawn "
+        "inside the air-gapped sandbox hangs it. Declare how the path is "
+        "air-gapped in mockworld.sandbox_main.SANDBOX_SEAMS (and wire the "
+        "seam: seed seam, _mockworld_fake_llm sentinel, injected Fake, or "
+        "config-disable in _apply_sandbox_config_overrides). Do NOT grow "
+        "GRANDFATHERED_SPAWN_BASELINE — the ratchet only shrinks."
+    )
+
+
+def test_grandfathered_baseline_only_shrinks() -> None:
+    current = scan_spawn_signatures(REPO_ROOT)
+    undeclared = undeclared_signatures(current, SANDBOX_SEAMS)
+    _new, resolved = ratchet_diff(undeclared, GRANDFATHERED_SPAWN_BASELINE)
+    assert not resolved, (
+        f"Baseline lists spawn paths no longer present or now seam-declared: "
+        f"{resolved}. Prune them from GRANDFATHERED_SPAWN_BASELINE in this "
+        "change so the baseline stays honest."
+    )
+
+
+def test_declared_seams_map_to_scanned_spawn_modules() -> None:
+    """SANDBOX_SEAMS may only name modules the scan actually sees spawning.
+
+    Keeps the registry prunable in both directions: a stale or typo'd key
+    (module renamed, spawn removed) fails here instead of silently
+    green-lighting an uncovered path under a near-miss name.
+    """
+    current = scan_spawn_signatures(REPO_ROOT)
+    scanned_modules = {signature_module(signature) for signature in current}
+    stale = set(SANDBOX_SEAMS) - scanned_modules
+    assert not stale, (
+        f"SANDBOX_SEAMS declares seams for modules with no scanned spawn "
+        f"sites: {sorted(stale)}. Rename or prune the declaration."
+    )
+
+
+def test_declared_seam_kinds_are_valid() -> None:
+    invalid = {
+        module: kind for module, kind in SANDBOX_SEAMS.items() if kind not in SEAM_KINDS
+    }
+    assert not invalid, (
+        f"SANDBOX_SEAMS entries with unknown seam kind: {invalid}. "
+        f"Valid kinds: {sorted(SEAM_KINDS)}."
+    )
+
+
+def test_baseline_entries_are_not_seam_declared() -> None:
+    """A module cannot be both grandfathered and seam-declared.
+
+    Adding a SANDBOX_SEAMS entry for a baselined module without pruning the
+    baseline would already fail the shrink test; this makes the conflict
+    explicit and self-describing.
+    """
+    conflicted = sorted(
+        {
+            signature_module(signature)
+            for signature in GRANDFATHERED_SPAWN_BASELINE
+            if signature_module(signature) in SANDBOX_SEAMS
+        }
+    )
+    assert not conflicted, (
+        f"Modules present in both SANDBOX_SEAMS and the grandfathered "
+        f"baseline: {conflicted}. Prune their baseline entries."
+    )

--- a/tests/regressions/test_sandbox_seam_guard.py
+++ b/tests/regressions/test_sandbox_seam_guard.py
@@ -1,0 +1,157 @@
+"""Regression: a new LLM/subprocess spawn path without a sandbox seam is red.
+
+The s51/s56/s57 wedge class (#10012): runners=fake_llm covers only the four
+original phase runners, so each NEW loop path that shelled out to a real
+``claude``/``make`` wedged the air-gapped sandbox at scenario time — s51
+(#9919 DiscoverRunner/ShapeRunner), s56 (SkillPromptEvalLoop refine path,
+seams hand-added in #10006), s57 (IssueRefinementLoop). This pins the guard
+mechanics on a synthetic tree: the scanner must SEE a new spawn call site in
+loop/runner scope, the ratchet must flag it when neither SANDBOX_SEAMS nor
+the grandfathered baseline covers it, and a stale baseline entry must demand
+pruning. If any of these regress, the completeness guard in
+tests/architecture/test_sandbox_seam_completeness.py goes vacuously green
+and the next wedge ships silently again.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+from tests.architecture.sandbox_seam_scan import (
+    ratchet_diff,
+    scan_spawn_signatures,
+    undeclared_signatures,
+)
+
+_NEW_LOOP = """
+    class SkillEvalV2Loop:
+        async def _refine(self, prompt: str) -> str:
+            return await run_lightweight_agent(prompt)
+
+        async def _run_corpus(self) -> None:
+            await asyncio.create_subprocess_exec("make", "trust-adversarial")
+    """
+
+_NEW_RUNNER = """
+    class ProbeRunner:
+        async def run(self, prompt: str) -> str:
+            return await stream_claude_process(cmd=["claude", "-p"], prompt=prompt)
+    """
+
+_OUT_OF_SCOPE = """
+    def helper() -> None:
+        run_subprocess(["gh", "pr", "view"])
+    """
+
+
+def _write_tree(root: Path) -> None:
+    spec = {
+        "src/skill_eval_v2_loop.py": _NEW_LOOP,
+        "src/runners/probe_runner.py": _NEW_RUNNER,
+        # Not *_loop.py / *_runner.py / runners/** — must stay out of scope.
+        "src/helpers.py": _OUT_OF_SCOPE,
+    }
+    for rel, body in spec.items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(dedent(body).lstrip("\n"))
+
+
+def test_scanner_sees_new_spawn_paths_in_loop_and_runner_scope(
+    tmp_path: Path,
+) -> None:
+    _write_tree(tmp_path)
+    current = scan_spawn_signatures(tmp_path)
+    assert current == {
+        "src/skill_eval_v2_loop.py::SkillEvalV2Loop._refine::run_lightweight_agent": 1,
+        (
+            "src/skill_eval_v2_loop.py::SkillEvalV2Loop._run_corpus"
+            "::create_subprocess_exec"
+        ): 1,
+        "src/runners/probe_runner.py::ProbeRunner.run::stream_claude_process": 1,
+    }
+
+
+def test_new_undeclared_spawn_path_reddens_the_ratchet(tmp_path: Path) -> None:
+    _write_tree(tmp_path)
+    current = scan_spawn_signatures(tmp_path)
+    # The runner module declares a seam; the new loop declares nothing and is
+    # not grandfathered — exactly the next-s51 shape the guard must catch.
+    undeclared = undeclared_signatures(current, {"probe_runner": "seed_seam"})
+    new, resolved = ratchet_diff(undeclared, {})
+    assert set(new) == {
+        "src/skill_eval_v2_loop.py::SkillEvalV2Loop._refine::run_lightweight_agent",
+        (
+            "src/skill_eval_v2_loop.py::SkillEvalV2Loop._run_corpus"
+            "::create_subprocess_exec"
+        ),
+    }
+    assert not resolved
+
+
+def test_declared_and_grandfathered_paths_stay_green(tmp_path: Path) -> None:
+    _write_tree(tmp_path)
+    current = scan_spawn_signatures(tmp_path)
+    undeclared = undeclared_signatures(current, {"probe_runner": "seed_seam"})
+    baseline = {
+        "src/skill_eval_v2_loop.py::SkillEvalV2Loop._refine::run_lightweight_agent": 1,
+        (
+            "src/skill_eval_v2_loop.py::SkillEvalV2Loop._run_corpus"
+            "::create_subprocess_exec"
+        ): 1,
+    }
+    new, resolved = ratchet_diff(undeclared, baseline)
+    assert not new
+    assert not resolved
+
+
+def test_covered_spawn_path_demands_baseline_prune(tmp_path: Path) -> None:
+    """The ratchet only shrinks.
+
+    Once a grandfathered path gains a seam declaration (or the spawn is
+    removed), its baseline entry becomes stale; leaving it would let the
+    module silently re-grow a spawn later. The diff must demand the prune.
+    """
+    _write_tree(tmp_path)
+    current = scan_spawn_signatures(tmp_path)
+    undeclared = undeclared_signatures(
+        current,
+        {"probe_runner": "seed_seam", "skill_eval_v2_loop": "seed_seam"},
+    )
+    stale_baseline = {
+        "src/skill_eval_v2_loop.py::SkillEvalV2Loop._refine::run_lightweight_agent": 1,
+    }
+    new, resolved = ratchet_diff(undeclared, stale_baseline)
+    assert not new
+    assert resolved == {
+        "src/skill_eval_v2_loop.py::SkillEvalV2Loop._refine::run_lightweight_agent": 1,
+    }
+
+
+def test_second_spawn_call_in_grandfathered_function_reddens(
+    tmp_path: Path,
+) -> None:
+    """Counts are load-bearing: baselines pin call-site multiplicity.
+
+    A grandfathered module adding ANOTHER spawn call to the same function
+    would be invisible to a set-based baseline; the count comparison must
+    flag the excess.
+    """
+    _write_tree(tmp_path)
+    loop_path = tmp_path / "src/skill_eval_v2_loop.py"
+    body = loop_path.read_text() + (
+        "\n"
+        "    async def _refine_twice(self, prompt: str) -> str:\n"
+        "        await run_lightweight_agent(prompt)\n"
+        "        return await run_lightweight_agent(prompt)\n"
+    )
+    loop_path.write_text(body)
+    current = scan_spawn_signatures(tmp_path)
+    signature = (
+        "src/skill_eval_v2_loop.py::SkillEvalV2Loop._refine_twice"
+        "::run_lightweight_agent"
+    )
+    assert current[signature] == 2
+    new, _resolved = ratchet_diff({signature: current[signature]}, {signature: 1})
+    assert new == {signature: 1}


### PR DESCRIPTION
## Summary
Guard test for the s51/s56/s57 wedge class: a loop/runner path spawning a real `claude`/`make` inside the air-gapped sandbox hangs it (s51 #9919, s55 #9925, s56 seams hand-added in #10006). This PR turns the next occurrence into a red unit test at PR time.

- **Enumeration**: `tests/architecture/sandbox_seam_scan.py` AST-scans `src/*_loop.py`, `src/*_runner.py`, and `src/runners/**` for call sites of `run_lightweight_agent` / `get_default_runner` / `stream_claude_process` / `create_subprocess_exec` / `run_subprocess` / `run_subprocess_result`. Signatures are line-number-free (`relpath::qualname::primitive`, with counts) so refactors don't churn the baseline.
- **Registry**: new enumerable `SANDBOX_SEAMS` dict in `src/mockworld/sandbox_main.py` (previously the seams were only if-blocks/sentinel assignments) mapping loop/worker module → seam kind: `fake_llm_runner`, `fake_subprocess_runner`, `mockworld_sentinel`, `seed_seam`, `config_disable`. Declared today: `base_runner`, `base_subprocess_runner`, `docker_runner`, `contract_refresh_loop` (s30), `skill_prompt_eval_loop` (s56), `issue_refinement_loop` (s57).
- **Ratchet**: `tests/architecture/test_sandbox_seam_completeness.py` grandfathers today's 24 undeclared spawn signatures (12 caretaker loops) in a shrink-only baseline mirroring `tests/test_disturbance_ratchet.py`'s new/resolved shape. A NEW spawn path without a declaration reddens; covering a grandfathered path requires pruning its entry in the same change. Cross-checks: anti-vacuity canary, declared keys ⊆ scanned modules, valid seam kinds, no declared∩baseline overlap.
- **Regression delta (P10.6)**: `tests/regressions/test_sandbox_seam_guard.py` pins the guard mechanics on a synthetic tree — new undeclared loop path reddens, declared/grandfathered stay green, stale baseline demands prune, call-site counts are load-bearing.

## Test evidence
- TDD red→green: guard first failed listing all 24 undeclared signatures, then went green after registry + baseline.
- `pytest tests/architecture/ tests/test_disturbance_ratchet.py tests/regressions/test_sandbox_seam_guard.py tests/test_sandbox_main_smoke.py tests/test_build_services_overrides.py tests/regressions/test_sandbox_merge_policy_airgap_9754.py` — 230 passed.
- `ruff check` + `ruff format --check` + `pyright` on all four touched files — clean; no new `noqa`/`type: ignore`.

Closes #10012

🤖 Generated with [Claude Code](https://claude.com/claude-code)