### PR TITLE
ci(#10049): advisory Linux signal smoke lane for subprocess/signal-touching PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       compose: ${{ steps.filter.outputs.compose }}
       sandbox_scenarios: ${{ steps.filter.outputs.sandbox_scenarios }}
       dashboard: ${{ steps.filter.outputs.dashboard }}
+      subprocess_signal: ${{ steps.filter.outputs.subprocess_signal }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -91,6 +92,29 @@ jobs:
               - 'src/route_types.py'
               - 'tests/scenarios/browser/**'
               - 'tests/scenarios/fakes/mock_world.py'
+            subprocess_signal:
+              # Signal/reap blast-radius set (#10049, deferred from #10010):
+              # the modules where a mocked `.pid` can reach a real os.killpg
+              # (#9983/#10002), plus their signal-focused test files. Positive
+              # globs ONLY, so this entry is safe in this default-quantifier
+              # step — negations belong exclusively in the core_filter step
+              # below (predicate-quantifier: every; see #9908). Keep this list
+              # in sync with the linux-signal-smoke job's pytest args —
+              # tests/regressions/test_issue_10049_linux_signal_lane.py
+              # guards both directions.
+              - 'src/execution.py'
+              - 'src/runner_utils.py'
+              - 'src/subprocess_util.py'
+              - 'src/process_group.py'
+              - 'tests/test_execution.py'
+              - 'tests/test_runner_utils.py'
+              - 'tests/test_subprocess_util.py'
+              - 'tests/regressions/test_reap_processlookuperror.py'
+              - 'tests/regressions/test_issue_9553.py'
+              - 'tests/regressions/test_issue_9579.py'
+              - 'tests/regressions/test_issue_9911_stop_path_reap.py'
+              - 'tests/regressions/test_issue_9641_unified_group_kill.py'
+              - 'tests/regressions/test_hostrunner_reap_grandchildren.py'
       # core_python lives in its OWN paths-filter step because it is the only
       # filter with `!` negations, and negation semantics depend on the
       # quantifier. Under the default `some`, each `!glob` independently
@@ -343,6 +367,54 @@ jobs:
       - name: Run regression tests
         run: PYTHONPATH=src uv run pytest tests/regressions/ -q
 
+  # Linux signal-context smoke lane (#10049, deferred from #10010). Reruns the
+  # reap/signal-focused test subset INSIDE a plain Linux container as root —
+  # not merely `runs-on: ubuntu-latest`, which the `test` job already is. The
+  # container-as-root process tree is the environment where a mocked `.pid`
+  # reaching the real `os.killpg` hit the container's own PID 1 and wedged the
+  # job until timeout-cancel (#9983/#10002): benign EPERM on a macOS dev box,
+  # fatal on Linux CI — that platform divergence IS the signal this lane
+  # surfaces at PR time instead of at the 30-minute Tests timeout. ADVISORY by
+  # design: no gates.toml record and deliberately NOT in ci-gate's `needs` —
+  # per #9922, an advisory lane must never block RC auto-merge. Keep the
+  # pytest file list in sync with the subprocess_signal filter above
+  # (tests/regressions/test_issue_10049_linux_signal_lane.py guards both
+  # directions).
+  linux-signal-smoke:
+    name: Linux Signal Smoke (advisory)
+    needs: changes
+    if: needs.changes.outputs.subprocess_signal == 'true' || needs.changes.outputs.ci == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run signal/reap test subset in a Linux container as root
+        run: |
+          # --init matters: without it bash is PID 1 and killed grandchildren
+          # zombify unreaped, so the real-process reap tests read them as
+          # still alive and fail spuriously (validated locally). The GitHub
+          # runner VM has a real init, so tini-as-PID-1 is the faithful
+          # container analogue; root + Linux killpg delivery — the #9983
+          # divergence — is unchanged.
+          docker run --rm --init -v "$PWD":/w -w /w \
+            -e UV_PROJECT_ENVIRONMENT=/opt/venv \
+            -e PYTHONDONTWRITEBYTECODE=1 \
+            -e PYTHONPATH=src \
+            python:3.11-slim bash -c '
+              pip install --quiet uv &&
+              uv sync --all-extras --quiet &&
+              uv run pytest \
+                tests/test_execution.py \
+                tests/test_runner_utils.py \
+                tests/test_subprocess_util.py \
+                tests/regressions/test_reap_processlookuperror.py \
+                tests/regressions/test_issue_9553.py \
+                tests/regressions/test_issue_9579.py \
+                tests/regressions/test_issue_9911_stop_path_reap.py \
+                tests/regressions/test_issue_9641_unified_group_kill.py \
+                tests/regressions/test_hostrunner_reap_grandchildren.py \
+                -q -p no:cacheprovider'
+
   audit:
     name: Principles Audit
     needs: changes
@@ -578,6 +650,8 @@ jobs:
   # skipped required check otherwise reads as "not passed" and blocks forever).
   # Not yet a required check: it must land on the base branch before being
   # required (see docs/standards/branch_protection/ADDING-A-GATE.md).
+  # linux-signal-smoke is EXCLUDED on purpose: it is an advisory lane (#10049)
+  # and must never gate RC auto-merge (#9922) — do not add it to `needs`.
   ci-gate:
     name: CI Gate
     runs-on: ubuntu-latest

--- a/tests/regressions/test_issue_10049_linux_signal_lane.py
+++ b/tests/regressions/test_issue_10049_linux_signal_lane.py
@@ -1,0 +1,181 @@
+"""Workflow-lint guard for the Linux signal smoke lane (#10049).
+
+The `linux-signal-smoke` job in `.github/workflows/ci.yml` reruns the
+reap/signal-focused test subset inside a Linux container as root — the
+process-tree/privilege context where a mocked `.pid` reaching the real
+`os.killpg` killed the container's own PID 1 (#9983/#10002). This guard
+pins the invariants that keep the lane honest:
+
+1. The `subprocess_signal` paths-filter entry lives in the DEFAULT-quantifier
+   filter step and contains positive globs only. A `!` negation there would
+   resurrect #9908 (under the default `some` quantifier each `!glob`
+   independently matches every file NOT under glob, so the filter fires on
+   every PR). Negations belong exclusively in the `core_filter` step, which
+   must keep `predicate-quantifier: every`.
+2. The filter's file list and the job's pytest args stay in lock-step:
+   src modules in the filter are exactly the signal blast-radius set, and
+   every test file the filter watches is a test file the job runs (and vice
+   versa). Drift in either direction silently un-gates or empties the lane.
+3. Every file either side references exists on disk — a rename would
+   otherwise leave the lane green-by-vacuity forever.
+4. The lane stays ADVISORY: it must NOT appear in `ci-gate`'s `needs`.
+   ci-gate is the umbrella that branch protection requires; per #9922 an
+   advisory lane must never gate RC auto-merge.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+SIGNAL_SRC_MODULES = {
+    "src/execution.py",
+    "src/runner_utils.py",
+    "src/subprocess_util.py",
+    "src/process_group.py",
+}
+
+
+def _load_ci() -> dict[str, Any]:
+    return yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _changes_steps() -> list[dict[str, Any]]:
+    return _load_ci()["jobs"]["changes"]["steps"]
+
+
+def _step_by_id(step_id: str) -> dict[str, Any]:
+    for step in _changes_steps():
+        if step.get("id") == step_id:
+            return step
+    msg = f"changes job has no step with id={step_id!r}"
+    raise AssertionError(msg)
+
+
+def _filters_of(step: dict[str, Any]) -> dict[str, list[str]]:
+    # dorny/paths-filter takes `filters` as a YAML string; parse the inner doc.
+    return yaml.safe_load(step["with"]["filters"])
+
+
+def _lane_pytest_files() -> set[str]:
+    job = _load_ci()["jobs"]["linux-signal-smoke"]
+    run_texts = [s.get("run", "") for s in job["steps"] if s.get("run")]
+    assert run_texts, "linux-signal-smoke has no run step"
+    files: set[str] = set()
+    for text in run_texts:
+        files.update(re.findall(r"tests/\S+\.py", text))
+    return files
+
+
+class TestSubprocessSignalFilter:
+    def test_filter_entry_exists_in_default_quantifier_step(self) -> None:
+        filters = _filters_of(_step_by_id("filter"))
+        assert "subprocess_signal" in filters, (
+            "the subprocess_signal paths-filter entry is gone — the "
+            "linux-signal-smoke lane no longer triggers on signal-path PRs"
+        )
+
+    def test_default_step_has_no_negations(self) -> None:
+        step = _step_by_id("filter")
+        assert "predicate-quantifier" not in step.get("with", {}), (
+            "the default filter step grew a predicate-quantifier — the "
+            "#9908 split (negations only in core_filter) has been disturbed"
+        )
+        for name, globs in _filters_of(step).items():
+            negated = [g for g in globs if str(g).startswith("!")]
+            assert not negated, (
+                f"filter {name!r} uses negation {negated} in the DEFAULT-"
+                "quantifier step. Under `some`, each `!glob` independently "
+                "matches every file NOT under glob (#9908). Move it to the "
+                "core_filter step (predicate-quantifier: every)."
+            )
+
+    def test_core_filter_step_keeps_every_quantifier(self) -> None:
+        step = _step_by_id("core_filter")
+        assert step["with"].get("predicate-quantifier") == "every", (
+            "core_filter lost `predicate-quantifier: every` — its `!` "
+            "negations now each match every file NOT under the glob and "
+            "core_python fires on every PR (#9908)"
+        )
+
+    def test_filter_src_set_is_the_signal_blast_radius(self) -> None:
+        globs = set(_filters_of(_step_by_id("filter"))["subprocess_signal"])
+        src_globs = {g for g in globs if g.startswith("src/")}
+        assert src_globs == SIGNAL_SRC_MODULES, (
+            f"subprocess_signal src set drifted from the #10010 blast-radius "
+            f"modules.\n  missing: {sorted(SIGNAL_SRC_MODULES - src_globs)}\n"
+            f"  extra: {sorted(src_globs - SIGNAL_SRC_MODULES)}"
+        )
+
+    def test_all_filter_paths_exist(self) -> None:
+        globs = _filters_of(_step_by_id("filter"))["subprocess_signal"]
+        missing = [g for g in globs if not (REPO_ROOT / g).is_file()]
+        assert not missing, (
+            f"subprocess_signal filter references nonexistent files "
+            f"{missing} — a rename left the lane gated on nothing"
+        )
+
+
+class TestLinuxSignalSmokeJob:
+    def test_job_gated_on_subprocess_signal_filter(self) -> None:
+        job = _load_ci()["jobs"]["linux-signal-smoke"]
+        condition = job.get("if", "")
+        assert "needs.changes.outputs.subprocess_signal" in condition, (
+            "linux-signal-smoke is no longer gated on the subprocess_signal "
+            "filter — it would run on every PR (or never)"
+        )
+        assert "changes" in job.get("needs", []) or job.get("needs") == "changes", (
+            "linux-signal-smoke must depend on the changes job for its gate"
+        )
+
+    def test_pytest_files_match_filter_test_set(self) -> None:
+        filter_tests = {
+            g
+            for g in _filters_of(_step_by_id("filter"))["subprocess_signal"]
+            if g.startswith("tests/")
+        }
+        lane_tests = _lane_pytest_files()
+        assert filter_tests == lane_tests, (
+            f"subprocess_signal filter and linux-signal-smoke pytest args "
+            f"drifted.\n  filter-only (job no longer runs them): "
+            f"{sorted(filter_tests - lane_tests)}\n  job-only (filter no "
+            f"longer triggers on them): {sorted(lane_tests - filter_tests)}"
+        )
+
+    def test_all_lane_test_files_exist(self) -> None:
+        missing = [f for f in _lane_pytest_files() if not (REPO_ROOT / f).is_file()]
+        assert not missing, (
+            f"linux-signal-smoke runs nonexistent test files {missing} — "
+            "pytest would error (or a rename emptied the lane)"
+        )
+
+    def test_lane_runs_inside_a_container_as_docker_run(self) -> None:
+        job = _load_ci()["jobs"]["linux-signal-smoke"]
+        run_text = "\n".join(s.get("run", "") for s in job["steps"])
+        assert "docker run" in run_text, (
+            "the lane no longer runs inside a Linux container — plain "
+            "runs-on: ubuntu-latest does NOT reproduce the container-as-root "
+            "PID-tree that made #9983/#10002 hang (that context is the point)"
+        )
+
+    def test_lane_is_advisory_not_in_ci_gate_needs(self) -> None:
+        ci = _load_ci()
+        gate_needs = ci["jobs"]["ci-gate"]["needs"]
+        assert "linux-signal-smoke" not in gate_needs, (
+            "linux-signal-smoke was added to ci-gate's needs — that makes an "
+            "advisory lane block the required umbrella check and stall RC "
+            "auto-merge (#9922). It must stay out of ci-gate."
+        )
+
+    def test_lane_has_a_timeout(self) -> None:
+        job = _load_ci()["jobs"]["linux-signal-smoke"]
+        assert isinstance(job.get("timeout-minutes"), int), (
+            "linux-signal-smoke has no timeout-minutes — a reproduced hang "
+            "would burn the runner for the 6h default instead of minutes"
+        )


### PR DESCRIPTION
## Summary

- New advisory `linux-signal-smoke` CI job (#10049, deferred from #10010): reruns the reap/signal-focused test subset INSIDE a Linux container as root (`docker run --init python:3.11-slim`) — the process-tree/privilege context where a mocked `.pid` reaching the real `os.killpg` hit the CI container's own PID 1 and wedged Tests until timeout-cancel (#9983/#10002). The macOS/Linux divergence (benign EPERM vs. real PID-1 kill) is exactly what the lane surfaces at PR time.
- Trigger: new `subprocess_signal` paths-filter entry — the 4 blast-radius modules (`src/execution.py`, `src/runner_utils.py`, `src/subprocess_util.py`, `src/process_group.py`) plus their signal-focused test files. Positive globs ONLY, placed in the default-quantifier filter step; negations remain exclusively in `core_filter` (`predicate-quantifier: every`), so the #9908 footgun is avoided by construction. Also fires on `ci` changes (mirrors every other job), so this PR itself exercises the lane.
- ADVISORY by design: no `gates.toml` record and deliberately NOT in `ci-gate`'s `needs` — per #9922 an advisory lane must never block RC auto-merge. A comment on `ci-gate` pins that exclusion.
- `--init` is load-bearing and was validated locally in docker: without a PID-1 reaper, killed grandchildren in the real-process reap tests zombify and read as alive (5 spurious failures across test_issue_9553/9579/9911/hostrunner_reap); with tini the full subset is green (RC=0, ~3 min cold). The GH runner VM has a real init, so tini is the faithful analogue; root + Linux killpg delivery is unchanged.
- Note: `tests/test_process_group*.py` from the original sketch does not exist; the honest substitution is `tests/test_subprocess_util.py` + the reap-family regressions (`test_issue_9911_stop_path_reap`, `test_issue_9641_unified_group_kill`, `test_hostrunner_reap_grandchildren`), all of which patch or exercise `process_group`/killpg.

## Test plan

- [x] `tests/regressions/test_issue_10049_linux_signal_lane.py` — workflow-lint guard: filter/pytest-args lock-step (both directions), all referenced files exist, no `!` negations in the default filter step, `every` retained on `core_filter`, lane absent from `ci-gate.needs`, timeout present, docker-run shape pinned
- [x] Container command line validated once in local docker (full subset green with `--init`; the 5 zombie false-reds without it are documented in the workflow comment)
- [x] `python -m scripts.gen_gates --check` — gates artifacts and workflow producers in sync
- [x] YAML parse, `ruff check` + `ruff format --check` on the new test, `tests/test_disturbance_ratchet.py`, `tests/test_bisect_probe_sync.py`, `tests/test_gate_health_loop.py` — green
- [ ] The lane runs on this PR itself (touches `ci.yml` + watched test paths) — verify it triggers and passes before merge

Closes #10049

🤖 Generated with [Claude Code](https://claude.com/claude-code)