### PR TITLE
fix(subprocess): route residual caretaker-loop spawns through the bounded helper (#9554/#10028)

### DIFF
--- a/disturbance/baselines/suppressions.yaml
+++ b/disturbance/baselines/suppressions.yaml
@@ -16,12 +16,16 @@ comment: "suppressions disturbance baseline. MUST NOT grow (gate fails on increa
   \ +decompose-to-converge PLC0415 lazy imports (decomposition_council/issue_decomposer/decompose_terminal/decomposition_docs\
   \ deferred run_lightweight_agent + models imports \u2014 circular-safe convention).\
   \ re-snapshot 2026-07-12: +1 sandbox_main type-ignore[attr-defined] (6\u21927) for\
-  \ the s54 DecompositionCouncil fake-LLM sentinel attach \u2014 same dynamic-attach idiom\
-  \ as the 6 existing sentinel wirings; -1 decision.py PLC0415 (the deferred\
+  \ the s54 DecompositionCouncil fake-LLM sentinel attach \u2014 same dynamic-attach\
+  \ idiom as the 6 existing sentinel wirings; -1 decision.py PLC0415 (the deferred\
   \ decompose_terminal imports no longer need the noqa after the b8ed6d8f cast fix).\
-  \ re-snapshot 2026-07-13: +1 sandbox_main type-ignore[misc] (3->4) — _apply_sandbox_config_overrides\
+  \ re-snapshot 2026-07-13: +1 sandbox_main type-ignore[misc] (3->4) \u2014 _apply_sandbox_config_overrides\
   \ sets config.merge_policy_enabled=False for the air-gap (#9754), same frozen-field\
-  \ assignment idiom as the 3 sibling overrides it now sits beside."
+  \ assignment idiom as the 3 sibling overrides it now sits beside. re-snapshot 2026-07-19:\
+  \ -2 staging_bisect_loop.py PLC0415 (#9554/#10028 \u2014 _run_bisect_probe/_run_gh\
+  \ migrated onto the shared subprocess_util.run_subprocess_result/run_subprocess\
+  \ bounded helper; each dropped a now-redundant local 'import asyncio' re-import\
+  \ that shadowed the module-level import)."
 entries:
   src/acceptance_criteria.py::noqa:PLC0415: 2
   src/admin_tasks.py::noqa:PLC0415: 7
@@ -296,7 +300,7 @@ entries:
   src/skill_prompt_eval_loop.py::noqa:BLE001: 1
   src/skill_prompt_eval_loop.py::noqa:PLC0415: 1
   src/staging_bisect_loop.py::noqa:BLE001: 3
-  src/staging_bisect_loop.py::noqa:PLC0415: 14
+  src/staging_bisect_loop.py::noqa:PLC0415: 12
   src/staging_bisect_loop.py::noqa:PLR0911: 2
   src/staging_promotion_loop.py::noqa:BLE001: 4
   src/state/_convergence.py::noqa:PLC0415: 1

--- a/src/adr_touchpoint_auditor_loop.py
+++ b/src/adr_touchpoint_auditor_loop.py
@@ -22,8 +22,6 @@ keys are ``adr_touchpoint_auditor:ADR-NNNN`` (no PR component).
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
 import json
 import logging
 import re
@@ -35,6 +33,7 @@ from adr_drift import compute_drift_by_adr
 from base_background_loop import BaseBackgroundLoop, LoopDeps  # noqa: TCH001
 from escalation_reconcile import EscalationReconciler
 from models import WorkCycleResult  # noqa: TCH001
+from subprocess_util import SubprocessTimeoutError, run_subprocess_result
 
 if TYPE_CHECKING:
     from adr_drift import DriftFinding
@@ -51,30 +50,10 @@ _DEFAULT_PR_LIMIT = 50  # gh pr list page size per tick
 
 # Hard cap on each ``gh`` read. A wedged ``gh`` child (auth prompt, network
 # black-hole) must not hang the loop cycle forever and freeze its heartbeat —
-# the #9410 silent-stall failure class (#9454 / #9508).
+# the #9410 silent-stall failure class (#9454 / #9508). Bounded (and, via
+# ``run_subprocess_result``, circuit-breaker/rate-limit/process-group
+# hardened — #9554/#10028) rather than a raw ``create_subprocess_exec``.
 _GH_TIMEOUT_SECONDS = 120
-
-
-async def _communicate_bounded(
-    proc: asyncio.subprocess.Process,
-) -> tuple[bytes, bytes]:
-    """``proc.communicate()`` bounded by ``_GH_TIMEOUT_SECONDS``.
-
-    On timeout the wedged child is killed and a ``TimeoutError`` propagates so
-    the caller can treat it as a failed read (rather than hanging the loop
-    cycle indefinitely).
-    """
-    try:
-        return await asyncio.wait_for(proc.communicate(), timeout=_GH_TIMEOUT_SECONDS)
-    except TimeoutError:
-        # proc.kill() itself raises ProcessLookupError when the child already
-        # exited — suppress it too, not just proc.wait() — so the TimeoutError
-        # (the intended failed-read signal) propagates instead of crashing the
-        # caller with ProcessLookupError. (#9794/#9814)
-        with contextlib.suppress(ProcessLookupError):
-            proc.kill()
-            await proc.wait()
-        raise
 
 
 def _rollup_key(adr_number: int) -> str:
@@ -177,28 +156,23 @@ class AdrTouchpointAuditorLoop(BaseBackgroundLoop):
         ]
         if cursor:
             cmd.extend(["--search", f"merged:>{cursor}"])
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
         try:
-            stdout, stderr = await _communicate_bounded(proc)
-        except TimeoutError:
+            result = await run_subprocess_result(*cmd, timeout=_GH_TIMEOUT_SECONDS)
+        except SubprocessTimeoutError:
             logger.warning(
                 "gh pr list timed out after %ss; skipping tick",
                 _GH_TIMEOUT_SECONDS,
             )
             return []
-        if proc.returncode != 0:
+        if result.returncode != 0:
             logger.warning(
                 "gh pr list failed (rc=%s): %s",
-                proc.returncode,
-                stderr.decode(errors="replace").strip(),
+                result.returncode,
+                result.stderr,
             )
             return []
         try:
-            payload = json.loads(stdout.decode() or "[]")
+            payload = json.loads(result.stdout or "[]")
         except json.JSONDecodeError:
             logger.warning("gh pr list returned non-JSON")
             return []
@@ -223,30 +197,25 @@ class AdrTouchpointAuditorLoop(BaseBackgroundLoop):
             "--json",
             "files",
         ]
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
         try:
-            stdout, stderr = await _communicate_bounded(proc)
-        except TimeoutError:
+            result = await run_subprocess_result(*cmd, timeout=_GH_TIMEOUT_SECONDS)
+        except SubprocessTimeoutError:
             logger.warning(
                 "gh pr view %s timed out after %ss; treating as no files",
                 pr_number,
                 _GH_TIMEOUT_SECONDS,
             )
             return []
-        if proc.returncode != 0:
+        if result.returncode != 0:
             logger.warning(
                 "gh pr view %s failed (rc=%s): %s",
                 pr_number,
-                proc.returncode,
-                stderr.decode(errors="replace").strip(),
+                result.returncode,
+                result.stderr,
             )
             return []
         try:
-            payload = json.loads(stdout.decode() or "{}")
+            payload = json.loads(result.stdout or "{}")
         except json.JSONDecodeError:
             logger.warning("gh pr view %s returned non-JSON", pr_number)
             return []

--- a/src/contract_refresh_loop.py
+++ b/src/contract_refresh_loop.py
@@ -20,7 +20,8 @@ Tick body (Tasks 15 + 16 + 20 wired; Tasks 17/18/19 still pending):
    per-adapter slugs, labels ``contract-refresh`` + ``auto-merge``,
    ``auto_merge=True``, ``raise_on_failure=False``.
 5. Post-refresh replay gate (Task 16): invoke ``make trust-contracts``
-   via :func:`subprocess.run`. Pass → clean exit. Fail → the fresh
+   via :func:`subprocess_util.run_subprocess_result` (#9554/#10028 bounded
+   helper). Pass → clean exit. Fail → the fresh
    cassettes have outrun the fakes; file a ``hydraflow-find`` +
    ``fake-drift`` companion issue via ``PRManager.create_issue`` so the
    factory dispatches a fake-repair implementer. Success of the PR's
@@ -49,7 +50,6 @@ Spec: ``docs/superpowers/specs/2026-04-22-trust-architecture-hardening-design.md
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import hashlib
 import json
 import logging
@@ -75,8 +75,8 @@ from contract_recording import (
 )
 from dedup_store import DedupStore
 from models import WorkCycleResult  # noqa: TCH001
-from process_group import kill_process_group
 from rollup_issue_manager import RollupIssueManager
+from subprocess_util import SubprocessTimeoutError, run_subprocess_result
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -503,8 +503,12 @@ class ContractRefreshLoop(BaseBackgroundLoop):
         ``_REPLAY_GATE_TIMEOUT_SECONDS`` (5 min). The earlier
         synchronous implementation called ``subprocess.run`` from the
         async ``_do_work`` path, freezing the event loop for the whole
-        duration. Use ``asyncio.create_subprocess_exec`` so other
-        loops keep ticking while the replay gate runs.
+        duration. Routes through the shared bounded helper
+        (:func:`subprocess_util.run_subprocess_result`, #9554/#10028) so
+        other loops keep ticking while the replay gate runs, and the
+        spawn inherits process-group registration + reap (#9911/#10019)
+        for free — on top of the group-kill-on-timeout already wired
+        here (#9579).
 
         Task 20 wraps the call in
         :func:`trace_collector.emit_loop_subprocess_trace` so the
@@ -513,35 +517,20 @@ class ContractRefreshLoop(BaseBackgroundLoop):
 
         Hard timeout defends the orchestrator: a hung recording
         cassette must not stall the entire async event loop. On
-        ``TimeoutError`` we synthesize a non-zero CompletedProcess so
-        the caller routes the timeout through the fake-drift
-        companion path (returncode=124, the bash timeout convention).
+        ``SubprocessTimeoutError`` we synthesize a non-zero
+        CompletedProcess so the caller routes the timeout through the
+        fake-drift companion path (returncode=124, the bash timeout
+        convention).
         """
         cmd = ["make", "trust-contracts"]
         t0 = time.perf_counter()
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            cwd=str(self._config.repo_root),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            # Group leader (pid == pgid) so the timeout reap kills the whole
-            # make → pytest replay subtree, not just the top-level make
-            # (#9579).
-            start_new_session=True,
-        )
         try:
-            stdout_b, stderr_b = await asyncio.wait_for(
-                proc.communicate(), timeout=_REPLAY_GATE_TIMEOUT_SECONDS
+            gated = await run_subprocess_result(
+                *cmd,
+                cwd=self._config.repo_root,
+                timeout=_REPLAY_GATE_TIMEOUT_SECONDS,
             )
-        except TimeoutError:
-            # Group-kill: a child-only proc.kill() orphaned the sub-make /
-            # pytest grandchildren at PPID=1 (#9579). The guarded primitive
-            # never raises — an already-exited child included — so the
-            # timeout is handled as a failure instead of crashing the loop
-            # cycle. (#9794/#9816/#9883)
-            kill_process_group(proc)
-            with contextlib.suppress(ProcessLookupError):
-                await proc.wait()
+        except SubprocessTimeoutError:
             logger.warning(
                 "Replay gate timed out after %ss; treating as failure",
                 _REPLAY_GATE_TIMEOUT_SECONDS,
@@ -561,13 +550,11 @@ class ContractRefreshLoop(BaseBackgroundLoop):
                 stderr_excerpt=timeout_proc.stderr,
             )
             return timeout_proc
-        stdout_txt = (stdout_b or b"").decode(errors="replace")
-        stderr_txt = (stderr_b or b"").decode(errors="replace")
         result = subprocess.CompletedProcess(
             args=cmd,
-            returncode=proc.returncode if proc.returncode is not None else -1,
-            stdout=stdout_txt,
-            stderr=stderr_txt,
+            returncode=gated.returncode,
+            stdout=gated.stdout,
+            stderr=gated.stderr,
         )
         duration_ms = int((time.perf_counter() - t0) * 1000)
         trace_collector.emit_loop_subprocess_trace(
@@ -575,7 +562,7 @@ class ContractRefreshLoop(BaseBackgroundLoop):
             command=cmd,
             exit_code=result.returncode,
             duration_ms=duration_ms,
-            stderr_excerpt=stderr_txt.strip() or None,
+            stderr_excerpt=gated.stderr.strip() or None,
         )
         return result
 

--- a/src/fake_coverage_auditor_loop.py
+++ b/src/fake_coverage_auditor_loop.py
@@ -37,7 +37,6 @@ from __future__ import annotations
 
 import ast
 import asyncio
-import contextlib
 import json
 import logging
 import re
@@ -51,6 +50,7 @@ import yaml
 from base_background_loop import BaseBackgroundLoop, LoopDeps  # noqa: TCH001
 from escalation_reconcile import EscalationReconciler
 from models import WorkCycleResult  # noqa: TCH001
+from subprocess_util import SubprocessTimeoutError, run_subprocess_result
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -73,30 +73,10 @@ def _escalation_subject(title: str) -> str | None:
 
 # Hard cap on each ``gh``/``rg`` read. A wedged child must not hang the loop
 # cycle forever and freeze its heartbeat — the #9410 silent-stall failure
-# class (#9454 / #9508).
+# class (#9454 / #9508). Bounded (and, via ``run_subprocess_result``,
+# circuit-breaker/rate-limit/process-group hardened — #9554/#10028) rather
+# than a raw ``create_subprocess_exec``.
 _SUBPROCESS_TIMEOUT_SECONDS = 120
-
-
-async def _communicate_bounded(
-    proc: asyncio.subprocess.Process,
-) -> tuple[bytes, bytes]:
-    """``proc.communicate()`` bounded by ``_SUBPROCESS_TIMEOUT_SECONDS``.
-
-    On timeout the wedged child is killed and a ``TimeoutError`` propagates so
-    the caller can treat it as a failed read (rather than hanging the loop
-    cycle indefinitely).
-    """
-    try:
-        return await asyncio.wait_for(
-            proc.communicate(), timeout=_SUBPROCESS_TIMEOUT_SECONDS
-        )
-    except TimeoutError:
-        # proc.kill() itself raises ProcessLookupError when the child already
-        # exited — suppress it too so the TimeoutError propagates. (#9794/#9814)
-        with contextlib.suppress(ProcessLookupError):
-            proc.kill()
-            await proc.wait()
-        raise
 
 
 _MAX_ATTEMPTS = 3
@@ -364,21 +344,18 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
                 needle,
                 str(tests_dir),
             ]
-            proc = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
             try:
-                stdout, _ = await _communicate_bounded(proc)
-            except TimeoutError:
+                result = await run_subprocess_result(
+                    *cmd, timeout=_SUBPROCESS_TIMEOUT_SECONDS
+                )
+            except SubprocessTimeoutError:
                 logger.warning(
                     "rg helper-usage scan timed out after %ss; treating as no match",
                     _SUBPROCESS_TIMEOUT_SECONDS,
                 )
                 return False
             # rg exits 0 on match, 1 on no-match, 2+ on error.
-            return proc.returncode == 0 and bool(stdout.strip())
+            return result.returncode == 0 and bool(result.stdout.strip())
 
         # Fallback when ripgrep isn't on PATH (e.g. CI runners, or a deploy
         # host without it) — a stdlib scan with identical fixed-string
@@ -566,16 +543,13 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
         for label in self._config.fake_coverage_gap_label:
             cmd.extend(["--label", label])
         try:
-            proc = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
+            result = await run_subprocess_result(
+                *cmd, timeout=_SUBPROCESS_TIMEOUT_SECONDS
             )
-            stdout, _ = await _communicate_bounded(proc)
-            if proc.returncode != 0:
+            if result.returncode != 0:
                 return set()
-            data = json.loads(stdout.decode() or "[]")
-        except (OSError, TimeoutError, json.JSONDecodeError):
+            data = json.loads(result.stdout or "[]")
+        except (OSError, SubprocessTimeoutError, json.JSONDecodeError):
             return set()
         return {entry.get("title", "") for entry in data}
 

--- a/src/flake_tracker_loop.py
+++ b/src/flake_tracker_loop.py
@@ -15,8 +15,6 @@ auto-close via the shared `EscalationReconciler` (#9618 class).
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
 import json
 import logging
 import re
@@ -29,6 +27,7 @@ from typing import TYPE_CHECKING, Any
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from escalation_reconcile import EscalationReconciler
 from models import WorkCycleResult
+from subprocess_util import SubprocessTimeoutError, run_subprocess_result
 
 if TYPE_CHECKING:
     from config import HydraFlowConfig
@@ -61,30 +60,10 @@ def _escalation_subject(title: str) -> str | None:
 
 # Hard cap on each ``gh`` read/download. A wedged child must not hang the loop
 # cycle forever and freeze its heartbeat — the #9410 silent-stall failure
-# class (#9454 / #9508).
+# class (#9454 / #9508). Bounded (and, via ``run_subprocess_result``,
+# circuit-breaker/rate-limit/process-group hardened — #9554/#10028) rather
+# than a raw ``create_subprocess_exec``.
 _GH_TIMEOUT_SECONDS = 120
-
-
-async def _communicate_bounded(
-    proc: asyncio.subprocess.Process,
-) -> tuple[bytes, bytes]:
-    """``proc.communicate()`` bounded by ``_GH_TIMEOUT_SECONDS``.
-
-    On timeout the wedged child is killed and a ``TimeoutError`` propagates so
-    the caller can treat it as a failed read (rather than hanging the loop
-    cycle indefinitely).
-    """
-    try:
-        return await asyncio.wait_for(proc.communicate(), timeout=_GH_TIMEOUT_SECONDS)
-    except TimeoutError:
-        # proc.kill() itself raises ProcessLookupError when the child already
-        # exited — suppress it too, not just proc.wait() — so the TimeoutError
-        # (the intended failed-read signal) propagates instead of crashing the
-        # caller with ProcessLookupError. (#9794/#9814)
-        with contextlib.suppress(ProcessLookupError):
-            proc.kill()
-            await proc.wait()
-        raise
 
 
 def parse_junit_xml(xml_bytes: bytes) -> dict[str, str]:
@@ -153,28 +132,23 @@ class FlakeTrackerLoop(BaseBackgroundLoop):
             "--json",
             "databaseId,url,conclusion,createdAt",
         ]
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
         try:
-            stdout, stderr = await _communicate_bounded(proc)
-        except TimeoutError:
+            result = await run_subprocess_result(*cmd, timeout=_GH_TIMEOUT_SECONDS)
+        except SubprocessTimeoutError:
             logger.warning(
                 "gh run list timed out after %ss; returning empty",
                 _GH_TIMEOUT_SECONDS,
             )
             return []
-        if proc.returncode != 0:
+        if result.returncode != 0:
             logger.warning(
                 "gh run list exit=%d: %s",
-                proc.returncode,
-                stderr.decode(errors="replace")[:400],
+                result.returncode,
+                result.stderr[:400],
             )
             return []
         try:
-            return json.loads(stdout.decode() or "[]")
+            return json.loads(result.stdout or "[]")
         except json.JSONDecodeError:
             logger.warning("gh run list non-JSON response; returning empty")
             return []
@@ -197,25 +171,20 @@ class FlakeTrackerLoop(BaseBackgroundLoop):
                 "--dir",
                 td,
             ]
-            proc = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
             try:
-                _, stderr = await _communicate_bounded(proc)
-            except TimeoutError:
+                result = await run_subprocess_result(*cmd, timeout=_GH_TIMEOUT_SECONDS)
+            except SubprocessTimeoutError:
                 logger.info(
                     "gh run download timed out after %ss for run %s",
                     _GH_TIMEOUT_SECONDS,
                     run_id,
                 )
                 return {}
-            if proc.returncode != 0:
+            if result.returncode != 0:
                 logger.info(
                     "no junit-scenario artifact for run %s: %s",
                     run_id,
-                    stderr.decode(errors="replace")[:200],
+                    result.stderr[:200],
                 )
                 return {}
             combined: dict[str, str] = {}

--- a/src/memory_backlog_loop.py
+++ b/src/memory_backlog_loop.py
@@ -13,8 +13,6 @@ gate.
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
 import logging
 import re
 from typing import TYPE_CHECKING
@@ -29,6 +27,7 @@ from memory_backlog_mirror import (
     update_status,
 )
 from models import WorkCycleResult  # noqa: TCH001
+from subprocess_util import SubprocessTimeoutError, run_subprocess_result
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -59,32 +58,10 @@ def _escalation_subject(title: str) -> str | None:
 
 # Hard cap on each ``git``/``gh`` child. A wedged subprocess must not hang the
 # loop cycle forever and freeze its heartbeat — the #9410 silent-stall failure
-# class (#9454 / #9508).
+# class (#9454 / #9508). Bounded (and, via ``run_subprocess_result``,
+# circuit-breaker/rate-limit/process-group hardened — #9554/#10028) rather
+# than a raw ``create_subprocess_exec``.
 _SUBPROCESS_TIMEOUT_SECONDS = 120
-
-
-async def _communicate_bounded(
-    proc: asyncio.subprocess.Process,
-) -> tuple[bytes, bytes]:
-    """``proc.communicate()`` bounded by ``_SUBPROCESS_TIMEOUT_SECONDS``.
-
-    On timeout the wedged child is killed and a ``TimeoutError`` propagates so
-    the caller can treat it as a failed read (rather than hanging the loop
-    cycle indefinitely).
-    """
-    try:
-        return await asyncio.wait_for(
-            proc.communicate(), timeout=_SUBPROCESS_TIMEOUT_SECONDS
-        )
-    except TimeoutError:
-        # proc.kill() itself raises ProcessLookupError when the child already
-        # exited — suppress it too, not just proc.wait() — so the TimeoutError
-        # (the intended failed-read signal) propagates instead of crashing the
-        # caller with ProcessLookupError. (#9794/#9816)
-        with contextlib.suppress(ProcessLookupError):
-            proc.kill()
-            await proc.wait()
-        raise
 
 
 class MemoryBacklogLoop(BaseBackgroundLoop):
@@ -212,28 +189,26 @@ class MemoryBacklogLoop(BaseBackgroundLoop):
             joined = ", ".join(f"#{n}" for n in issue_numbers)
             title = f"chore(memory-backlog): file issues {joined}"
 
-        add_proc = await asyncio.create_subprocess_exec(
-            "git",
-            "-C",
-            repo_root,
-            "add",
-            mirror_relpath,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
         try:
-            _, add_err = await _communicate_bounded(add_proc)
-        except TimeoutError:
+            add_result = await run_subprocess_result(
+                "git",
+                "-C",
+                repo_root,
+                "add",
+                mirror_relpath,
+                timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+            )
+        except SubprocessTimeoutError:
             logger.warning(
                 "memory_backlog: git add timed out after %ss",
                 _SUBPROCESS_TIMEOUT_SECONDS,
             )
             return
-        if add_proc.returncode != 0:
+        if add_result.returncode != 0:
             logger.warning(
                 "memory_backlog: git add failed (rc=%s): %s",
-                add_proc.returncode,
-                add_err.decode(errors="replace").strip(),
+                add_result.returncode,
+                add_result.stderr,
             )
             return
 
@@ -243,32 +218,30 @@ class MemoryBacklogLoop(BaseBackgroundLoop):
         if self._config.git_user_name:
             identity_args += ["-c", f"user.name={self._config.git_user_name}"]
 
-        commit_proc = await asyncio.create_subprocess_exec(
-            "git",
-            "-C",
-            repo_root,
-            *identity_args,
-            "commit",
-            "-m",
-            title,
-            "--",
-            mirror_relpath,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
         try:
-            _, commit_err = await _communicate_bounded(commit_proc)
-        except TimeoutError:
+            commit_result = await run_subprocess_result(
+                "git",
+                "-C",
+                repo_root,
+                *identity_args,
+                "commit",
+                "-m",
+                title,
+                "--",
+                mirror_relpath,
+                timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+            )
+        except SubprocessTimeoutError:
             logger.warning(
                 "memory_backlog: git commit timed out after %ss",
                 _SUBPROCESS_TIMEOUT_SECONDS,
             )
             return
-        if commit_proc.returncode != 0:
+        if commit_result.returncode != 0:
             logger.warning(
                 "memory_backlog: git commit failed (rc=%s): %s",
-                commit_proc.returncode,
-                commit_err.decode(errors="replace").strip(),
+                commit_result.returncode,
+                commit_result.stderr,
             )
 
     async def _file_backlog_issue(self, entry: MirrorEntry) -> int:

--- a/src/principles_audit_loop.py
+++ b/src/principles_audit_loop.py
@@ -8,23 +8,22 @@ subsystems take effect.
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
 import json
 import logging
 import re
 import time
 from datetime import UTC, datetime
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import trace_collector
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from exception_classify import reraise_on_credit_or_bug
 from models import WorkCycleResult
-from process_group import kill_process_group
+from subprocess_util import SubprocessTimeoutError, run_subprocess_result
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from config import HydraFlowConfig, ManagedRepo
     from pr_manager import PRManager
     from state import StateTracker
@@ -34,35 +33,11 @@ logger = logging.getLogger("hydraflow.principles_audit_loop")
 # Hard caps on subprocess reads. A wedged child must not hang the loop cycle
 # forever and freeze its heartbeat — the #9410 silent-stall failure class
 # (#9454 / #9508). ``make audit-json`` runs a full audit so it gets a longer
-# bound than a plain ``git`` call.
+# bound than a plain ``git`` call. Bounded (and, via ``run_subprocess_result``,
+# process-group hardened — #9554/#10028) rather than a raw
+# ``create_subprocess_exec``.
 _AUDIT_TIMEOUT_SECONDS = 1800
 _GIT_TIMEOUT_SECONDS = 120
-
-
-async def _communicate_bounded(
-    proc: asyncio.subprocess.Process, timeout: float
-) -> tuple[bytes, bytes]:
-    """``proc.communicate()`` bounded by *timeout* seconds.
-
-    On timeout the wedged child's whole PROCESS GROUP is reaped and a
-    ``TimeoutError`` propagates so the caller ends its cycle (and is
-    restarted by the supervisor) rather than hanging indefinitely.
-
-    Callers must spawn with ``start_new_session=True`` (child is its own
-    group leader): ``make audit-json`` fans out sub-make → pytest → LLM
-    grandchildren, and a child-only ``proc.kill()`` re-parented them to
-    init where they kept burning API credits (#9579). The guarded
-    primitive never raises — an already-exited child included — so the
-    TimeoutError (the intended failed-read signal) still propagates
-    (#9794/#9816).
-    """
-    try:
-        return await asyncio.wait_for(proc.communicate(), timeout=timeout)
-    except TimeoutError:
-        kill_process_group(proc)
-        with contextlib.suppress(ProcessLookupError):
-            await proc.wait()
-        raise
 
 
 _HYDRAFLOW_SELF = "hydraflow-self"
@@ -234,21 +209,11 @@ class PrinciplesAuditLoop(BaseBackgroundLoop):
         """Invoke ``make audit-json`` → parsed JSON report (spec §4.4)."""
         cmd = ["make", "audit-json", f"DIR={repo_root}"]
         t0 = time.perf_counter()
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            cwd=self._config.repo_root,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            # Group leader (pid == pgid) so the timeout reap in
-            # _communicate_bounded kills the whole make → pytest → LLM
-            # subtree, not just the top-level make (#9579).
-            start_new_session=True,
-        )
         try:
-            stdout, stderr = await _communicate_bounded(
-                proc, timeout=_AUDIT_TIMEOUT_SECONDS
+            result = await run_subprocess_result(
+                *cmd, cwd=self._config.repo_root, timeout=_AUDIT_TIMEOUT_SECONDS
             )
-        except TimeoutError as exc:
+        except SubprocessTimeoutError as exc:
             duration_ms = int((time.perf_counter() - t0) * 1000)
             trace_collector.emit_loop_subprocess_trace(
                 loop="principles_audit",
@@ -261,24 +226,23 @@ class PrinciplesAuditLoop(BaseBackgroundLoop):
                 f"make audit-json timed out after {_AUDIT_TIMEOUT_SECONDS}s for {slug}"
             ) from exc
         duration_ms = int((time.perf_counter() - t0) * 1000)
-        exit_code = proc.returncode or 0
-        stderr_text = stderr.decode(errors="replace")
+        exit_code = result.returncode
         trace_collector.emit_loop_subprocess_trace(
             loop="principles_audit",
             command=cmd,
             exit_code=exit_code,
             duration_ms=duration_ms,
-            stderr_excerpt=stderr_text if stderr_text else None,
+            stderr_excerpt=result.stderr if result.stderr else None,
         )
         if exit_code not in (0, 1):  # audit uses 1 for "failures present"
             logger.warning(
                 "make audit-json exit=%d for %s: %s",
                 exit_code,
                 slug,
-                stderr_text[:400],
+                result.stderr[:400],
             )
         try:
-            return json.loads(stdout.decode())
+            return json.loads(result.stdout)
         except json.JSONDecodeError as exc:
             raise RuntimeError(
                 f"audit-json emitted non-JSON for {slug}: {exc}"
@@ -300,18 +264,11 @@ class PrinciplesAuditLoop(BaseBackgroundLoop):
         """Run a git subcommand; returns ``(exit_code, combined_output)``."""
         cmd = ["git", *args]
         t0 = time.perf_counter()
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            cwd=cwd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-            # Group leader: _communicate_bounded reaps via killpg, which is
-            # only meaningful when the child owns its group (#9579).
-            start_new_session=True,
-        )
         try:
-            out, _ = await _communicate_bounded(proc, timeout=_GIT_TIMEOUT_SECONDS)
-        except TimeoutError as exc:
+            result = await run_subprocess_result(
+                *cmd, cwd=cwd, timeout=_GIT_TIMEOUT_SECONDS
+            )
+        except SubprocessTimeoutError as exc:
             duration_ms = int((time.perf_counter() - t0) * 1000)
             trace_collector.emit_loop_subprocess_trace(
                 loop="principles_audit",
@@ -324,8 +281,12 @@ class PrinciplesAuditLoop(BaseBackgroundLoop):
                 f"git timed out after {_GIT_TIMEOUT_SECONDS}s: {' '.join(cmd)}"
             ) from exc
         duration_ms = int((time.perf_counter() - t0) * 1000)
-        exit_code = proc.returncode or 0
-        combined = out.decode(errors="replace")
+        exit_code = result.returncode
+        # The shared helper returns separate stdout/stderr (no stderr=STDOUT
+        # redirect); reconstruct the combined text this method's contract
+        # promises. Only used for error messages/trace excerpts, so exact
+        # interleaving with the original redirect doesn't matter.
+        combined = "\n".join(p for p in (result.stdout, result.stderr) if p)
         trace_collector.emit_loop_subprocess_trace(
             loop="principles_audit",
             command=cmd,

--- a/src/rc_budget_loop.py
+++ b/src/rc_budget_loop.py
@@ -21,8 +21,6 @@ Kill-switch: ``LoopDeps.enabled_cb("rc_budget")`` — **no
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
 import json
 import logging
 import re
@@ -37,6 +35,7 @@ from typing import TYPE_CHECKING, Any
 from base_background_loop import BaseBackgroundLoop, LoopDeps  # noqa: TCH001
 from escalation_reconcile import EscalationReconciler
 from models import WorkCycleResult  # noqa: TCH001
+from subprocess_util import SubprocessTimeoutError, run_subprocess_result
 
 if TYPE_CHECKING:
     from config import HydraFlowConfig
@@ -73,28 +72,10 @@ def _escalation_subject(title: str) -> str | None:
 
 # Hard cap on each ``gh`` read/download. A wedged child must not hang the loop
 # cycle forever and freeze its heartbeat — the #9410 silent-stall failure
-# class (#9454 / #9508).
+# class (#9454 / #9508). Bounded (and, via ``run_subprocess_result``,
+# circuit-breaker/rate-limit/process-group hardened — #9554/#10028) rather
+# than a raw ``create_subprocess_exec``.
 _GH_TIMEOUT_SECONDS = 120
-
-
-async def _communicate_bounded(
-    proc: asyncio.subprocess.Process,
-) -> tuple[bytes, bytes]:
-    """``proc.communicate()`` bounded by ``_GH_TIMEOUT_SECONDS``.
-
-    On timeout the wedged child is killed and a ``TimeoutError`` propagates so
-    the caller can treat it as a failed read (rather than hanging the loop
-    cycle indefinitely).
-    """
-    try:
-        return await asyncio.wait_for(proc.communicate(), timeout=_GH_TIMEOUT_SECONDS)
-    except TimeoutError:
-        # proc.kill() itself raises ProcessLookupError when the child already
-        # exited — suppress it too so the TimeoutError propagates. (#9794/#9814)
-        with contextlib.suppress(ProcessLookupError):
-            proc.kill()
-            await proc.wait()
-        raise
 
 
 def _parse_iso(value: str | None) -> datetime | None:
@@ -228,28 +209,23 @@ class RCBudgetLoop(BaseBackgroundLoop):
             "--json",
             "databaseId,url,conclusion,createdAt,updatedAt,startedAt",
         ]
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
         try:
-            stdout, stderr = await _communicate_bounded(proc)
-        except TimeoutError:
+            result = await run_subprocess_result(*cmd, timeout=_GH_TIMEOUT_SECONDS)
+        except SubprocessTimeoutError:
             logger.warning(
                 "gh run list timed out after %ss; returning empty",
                 _GH_TIMEOUT_SECONDS,
             )
             return []
-        if proc.returncode != 0:
+        if result.returncode != 0:
             logger.warning(
                 "gh run list exit=%d: %s",
-                proc.returncode,
-                stderr.decode(errors="replace")[:400],
+                result.returncode,
+                result.stderr[:400],
             )
             return []
         try:
-            raw = json.loads(stdout.decode() or "[]")
+            raw = json.loads(result.stdout or "[]")
         except json.JSONDecodeError:
             return []
         cutoff = datetime.now(UTC) - timedelta(days=_WINDOW_DAYS)
@@ -315,19 +291,14 @@ class RCBudgetLoop(BaseBackgroundLoop):
             "--json",
             "jobs",
         ]
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
         try:
-            stdout, _ = await _communicate_bounded(proc)
-        except TimeoutError:
+            result = await run_subprocess_result(*cmd, timeout=_GH_TIMEOUT_SECONDS)
+        except SubprocessTimeoutError:
             return []
-        if proc.returncode != 0:
+        if result.returncode != 0:
             return []
         try:
-            payload = json.loads(stdout.decode() or "{}")
+            payload = json.loads(result.stdout or "{}")
         except json.JSONDecodeError:
             return []
         out: list[dict[str, Any]] = []
@@ -363,16 +334,11 @@ class RCBudgetLoop(BaseBackgroundLoop):
                 "--dir",
                 td,
             ]
-            proc = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
             try:
-                await _communicate_bounded(proc)
-            except TimeoutError:
+                result = await run_subprocess_result(*cmd, timeout=_GH_TIMEOUT_SECONDS)
+            except SubprocessTimeoutError:
                 return []
-            if proc.returncode != 0:
+            if result.returncode != 0:
                 return []
             results: list[tuple[str, float]] = []
             for xml_path in Path(td).rglob("*.xml"):

--- a/src/skill_prompt_eval_loop.py
+++ b/src/skill_prompt_eval_loop.py
@@ -16,11 +16,9 @@ Spec: `docs/superpowers/specs/2026-04-22-trust-architecture-hardening-design.md`
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import json
 import logging
 import math
-import os
 import random
 import re
 import sys
@@ -35,7 +33,6 @@ from escalation_reconcile import EscalationReconciler
 from exception_classify import reraise_on_credit_or_bug
 from execution import get_default_runner
 from models import WorkCycleResult
-from process_group import kill_process_group
 from prompt_efficiency import (
     INEFFICIENCY_THRESHOLD,
     SkillEfficiencyRow,
@@ -56,6 +53,7 @@ from prompt_refiner import (
 )
 from prompt_telemetry import PromptTelemetry
 from runner_utils import run_lightweight_agent
+from subprocess_util import SubprocessTimeoutError, run_subprocess_result
 
 if TYPE_CHECKING:
     from config import HydraFlowConfig
@@ -89,34 +87,10 @@ def _escalation_subject(title: str) -> str | None:
 # forever and freeze its heartbeat — the #9410 silent-stall failure class
 # (#9454 / #9508). ``make trust-adversarial`` drives an LLM eval harness so it
 # gets a generous bound. (The former ``gh`` reconcile read now goes through
-# the PRPort via the shared ``EscalationReconciler``.)
+# the PRPort via the shared ``EscalationReconciler``.) Bounded (and, via
+# ``run_subprocess_result``, process-group hardened — #9554/#10028) rather
+# than a raw ``create_subprocess_exec``.
 _ADVERSARIAL_TIMEOUT_SECONDS = 3600
-
-
-async def _communicate_bounded(
-    proc: asyncio.subprocess.Process, timeout: float
-) -> tuple[bytes, bytes]:
-    """``proc.communicate()`` bounded by *timeout* seconds.
-
-    On timeout the wedged child's whole PROCESS GROUP is reaped and a
-    ``TimeoutError`` propagates so the caller can treat it as a failed read
-    (rather than hanging the loop cycle indefinitely).
-
-    Callers must spawn with ``start_new_session=True`` (child is its own
-    group leader): the corpus/validation spawns fan out sub-make → pytest →
-    LLM-agent grandchildren, and a child-only ``proc.kill()`` re-parented
-    them to init where they kept burning API credits (#9579). The guarded
-    primitive never raises — an already-exited child included — so the
-    TimeoutError (the intended failed-read signal) still propagates
-    (#9794/#9816).
-    """
-    try:
-        return await asyncio.wait_for(proc.communicate(), timeout=timeout)
-    except TimeoutError:
-        kill_process_group(proc)
-        with contextlib.suppress(ProcessLookupError):
-            await proc.wait()
-        raise
 
 
 # --- Prompt self-refinement (#9724) ------------------------------------------
@@ -174,40 +148,49 @@ async def _assert_only_module_changed(worktree: Path, module_rel: str) -> None:
 
     Raises ``RuntimeError`` naming the unexpected/missing paths when the
     touched set is not exactly ``{module_rel}`` — modified, added, and
-    untracked files all count as "touched".
+    untracked files all count as "touched". A timeout also raises
+    ``RuntimeError`` (``SubprocessTimeoutError``, via the shared bounded
+    helper) — the caller's ``except RuntimeError`` treats it the same as a
+    path tripwire, a safe default for an unexplained wedged git status.
     """
-    proc = await asyncio.create_subprocess_exec(
-        "git",
-        "status",
-        "--porcelain",
-        cwd=worktree,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
     try:
-        stdout, stderr = await asyncio.wait_for(
-            proc.communicate(), timeout=_GIT_STATUS_TIMEOUT_SECONDS
+        result = await run_subprocess_result(
+            "git",
+            "status",
+            "--porcelain",
+            cwd=worktree,
+            timeout=_GIT_STATUS_TIMEOUT_SECONDS,
         )
-    except TimeoutError:
-        # An already-exited child makes proc.kill() raise ProcessLookupError,
-        # which would otherwise crash the loop cycle instead of surfacing the
-        # TimeoutError (#9794/#9816/#9883 gh-timeout-storm class).
-        with contextlib.suppress(ProcessLookupError):
-            proc.kill()
-            await proc.wait()
-        raise
-    if proc.returncode != 0:
-        detail = stderr.decode(errors="replace")[:400]
-        msg = f"git status failed (rc={proc.returncode}): {detail}"
+    except SubprocessTimeoutError as exc:
+        raise RuntimeError(
+            f"git status timed out after {_GIT_STATUS_TIMEOUT_SECONDS}s"
+        ) from exc
+    if result.returncode != 0:
+        detail = result.stderr[:400]
+        msg = f"git status failed (rc={result.returncode}): {detail}"
         raise RuntimeError(msg)
 
     touched: set[str] = set()
-    for line in stdout.decode(errors="replace").splitlines():
+    for idx, line in enumerate(result.stdout.splitlines()):
         if not line:
             continue
-        # Porcelain v1 shape: 2 status chars + a space + the path. A rename
-        # (or copy) carries both sides as "old -> new"; both count as touched.
-        rest = line[3:]
+        # Porcelain v1 shape: 2 status chars + a space + the path, so the
+        # separator is always at a fixed index 2. BUT `result.stdout` comes
+        # from `run_subprocess_result` -> `HostRunner.run_simple`, whose
+        # `SimpleResult.stdout` is `.strip()`-ped across the WHOLE blob — if
+        # the first status char is itself a space (e.g. " M path", modified
+        # in the worktree but not staged), that leading space is eaten,
+        # shifting the first line left by one and corrupting a fixed
+        # `line[3:]` slice (observed: "src/x.py" -> "rc/x.py"). Detect the
+        # shift instead of assuming a fixed offset: a well-formed
+        # (unshifted) line always has its separator at index 2; only the
+        # shifted first line can have it at index 1.
+        if len(line) > 2 and line[2] == " ":
+            rest = line[3:]
+        elif idx == 0 and len(line) > 1 and line[1] == " ":
+            rest = line[2:]
+        else:
+            rest = line[3:]
         old, sep, new = rest.partition(" -> ")
         if sep:
             touched.add(old.strip())
@@ -343,40 +326,30 @@ class SkillPromptEvalLoop(BaseBackgroundLoop):
         below is the operator-visible backstop.
         """
         cmd = ["make", "trust-adversarial", "FORMAT=json"]
-        env = {
-            **os.environ,
-            "HYDRAFLOW_TRUST_ADVERSARIAL_MAX_CASES": str(
-                self._config.skill_prompt_eval_max_corpus_cases
-            ),
-        }
         try:
-            proc = await asyncio.create_subprocess_exec(
+            result = await run_subprocess_result(
                 *cmd,
                 cwd=self._config.repo_root,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                env=env,
-                # Group leader (pid == pgid) so the timeout reap in
-                # _communicate_bounded kills the whole make → pytest →
-                # LLM-agent subtree, not just the top-level make (#9579).
-                start_new_session=True,
-            )
-            stdout, stderr = await _communicate_bounded(
-                proc, timeout=_ADVERSARIAL_TIMEOUT_SECONDS
+                timeout=_ADVERSARIAL_TIMEOUT_SECONDS,
+                extra_env={
+                    "HYDRAFLOW_TRUST_ADVERSARIAL_MAX_CASES": str(
+                        self._config.skill_prompt_eval_max_corpus_cases
+                    ),
+                },
             )
         except Exception as exc:  # noqa: BLE001
             reraise_on_credit_or_bug(exc)
             logger.warning("trust-adversarial subprocess failed: %s", exc)
             return []
-        if proc.returncode not in (0, 1):  # 1 = failures present; still valid output
+        if result.returncode not in (0, 1):  # 1 = failures present; still valid output
             logger.warning(
                 "trust-adversarial exit=%d: %s",
-                proc.returncode,
-                stderr.decode(errors="replace")[:400],
+                result.returncode,
+                result.stderr[:400],
             )
             return []
         try:
-            return json.loads(stdout.decode() or "[]")
+            return json.loads(result.stdout or "[]")
         except json.JSONDecodeError:
             logger.warning("trust-adversarial non-JSON response")
             return []
@@ -884,30 +857,26 @@ class SkillPromptEvalLoop(BaseBackgroundLoop):
         """Apply *patch_text* to *worktree* via ``git apply --whitespace=nowarn -``.
 
         Raises ``RuntimeError`` on a non-zero exit so the caller's generate
-        callback aborts (→ no PR) when a candidate patch doesn't apply cleanly.
+        callback aborts (→ no PR) when a candidate patch doesn't apply
+        cleanly. A timeout also raises ``RuntimeError``
+        (``SubprocessTimeoutError``, via the shared bounded helper) rather
+        than a bare ``TimeoutError``.
         """
-        proc = await asyncio.create_subprocess_exec(
-            "git",
-            "apply",
-            "--whitespace=nowarn",
-            "-",
-            cwd=worktree,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
         try:
-            _, stderr = await asyncio.wait_for(
-                proc.communicate(patch_text.encode()), timeout=60
+            result = await run_subprocess_result(
+                "git",
+                "apply",
+                "--whitespace=nowarn",
+                "-",
+                cwd=worktree,
+                stdin_input=patch_text.encode(),
+                timeout=60,
             )
-        except TimeoutError:
-            with contextlib.suppress(ProcessLookupError):
-                proc.kill()
-                await proc.wait()
-            raise
-        if proc.returncode != 0:
-            detail = stderr.decode(errors="replace")[:400]
-            msg = f"git apply failed (rc={proc.returncode}): {detail}"
+        except SubprocessTimeoutError as exc:
+            raise RuntimeError("git apply timed out after 60s") from exc
+        if result.returncode != 0:
+            detail = result.stderr[:400]
+            msg = f"git apply failed (rc={result.returncode}): {detail}"
             raise RuntimeError(msg)
 
     async def _validate_candidate(
@@ -933,25 +902,15 @@ class SkillPromptEvalLoop(BaseBackgroundLoop):
             "--cases",
             ",".join(case_ids),
         ]
-        env = {
-            **os.environ,
-            "HYDRAFLOW_TRUST_ADVERSARIAL_LIVE": "1",
-            "PYTHONPATH": "src:.",
-        }
         try:
-            proc = await asyncio.create_subprocess_exec(
+            result = await run_subprocess_result(
                 *cmd,
                 cwd=worktree,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                env=env,
-                # Group leader (pid == pgid) so the timeout reap in
-                # _communicate_bounded kills the whole corpus-runner →
-                # LLM-agent subtree, not just the direct child (#9579).
-                start_new_session=True,
-            )
-            stdout, stderr = await _communicate_bounded(
-                proc, timeout=_ADVERSARIAL_TIMEOUT_SECONDS
+                timeout=_ADVERSARIAL_TIMEOUT_SECONDS,
+                extra_env={
+                    "HYDRAFLOW_TRUST_ADVERSARIAL_LIVE": "1",
+                    "PYTHONPATH": "src:.",
+                },
             )
         except Exception as exc:
             reraise_on_credit_or_bug(exc)
@@ -959,14 +918,14 @@ class SkillPromptEvalLoop(BaseBackgroundLoop):
                 "refine validation subprocess failed for %s: %s", case_id, exc
             )
             return False
-        if proc.returncode != 0:
+        if result.returncode != 0:
             logger.warning(
                 "refine validation exit=%d: %s",
-                proc.returncode,
-                stderr.decode(errors="replace")[:400],
+                result.returncode,
+                result.stderr[:400],
             )
             return False
-        passed = _all_required_pass(stdout.decode())
+        passed = _all_required_pass(result.stdout)
         if not passed:
             logger.warning(
                 "refine validation for %s: no all-PASS non-SKIPPED result set "

--- a/src/staging_bisect_loop.py
+++ b/src/staging_bisect_loop.py
@@ -26,6 +26,11 @@ from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import HydraFlowConfig
 from dedup_store import DedupStore
 from process_group import kill_process_group
+from subprocess_util import (
+    SubprocessTimeoutError,
+    run_subprocess,
+    run_subprocess_result,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -175,48 +180,29 @@ class StagingBisectLoop(BaseBackgroundLoop):
         timeout_s = self._config.staging_bisect_runtime_cap_seconds
         cmd = ["make", "bisect-probe"]
         t0 = time.perf_counter()
-        exit_code: int | None = None
-        stderr_excerpt: str | None = None
         try:
-            proc = await asyncio.create_subprocess_exec(
-                *cmd,
-                cwd=str(self._config.repo_root),
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                # Group leader (pid == pgid) so the timeout reap kills the
-                # whole make → pytest probe subtree, not just the top-level
-                # make (#9579).
-                start_new_session=True,
+            result = await run_subprocess_result(
+                *cmd, cwd=self._config.repo_root, timeout=timeout_s
             )
-            try:
-                stdout_b, stderr_b = await asyncio.wait_for(
-                    proc.communicate(), timeout=timeout_s
-                )
-            except TimeoutError:
-                # Group-kill: a child-only proc.kill() orphaned the sub-make /
-                # pytest grandchildren at PPID=1 (#9579). The guarded
-                # primitive never raises — an already-exited child included —
-                # so the timeout surfaces as a probe failure instead of
-                # crashing the loop. (#9794/#9816/#9883)
-                kill_process_group(proc)
-                with contextlib.suppress(ProcessLookupError):
-                    await proc.wait()
-                exit_code = 124  # bash convention
-                stderr_excerpt = f"timeout after {timeout_s}s"
-                self._emit_trace(t0, cmd, exit_code, stderr_excerpt)
-                return False, f"bisect-probe timed out after {timeout_s}s"
+        except SubprocessTimeoutError:
+            # The shared helper (run_simple) already group-kills the whole
+            # make → pytest probe subtree on timeout (#9579/#9554/#10028) —
+            # this method just surfaces the failure instead of crashing the
+            # loop. (#9794/#9816/#9883)
+            exit_code = 124  # bash convention
+            stderr_excerpt = f"timeout after {timeout_s}s"
+            self._emit_trace(t0, cmd, exit_code, stderr_excerpt)
+            return False, f"bisect-probe timed out after {timeout_s}s"
         except OSError as exc:
             self._emit_trace(t0, cmd, -1, f"exec failed: {exc}")
             return False, f"bisect-probe exec failed: {exc}"
-        combined = (stdout_b or b"").decode(errors="replace") + (
-            stderr_b or b""
-        ).decode(errors="replace")
-        exit_code = proc.returncode if proc.returncode is not None else -1
+        combined = result.stdout + result.stderr
+        exit_code = result.returncode
         self._emit_trace(
             t0,
             cmd,
             exit_code,
-            (stderr_b or b"").decode(errors="replace").strip()[:200] or None,
+            result.stderr.strip()[:200] or None,
         )
         return exit_code == 0, combined
 
@@ -487,7 +473,6 @@ class StagingBisectLoop(BaseBackgroundLoop):
         caller's own enabled-check at ``_do_work`` entry catches the
         next tick.
         """
-        import asyncio  # noqa: PLC0415
 
         proc = await asyncio.create_subprocess_exec(
             *cmd,
@@ -592,33 +577,21 @@ class StagingBisectLoop(BaseBackgroundLoop):
             await self._cleanup_worktree(worktree_dir)
 
     async def _run_gh(self, cmd: list[str]) -> str:
-        """Run a ``gh`` command and return stdout. Overridable in tests."""
-        import asyncio  # noqa: PLC0415
+        """Run a ``gh`` command and return stdout. Overridable in tests.
 
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            cwd=self._config.repo_root,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
+        Routes through the shared bounded helper (#9554/#10028) —
+        ``run_subprocess`` raises on non-zero exit (same stdout-or-raise
+        contract as before) and inherits the gh circuit-breaker/rate-limit
+        gating plus process-group registration for free.
+        """
         try:
-            stdout, stderr = await asyncio.wait_for(
-                proc.communicate(), timeout=_GH_TIMEOUT_SECONDS
+            return await run_subprocess(
+                *cmd, cwd=self._config.repo_root, timeout=_GH_TIMEOUT_SECONDS
             )
-        except TimeoutError as exc:
-            # proc.kill() itself raises ProcessLookupError when the child
-            # already exited — suppress it too, not just proc.wait(), so the
-            # RuntimeError below propagates instead of crashing the loop cycle.
-            # (#9794/#9816/#9883)
-            with contextlib.suppress(ProcessLookupError):
-                proc.kill()
-                await proc.wait()
+        except SubprocessTimeoutError as exc:
             raise RuntimeError(
                 f"gh timed out after {_GH_TIMEOUT_SECONDS}s: {' '.join(cmd)}"
             ) from exc
-        if proc.returncode != 0:
-            raise RuntimeError(f"gh failed: {stderr.decode()[:500]}")
-        return stdout.decode()
 
     async def _attribute_culprit(self, sha: str) -> tuple[int, str]:
         """Resolve *sha* to ``(pr_number, pr_title)``.

--- a/src/subprocess_util.py
+++ b/src/subprocess_util.py
@@ -20,7 +20,7 @@ from zoneinfo import ZoneInfo
 
 if TYPE_CHECKING:
     from circuit_breaker import CircuitBreaker
-    from execution import SubprocessRunner
+    from execution import SimpleResult, SubprocessRunner
 
 logger = logging.getLogger("hydraflow.subprocess")
 
@@ -920,28 +920,41 @@ def make_docker_env(
 _GH_COMMANDS = frozenset({"gh", "git"})
 
 
-async def run_subprocess(
+async def _run_gated(
     *cmd: str,
     cwd: Path | None = None,
     gh_token: str = "",
     timeout: float = 120.0,
     runner: SubprocessRunner | None = None,
-) -> str:
-    """Run a subprocess and return stripped stdout.
+    extra_env: dict[str, str] | None = None,
+    stdin_input: bytes | None = None,
+    check: bool,
+) -> SimpleResult:
+    """Shared gated core for :func:`run_subprocess`/:func:`run_subprocess_result`.
 
-    Strips the ``CLAUDECODE`` key from the environment to prevent
-    nesting detection.  When *gh_token* is non-empty it is injected
-    as ``GH_TOKEN``.
+    Applies identical hardening regardless of *check*: ``gh``/``git`` commands
+    are gated through the global concurrency semaphore, the rate-limit
+    cooldown, and (``gh`` only) the circuit breaker; every call is bounded by
+    *timeout* via the injected/default :class:`SubprocessRunner`, which also
+    supplies process-group registration and reap (``HostRunner.run_simple``,
+    #9911/#10017/#10019) — free to every caller of this helper.
 
-    For ``gh`` and ``git`` commands, execution is gated through a global
-    semaphore to prevent GitHub API rate limiting from concurrent calls.
+    ``check=True`` (used by :func:`run_subprocess`) raises ``RuntimeError`` /
+    ``AuthenticationError`` on a non-zero exit, matching historical
+    ``run_subprocess`` behavior. ``check=False`` (used by
+    :func:`run_subprocess_result`) never raises for a non-zero exit — the
+    caller branches on ``SimpleResult.returncode`` instead. Both raise
+    :class:`SubprocessTimeoutError` on timeout and :class:`CircuitBreakerOpenError`
+    when the breaker is OPEN — those are infrastructure failures, not business
+    outcomes a caretaker loop should have to special-case per call site.
 
-    Raises :class:`SubprocessTimeoutError` if the command exceeds *timeout* seconds.
-    Raises :class:`RuntimeError` on non-zero exit.
+    Module-private: never imported outside this file.
     """
     from execution import get_default_runner
 
     env = make_clean_env(gh_token)
+    if extra_env:
+        env.update(extra_env)
 
     resolved_runner = runner if runner is not None else get_default_runner()
 
@@ -959,13 +972,14 @@ async def run_subprocess(
         else None
     )
 
-    async def _exec() -> str:
+    async def _exec() -> SimpleResult:
         try:
             result = await resolved_runner.run_simple(
                 list(cmd),
                 cwd=str(cwd) if cwd is not None else None,
                 env=env,
                 timeout=timeout,
+                input=stdin_input,
             )
         except TimeoutError as exc:
             if breaker is not None:
@@ -989,24 +1003,30 @@ async def run_subprocess(
                 # Auth failure = bad/again-rejected credentials, not an outage;
                 # opening the breaker wouldn't help (the token is still bad after
                 # the reset window), so it must not count toward it.
-                raise AuthenticationError(msg) from cause
+                if check:
+                    raise AuthenticationError(msg) from cause
+                return result
             if _is_rate_limited(result.stderr):
                 _trigger_rate_limit_cooldown()
                 # A rate limit has its own global cooldown and is not a
                 # GitHub-down signal, so it must NOT count toward the breaker.
-                raise RuntimeError(msg) from cause
+                if check:
+                    raise RuntimeError(msg) from cause
+                return result
             # Count toward the breaker ONLY genuine GitHub/network outages — a
             # 4xx / business-logic non-zero exit (404, "label does not exist",
             # "cannot approve your own pull request", …) is normal control flow
             # and must not accumulate toward an OPEN that halts the factory.
             if breaker is not None and _is_gh_outage_error(result.stderr):
                 breaker.record_failure()
-            raise RuntimeError(msg) from cause
+            if check:
+                raise RuntimeError(msg) from cause
+            return result
         _reset_rate_limit_backoff()
         if breaker is not None:
             breaker.record_success()
         _maybe_sample_shadow(cmd, result.returncode, result.stdout, result.stderr)
-        return result.stdout
+        return result
 
     if use_semaphore:
         if breaker is not None and not breaker.allow_request():
@@ -1022,6 +1042,73 @@ async def run_subprocess(
         async with _get_gh_semaphore():
             return await _exec()
     return await _exec()
+
+
+async def run_subprocess(
+    *cmd: str,
+    cwd: Path | None = None,
+    gh_token: str = "",
+    timeout: float = 120.0,
+    runner: SubprocessRunner | None = None,
+) -> str:
+    """Run a subprocess and return stripped stdout.
+
+    Strips the ``CLAUDECODE`` key from the environment to prevent
+    nesting detection.  When *gh_token* is non-empty it is injected
+    as ``GH_TOKEN``.
+
+    For ``gh`` and ``git`` commands, execution is gated through a global
+    semaphore to prevent GitHub API rate limiting from concurrent calls.
+
+    Raises :class:`SubprocessTimeoutError` if the command exceeds *timeout* seconds.
+    Raises :class:`RuntimeError` on non-zero exit.
+    """
+    result = await _run_gated(
+        *cmd, cwd=cwd, gh_token=gh_token, timeout=timeout, runner=runner, check=True
+    )
+    return result.stdout
+
+
+async def run_subprocess_result(
+    *cmd: str,
+    cwd: Path | None = None,
+    gh_token: str = "",
+    timeout: float = 120.0,
+    runner: SubprocessRunner | None = None,
+    extra_env: dict[str, str] | None = None,
+    stdin_input: bytes | None = None,
+) -> SimpleResult:
+    """Run a subprocess and return the full result, never raising on non-zero exit.
+
+    Sibling of :func:`run_subprocess` for callers that branch on
+    ``proc.returncode`` themselves (e.g. accepting ``rc in {0, 1}`` for
+    ``make``/``rg``, or treating any non-zero as "skip this tick"). Applies
+    identical hardening: timeout bound + process-group reap + registry-join
+    (via the injected/default ``SubprocessRunner``), and for ``gh``/``git``
+    the global concurrency semaphore, rate-limit cooldown, and circuit
+    breaker accounting.
+
+    *extra_env* is merged on top of :func:`make_clean_env`'s output (e.g. to
+    forward a harness-specific env var). *stdin_input*, when provided, is
+    written to the child's stdin (mirrors ``HostRunner.run_simple``'s
+    ``input`` param — renamed here to avoid shadowing the ``input`` builtin).
+
+    Raises :class:`SubprocessTimeoutError` if the command exceeds *timeout*
+    seconds, and :class:`CircuitBreakerOpenError` if the ``gh`` circuit
+    breaker is OPEN — both are infrastructure failures, not business
+    outcomes. Does **not** raise for a non-zero exit (including auth or
+    rate-limit failures): the caller inspects ``result.returncode``.
+    """
+    return await _run_gated(
+        *cmd,
+        cwd=cwd,
+        gh_token=gh_token,
+        timeout=timeout,
+        runner=runner,
+        extra_env=extra_env,
+        stdin_input=stdin_input,
+        check=False,
+    )
 
 
 _RETRYABLE_PATTERNS = (

--- a/src/trust_fleet_sanity_loop.py
+++ b/src/trust_fleet_sanity_loop.py
@@ -20,8 +20,6 @@ by Plan 6b (§4.11 factory-cost work).
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
 import json
 import logging
 import re
@@ -32,6 +30,7 @@ from typing import TYPE_CHECKING, Any
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from exception_classify import reraise_on_credit_or_bug
 from models import WorkCycleResult
+from subprocess_util import SubprocessTimeoutError, run_subprocess_result
 from trust_fleet_anomaly_detectors import (
     REPAIRED_SUCCESS_KEYS,
     TRUST_LOOP_WORKERS,
@@ -377,24 +376,14 @@ class TrustFleetSanityLoop(BaseBackgroundLoop):
             "number,title",
         ]
         try:
-            proc = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
             try:
-                stdout, _ = await asyncio.wait_for(
-                    proc.communicate(), timeout=_RECONCILE_GH_TIMEOUT_SECONDS
+                result = await run_subprocess_result(
+                    *cmd, timeout=_RECONCILE_GH_TIMEOUT_SECONDS
                 )
-            except TimeoutError:
-                # proc.kill() raises ProcessLookupError if the child already
-                # exited — suppress it so the timeout is handled here instead of
-                # crashing the loop cycle. (#9794/#9816/#9883)
-                with contextlib.suppress(ProcessLookupError):
-                    proc.kill()
+            except SubprocessTimeoutError:
                 logger.warning("open-escalation probe timed out — filing anyway")
                 return 0
-            rows = json.loads(stdout.decode() or "[]")
+            rows = json.loads(result.stdout or "[]")
         except (OSError, ValueError, RuntimeError) as exc:
             reraise_on_credit_or_bug(exc)
             logger.debug("open-escalation probe failed: %s", exc)
@@ -476,25 +465,15 @@ class TrustFleetSanityLoop(BaseBackgroundLoop):
             "title",
         ]
         try:
-            proc = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
             try:
-                stdout, _ = await asyncio.wait_for(
-                    proc.communicate(), timeout=_RECONCILE_GH_TIMEOUT_SECONDS
+                result = await run_subprocess_result(
+                    *cmd, timeout=_RECONCILE_GH_TIMEOUT_SECONDS
                 )
-            except TimeoutError:
-                # Kill the orphaned `gh` and skip this reconcile pass rather
-                # than hang the cycle forever; the next tick retries. A visible
-                # warning (not debug) is deliberate — the original failure was a
-                # *silent* stall that only the dead-man-switch caught (#9410).
-                # proc.kill() raises ProcessLookupError if the child already
-                # exited — suppress it so the timeout is handled here instead of
-                # crashing the loop cycle. (#9794/#9816/#9883)
-                with contextlib.suppress(ProcessLookupError):
-                    proc.kill()
+            except SubprocessTimeoutError:
+                # Skip this reconcile pass rather than hang the cycle forever;
+                # the next tick retries. A visible warning (not debug) is
+                # deliberate — the original failure was a *silent* stall that
+                # only the dead-man-switch caught (#9410).
                 logger.warning(
                     "gh issue list timed out after %ss; skipping reconcile pass",
                     _RECONCILE_GH_TIMEOUT_SECONDS,
@@ -504,10 +483,10 @@ class TrustFleetSanityLoop(BaseBackgroundLoop):
             reraise_on_credit_or_bug(exc)
             logger.debug("gh issue list failed", exc_info=True)
             return
-        if proc.returncode != 0:
+        if result.returncode != 0:
             return
         try:
-            closed = json.loads(stdout.decode() or "[]")
+            closed = json.loads(result.stdout or "[]")
         except json.JSONDecodeError:
             return
         current = self._dedup.get() or set()

--- a/tests/architecture/test_sandbox_seam_completeness.py
+++ b/tests/architecture/test_sandbox_seam_completeness.py
@@ -37,29 +37,40 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 # ENTRIES: a new spawn path must declare a seam in SANDBOX_SEAMS (seed seam,
 # sentinel, injected fake, or config-disable) instead. Remove entries as
 # seams are added — the ratchet only shrinks.
+#
+# #9554/#10028: the sites below that used to key off ``create_subprocess_exec``
+# migrated onto the shared bounded helper (``subprocess_util.run_subprocess``/
+# ``run_subprocess_result``) for circuit-breaker/rate-limit/process-group-registry
+# hardening — a DIFFERENT concern than this guard's air-gap seam. They are
+# still real, undeclared subprocess spawns from the sandbox's point of view,
+# so they stay grandfathered here, just re-keyed to the new primitive name
+# (``run_subprocess_result``, or ``run_subprocess`` for the one raising-variant
+# call site, ``staging_bisect_loop._run_gh``). ``staging_bisect_loop._run_git``
+# is unchanged (excluded from that migration — cooperative kill-switch
+# cancellation) and keeps its original ``create_subprocess_exec`` key.
 GRANDFATHERED_SPAWN_BASELINE: dict[str, int] = {
-    "src/adr_touchpoint_auditor_loop.py::AdrTouchpointAuditorLoop._fetch_pr_changed_files::create_subprocess_exec": 1,
-    "src/adr_touchpoint_auditor_loop.py::AdrTouchpointAuditorLoop._list_recent_merged_prs::create_subprocess_exec": 1,
-    "src/fake_coverage_auditor_loop.py::FakeCoverageAuditorLoop._grep_scenario_for_helper::create_subprocess_exec": 1,
-    "src/fake_coverage_auditor_loop.py::FakeCoverageAuditorLoop._list_open_rollup_titles::create_subprocess_exec": 1,
-    "src/flake_tracker_loop.py::FlakeTrackerLoop._download_junit::create_subprocess_exec": 1,
-    "src/flake_tracker_loop.py::FlakeTrackerLoop._fetch_recent_runs::create_subprocess_exec": 1,
+    "src/adr_touchpoint_auditor_loop.py::AdrTouchpointAuditorLoop._fetch_pr_changed_files::run_subprocess_result": 1,
+    "src/adr_touchpoint_auditor_loop.py::AdrTouchpointAuditorLoop._list_recent_merged_prs::run_subprocess_result": 1,
+    "src/fake_coverage_auditor_loop.py::FakeCoverageAuditorLoop._grep_scenario_for_helper::run_subprocess_result": 1,
+    "src/fake_coverage_auditor_loop.py::FakeCoverageAuditorLoop._list_open_rollup_titles::run_subprocess_result": 1,
+    "src/flake_tracker_loop.py::FlakeTrackerLoop._download_junit::run_subprocess_result": 1,
+    "src/flake_tracker_loop.py::FlakeTrackerLoop._fetch_recent_runs::run_subprocess_result": 1,
     "src/health_monitor_loop.py::HealthMonitorLoop._check_stale_code::run_subprocess": 1,
-    "src/memory_backlog_loop.py::MemoryBacklogLoop._commit_mirror_updates::create_subprocess_exec": 2,
-    "src/principles_audit_loop.py::PrinciplesAuditLoop._run_audit::create_subprocess_exec": 1,
-    "src/principles_audit_loop.py::PrinciplesAuditLoop._run_git::create_subprocess_exec": 1,
-    "src/rc_budget_loop.py::RCBudgetLoop._fetch_job_breakdown::create_subprocess_exec": 1,
-    "src/rc_budget_loop.py::RCBudgetLoop._fetch_junit_tests::create_subprocess_exec": 1,
-    "src/rc_budget_loop.py::RCBudgetLoop._fetch_recent_runs::create_subprocess_exec": 1,
+    "src/memory_backlog_loop.py::MemoryBacklogLoop._commit_mirror_updates::run_subprocess_result": 2,
+    "src/principles_audit_loop.py::PrinciplesAuditLoop._run_audit::run_subprocess_result": 1,
+    "src/principles_audit_loop.py::PrinciplesAuditLoop._run_git::run_subprocess_result": 1,
+    "src/rc_budget_loop.py::RCBudgetLoop._fetch_job_breakdown::run_subprocess_result": 1,
+    "src/rc_budget_loop.py::RCBudgetLoop._fetch_junit_tests::run_subprocess_result": 1,
+    "src/rc_budget_loop.py::RCBudgetLoop._fetch_recent_runs::run_subprocess_result": 1,
     "src/repo_wiki_loop.py::RepoWikiLoop._adopt_open_maintenance_pr::run_subprocess": 1,
     "src/repo_wiki_loop.py::RepoWikiLoop._maintenance_batch_forced_by_age::run_subprocess": 1,
     "src/repo_wiki_loop.py::RepoWikiLoop._poll_and_merge_open_pr::run_subprocess": 3,
-    "src/staging_bisect_loop.py::StagingBisectLoop._run_bisect_probe::create_subprocess_exec": 1,
-    "src/staging_bisect_loop.py::StagingBisectLoop._run_gh::create_subprocess_exec": 1,
+    "src/staging_bisect_loop.py::StagingBisectLoop._run_bisect_probe::run_subprocess_result": 1,
+    "src/staging_bisect_loop.py::StagingBisectLoop._run_gh::run_subprocess": 1,
     "src/staging_bisect_loop.py::StagingBisectLoop._run_git::create_subprocess_exec": 1,
     "src/staging_promotion_loop.py::StagingPromotionLoop._list_merged_promotion_prs::run_subprocess": 1,
-    "src/trust_fleet_sanity_loop.py::TrustFleetSanityLoop._find_open_escalation::create_subprocess_exec": 1,
-    "src/trust_fleet_sanity_loop.py::TrustFleetSanityLoop._reconcile_closed_escalations::create_subprocess_exec": 1,
+    "src/trust_fleet_sanity_loop.py::TrustFleetSanityLoop._find_open_escalation::run_subprocess_result": 1,
+    "src/trust_fleet_sanity_loop.py::TrustFleetSanityLoop._reconcile_closed_escalations::run_subprocess_result": 1,
     "src/workspace_gc_loop.py::WorkspaceGCLoop._collect_orphaned_branches::run_subprocess": 2,
     "src/workspace_gc_loop.py::WorkspaceGCLoop._get_issue_state::run_subprocess": 1,
 }

--- a/tests/regressions/test_issue_9410.py
+++ b/tests/regressions/test_issue_9410.py
@@ -53,10 +53,15 @@ class _HangingProcess:
         # leak; the stub just records that it happened.
         self.killed = True
 
-    async def communicate(self) -> tuple[bytes, bytes]:
+    async def wait(self) -> int:
+        return -9
+
+    async def communicate(self, **_kwargs: object) -> tuple[bytes, bytes]:
         # Model a wedged `gh issue list` — block effectively forever. A bounded
         # caller (the fix) cancels this via its own timeout; the unbounded
         # caller (current code) waits here until the heat death of the universe.
+        # Accepts **kwargs so it also matches HostRunner.run_simple's
+        # communicate(input=...) call shape (#9554/#10028 migration).
         await asyncio.sleep(1_000_000)
         return b"[]", b""
 

--- a/tests/regressions/test_issue_9454.py
+++ b/tests/regressions/test_issue_9454.py
@@ -53,14 +53,22 @@ _REPO = Path(__file__).resolve().parent.parent.parent
 # ``gh`` reconcile read moved behind the PRPort (shared EscalationReconciler),
 # so the module no longer spawns subprocesses at all — same shape as the
 # ``wiki_rot_detector_loop.py`` exclusion above.
+#
+# ``memory_backlog_loop.py``/``adr_touchpoint_auditor_loop.py``/
+# ``rc_budget_loop.py``/``skill_prompt_eval_loop.py``/
+# ``principles_audit_loop.py``/``fake_coverage_auditor_loop.py``/
+# ``flake_tracker_loop.py`` left the list with #9554/#10028: every raw
+# ``asyncio.create_subprocess_exec`` + ``proc.communicate()`` site in these
+# modules migrated onto the shared bounded helper
+# (``subprocess_util.run_subprocess``/``run_subprocess_result``, which owns
+# its own internal, already-hardened ``communicate()`` inside
+# ``execution.HostRunner.run_simple``) — same false-positive shape as the
+# two exclusions above: no direct ``proc.communicate()`` remains to flag.
+# ``staging_bisect_loop.py`` stays: ``_run_git`` (cooperative kill-switch
+# cancellation) is deliberately excluded from that migration and still calls
+# ``proc.communicate()`` directly (bounded via the ``create_task`` +
+# deadline-loop form below).
 _UNHARDENED_COMMUNICATE_MODULES = [
-    "src/memory_backlog_loop.py",
-    "src/adr_touchpoint_auditor_loop.py",
-    "src/rc_budget_loop.py",
-    "src/skill_prompt_eval_loop.py",
-    "src/principles_audit_loop.py",
-    "src/fake_coverage_auditor_loop.py",
-    "src/flake_tracker_loop.py",
     "src/staging_bisect_loop.py",
 ]
 

--- a/tests/regressions/test_issue_9579.py
+++ b/tests/regressions/test_issue_9579.py
@@ -9,32 +9,39 @@ The four heavy-make sites (``skill_prompt_eval_loop``,
 LLM-agent grandchildren re-parented to init (PPID=1) and kept burning API
 credits against an abandoned cycle.
 
-Fix shape (#10017's guarded primitive, no local killpg re-derivation):
+Original fix shape (#10017's guarded primitive, no local killpg
+re-derivation): every heavy spawn passed ``start_new_session=True`` and every
+timeout/cancel reap routed through ``process_group.kill_process_group``
+directly in each loop file.
 
-* every heavy spawn passes ``start_new_session=True`` (child is its own
-  process-group leader, ``pid == pgid``);
-* every timeout/cancel reap routes through
-  ``process_group.kill_process_group`` (guarded: real-int-pid only, mock
-  fakes fall back to child-only ``proc.kill()``, never raises).
+**#9554/#10028 follow-up:** every one of those sites except
+``staging_bisect_loop._run_git`` has since migrated onto the shared bounded
+helper (``subprocess_util.run_subprocess``/``run_subprocess_result``, which
+delegates to ``execution.HostRunner.run_simple``) — the per-file
+``_communicate_bounded`` copies and local raw
+``asyncio.create_subprocess_exec`` + ``start_new_session=True`` +
+``kill_process_group`` triplets are gone. The #9579 guarantee (group-leader
+spawn, group-kill reap on timeout) now lives ONCE in
+``execution.HostRunner.run_simple`` — pinned end-to-end with a real
+subprocess+grandchild by ``tests/regressions/test_hostrunner_reap_grandchildren.py``
+(#9648) — rather than being re-derived per loop. ``staging_bisect_loop._run_git``
+is the sole survivor here: its mid-run ``enabled_cb`` polling for cooperative
+kill-switch cancellation cannot be expressed through the shared helper (see
+``tests/regressions/test_issue_9508.py`` / the #9554 migration notes), so it
+keeps its own local spawn + reap and remains pinned below.
 
-Three layers below:
+Two layers below (for the one surviving raw site):
 
-1. AST pin — the spawn sites carry ``start_new_session=True`` and the reap
-   paths call ``kill_process_group`` (no bare ``proc.kill()`` regression);
-2. behavior pin — the shared ``_communicate_bounded`` helpers invoke the
-   primitive on timeout and still surface ``TimeoutError``;
-3. end-to-end — a REAL child that forks a grandchild into its group is
-   reaped grandchild-and-all by a converted helper.
+1. AST pin — the spawn carries ``start_new_session=True`` and the reap path
+   calls ``kill_process_group`` (no bare ``proc.kill()`` regression);
+2. end-to-end — a REAL child that forks a grandchild into its group is
+   reaped grandchild-and-all.
 """
 
 from __future__ import annotations
 
 import ast
-import asyncio
-import contextlib
-import os
 import sys
-import time
 from pathlib import Path
 
 import pytest
@@ -43,16 +50,12 @@ SRC_DIR = Path(__file__).resolve().parent.parent.parent / "src"
 sys.path.insert(0, str(SRC_DIR))
 
 # (module, function) → every asyncio.create_subprocess_exec inside must
-# carry start_new_session=True. These are the heavy-make / heavy-subtree
-# spawn sites named by #9579 (staging_bisect._run_git runs
-# `git bisect run make bisect-probe`, a per-step make → pytest subtree).
+# carry start_new_session=True. ``staging_bisect_loop._run_git`` is the sole
+# remaining raw heavy spawn (see module docstring) — every other #9579 site
+# migrated onto the shared bounded helper (#9554/#10028) and is pinned
+# instead by each loop's own test file + tests/test_subprocess_util.py +
+# tests/regressions/test_hostrunner_reap_grandchildren.py.
 _HEAVY_SPAWN_SITES = [
-    ("skill_prompt_eval_loop", "_run_corpus"),
-    ("skill_prompt_eval_loop", "_validate_candidate"),
-    ("principles_audit_loop", "_run_audit"),
-    ("principles_audit_loop", "_run_git"),
-    ("contract_refresh_loop", "_run_replay_gate"),
-    ("staging_bisect_loop", "_run_bisect_probe"),
     ("staging_bisect_loop", "_run_git"),
 ]
 
@@ -60,10 +63,6 @@ _HEAVY_SPAWN_SITES = [
 # the guarded primitive (a `kill_process_group(...)` call) and must not
 # fall back to a child-only bare `proc.kill()`.
 _GROUP_REAP_SITES = [
-    ("skill_prompt_eval_loop", "_communicate_bounded"),
-    ("principles_audit_loop", "_communicate_bounded"),
-    ("contract_refresh_loop", "_run_replay_gate"),
-    ("staging_bisect_loop", "_run_bisect_probe"),
     ("staging_bisect_loop", "_run_git"),
 ]
 
@@ -145,121 +144,23 @@ def test_heavy_reap_sites_use_the_guarded_group_primitive(
     )
 
 
-class _HangingProc:
-    """communicate() outlives any test timeout; pid=None keeps the guarded
-    primitive on its child-only fallback if it is ever reached for real
-    (never signal a fabricated pid — mock .pid → killpg(1) kills CI)."""
-
-    returncode: int | None = None
-    pid: None = None
-
-    def __init__(self) -> None:
-        self.killed = False
-
-    async def communicate(self) -> tuple[bytes, bytes]:
-        await asyncio.sleep(30)
-        return (b"", b"")
-
-    def kill(self) -> None:
-        self.killed = True
-
-    async def wait(self) -> int:
-        return -9
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "module_name", ["skill_prompt_eval_loop", "principles_audit_loop"]
-)
-async def test_communicate_bounded_reaps_the_group_on_timeout(
-    monkeypatch: pytest.MonkeyPatch, module_name: str
-) -> None:
-    """On timeout the shared helper must invoke the GROUP primitive exactly
-    once and still surface TimeoutError (the intended failed-read signal)."""
-    module = __import__(module_name)
-    reaped: list[object] = []
-
-    def _record_reap(proc: object) -> None:
-        reaped.append(proc)
-
-    monkeypatch.setattr(module, "kill_process_group", _record_reap)
-    proc = _HangingProc()
-    with pytest.raises(TimeoutError):
-        await module._communicate_bounded(proc, timeout=0.01)
-    assert reaped == [proc], (
-        "timeout must route through process_group.kill_process_group "
-        "(group reap), not a child-only proc.kill()"
-    )
-    assert not proc.killed, (
-        "child-only proc.kill() was called from the loop helper — the group "
-        "primitive owns the fallback decision (#9579)"
-    )
-
-
-_CHILD_SCRIPT = """
-import subprocess, sys, time
-
-# Grandchild joins THIS child's (new) session/process group — the exact
-# shape of make -> pytest under a caretaker loop.
-grandchild = subprocess.Popen(["sleep", "300"])
-with open(sys.argv[1], "w") as fh:
-    fh.write(str(grandchild.pid))
-time.sleep(300)
-"""
-
-
-@pytest.mark.asyncio
-async def test_timed_out_heavy_subtree_reaps_grandchildren(
-    tmp_path: Path,
-) -> None:
-    """End-to-end #9579: a converted helper must kill the GRANDCHILD, not
-    just the direct child, when the heavy subtree times out."""
-    from principles_audit_loop import _communicate_bounded
-
-    pid_file = tmp_path / "grandchild.pid"
-    proc = await asyncio.create_subprocess_exec(
-        sys.executable,
-        "-c",
-        _CHILD_SCRIPT,
-        str(pid_file),
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        start_new_session=True,  # as the production spawn sites now do
-    )
-    grandchild_pid: int | None = None
-    try:
-        deadline = time.monotonic() + 10.0
-        while time.monotonic() < deadline:
-            if pid_file.exists() and pid_file.read_text().strip():
-                grandchild_pid = int(pid_file.read_text().strip())
-                break
-            await asyncio.sleep(0.05)
-        assert grandchild_pid is not None, "child never reported its grandchild pid"
-
-        with pytest.raises(TimeoutError):
-            await _communicate_bounded(proc, timeout=0.2)
-
-        # SIGKILL delivery + init reaping are asynchronous — poll briefly.
-        deadline = time.monotonic() + 5.0
-        grandchild_dead = False
-        while time.monotonic() < deadline:
-            try:
-                os.kill(grandchild_pid, 0)
-            except ProcessLookupError:
-                grandchild_dead = True
-                break
-            await asyncio.sleep(0.1)
-        assert grandchild_dead, (
-            f"grandchild sleep(300) [pid {grandchild_pid}] survived the "
-            "timeout reap — the #9579 orphaned-subtree leak is back"
-        )
-    finally:
-        # Belt-and-braces: never leak the subtree out of the test run.
-        from process_group import kill_process_group
-
-        kill_process_group(proc)
-        if grandchild_pid is not None:
-            with contextlib.suppress(ProcessLookupError, OSError):
-                os.kill(grandchild_pid, 9)
-        with contextlib.suppress(ProcessLookupError, OSError):
-            await proc.wait()
+# --- Behavior + end-to-end pins for the migrated sites ---------------------
+#
+# `skill_prompt_eval_loop`/`principles_audit_loop` no longer define a local
+# `_communicate_bounded` (deleted by #9554/#10028 — they route through
+# `subprocess_util.run_subprocess_result`/`run_subprocess`, which delegates to
+# `execution.HostRunner.run_simple`), so the behavior pin that used to live
+# here (timeout -> exactly one `kill_process_group` call, `TimeoutError`
+# still surfaces) and the end-to-end real-grandchild-reap pin both moved to
+# the shared layer they now depend on:
+#
+# * behavior (non-raising timeout -> SubprocessTimeoutError, gh/git hardening
+#   side effects): tests/test_subprocess_util.py::TestRunSubprocessResult
+# * end-to-end (a REAL child that forks a grandchild is reaped
+#   grandchild-and-all on `run_simple`'s own timeout): #9648 —
+#   tests/regressions/test_hostrunner_reap_grandchildren.py
+#
+# `staging_bisect_loop._run_git` (the one surviving raw site) keeps its own
+# bespoke reap path — pinned by `_HEAVY_SPAWN_SITES`/`_GROUP_REAP_SITES`
+# above plus its dedicated cooperative-cancellation tests in
+# tests/test_staging_bisect_loop.py.

--- a/tests/regressions/test_reap_processlookuperror.py
+++ b/tests/regressions/test_reap_processlookuperror.py
@@ -59,50 +59,23 @@ class _DeadProc:
         return 0
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "module_name,timeout_attr",
-    [
-        ("flake_tracker_loop", "_GH_TIMEOUT_SECONDS"),
-        ("rc_budget_loop", "_GH_TIMEOUT_SECONDS"),
-        ("fake_coverage_auditor_loop", "_SUBPROCESS_TIMEOUT_SECONDS"),
-        ("adr_touchpoint_auditor_loop", "_GH_TIMEOUT_SECONDS"),
-        # #9883: sibling loops that shared the identical unguarded shape.
-        # (corpus_learning_loop was later migrated off raw gh to PRPort in
-        # #9932, so its _communicate_bounded helper no longer exists.)
-        ("memory_backlog_loop", "_SUBPROCESS_TIMEOUT_SECONDS"),
-        # These two take the timeout as a call argument (no module-level attr),
-        # signalled by timeout_attr=None below.
-        ("skill_prompt_eval_loop", None),
-        ("principles_audit_loop", None),
-    ],
-)
-async def test_communicate_bounded_surfaces_timeout_not_processlookup(
-    monkeypatch, module_name, timeout_attr
-):
-    module = __import__(module_name)
-
-    # #9579 moved the heavy-make loops (skill_prompt_eval, principles_audit)
-    # onto process_group.kill_process_group, which group-kills a REAL int pid
-    # via os.killpg. _DeadProc models an already-reaped child, so patch killpg
-    # to raise ProcessLookupError (group already gone) — and never signal a
-    # live pgid that happens to match the fake pid. Harmless for the loops
-    # still on guarded proc.kill(): they never call killpg.
-    def _dead_killpg(_pgid: int, _sig: int) -> None:
-        raise ProcessLookupError()
-
-    monkeypatch.setattr(os, "killpg", _dead_killpg)
-
-    if timeout_attr is None:
-        # ``_communicate_bounded(proc, timeout)`` — timeout is a call arg.
-        coro = module._communicate_bounded(_DeadProc(), timeout=0.01)
-    else:
-        monkeypatch.setattr(module, timeout_attr, 0.01)
-        coro = module._communicate_bounded(_DeadProc())
-    # Must raise TimeoutError (caller treats as failed read), never the
-    # ProcessLookupError from the already-dead child's reap.
-    with pytest.raises(TimeoutError):
-        await coro
+# #9554/#10028: flake_tracker_loop, rc_budget_loop, fake_coverage_auditor_loop,
+# adr_touchpoint_auditor_loop, memory_backlog_loop, skill_prompt_eval_loop and
+# principles_audit_loop each carried a copy-pasted ``_communicate_bounded``
+# helper (the exact behavior this parametrized test pinned) — all seven were
+# deleted when their raw ``asyncio.create_subprocess_exec`` sites migrated
+# onto the shared bounded helper (``subprocess_util.run_subprocess``/
+# ``run_subprocess_result``, which delegates to
+# ``execution.HostRunner.run_simple``). The ProcessLookupError-vs-TimeoutError
+# guarantee those per-file helpers pinned now lives ONCE in
+# ``execution.HostRunner.run_simple`` — pinned immediately below by
+# ``test_host_runner_run_simple_surfaces_timeout_not_processlookup`` — so this
+# parametrized case was removed rather than updated to import a function that
+# no longer exists in any of those modules. ``staging_bisect_loop._run_git``
+# (the sole remaining raw spawn, excluded for cooperative-cancellation
+# reasons) keeps its own inline reap via ``process_group.kill_process_group``,
+# which never raises ProcessLookupError (guarded internally) — nothing left
+# to pin at the loop layer for it either.
 
 
 @pytest.mark.asyncio

--- a/tests/scenarios/test_contract_refresh_scenario.py
+++ b/tests/scenarios/test_contract_refresh_scenario.py
@@ -26,9 +26,10 @@ The loop's external surfaces are handled as follows:
   ``generate`` callback is not invoked while the helper is mocked, so the
   scenario asserts the call kwargs (branch, labels, path_specs, callable
   generate) rather than written cassette bytes.
-* :func:`subprocess.run` (the replay gate) is monkey-patched at the
-  module level for the drift scenario so the loop's
-  ``make trust-contracts`` call does not spawn a real make.
+* :func:`subprocess_util.run_subprocess_result` (the replay gate's shared
+  bounded helper, #9554/#10028) is monkey-patched at the module level for
+  the drift scenario so the loop's ``make trust-contracts`` call does not
+  spawn a real make.
 
 The committed cassette is written under ``config.repo_root / tests /
 trust / contracts / cassettes / git`` so the real
@@ -42,7 +43,6 @@ stays inside the MockWorld's ``tmp_path`` sandbox.
 
 from __future__ import annotations
 
-import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -202,16 +202,25 @@ class TestContractRefreshScenario:
                 pr_url="https://github.com/hydra/hydraflow/pull/42",
             )
 
-        # Replay gate: stub ``subprocess.run`` on the loop's module
-        # so ``make trust-contracts`` does not actually spawn.
+        # Replay gate: stub the shared bounded helper
+        # (``subprocess_util.run_subprocess_result``) on the loop's module so
+        # ``make trust-contracts`` does not actually spawn. The loop's
+        # ``_run_replay_gate`` uses ``asyncio.create_subprocess_exec`` (via
+        # ``run_subprocess_result``, #9554/#10028) — the previous stub here
+        # patched ``subprocess.run``, which the loop never calls, so it was a
+        # no-op and a real ``make trust-contracts`` spawned in-scenario
+        # (#9647).
         import contract_refresh_loop as _module
+        from execution import SimpleResult
 
-        def _fake_run(argv: Any, *_a: Any, **_k: Any) -> subprocess.CompletedProcess:
-            return subprocess.CompletedProcess(
-                args=argv, returncode=0, stdout="OK\n", stderr=""
-            )
+        async def _fake_run_subprocess_result(
+            *_argv: Any, **_kwargs: Any
+        ) -> SimpleResult:
+            return SimpleResult(stdout="OK\n", stderr="", returncode=0)
 
-        monkeypatch.setattr(_module.subprocess, "run", _fake_run)
+        monkeypatch.setattr(
+            _module, "run_subprocess_result", _fake_run_subprocess_result
+        )
 
         _seed_ports(
             world,

--- a/tests/test_adr_touchpoint_auditor_loop.py
+++ b/tests/test_adr_touchpoint_auditor_loop.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -618,3 +619,129 @@ async def test_close_reconcile_clears_dedup(loop_env, monkeypatch) -> None:
     assert "adr_touchpoint_auditor:ADR-0042" in remaining
     state.clear_adr_audit_attempts.assert_called_with(stuck_attempt_key)
     state.clear_adr_rollup.assert_called_with(stuck_attempt_key)
+
+
+# --- #9554/#10028: gh subprocess sites route through run_subprocess_result ---
+
+
+async def test_list_recent_merged_prs_routes_through_bounded_helper(
+    loop_env, monkeypatch
+) -> None:
+    """Success path: parses gh pr list JSON via the shared helper."""
+    from execution import SimpleResult
+
+    cfg, state, pr, dedup, idx = loop_env
+    stop = asyncio.Event()
+    loop = AdrTouchpointAuditorLoop(
+        config=cfg,
+        state=state,
+        pr_manager=pr,
+        dedup=dedup,
+        adr_index=idx,
+        deps=_deps(stop),
+    )
+
+    captured: dict[str, Any] = {}
+
+    async def fake_result(*cmd: str, **kwargs: Any) -> SimpleResult:
+        captured["cmd"] = cmd
+        captured["timeout"] = kwargs.get("timeout")
+        return SimpleResult(
+            stdout='[{"number": 1, "mergedAt": "2026-05-02T00:00:00Z"}]',
+            stderr="",
+            returncode=0,
+        )
+
+    monkeypatch.setattr(
+        "adr_touchpoint_auditor_loop.run_subprocess_result", fake_result
+    )
+
+    prs = await loop._list_recent_merged_prs("2026-05-01T00:00:00Z")
+
+    assert prs == [{"number": 1, "mergedAt": "2026-05-02T00:00:00Z"}]
+    assert captured["cmd"][0] == "gh"
+    assert captured["timeout"] == 120
+
+
+async def test_list_recent_merged_prs_nonzero_returns_empty(
+    loop_env, monkeypatch
+) -> None:
+    """Non-zero exit (never raised by the helper) yields an empty list."""
+    from execution import SimpleResult
+
+    cfg, state, pr, dedup, idx = loop_env
+    stop = asyncio.Event()
+    loop = AdrTouchpointAuditorLoop(
+        config=cfg,
+        state=state,
+        pr_manager=pr,
+        dedup=dedup,
+        adr_index=idx,
+        deps=_deps(stop),
+    )
+
+    async def fake_result(*_cmd: str, **_kwargs: Any) -> SimpleResult:
+        return SimpleResult(stdout="", stderr="rate limited", returncode=1)
+
+    monkeypatch.setattr(
+        "adr_touchpoint_auditor_loop.run_subprocess_result", fake_result
+    )
+
+    assert await loop._list_recent_merged_prs("2026-05-01T00:00:00Z") == []
+
+
+async def test_list_recent_merged_prs_timeout_returns_empty(
+    loop_env, monkeypatch
+) -> None:
+    """A timeout from the shared helper is caught locally and yields []."""
+    from subprocess_util import SubprocessTimeoutError
+
+    cfg, state, pr, dedup, idx = loop_env
+    stop = asyncio.Event()
+    loop = AdrTouchpointAuditorLoop(
+        config=cfg,
+        state=state,
+        pr_manager=pr,
+        dedup=dedup,
+        adr_index=idx,
+        deps=_deps(stop),
+    )
+
+    async def fake_result(*_cmd: str, **_kwargs: Any) -> Any:
+        raise SubprocessTimeoutError("timed out")
+
+    monkeypatch.setattr(
+        "adr_touchpoint_auditor_loop.run_subprocess_result", fake_result
+    )
+
+    assert await loop._list_recent_merged_prs("2026-05-01T00:00:00Z") == []
+
+
+async def test_fetch_pr_changed_files_routes_through_bounded_helper(
+    loop_env, monkeypatch
+) -> None:
+    from execution import SimpleResult
+
+    cfg, state, pr, dedup, idx = loop_env
+    stop = asyncio.Event()
+    loop = AdrTouchpointAuditorLoop(
+        config=cfg,
+        state=state,
+        pr_manager=pr,
+        dedup=dedup,
+        adr_index=idx,
+        deps=_deps(stop),
+    )
+
+    async def fake_result(*_cmd: str, **_kwargs: Any) -> SimpleResult:
+        return SimpleResult(
+            stdout='{"files": [{"path": "src/agent.py"}]}', stderr="", returncode=0
+        )
+
+    monkeypatch.setattr(
+        "adr_touchpoint_auditor_loop.run_subprocess_result", fake_result
+    )
+
+    files = await loop._fetch_pr_changed_files(101)
+
+    assert files == ["src/agent.py"]

--- a/tests/test_contract_refresh_integration.py
+++ b/tests/test_contract_refresh_integration.py
@@ -266,38 +266,28 @@ def _patch_subprocess_run(
 ) -> list[list[str]]:
     """Patch the replay-gate subprocess used by ``_run_replay_gate``.
 
-    G14: ``_run_replay_gate`` is now async (``asyncio.create_subprocess_exec``).
-    The stub returns a fake process whose ``communicate()`` resolves
-    to canned bytes and whose ``returncode`` reads as configured.
+    ``_run_replay_gate`` routes through the shared bounded helper
+    (``subprocess_util.run_subprocess_result``, #9554/#10028) rather than a
+    raw ``asyncio.create_subprocess_exec`` — stub that seam directly so the
+    fake never has to shape-match the real ``HostRunner.run_simple`` call
+    (which always passes ``input=``).
 
     Returns a mutable list the tests can inspect after ``_do_work``
     completes. Every replay-gate call goes through this stub.
     """
+    from execution import SimpleResult
+
     calls: list[list[str]] = []
-    stdout_bytes = b"OK\n" if returncode == 0 else b"FAILED\n"
-    stderr_bytes = stderr.encode()
+    stdout_text = "OK\n" if returncode == 0 else "FAILED\n"
 
-    class _FakeProc:
-        def __init__(self) -> None:
-            self.returncode = returncode
-
-        async def communicate(self) -> tuple[bytes, bytes]:
-            return stdout_bytes, stderr_bytes
-
-        async def wait(self) -> int:
-            return returncode
-
-        def kill(self) -> None:
-            pass
-
-    async def _fake_create_subprocess_exec(*argv: str, **_kwargs: Any) -> _FakeProc:
+    async def _fake_run_subprocess_result(*argv: str, **_kwargs: Any) -> SimpleResult:
         calls.append(list(argv))
-        return _FakeProc()
+        return SimpleResult(stdout=stdout_text, stderr=stderr, returncode=returncode)
 
     monkeypatch.setattr(
-        crl_module.asyncio,
-        "create_subprocess_exec",
-        _fake_create_subprocess_exec,
+        crl_module,
+        "run_subprocess_result",
+        _fake_run_subprocess_result,
     )
     return calls
 

--- a/tests/test_contract_refresh_loop.py
+++ b/tests/test_contract_refresh_loop.py
@@ -200,25 +200,25 @@ def _install_async_subprocess_stub(
     stdout: bytes,
     stderr: bytes,
 ) -> list[list[str]]:
-    class _FakeProc:
-        def __init__(self) -> None:
-            self.returncode = returncode
+    """Stub the replay gate's shared bounded helper (#9554/#10028).
 
-        async def communicate(self) -> tuple[bytes, bytes]:
-            return stdout, stderr
+    ``_run_replay_gate`` routes through ``subprocess_util.run_subprocess_result``
+    rather than a raw ``asyncio.create_subprocess_exec`` — stub that seam
+    directly so the fake never has to shape-match the real
+    ``HostRunner.run_simple`` call (which always passes ``input=``).
+    """
+    from execution import SimpleResult
 
-        async def wait(self) -> int:
-            return returncode
-
-        def kill(self) -> None:
-            pass
-
-    async def _fake_create_subprocess_exec(*argv: str, **_kwargs: Any) -> _FakeProc:
+    async def _fake_run_subprocess_result(*argv: str, **_kwargs: Any) -> SimpleResult:
         calls.append(list(argv))
-        return _FakeProc()
+        return SimpleResult(
+            stdout=stdout.decode(errors="replace"),
+            stderr=stderr.decode(errors="replace"),
+            returncode=returncode,
+        )
 
     monkeypatch.setattr(
-        crl_module.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec
+        crl_module, "run_subprocess_result", _fake_run_subprocess_result
     )
     return calls
 

--- a/tests/test_fake_coverage_auditor_loop.py
+++ b/tests/test_fake_coverage_auditor_loop.py
@@ -1169,3 +1169,123 @@ async def test_grep_helper_uses_stdlib_fallback_when_ripgrep_absent(
     # Present in a unit test → found via the fallback; absent → not found.
     assert await loop._grep_scenario_for_helper("script_ci") is True
     assert await loop._grep_scenario_for_helper("never_called_helper") is False
+
+
+# --- #9554/#10028: rg/gh subprocess sites route through run_subprocess_result ---
+
+
+async def test_grep_scenario_for_helper_timeout_returns_false(
+    loop_env, tmp_path, monkeypatch
+) -> None:
+    """A rg-scan timeout (via the shared helper) is caught locally as no-match."""
+    from subprocess_util import SubprocessTimeoutError
+
+    cfg, state, pr, dedup = loop_env
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir(parents=True)
+    # Force the rg branch regardless of whether ripgrep is on this machine's
+    # PATH — otherwise the stdlib fallback would silently bypass the patched
+    # helper and this test would pass for the wrong reason.
+    monkeypatch.setattr("shutil.which", lambda _name: "/usr/bin/rg")
+
+    async def fake_result(*_cmd: str, **_kwargs: object) -> object:
+        raise SubprocessTimeoutError("timed out")
+
+    monkeypatch.setattr("fake_coverage_auditor_loop.run_subprocess_result", fake_result)
+
+    stop = asyncio.Event()
+    loop = FakeCoverageAuditorLoop(
+        config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=_deps(stop)
+    )
+
+    assert await loop._grep_scenario_for_helper("script_discover") is False
+
+
+async def test_grep_scenario_for_helper_no_match_returns_false(
+    loop_env, tmp_path, monkeypatch
+) -> None:
+    """rg exit=1 (no match, never raised by the shared helper) → False."""
+    from execution import SimpleResult
+
+    cfg, state, pr, dedup = loop_env
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir(parents=True)
+    monkeypatch.setattr("shutil.which", lambda _name: "/usr/bin/rg")
+
+    async def fake_result(*_cmd: str, **_kwargs: object) -> SimpleResult:
+        return SimpleResult(stdout="", stderr="", returncode=1)
+
+    monkeypatch.setattr("fake_coverage_auditor_loop.run_subprocess_result", fake_result)
+
+    stop = asyncio.Event()
+    loop = FakeCoverageAuditorLoop(
+        config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=_deps(stop)
+    )
+
+    assert await loop._grep_scenario_for_helper("script_discover") is False
+
+
+async def test_list_open_rollup_titles_routes_through_bounded_helper(
+    loop_env, monkeypatch
+) -> None:
+    from execution import SimpleResult
+
+    cfg, state, pr, dedup = loop_env
+
+    async def fake_result(*_cmd: str, **_kwargs: object) -> SimpleResult:
+        return SimpleResult(
+            stdout='[{"title": "Fake coverage gap: X adapter surface (1 methods)"}]',
+            stderr="",
+            returncode=0,
+        )
+
+    monkeypatch.setattr("fake_coverage_auditor_loop.run_subprocess_result", fake_result)
+
+    stop = asyncio.Event()
+    loop = FakeCoverageAuditorLoop(
+        config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=_deps(stop)
+    )
+
+    titles = await loop._list_open_rollup_titles()
+
+    assert titles == {"Fake coverage gap: X adapter surface (1 methods)"}
+
+
+async def test_list_open_rollup_titles_nonzero_returns_empty_set(
+    loop_env, monkeypatch
+) -> None:
+    from execution import SimpleResult
+
+    cfg, state, pr, dedup = loop_env
+
+    async def fake_result(*_cmd: str, **_kwargs: object) -> SimpleResult:
+        return SimpleResult(stdout="", stderr="boom", returncode=1)
+
+    monkeypatch.setattr("fake_coverage_auditor_loop.run_subprocess_result", fake_result)
+
+    stop = asyncio.Event()
+    loop = FakeCoverageAuditorLoop(
+        config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=_deps(stop)
+    )
+
+    assert await loop._list_open_rollup_titles() == set()
+
+
+async def test_list_open_rollup_titles_timeout_returns_empty_set(
+    loop_env, monkeypatch
+) -> None:
+    from subprocess_util import SubprocessTimeoutError
+
+    cfg, state, pr, dedup = loop_env
+
+    async def fake_result(*_cmd: str, **_kwargs: object) -> object:
+        raise SubprocessTimeoutError("timed out")
+
+    monkeypatch.setattr("fake_coverage_auditor_loop.run_subprocess_result", fake_result)
+
+    stop = asyncio.Event()
+    loop = FakeCoverageAuditorLoop(
+        config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=_deps(stop)
+    )
+
+    assert await loop._list_open_rollup_titles() == set()

--- a/tests/test_flake_tracker_loop.py
+++ b/tests/test_flake_tracker_loop.py
@@ -439,35 +439,45 @@ async def test_download_junit_missing_database_id_explicit_none(loop_env) -> Non
 
 async def test_download_junit_gh_failure_returns_empty(loop_env, monkeypatch) -> None:
     """Non-zero returncode from gh run download → {} (artifact not present)."""
+    from execution import SimpleResult
+
     loop = _make_loop(loop_env)
 
-    class _FailProc:
-        returncode = 1
+    async def fake_result(*_cmd: str, **_kwargs: object) -> SimpleResult:
+        return SimpleResult(
+            stdout="", stderr="no artifact named junit-scenario", returncode=1
+        )
 
-        async def communicate(self):
-            return b"", b"no artifact named junit-scenario"
-
-    monkeypatch.setattr(
-        asyncio, "create_subprocess_exec", AsyncMock(return_value=_FailProc())
-    )
+    monkeypatch.setattr("flake_tracker_loop.run_subprocess_result", fake_result)
     result = await loop._download_junit({"databaseId": 99})
+    assert result == {}
+
+
+async def test_download_junit_timeout_returns_empty(loop_env, monkeypatch) -> None:
+    """A gh-download timeout (SubprocessTimeoutError) is caught locally as {}."""
+    from subprocess_util import SubprocessTimeoutError
+
+    loop = _make_loop(loop_env)
+
+    async def fake_result(*_cmd: str, **_kwargs: object) -> object:
+        raise SubprocessTimeoutError("timed out")
+
+    monkeypatch.setattr("flake_tracker_loop.run_subprocess_result", fake_result)
+    result = await loop._download_junit({"databaseId": 100})
     assert result == {}
 
 
 async def test_download_junit_no_xml_files_returns_empty(loop_env, monkeypatch) -> None:
     """gh succeeds but writes no *.xml files → {}."""
+    from execution import SimpleResult
+
     loop = _make_loop(loop_env)
 
-    class _OkProc:
-        returncode = 0
-
-        async def communicate(self):
-            return b"", b""
-
     # The subprocess writes nothing; the temp dir remains empty.
-    monkeypatch.setattr(
-        asyncio, "create_subprocess_exec", AsyncMock(return_value=_OkProc())
-    )
+    async def fake_result(*_cmd: str, **_kwargs: object) -> SimpleResult:
+        return SimpleResult(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr("flake_tracker_loop.run_subprocess_result", fake_result)
     result = await loop._download_junit({"databaseId": 7})
     assert result == {}
 
@@ -476,25 +486,17 @@ async def test_download_junit_valid_xml_returns_parsed_results(
     loop_env, monkeypatch
 ) -> None:
     """gh succeeds and writes a valid JUnit XML → parsed pass/fail dict."""
+    from execution import SimpleResult
+
     loop = _make_loop(loop_env)
-    captured_dir: list[str] = []
 
-    class _OkProc:
-        returncode = 0
-
-        async def communicate(self):
-            # Plant the XML in the directory that the loop passed via --dir.
-            (Path(captured_dir[0]) / "results.xml").write_bytes(_GOOD_XML)
-            return b"", b""
-
-    async def _fake_exec(*args, **kwargs):
-        # args[0] is the full command list; --dir <path> is the last two elements.
-        cmd = list(args)
+    async def fake_result(*cmd: str, **_kwargs: object) -> SimpleResult:
+        # Plant the XML in the directory the loop passed via --dir.
         dir_idx = cmd.index("--dir")
-        captured_dir.append(cmd[dir_idx + 1])
-        return _OkProc()
+        (Path(cmd[dir_idx + 1]) / "results.xml").write_bytes(_GOOD_XML)
+        return SimpleResult(stdout="", stderr="", returncode=0)
 
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+    monkeypatch.setattr("flake_tracker_loop.run_subprocess_result", fake_result)
     result = await loop._download_junit({"databaseId": 42})
     assert result == {
         "tests.a.test_one": "pass",
@@ -504,25 +506,18 @@ async def test_download_junit_valid_xml_returns_parsed_results(
 
 async def test_download_junit_malformed_xml_skipped(loop_env, monkeypatch) -> None:
     """ET.ParseError on a single file → that file is skipped; valid files still parsed."""
+    from execution import SimpleResult
+
     loop = _make_loop(loop_env)
-    captured_dir: list[str] = []
 
-    class _OkProc:
-        returncode = 0
-
-        async def communicate(self):
-            d = Path(captured_dir[0])
-            (d / "bad.xml").write_bytes(b"<<< not xml >>>")
-            (d / "good.xml").write_bytes(_GOOD_XML)
-            return b"", b""
-
-    async def _fake_exec(*args, **kwargs):
-        cmd = list(args)
+    async def fake_result(*cmd: str, **_kwargs: object) -> SimpleResult:
         dir_idx = cmd.index("--dir")
-        captured_dir.append(cmd[dir_idx + 1])
-        return _OkProc()
+        d = Path(cmd[dir_idx + 1])
+        (d / "bad.xml").write_bytes(b"<<< not xml >>>")
+        (d / "good.xml").write_bytes(_GOOD_XML)
+        return SimpleResult(stdout="", stderr="", returncode=0)
 
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+    monkeypatch.setattr("flake_tracker_loop.run_subprocess_result", fake_result)
     result = await loop._download_junit({"databaseId": 5})
     # bad.xml triggers ET.ParseError → skipped; good.xml is parsed normally.
     assert "tests.a.test_one" in result
@@ -531,8 +526,9 @@ async def test_download_junit_malformed_xml_skipped(loop_env, monkeypatch) -> No
 
 async def test_download_junit_multiple_xml_files_merged(loop_env, monkeypatch) -> None:
     """Multiple *.xml files in the artifact dir → results merged into one dict."""
+    from execution import SimpleResult
+
     loop = _make_loop(loop_env)
-    captured_dir: list[str] = []
 
     second_xml = b"""<?xml version="1.0" encoding="utf-8"?>
 <testsuites>
@@ -544,22 +540,14 @@ async def test_download_junit_multiple_xml_files_merged(loop_env, monkeypatch) -
 </testsuites>
 """
 
-    class _OkProc:
-        returncode = 0
-
-        async def communicate(self):
-            d = Path(captured_dir[0])
-            (d / "first.xml").write_bytes(_GOOD_XML)
-            (d / "second.xml").write_bytes(second_xml)
-            return b"", b""
-
-    async def _fake_exec(*args, **kwargs):
-        cmd = list(args)
+    async def fake_result(*cmd: str, **_kwargs: object) -> SimpleResult:
         dir_idx = cmd.index("--dir")
-        captured_dir.append(cmd[dir_idx + 1])
-        return _OkProc()
+        d = Path(cmd[dir_idx + 1])
+        (d / "first.xml").write_bytes(_GOOD_XML)
+        (d / "second.xml").write_bytes(second_xml)
+        return SimpleResult(stdout="", stderr="", returncode=0)
 
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+    monkeypatch.setattr("flake_tracker_loop.run_subprocess_result", fake_result)
     result = await loop._download_junit({"databaseId": 13})
     assert result["tests.a.test_one"] == "pass"
     assert result["tests.a.test_two"] == "fail"
@@ -570,26 +558,68 @@ async def test_download_junit_only_malformed_xml_returns_empty(
     loop_env, monkeypatch
 ) -> None:
     """All XML files malformed → {} (every file triggers ET.ParseError and is skipped)."""
+    from execution import SimpleResult
+
     loop = _make_loop(loop_env)
-    captured_dir: list[str] = []
 
-    class _OkProc:
-        returncode = 0
-
-        async def communicate(self):
-            d = Path(captured_dir[0])
-            (d / "broken.xml").write_bytes(b"<not><valid xml")
-            return b"", b""
-
-    async def _fake_exec(*args, **kwargs):
-        cmd = list(args)
+    async def fake_result(*cmd: str, **_kwargs: object) -> SimpleResult:
         dir_idx = cmd.index("--dir")
-        captured_dir.append(cmd[dir_idx + 1])
-        return _OkProc()
+        d = Path(cmd[dir_idx + 1])
+        (d / "broken.xml").write_bytes(b"<not><valid xml")
+        return SimpleResult(stdout="", stderr="", returncode=0)
 
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+    monkeypatch.setattr("flake_tracker_loop.run_subprocess_result", fake_result)
     result = await loop._download_junit({"databaseId": 3})
     assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# _fetch_recent_runs — unit tests (#9554/#10028: routes through the shared
+# bounded helper instead of a raw create_subprocess_exec)
+# ---------------------------------------------------------------------------
+
+
+async def test_fetch_recent_runs_success_parses_json(loop_env, monkeypatch) -> None:
+    from execution import SimpleResult
+
+    loop = _make_loop(loop_env)
+
+    async def fake_result(*cmd: str, **kwargs: object) -> SimpleResult:
+        assert cmd[0] == "gh"
+        assert kwargs["timeout"] == 120
+        return SimpleResult(
+            stdout='[{"databaseId": 1, "conclusion": "success"}]',
+            stderr="",
+            returncode=0,
+        )
+
+    monkeypatch.setattr("flake_tracker_loop.run_subprocess_result", fake_result)
+    result = await loop._fetch_recent_runs()
+    assert result == [{"databaseId": 1, "conclusion": "success"}]
+
+
+async def test_fetch_recent_runs_nonzero_returns_empty(loop_env, monkeypatch) -> None:
+    from execution import SimpleResult
+
+    loop = _make_loop(loop_env)
+
+    async def fake_result(*_cmd: str, **_kwargs: object) -> SimpleResult:
+        return SimpleResult(stdout="", stderr="rate limited", returncode=1)
+
+    monkeypatch.setattr("flake_tracker_loop.run_subprocess_result", fake_result)
+    assert await loop._fetch_recent_runs() == []
+
+
+async def test_fetch_recent_runs_timeout_returns_empty(loop_env, monkeypatch) -> None:
+    from subprocess_util import SubprocessTimeoutError
+
+    loop = _make_loop(loop_env)
+
+    async def fake_result(*_cmd: str, **_kwargs: object) -> object:
+        raise SubprocessTimeoutError("timed out")
+
+    monkeypatch.setattr("flake_tracker_loop.run_subprocess_result", fake_result)
+    assert await loop._fetch_recent_runs() == []
 
 
 async def test_reconcile_open_round_trips_spaced_test_id(loop_env) -> None:

--- a/tests/test_memory_backlog_loop.py
+++ b/tests/test_memory_backlog_loop.py
@@ -268,6 +268,50 @@ async def test_filing_commits_frontmatter_to_git(env) -> None:
 
 
 @pytest.mark.asyncio
+async def test_commit_mirror_updates_git_add_failure_skips_commit(
+    env, monkeypatch
+) -> None:
+    """git add failure (via the shared helper) logs + returns without
+    attempting the commit — never raises, never calls git commit."""
+    from execution import SimpleResult
+
+    cfg, *_ = env
+    loop = _make_loop(env)
+
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_result(*cmd: str, **_kwargs: object) -> SimpleResult:
+        calls.append(cmd)
+        return SimpleResult(
+            stdout="", stderr="fatal: not a git repository", returncode=128
+        )
+
+    monkeypatch.setattr("memory_backlog_loop.run_subprocess_result", fake_result)
+
+    await loop._commit_mirror_updates([1])
+
+    assert len(calls) == 1  # git add attempted; commit never reached
+    assert calls[0][:2] == ("git", "-C")
+
+
+@pytest.mark.asyncio
+async def test_commit_mirror_updates_timeout_returns_quietly(env, monkeypatch) -> None:
+    """A git-add timeout (SubprocessTimeoutError from the shared helper) is
+    caught locally and does not propagate out of the loop cycle."""
+    from subprocess_util import SubprocessTimeoutError
+
+    cfg, *_ = env
+    loop = _make_loop(env)
+
+    async def fake_result(*_cmd: str, **_kwargs: object) -> object:
+        raise SubprocessTimeoutError("timed out")
+
+    monkeypatch.setattr("memory_backlog_loop.run_subprocess_result", fake_result)
+
+    await loop._commit_mirror_updates([1])  # must not raise
+
+
+@pytest.mark.asyncio
 async def test_no_commit_when_nothing_filed(env) -> None:
     """Tick that filed zero issues should NOT make a git commit."""
     _, _, pr, dedup, mirror_dir = env

--- a/tests/test_principles_audit_loop.py
+++ b/tests/test_principles_audit_loop.py
@@ -350,16 +350,12 @@ async def test_run_audit_emits_subprocess_trace(loop_env, monkeypatch, tmp_path)
 
     monkeypatch.setattr(trace_collector, "emit_loop_subprocess_trace", fake_emit)
 
-    class FakeProc:
-        returncode = 0
+    from execution import SimpleResult
 
-        async def communicate(self):
-            return (b'{"findings": []}', b"")
+    async def fake_result(*_cmd: str, **_kwargs: object) -> SimpleResult:
+        return SimpleResult(stdout='{"findings": []}', stderr="", returncode=0)
 
-    async def fake_subproc(*args, **kwargs):
-        return FakeProc()
-
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subproc)
+    monkeypatch.setattr("principles_audit_loop.run_subprocess_result", fake_result)
 
     await loop._run_audit("hydraflow-self", tmp_path)
 
@@ -385,16 +381,12 @@ async def test_run_audit_emits_trace_on_nonzero_exit(loop_env, monkeypatch, tmp_
         lambda **kw: emitted.append(kw),
     )
 
-    class FakeProc:
-        returncode = 2
+    from execution import SimpleResult
 
-        async def communicate(self):
-            return (b'{"findings": []}', b"boom")
+    async def fake_result(*_cmd: str, **_kwargs: object) -> SimpleResult:
+        return SimpleResult(stdout='{"findings": []}', stderr="boom", returncode=2)
 
-    async def fake_subproc(*args, **kwargs):
-        return FakeProc()
-
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subproc)
+    monkeypatch.setattr("principles_audit_loop.run_subprocess_result", fake_result)
 
     await loop._run_audit("hydraflow-self", tmp_path)
 
@@ -418,16 +410,12 @@ async def test_run_git_emits_subprocess_trace(loop_env, monkeypatch, tmp_path):
         lambda **kw: emitted.append(kw),
     )
 
-    class FakeProc:
-        returncode = 0
+    from execution import SimpleResult
 
-        async def communicate(self):
-            return (b"ok", b"")
+    async def fake_result(*_cmd: str, **_kwargs: object) -> SimpleResult:
+        return SimpleResult(stdout="ok", stderr="", returncode=0)
 
-    async def fake_subproc(*args, **kwargs):
-        return FakeProc()
-
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subproc)
+    monkeypatch.setattr("principles_audit_loop.run_subprocess_result", fake_result)
 
     code, out = await loop._run_git("fetch", "--depth", "1", "origin", "main")
 
@@ -436,6 +424,81 @@ async def test_run_git_emits_subprocess_trace(loop_env, monkeypatch, tmp_path):
     assert emitted[0]["loop"] == "principles_audit"
     assert emitted[0]["command"][0] == "git"
     assert "fetch" in emitted[0]["command"]
+
+
+# --- #9554/#10028: _run_audit/_run_git route through run_subprocess_result ---
+
+
+async def test_run_audit_timeout_raises_runtime_error(
+    loop_env, monkeypatch, tmp_path
+) -> None:
+    """A SubprocessTimeoutError from the shared helper surfaces as a
+    RuntimeError with exit_code=124 traced (matching prior TimeoutError
+    handling)."""
+    from subprocess_util import SubprocessTimeoutError
+
+    cfg, state, pr = loop_env
+    stop = asyncio.Event()
+    loop = PrinciplesAuditLoop(config=cfg, state=state, pr_manager=pr, deps=_deps(stop))
+
+    import trace_collector
+
+    emitted: list[dict] = []
+    monkeypatch.setattr(
+        trace_collector,
+        "emit_loop_subprocess_trace",
+        lambda **kw: emitted.append(kw),
+    )
+
+    async def fake_result(*_cmd: str, **_kwargs: object) -> object:
+        raise SubprocessTimeoutError("timed out")
+
+    monkeypatch.setattr("principles_audit_loop.run_subprocess_result", fake_result)
+
+    with pytest.raises(RuntimeError, match="timed out"):
+        await loop._run_audit("hydraflow-self", tmp_path)
+
+    assert emitted[0]["exit_code"] == 124
+
+
+async def test_run_git_timeout_raises_runtime_error(
+    loop_env, monkeypatch, tmp_path
+) -> None:
+    from subprocess_util import SubprocessTimeoutError
+
+    cfg, state, pr = loop_env
+    stop = asyncio.Event()
+    loop = PrinciplesAuditLoop(config=cfg, state=state, pr_manager=pr, deps=_deps(stop))
+
+    async def fake_result(*_cmd: str, **_kwargs: object) -> object:
+        raise SubprocessTimeoutError("timed out")
+
+    monkeypatch.setattr("principles_audit_loop.run_subprocess_result", fake_result)
+
+    with pytest.raises(RuntimeError, match="timed out"):
+        await loop._run_git("fetch", "--depth", "1", "origin", "main")
+
+
+async def test_run_git_combines_stdout_and_stderr(
+    loop_env, monkeypatch, tmp_path
+) -> None:
+    """Both stdout and stderr text land in the combined-output contract."""
+    from execution import SimpleResult
+
+    cfg, state, pr = loop_env
+    stop = asyncio.Event()
+    loop = PrinciplesAuditLoop(config=cfg, state=state, pr_manager=pr, deps=_deps(stop))
+
+    async def fake_result(*_cmd: str, **_kwargs: object) -> SimpleResult:
+        return SimpleResult(stdout="some output", stderr="a warning", returncode=1)
+
+    monkeypatch.setattr("principles_audit_loop.run_subprocess_result", fake_result)
+
+    code, out = await loop._run_git("fetch", cwd=tmp_path)
+
+    assert code == 1
+    assert "some output" in out
+    assert "a warning" in out
 
 
 async def test_no_emission_when_loop_disabled(loop_env, monkeypatch, tmp_path):

--- a/tests/test_rc_budget_loop.py
+++ b/tests/test_rc_budget_loop.py
@@ -250,6 +250,38 @@ async def test_reconcile_closed_escalations_clears_dedup(loop_env, monkeypatch) 
     state.clear_rc_budget_attempts.assert_called_once_with("median")
 
 
+async def test_fetch_recent_runs_nonzero_returns_empty(
+    loop_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """gh run list exit!=0 (never raised by the shared helper) → []."""
+    from execution import SimpleResult
+
+    loop = _loop(loop_env)
+
+    async def fake_result(*_cmd: str, **_kwargs: object) -> SimpleResult:
+        return SimpleResult(stdout="", stderr="boom", returncode=1)
+
+    monkeypatch.setattr("rc_budget_loop.run_subprocess_result", fake_result)
+
+    assert await loop._fetch_recent_runs() == []
+
+
+async def test_fetch_recent_runs_timeout_returns_empty(
+    loop_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A gh timeout (SubprocessTimeoutError) is caught locally as []."""
+    from subprocess_util import SubprocessTimeoutError
+
+    loop = _loop(loop_env)
+
+    async def fake_result(*_cmd: str, **_kwargs: object) -> object:
+        raise SubprocessTimeoutError("timed out")
+
+    monkeypatch.setattr("rc_budget_loop.run_subprocess_result", fake_result)
+
+    assert await loop._fetch_recent_runs() == []
+
+
 async def test_fetch_job_breakdown_sorts_and_caps_slowest_jobs(
     loop_env, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -263,17 +295,13 @@ async def test_fetch_job_breakdown_sorts_and_caps_slowest_jobs(
         for idx in range(1, 13)
     ]
 
-    class _Proc:
-        returncode = 0
+    from execution import SimpleResult
 
-        async def communicate(self):
-            return (json.dumps({"jobs": jobs}).encode(), b"")
+    async def fake_result(*cmd: str, **_kwargs: object) -> SimpleResult:
+        assert cmd[:4] == ("gh", "run", "view", "123")
+        return SimpleResult(stdout=json.dumps({"jobs": jobs}), stderr="", returncode=0)
 
-    async def fake_subproc(*args, **kwargs):
-        assert args[:4] == ("gh", "run", "view", "123")
-        return _Proc()
-
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subproc)
+    monkeypatch.setattr("rc_budget_loop.run_subprocess_result", fake_result)
 
     result = await loop._fetch_job_breakdown({"databaseId": 123})
 
@@ -287,24 +315,20 @@ async def test_fetch_junit_tests_parses_and_caps_slowest_tests(
 ) -> None:
     loop = _loop(loop_env)
 
-    class _Proc:
-        returncode = 0
+    from execution import SimpleResult
 
-        async def communicate(self):
-            return (b"", b"")
-
-    async def fake_subproc(*args, **kwargs):
-        assert args[:4] == ("gh", "run", "download", "123")
-        out_dir = Path(args[args.index("--dir") + 1])
+    async def fake_result(*cmd: str, **_kwargs: object) -> SimpleResult:
+        assert cmd[:4] == ("gh", "run", "download", "123")
+        out_dir = Path(cmd[cmd.index("--dir") + 1])
         out_dir.mkdir(parents=True, exist_ok=True)
         cases = "\n".join(
             f'<testcase classname="pkg.TestSuite" name="test_{idx}" time="{idx / 10}" />'
             for idx in range(1, 13)
         )
         (out_dir / "junit.xml").write_text(f"<testsuite>{cases}</testsuite>")
-        return _Proc()
+        return SimpleResult(stdout="", stderr="", returncode=0)
 
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subproc)
+    monkeypatch.setattr("rc_budget_loop.run_subprocess_result", fake_result)
 
     result = await loop._fetch_junit_tests({"databaseId": 123})
 

--- a/tests/test_staging_bisect_loop.py
+++ b/tests/test_staging_bisect_loop.py
@@ -1342,3 +1342,134 @@ class TestG10RetryLineageWiring:
         # past cap.
         all_labels = [c.args[2] for c in prs.create_issue.await_args_list]
         assert all("hitl-escalation" not in lbls for lbls in all_labels)
+
+
+# ---------------------------------------------------------------------------
+# _run_bisect_probe / _run_gh — #9554/#10028: route through the shared
+# bounded helper instead of a raw create_subprocess_exec. (_run_git is
+# deliberately EXCLUDED from this migration — its mid-run enabled_cb polling
+# for cooperative kill-switch cancellation cannot be expressed through the
+# shared helper.)
+# ---------------------------------------------------------------------------
+
+
+async def test_run_bisect_probe_success_returns_true(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from execution import SimpleResult
+
+    loop, _prs, _state = _make_loop(tmp_path, monkeypatch)
+
+    async def fake_result(*cmd: str, **_kwargs: object) -> SimpleResult:
+        assert cmd == ("make", "bisect-probe")
+        return SimpleResult(stdout="all green", stderr="", returncode=0)
+
+    monkeypatch.setattr("staging_bisect_loop.run_subprocess_result", fake_result)
+
+    passed, output = await loop._run_bisect_probe("red123")  # type: ignore[attr-defined]
+
+    assert passed is True
+    assert "all green" in output
+
+
+async def test_run_bisect_probe_nonzero_returns_false(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from execution import SimpleResult
+
+    loop, _prs, _state = _make_loop(tmp_path, monkeypatch)
+
+    async def fake_result(*_cmd: str, **_kwargs: object) -> SimpleResult:
+        return SimpleResult(stdout="", stderr="test_foo failed", returncode=1)
+
+    monkeypatch.setattr("staging_bisect_loop.run_subprocess_result", fake_result)
+
+    passed, output = await loop._run_bisect_probe("red123")  # type: ignore[attr-defined]
+
+    assert passed is False
+    assert "test_foo failed" in output
+
+
+async def test_run_bisect_probe_timeout_returns_false(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The shared helper group-kills the whole make -> pytest subtree on
+    timeout (#9579); this method just surfaces the failure."""
+    from subprocess_util import SubprocessTimeoutError
+
+    loop, _prs, _state = _make_loop(tmp_path, monkeypatch)
+
+    async def fake_result(*_cmd: str, **_kwargs: object) -> object:
+        raise SubprocessTimeoutError("timed out")
+
+    monkeypatch.setattr("staging_bisect_loop.run_subprocess_result", fake_result)
+
+    passed, output = await loop._run_bisect_probe("red123")  # type: ignore[attr-defined]
+
+    assert passed is False
+    assert "timed out" in output
+
+
+async def test_run_bisect_probe_exec_failure_returns_false(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """make not found (FileNotFoundError, an OSError) -> probe failure."""
+    loop, _prs, _state = _make_loop(tmp_path, monkeypatch)
+
+    async def fake_result(*_cmd: str, **_kwargs: object) -> object:
+        raise FileNotFoundError("make: not found")
+
+    monkeypatch.setattr("staging_bisect_loop.run_subprocess_result", fake_result)
+
+    passed, output = await loop._run_bisect_probe("red123")  # type: ignore[attr-defined]
+
+    assert passed is False
+    assert "exec failed" in output
+
+
+async def test_run_gh_success_returns_stdout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    loop, _prs, _state = _make_loop(tmp_path, monkeypatch)
+
+    async def fake_run_subprocess(*cmd: str, **_kwargs: object) -> str:
+        assert cmd[0] == "gh"
+        return "https://github.com/x/y/pull/42"
+
+    monkeypatch.setattr("staging_bisect_loop.run_subprocess", fake_run_subprocess)
+
+    out = await loop._run_gh(["gh", "pr", "create"])  # type: ignore[attr-defined]
+
+    assert out == "https://github.com/x/y/pull/42"
+
+
+async def test_run_gh_nonzero_raises_runtime_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-zero gh exit (never raised by run_subprocess_result — but
+    run_subprocess IS raising) surfaces as RuntimeError."""
+    loop, _prs, _state = _make_loop(tmp_path, monkeypatch)
+
+    async def fake_run_subprocess(*_cmd: str, **_kwargs: object) -> str:
+        raise RuntimeError("Command ('gh', 'pr', 'create') failed (rc=1): boom")
+
+    monkeypatch.setattr("staging_bisect_loop.run_subprocess", fake_run_subprocess)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await loop._run_gh(["gh", "pr", "create"])  # type: ignore[attr-defined]
+
+
+async def test_run_gh_timeout_raises_runtime_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from subprocess_util import SubprocessTimeoutError
+
+    loop, _prs, _state = _make_loop(tmp_path, monkeypatch)
+
+    async def fake_run_subprocess(*_cmd: str, **_kwargs: object) -> str:
+        raise SubprocessTimeoutError("timed out")
+
+    monkeypatch.setattr("staging_bisect_loop.run_subprocess", fake_run_subprocess)
+
+    with pytest.raises(RuntimeError, match="gh timed out"):
+        await loop._run_gh(["gh", "pr", "create"])  # type: ignore[attr-defined]

--- a/tests/test_subprocess_util.py
+++ b/tests/test_subprocess_util.py
@@ -1179,8 +1179,219 @@ class TestGhCircuitBreaker:
 
 
 # ---------------------------------------------------------------------------
-# Credit exhaustion detection — Anthropic API spend-cap rejections
+# run_subprocess_result — non-raising, returncode-exposing sibling (#9554)
 # ---------------------------------------------------------------------------
+
+
+class TestRunSubprocessResult:
+    @pytest.fixture(autouse=True)
+    def _reset_state(self) -> None:
+        import subprocess_util
+
+        subprocess_util._gh_semaphore = None
+        subprocess_util._rate_limit_until = None
+        subprocess_util._gh_circuit_breaker = None
+        subprocess_util._gh_circuit_breaker_enabled = False
+
+    @staticmethod
+    def _runner(stderr: str = "", returncode: int = 0, stdout: str = "done"):
+        async def _run(cmd: list[str], **_kwargs: object) -> SimpleResult:
+            return SimpleResult(stdout=stdout, stderr=stderr, returncode=returncode)
+
+        runner = MagicMock()
+        runner.run_simple = _run
+        return runner
+
+    @pytest.mark.asyncio
+    async def test_success_returns_simple_result(self) -> None:
+        from subprocess_util import run_subprocess_result
+
+        result = await run_subprocess_result(
+            "echo", "hi", runner=self._runner(stdout="hello world")
+        )
+
+        assert result.returncode == 0
+        assert result.stdout == "hello world"
+
+    @pytest.mark.asyncio
+    async def test_nonzero_exit_is_returned_not_raised(self) -> None:
+        """The defining difference from run_subprocess: no RuntimeError."""
+        from subprocess_util import run_subprocess_result
+
+        result = await run_subprocess_result(
+            "false", runner=self._runner(returncode=1, stderr="boom")
+        )
+
+        assert result.returncode == 1
+        assert result.stderr == "boom"
+
+    @pytest.mark.asyncio
+    async def test_auth_failure_is_returned_not_raised(self) -> None:
+        """Unlike run_subprocess, an auth-pattern stderr does not raise either —
+        callers of the result variant branch on returncode uniformly."""
+        from subprocess_util import run_subprocess_result
+
+        result = await run_subprocess_result(
+            "gh",
+            "api",
+            runner=self._runner(returncode=1, stderr="Authentication required"),
+        )
+
+        assert result.returncode == 1
+
+    @pytest.mark.asyncio
+    async def test_timeout_raises_subprocess_timeout_error(self) -> None:
+        from subprocess_util import SubprocessTimeoutError, run_subprocess_result
+
+        async def _timeout(cmd: list[str], **_kwargs: object) -> SimpleResult:
+            raise TimeoutError
+
+        runner = MagicMock()
+        runner.run_simple = _timeout
+
+        with pytest.raises(SubprocessTimeoutError):
+            await run_subprocess_result("gh", "api", timeout=0.01, runner=runner)
+
+    @pytest.mark.asyncio
+    async def test_breaker_open_raises_circuit_breaker_open_error(self) -> None:
+        from subprocess_util import (
+            CircuitBreakerOpenError,
+            configure_gh_circuit_breaker,
+            run_subprocess_result,
+        )
+
+        configure_gh_concurrency(5)
+        configure_gh_circuit_breaker(enabled=True, max_failures=1, reset_timeout=60.0)
+        fail = self._runner(stderr="fatal: unable to access (HTTP 500)", returncode=1)
+        result = await run_subprocess_result("gh", "api", "x", runner=fail)
+        assert result.returncode == 1
+
+        with pytest.raises(CircuitBreakerOpenError):
+            await run_subprocess_result("gh", "api", "x", runner=fail)
+
+    @pytest.mark.asyncio
+    async def test_gh_outage_error_records_breaker_failure(self) -> None:
+        import subprocess_util
+        from subprocess_util import configure_gh_circuit_breaker, run_subprocess_result
+
+        configure_gh_concurrency(5)
+        configure_gh_circuit_breaker(enabled=True, max_failures=5, reset_timeout=60.0)
+        result = await run_subprocess_result(
+            "gh",
+            "api",
+            "x",
+            runner=self._runner(stderr="HTTP 503 Service Unavailable", returncode=1),
+        )
+
+        assert result.returncode == 1
+        assert subprocess_util._gh_circuit_breaker._failure_count == 1
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_triggers_cooldown_without_raising(self) -> None:
+        import subprocess_util
+        from subprocess_util import run_subprocess_result
+
+        configure_gh_concurrency(5)
+        result = await run_subprocess_result(
+            "gh",
+            "api",
+            "x",
+            runner=self._runner(
+                stderr="API rate limit exceeded (HTTP 403)", returncode=1
+            ),
+        )
+
+        assert result.returncode == 1
+        assert subprocess_util._rate_limit_until is not None
+
+    @pytest.mark.asyncio
+    async def test_success_resets_backoff_and_records_breaker_success(self) -> None:
+        import subprocess_util
+        from subprocess_util import configure_gh_circuit_breaker, run_subprocess_result
+
+        configure_gh_concurrency(5)
+        configure_gh_circuit_breaker(enabled=True, max_failures=5, reset_timeout=60.0)
+        subprocess_util._rate_limit_current_cooldown = 240
+
+        result = await run_subprocess_result("gh", "api", "x", runner=self._runner())
+
+        assert result.returncode == 0
+        assert subprocess_util._rate_limit_current_cooldown == 60
+        assert subprocess_util._gh_circuit_breaker.state == "closed"
+
+    @pytest.mark.asyncio
+    async def test_extra_env_merged_over_clean_env(self) -> None:
+        from subprocess_util import run_subprocess_result
+
+        captured: dict[str, object] = {}
+
+        async def _run(cmd: list[str], **kwargs: object) -> SimpleResult:
+            captured.update(kwargs)
+            return SimpleResult(stdout="", stderr="", returncode=0)
+
+        runner = MagicMock()
+        runner.run_simple = _run
+
+        with patch.dict("os.environ", {"CLAUDECODE": "1"}, clear=False):
+            await run_subprocess_result(
+                "make", "audit-json", extra_env={"FOO": "bar"}, runner=runner
+            )
+
+        env = captured["env"]
+        assert env["FOO"] == "bar"
+        assert "CLAUDECODE" not in env
+
+    @pytest.mark.asyncio
+    async def test_input_passed_through_to_runner(self) -> None:
+        from subprocess_util import run_subprocess_result
+
+        captured: dict[str, object] = {}
+
+        async def _run(cmd: list[str], **kwargs: object) -> SimpleResult:
+            captured.update(kwargs)
+            return SimpleResult(stdout="", stderr="", returncode=0)
+
+        runner = MagicMock()
+        runner.run_simple = _run
+
+        await run_subprocess_result(
+            "git", "apply", "-", stdin_input=b"patch text", runner=runner
+        )
+
+        assert captured["input"] == b"patch text"
+
+    @pytest.mark.asyncio
+    async def test_cwd_passed_through(self) -> None:
+        from subprocess_util import run_subprocess_result
+
+        captured: dict[str, object] = {}
+
+        async def _run(cmd: list[str], **kwargs: object) -> SimpleResult:
+            captured.update(kwargs)
+            return SimpleResult(stdout="", stderr="", returncode=0)
+
+        runner = MagicMock()
+        runner.run_simple = _run
+
+        await run_subprocess_result("ls", cwd=Path("/some/dir"), runner=runner)
+
+        assert captured["cwd"] == "/some/dir"
+
+    @pytest.mark.asyncio
+    async def test_non_gh_command_bypasses_semaphore_and_breaker(self) -> None:
+        """`make`/`rg` calls skip the gh/git gating entirely (no breaker check)."""
+        from subprocess_util import (
+            configure_gh_circuit_breaker,
+            run_subprocess_result,
+        )
+
+        configure_gh_circuit_breaker(enabled=True, max_failures=1, reset_timeout=60.0)
+        # Even with a breaker OPEN (were it gh), a non-gh/git command must not
+        # be gated at all — this must not raise CircuitBreakerOpenError.
+        result = await run_subprocess_result(
+            "make", "audit-json", runner=self._runner(returncode=2, stderr="fail")
+        )
+        assert result.returncode == 2
 
 
 class TestIsCreditExhaustion:

--- a/tests/test_trust_fleet_sanity_loop.py
+++ b/tests/test_trust_fleet_sanity_loop.py
@@ -282,21 +282,18 @@ async def test_reconcile_closed_escalations_clears_dedup(loop_env, monkeypatch) 
     }
     loop = _loop(loop_env)
 
-    class _P:
-        returncode = 0
+    from execution import SimpleResult
 
-        async def communicate(self):
-            # Only the ci_monitor escalation was closed.
-            return (
-                b'[{"title": "HITL: trust-loop anomaly \xe2\x80\x94 '
-                b'ci_monitor issues_per_hour"}]',
-                b"",
-            )
+    async def fake_result(*_cmd: str, **_kwargs: object) -> SimpleResult:
+        # Only the ci_monitor escalation was closed.
+        return SimpleResult(
+            stdout='[{"title": "HITL: trust-loop anomaly — '
+            'ci_monitor issues_per_hour"}]',
+            stderr="",
+            returncode=0,
+        )
 
-    async def fake_subproc(*args, **kwargs):
-        return _P()
-
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subproc)
+    monkeypatch.setattr("trust_fleet_sanity_loop.run_subprocess_result", fake_result)
     await loop._reconcile_closed_escalations()
     dedup.set_all.assert_called_once()
     remaining = dedup.set_all.call_args.args[0]
@@ -443,10 +440,10 @@ async def test_reconcile_tolerates_subprocess_exception(loop_env, monkeypatch) -
     cfg, state, bg_workers, pr, dedup, bus = loop_env
     dedup.get.return_value = {"trust_fleet_sanity:issues_per_hour:rc_budget"}
 
-    async def boom(*args, **kwargs):
+    async def boom(*_cmd: str, **_kwargs: object) -> object:
         raise OSError("no gh binary")
 
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", boom)
+    monkeypatch.setattr("trust_fleet_sanity_loop.run_subprocess_result", boom)
     # Must not raise; dedup must not be modified.
     await loop._reconcile_closed_escalations()
     dedup.set_all.assert_not_called()
@@ -454,38 +451,30 @@ async def test_reconcile_tolerates_subprocess_exception(loop_env, monkeypatch) -
 
 async def test_reconcile_tolerates_nonzero_returncode(loop_env, monkeypatch) -> None:
     """gh exits non-zero -> early return, dedup unchanged."""
+    from execution import SimpleResult
+
     loop = _loop(loop_env)
     cfg, state, bg_workers, pr, dedup, bus = loop_env
 
-    class _P:
-        returncode = 1
+    async def fake_result(*_cmd: str, **_kwargs: object) -> SimpleResult:
+        return SimpleResult(stdout="", stderr="error", returncode=1)
 
-        async def communicate(self):
-            return b"", b"error"
-
-    async def fake_subproc(*a, **k):
-        return _P()
-
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subproc)
+    monkeypatch.setattr("trust_fleet_sanity_loop.run_subprocess_result", fake_result)
     await loop._reconcile_closed_escalations()
     dedup.set_all.assert_not_called()
 
 
 async def test_reconcile_tolerates_invalid_json(loop_env, monkeypatch) -> None:
     """gh returns non-JSON stdout -> JSONDecodeError swallowed, dedup unchanged."""
+    from execution import SimpleResult
+
     loop = _loop(loop_env)
     cfg, state, bg_workers, pr, dedup, bus = loop_env
 
-    class _P:
-        returncode = 0
+    async def fake_result(*_cmd: str, **_kwargs: object) -> SimpleResult:
+        return SimpleResult(stdout="not valid json{{", stderr="", returncode=0)
 
-        async def communicate(self):
-            return b"not valid json{{", b""
-
-    async def fake_subproc(*a, **k):
-        return _P()
-
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subproc)
+    monkeypatch.setattr("trust_fleet_sanity_loop.run_subprocess_result", fake_result)
     await loop._reconcile_closed_escalations()
     dedup.set_all.assert_not_called()
 
@@ -494,20 +483,20 @@ async def test_reconcile_skips_issues_with_unmatched_title(
     loop_env, monkeypatch
 ) -> None:
     """Closed issue whose title doesn't match _TITLE_RE -> key NOT cleared."""
+    from execution import SimpleResult
+
     loop = _loop(loop_env)
     cfg, state, bg_workers, pr, dedup, bus = loop_env
     dedup.get.return_value = {"trust_fleet_sanity:staleness:rc_budget"}
 
-    class _P:
-        returncode = 0
+    async def fake_result(*_cmd: str, **_kwargs: object) -> SimpleResult:
+        return SimpleResult(
+            stdout='[{"title": "Some unrelated issue title"}]',
+            stderr="",
+            returncode=0,
+        )
 
-        async def communicate(self):
-            return b'[{"title": "Some unrelated issue title"}]', b""
-
-    async def fake_subproc(*a, **k):
-        return _P()
-
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subproc)
+    monkeypatch.setattr("trust_fleet_sanity_loop.run_subprocess_result", fake_result)
     await loop._reconcile_closed_escalations()
     # No regex match -> set_all never called, existing key preserved.
     dedup.set_all.assert_not_called()
@@ -675,3 +664,60 @@ def test_emit_trace_survives_emission_exception(loop_env, monkeypatch) -> None:
     monkeypatch.setitem(sys.modules, "trace_collector", fake_module)
     # Should not raise.
     loop._emit_trace(0.0, anomalies=1)
+
+
+# ---------------------------------------------------------------------------
+# _find_open_escalation — #9554/#10028: routes through run_subprocess_result
+# ---------------------------------------------------------------------------
+
+
+async def test_find_open_escalation_reuses_matching_open_issue(
+    loop_env, monkeypatch
+) -> None:
+    from execution import SimpleResult
+
+    loop = _loop(loop_env)
+
+    async def fake_result(*cmd: str, **_kwargs: object) -> SimpleResult:
+        assert cmd[0] == "gh"
+        return SimpleResult(
+            stdout='[{"number": 555, "title": "HITL: trust-loop anomaly — '
+            'rc_budget staleness"}]',
+            stderr="",
+            returncode=0,
+        )
+
+    monkeypatch.setattr("trust_fleet_sanity_loop.run_subprocess_result", fake_result)
+
+    found = await loop._find_open_escalation("rc_budget", "staleness")
+
+    assert found == 555
+
+
+async def test_find_open_escalation_timeout_fails_open(loop_env, monkeypatch) -> None:
+    """A gh timeout (SubprocessTimeoutError) fails open — filing is safe."""
+    from subprocess_util import SubprocessTimeoutError
+
+    loop = _loop(loop_env)
+
+    async def fake_result(*_cmd: str, **_kwargs: object) -> object:
+        raise SubprocessTimeoutError("timed out")
+
+    monkeypatch.setattr("trust_fleet_sanity_loop.run_subprocess_result", fake_result)
+
+    assert await loop._find_open_escalation("rc_budget", "staleness") == 0
+
+
+async def test_find_open_escalation_no_match_returns_zero(
+    loop_env, monkeypatch
+) -> None:
+    from execution import SimpleResult
+
+    loop = _loop(loop_env)
+
+    async def fake_result(*_cmd: str, **_kwargs: object) -> SimpleResult:
+        return SimpleResult(stdout="[]", stderr="", returncode=0)
+
+    monkeypatch.setattr("trust_fleet_sanity_loop.run_subprocess_result", fake_result)
+
+    assert await loop._find_open_escalation("rc_budget", "staleness") == 0


### PR DESCRIPTION
## Summary
- Migrates the 22 remaining raw `asyncio.create_subprocess_exec` sites across 10 caretaker loops (adr_touchpoint_auditor, fake_coverage_auditor, memory_backlog, flake_tracker, rc_budget, trust_fleet_sanity, contract_refresh, principles_audit, skill_prompt_eval, staging_bisect) onto a new shared `subprocess_util._run_gated()` core, exposed as `run_subprocess()` (raising, unchanged) and the new `run_subprocess_result()` (non-raising, for returncode-branching callers).
- Both delegate to `execution.HostRunner.run_simple()`, so every migrated site inherits gh/git circuit-breaker + rate-limit + concurrency-semaphore gating for free, plus `run_simple`'s existing process-group registration/reap (#9911/#10017/#10019) — closing the #10028 registry gap for these sites without re-deriving group-kill semantics per file.
- Deletes all 7 duplicated per-file `_communicate_bounded` helpers.
- `staging_bisect_loop._run_git` remains the sole excluded raw spawn (documented, consistent with every prior planning pass): its mid-run `enabled_cb` polling for cooperative kill-switch cancellation can't be expressed through the shared helper.
- Fixes the stale MockWorld scenario stub (#9647): `test_contract_refresh_scenario.py` patched `subprocess.run`, which the loop never calls, letting a real `make trust-contracts` spawn in-scenario.
- Fixes a real bug the migration surfaced: `SimpleResult.stdout`'s whole-blob `.strip()` shifts the first line of `git status --porcelain` output when its leading status char is a space, corrupting `skill_prompt_eval_loop._assert_only_module_changed`'s fixed-column parse — caught by existing real-git regression tests.
- Reconciles two ratchet baselines this diff's shape touches: `disturbance/baselines/suppressions.yaml` (two fewer redundant local `import asyncio` re-imports) and the new `tests/architecture/test_sandbox_seam_completeness.py` grandfathered spawn baseline (renamed entries only — same real spawns, landed via the mid-task staging merge).

Closes #9554
Part of #10028 (registry-join covered for every listed site except the documented `staging_bisect_loop._run_git` exclusion)

## Test plan
- [x] `tests/test_subprocess_util.py` — new `TestRunSubprocessResult` suite (success/non-raising-nonzero/timeout/breaker-open/rate-limit/outage/extra_env/stdin passthrough)
- [x] Every touched loop's unit test file green, with new tests for each migrated method's success/nonzero/timeout paths
- [x] `tests/regressions/test_issue_9579.py`, `test_issue_9454.py`, `test_reap_processlookuperror.py`, `test_issue_9410.py` updated for the new call shape and green
- [x] `tests/scenarios/` (`-m scenario_loops`) green, including the fixed `test_contract_refresh_scenario.py`
- [x] `tests/architecture/` green (including the new sandbox-seam-completeness guard with baseline reconciled)
- [x] `tests/test_disturbance_ratchet.py` green (suppressions baseline pruned)
- [x] Full `pytest tests/` (matching `make quality`'s scope) green — 0 failed, 0 errors, exit 0
- [x] `ruff check .` / `ruff format . --check` / `pyright` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)