### PR TITLE
feat(queue): default to weighted_mix so the factory picks by priority out of the box (#10037)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -852,16 +852,19 @@ class HydraFlowConfig(BaseModel):
 
     # Work-queue discipline (#10037) — how IssueStore orders each stage queue.
     # ``IssueRefinementLoop`` (#9957) produces the P0/P1/P2 labels these read.
-    # Default is 'fifo' — the pre-#10037 ordering — so shipping this PR changes
-    # no behaviour on its own; flipping to 'weighted_mix' is the operator's
-    # System-tab action, keeping the discipline change reviewable in isolation.
+    # Default is 'weighted_mix': priority-driven selection is the intended
+    # out-of-the-box behaviour, so a fresh instance picks by priority rather
+    # than oldest-first. #10045 shipped 'fifo' to make the merge behaviour-
+    # neutral; this makes the deliberate cutover. 'fifo' remains the escape
+    # hatch — a live System-tab dial away, no restart (issue_store re-reads it
+    # on every dequeue) — restoring the pre-#10037 ordering without a deploy.
     queue_strategy: QueueStrategy = Field(
-        default=QueueStrategy.FIFO,
+        default=QueueStrategy.WEIGHTED_MIX,
         description=(
-            "Stage-queue ordering: 'fifo' (oldest first, pre-#10037 behaviour "
-            "and the migration default), 'priority' (strict P0>P1>P2, starves "
-            "lower bands), or 'weighted_mix' (P0 preempts, then a weighted ratio "
-            "draw with an age-based starvation guard)"
+            "Stage-queue ordering: 'weighted_mix' (default — P0 preempts, then "
+            "a weighted ratio draw with an age-based starvation guard), "
+            "'priority' (strict P0>P1>P2, starves lower bands), or 'fifo' "
+            "(oldest first, the pre-#10037 behaviour and escape hatch)"
         ),
     )
     # Weights are the relative share each band draws under 'weighted_mix'.

--- a/tests/regressions/regression_issue_10037.py
+++ b/tests/regressions/regression_issue_10037.py
@@ -3,12 +3,11 @@
 Two invariants that a future change to ``IssueStore._take_from_queue`` could
 silently break:
 
-1. **``fifo`` is a behaviour pin.** The whole safety story of #10037 is that the
-   new default (``fifo``, the migration default) reproduces the pre-#10037
-   oldest-first ordering *exactly*, so shipping the feature changes nothing
-   until an operator flips the knob. If ``fifo`` ever stops being a faithful
-   arrival-order pass-through, the "no behaviour change on merge" guarantee is
-   gone.
+1. **``fifo`` is a behaviour pin.** ``fifo`` is the escape hatch back to the
+   pre-#10037 oldest-first ordering (the default is now ``weighted_mix``). Its
+   whole value is being a *faithful* arrival-order pass-through: an operator
+   setting ``fifo`` must get exactly the pre-#10037 behaviour with no
+   reordering. If that ever drifts, the escape hatch silently stops being one.
 
 2. **The crate (milestone) gate was absorbed, not retired, and unmilestoned
    repos keep flowing.** #10037 folded the dormant crate scope-filter

--- a/tests/test_config_env.py
+++ b/tests/test_config_env.py
@@ -748,4 +748,4 @@ class TestEnvVarEnumOverride:
             workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
-        assert cfg.queue_strategy is QueueStrategy.FIFO
+        assert cfg.queue_strategy is QueueStrategy.WEIGHTED_MIX


### PR DESCRIPTION
## What

Flip the shipped `queue_strategy` code default from `fifo` to `weighted_mix`, so a fresh HydraFlow instance picks work by priority out of the box instead of oldest-first.

## Why

#10037's selectable work-queue discipline shipped (#10045) defaulted to `fifo` — the pre-#10037 oldest-first ordering — so the merge changed no behaviour. That left the feature inert: the factory kept grinding the oldest issues (the stale P2 backlog that sits at the front of every stage queue) even though `IssueRefinementLoop` (#9957) was labelling the backlog P0/P1/P2 the whole time.

This makes the deliberate cutover. Priority-driven, starvation-guarded selection is the intended default; `fifo` stays as the escape hatch.

## Still fully config-driven

Nothing about the knob changes — only its default:

- **System tab** — `queue_strategy` dial, `live=True` (re-read on every dequeue, no restart)
- **Env** — `HYDRAFLOW_QUEUE_STRATEGY`
- **Config file** — `.hydraflow/config.json`

Setting any of them to `fifo` restores the old ordering live, without a deploy. The escape hatch is one dropdown away.

## Changes

- `src/config.py` — `default=QueueStrategy.WEIGHTED_MIX`, description reordered to lead with the new default and frame `fifo` as the escape hatch.
- `tests/test_config_env.py` — `test_invalid_queue_strategy_value_is_ignored_and_default_kept` now asserts the kept default is `weighted_mix` (an invalid env value still falls back to the shipped default; only the default value changed).
- `tests/regressions/regression_issue_10037.py` — the `fifo` **behaviour** pin stays (an operator selecting `fifo` must still get a faithful arrival-order pass-through); only its docstring is retitled from "the migration default" to "the escape hatch", since that is what `fifo` now is.

`make quality` green.

Related: #10037, #10045 (feature), #10053 (guard + per-PR gate).
