### PR TITLE
fix(contract-recording): synthetic commit + stable args in _record_merge_pr (#9535)

### DIFF
--- a/src/contract_recording.py
+++ b/src/contract_recording.py
@@ -235,6 +235,23 @@ def _require_success(
     return True
 
 
+def _gh_api_scalar(argv: list[str], *, label: str) -> str | None:
+    """Run a scalar-returning ``gh api`` call and return its stripped, non-empty
+    stdout — or ``None`` (warn-logged) on a missing binary, non-zero exit, or
+    empty output. Collapses the run → require-success → strip → non-empty guard
+    that every Git-Data-API read/write in ``_provision_scratch_branch`` repeats.
+    """
+    proc = _run(argv)
+    if not _require_success(proc, label=label):
+        return None
+    assert proc is not None
+    value = proc.stdout.strip().strip('"')
+    if not value:
+        logger.warning("contract_recording: %s returned empty output", label)
+        return None
+    return value
+
+
 # ---------------------------------------------------------------------------
 # Public recorders
 # ---------------------------------------------------------------------------
@@ -245,6 +262,27 @@ def _require_success(
 # The recorder captures the real CLI exit code but stores this constant so the
 # replay test compares apples-to-apples (same pattern as record_docker).
 _FAKE_CREATE_ISSUE_STDOUT = "https://github.com/test-org/test-repo/issues/9001\n"
+
+# Fixed scratch branch + synthetic-commit message used by
+# ``_provision_scratch_branch``. The branch name is intentionally constant (not
+# per-run) for determinism: the happy-path ``gh pr merge --delete-branch``
+# removes it, and the best-effort pre-delete in ``_provision_scratch_branch``
+# makes the fixed name idempotent across a prior interrupted tick.
+_SCRATCH_BRANCH = "contract-recorder-scratch"
+_SCRATCH_COMMIT_MESSAGE = "contract recorder scratch commit"
+
+# Stable logical PR/issue numbers written into the merge_pr / close_issue
+# cassettes. The live sandbox numbers are volatile, and
+# ``contract_diff._canonical_payload`` does NOT normalize ``input.args`` (it
+# drops only ``recorded_at``/``recorder_sha`` and runs normalizers on
+# ``stdin``/``stdout``/``stderr`` only). Recording the live number would diff
+# against the committed cassettes' ``args: ["42"]`` and file a phantom
+# ``contract-refresh`` PR on every weekly tick. We store these constants (which
+# match the committed cassettes byte-for-byte) in the cassette and use the live
+# numbers only for the side-effecting CLI calls — mirroring the stable-shape
+# ``_FAKE_CREATE_ISSUE_STDOUT`` pattern.
+_FAKE_MERGE_PR_NUMBER = "42"
+_FAKE_CLOSE_ISSUE_NUMBER = "42"
 
 
 def _parse_trailing_int(url: str) -> int | None:
@@ -291,7 +329,11 @@ def _record_close_issue(sandbox_repo: str, tmp_dir: Path) -> Path | None:
         interaction="close_issue",
         fixture_repo=sandbox_repo,
         command="close_issue",
-        args=[str(issue_number)],
+        # STABLE logical arg — the live ``issue_number`` still drives the
+        # side-effecting ``gh issue close`` above, but ``input.args`` is
+        # compared verbatim by the drift layer, so it must equal the committed
+        # cassette's ["42"] to avoid a phantom refresh PR every tick.
+        args=[_FAKE_CLOSE_ISSUE_NUMBER],
         exit_code=close.returncode,
         # Fake-shaped: FakeGitHub.close_issue returns empty stdout/stderr.
         # Real gh CLI may print a confirmation line; we discard it so the
@@ -367,21 +409,52 @@ def _record_create_issue(sandbox_repo: str, tmp_dir: Path) -> Path | None:
     return path
 
 
-def _record_merge_pr(sandbox_repo: str, tmp_dir: Path) -> Path | None:
-    """Create a scratch branch + PR in the sandbox, merge it; write merge_pr cassette."""
-    get_sha = _run(
+def _provision_scratch_branch(sandbox_repo: str, *, branch: str) -> str | None:
+    """Create *branch* in *sandbox_repo* carrying a single tree-identical commit.
+
+    GitHub rejects ``gh pr create`` when the head branch has no commits between
+    it and its base ("No commits between main and <branch>"). The old recorder
+    created the branch ref at ``main``'s SHA with no further commit, so it never
+    produced a mergeable PR. We POST a commit whose tree equals ``main``'s tree
+    (an empty-diff commit) parented on ``main`` and fast-forward the branch ref
+    to it — the PR carries one commit (zero file changes) which GitHub accepts,
+    and the eventual merge leaves ``main``'s tree unchanged, so every refresh
+    tick is idempotent. Mirrors the proven ``PRManager.push_synthetic_commit``.
+
+    Best-effort deletes any stale ref left by a prior interrupted recording so
+    the fixed branch name is re-runnable. Returns the new commit SHA on success,
+    or ``None`` (warn-logged) on any failed step — the recorder degrades to "no
+    cassette written" rather than raising into the background loop.
+
+    This helper deliberately shells out to the real ``gh`` CLI via ``_run``
+    (not ``PRPort``): the whole point of the recorder is to capture the *live*
+    contract, so routing through the fake would defeat it.
+    """
+    # Best-effort cleanup of a stale scratch ref (a prior tick interrupted
+    # before ``gh pr merge --delete-branch``). A 404/422 here is expected and
+    # deliberately NOT gated on ``_require_success``.
+    _run(
+        [
+            "gh",
+            "api",
+            f"repos/{sandbox_repo}/git/refs/heads/{branch}",
+            "--method",
+            "DELETE",
+        ]
+    )
+
+    main_sha = _gh_api_scalar(
         [
             "gh",
             "api",
             f"repos/{sandbox_repo}/git/ref/heads/main",
             "--jq",
             ".object.sha",
-        ]
+        ],
+        label="gh api get main sha",
     )
-    if not _require_success(get_sha, label="gh api get main sha"):
+    if main_sha is None:
         return None
-    assert get_sha is not None
-    sha = get_sha.stdout.strip()
 
     create_branch = _run(
         [
@@ -389,12 +462,79 @@ def _record_merge_pr(sandbox_repo: str, tmp_dir: Path) -> Path | None:
             "api",
             f"repos/{sandbox_repo}/git/refs",
             "--raw-field",
-            "ref=refs/heads/contract-recorder-scratch",
+            f"ref=refs/heads/{branch}",
             "--raw-field",
-            f"sha={sha}",
+            f"sha={main_sha}",
         ]
     )
     if not _require_success(create_branch, label="gh api create branch"):
+        return None
+
+    tree_sha = _gh_api_scalar(
+        [
+            "gh",
+            "api",
+            f"repos/{sandbox_repo}/git/commits/{main_sha}",
+            "--jq",
+            ".tree.sha",
+        ],
+        label="gh api get main tree",
+    )
+    if tree_sha is None:
+        return None
+
+    # Tree-identical (empty-diff) commit parented on main: the branch gains one
+    # commit (so ``gh pr create`` is accepted) without changing main's tree.
+    commit_sha = _gh_api_scalar(
+        [
+            "gh",
+            "api",
+            f"repos/{sandbox_repo}/git/commits",
+            "--method",
+            "POST",
+            "--raw-field",
+            f"message={_SCRATCH_COMMIT_MESSAGE}",
+            "--raw-field",
+            f"tree={tree_sha}",
+            "--raw-field",
+            f"parents[]={main_sha}",
+            "--jq",
+            ".sha",
+        ],
+        label="gh api create commit",
+    )
+    if commit_sha is None:
+        return None
+
+    patch_ref = _run(
+        [
+            "gh",
+            "api",
+            f"repos/{sandbox_repo}/git/refs/heads/{branch}",
+            "--method",
+            "PATCH",
+            "--raw-field",
+            f"sha={commit_sha}",
+        ]
+    )
+    if not _require_success(patch_ref, label="gh api patch branch ref"):
+        return None
+
+    return commit_sha
+
+
+def _record_merge_pr(sandbox_repo: str, tmp_dir: Path) -> Path | None:
+    """Provision a scratch branch with a synthetic commit, open + merge a PR;
+    write the merge_pr cassette with STABLE logical args.
+
+    ``_provision_scratch_branch`` puts one tree-identical (empty-diff) commit on
+    the scratch branch so ``gh pr create`` is accepted while the sandbox
+    ``main`` tree never grows. The cassette records the stable logical PR number
+    (``"42"``), never the volatile live sandbox number — ``input.args`` is
+    compared verbatim by the drift layer, so a live number would phantom-drift
+    every tick.
+    """
+    if not _provision_scratch_branch(sandbox_repo, branch=_SCRATCH_BRANCH):
         return None
 
     create_pr = _run(
@@ -405,7 +545,7 @@ def _record_merge_pr(sandbox_repo: str, tmp_dir: Path) -> Path | None:
             "--repo",
             sandbox_repo,
             "--head",
-            "contract-recorder-scratch",
+            _SCRATCH_BRANCH,
             "--base",
             "main",
             "--title",
@@ -424,6 +564,7 @@ def _record_merge_pr(sandbox_repo: str, tmp_dir: Path) -> Path | None:
         )
         return None
 
+    # The side-effecting merge targets the LIVE PR number; the cassette does not.
     merge = _run(
         [
             "gh",
@@ -440,15 +581,19 @@ def _record_merge_pr(sandbox_repo: str, tmp_dir: Path) -> Path | None:
         return None
     assert merge is not None
 
-    # Fake-shaped stdout mirrors FakeGitHub.merge_pr; pr_number normalizer
-    # collapses the sandbox PR number so replay is deterministic.
-    fake_stdout = f"merged pull request https://github.com/_/_/pull/{pr_number}\n"
+    # Fake-shaped stdout mirrors FakeGitHub.merge_pr; the pr_number normalizer
+    # collapses the number so replay is deterministic. Both stdout and args use
+    # the STABLE _FAKE_MERGE_PR_NUMBER — args are compared verbatim by the drift
+    # layer, so they must equal the committed cassette's ["42"].
+    fake_stdout = (
+        f"merged pull request https://github.com/_/_/pull/{_FAKE_MERGE_PR_NUMBER}\n"
+    )
     payload = _build_cassette_payload(
         adapter="github",
         interaction="merge_pr",
         fixture_repo=sandbox_repo,
         command="merge_pr",
-        args=[str(pr_number)],
+        args=[_FAKE_MERGE_PR_NUMBER],
         exit_code=merge.returncode,
         stdout=fake_stdout,
         stderr="",

--- a/tests/regressions/test_issue_9535_merge_pr_recorder.py
+++ b/tests/regressions/test_issue_9535_merge_pr_recorder.py
@@ -1,0 +1,121 @@
+"""Regression: ``_record_merge_pr`` no-diff PR + volatile args (issue #9535).
+
+Two independent defects meant the ``merge_pr`` GitHub cassette was never
+live-recorded drift-free:
+
+1. **No-diff PR.** The recorder created the scratch branch at ``main``'s SHA
+   with no commit, then called ``gh pr create``. GitHub rejects a PR with no
+   commits between head and base ("No commits between main and
+   contract-recorder-scratch"), so the recorder returned ``None`` every weekly
+   tick and the cassette was never refreshed.
+2. **Volatile args.** Even if recording succeeded it wrote
+   ``args=[str(pr_number)]`` using the live sandbox PR number.
+   ``contract_diff._canonical_payload`` does NOT normalize ``input.args`` (it
+   drops only ``recorded_at``/``recorder_sha`` and normalizes
+   ``stdin``/``stdout``/``stderr``), so a real number would phantom-drift
+   against the committed ``args: ["42"]`` and file a spurious
+   ``contract-refresh`` PR every tick.
+
+The fix provisions a tree-identical synthetic commit before ``gh pr create``
+(mirroring ``PRManager.push_synthetic_commit``) and records stable logical
+``args`` (``["42"]``). ``_record_close_issue`` carried the identical
+volatile-args bug and is fixed the same way.
+
+These tests drive the recorder through a mocked ``gh`` returning live numbers
+DIFFERENT from 42 (PR 9999, issue 537) and pin (a) drift-free recording vs the
+committed baseline and (b) the synthetic-commit provisioning step. They are
+hermetic: no ``tests/architecture`` conftest fixtures, only ``tmp_path`` + the
+repo root resolved from ``__file__``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from contract_diff import detect_adapter_drift
+from contract_recording import record_github_mutation
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_COMMITTED = _REPO_ROOT / "tests/trust/contracts/cassettes/github"
+# Must equal the committed cassettes' ``fixture_repo`` so a correctly-recorded
+# cassette canonically matches the baseline (config.contracts_sandbox_repo
+# default).
+_SANDBOX = "T-rav-Hydra-Ops/hydraflow-contracts-sandbox"
+
+
+def _completed(
+    argv: list[str], *, stdout: str = "", returncode: int = 0
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=argv, returncode=returncode, stdout=stdout, stderr=""
+    )
+
+
+def _fake_gh(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+    """Simulate ``gh`` with live numbers deliberately DIFFERENT from 42."""
+    # Git Data API: tree read + synthetic-commit POST → non-empty SHA.
+    if "api" in argv and any("git/commits" in a for a in argv):
+        return _completed(argv, stdout="c" * 40 + "\n")
+    # Git Data API: ref get/create/delete/patch → main SHA (output mostly unused).
+    if "api" in argv and any("git/ref" in a for a in argv):
+        return _completed(argv, stdout="a" * 40 + "\n")
+    if "issue" in argv and "create" in argv:  # live issue #537 (≠ 42)
+        return _completed(argv, stdout=f"https://github.com/{_SANDBOX}/issues/537\n")
+    if "pr" in argv and "create" in argv:  # live PR #9999 (≠ 42)
+        return _completed(argv, stdout=f"https://github.com/{_SANDBOX}/pull/9999\n")
+    # gh issue close / gh pr merge / git rev-parse → success, no output.
+    return _completed(argv, stdout="")
+
+
+def test_merge_pr_recording_is_drift_free_against_committed(tmp_path: Path) -> None:
+    with patch("contract_recording.subprocess.run", side_effect=_fake_gh):
+        record_github_mutation(sandbox_repo=_SANDBOX, tmp_cassette_dir=tmp_path)
+
+    recorded = tmp_path / "merge_pr.yaml"
+    assert recorded.exists(), (
+        "merge_pr cassette must be written — the no-diff-PR regression is fixed"
+    )
+    report = detect_adapter_drift("github", [recorded], [_COMMITTED / "merge_pr.yaml"])
+    assert report is None, f"merge_pr drifted despite live PR 9999: {report}"
+
+
+def test_close_issue_recording_is_drift_free_against_committed(tmp_path: Path) -> None:
+    with patch("contract_recording.subprocess.run", side_effect=_fake_gh):
+        record_github_mutation(sandbox_repo=_SANDBOX, tmp_cassette_dir=tmp_path)
+
+    recorded = tmp_path / "close_issue.yaml"
+    assert recorded.exists()
+    report = detect_adapter_drift(
+        "github", [recorded], [_COMMITTED / "close_issue.yaml"]
+    )
+    assert report is None, f"close_issue drifted despite live issue 537: {report}"
+
+
+def test_merge_pr_recorder_posts_synthetic_commit_before_pr_create(
+    tmp_path: Path,
+) -> None:
+    calls: list[list[str]] = []
+
+    def capture(argv: list[str], **kw: object) -> subprocess.CompletedProcess[str]:
+        calls.append(list(argv))
+        return _fake_gh(argv, **kw)
+
+    with patch("contract_recording.subprocess.run", side_effect=capture):
+        record_github_mutation(sandbox_repo=_SANDBOX, tmp_cassette_dir=tmp_path)
+
+    commit_post = [
+        i
+        for i, c in enumerate(calls)
+        if any(str(a).startswith("parents[]=") for a in c)
+    ]
+    pr_create = [i for i, c in enumerate(calls) if "pr" in c and "create" in c]
+
+    assert commit_post, (
+        "recorder must POST a synthetic commit (parents[]= field) — no-diff-PR guard"
+    )
+    assert pr_create, "recorder must call gh pr create"
+    assert commit_post[0] < pr_create[0], (
+        "synthetic commit POST must precede gh pr create"
+    )

--- a/tests/test_contract_recording.py
+++ b/tests/test_contract_recording.py
@@ -436,12 +436,15 @@ def _mutation_fake_run(
     argv: list[str], **_: object
 ) -> subprocess.CompletedProcess[str]:
     """Simulate gh CLI responses for the three mutation recordings."""
-    # gh api .../git/ref/heads/main  → main SHA
+    # gh api .../git/commits/<sha> --jq .tree.sha  (read main's tree)
+    # gh api .../git/commits (POST synthetic commit) --jq .sha
+    # Both resolve to a non-empty SHA so _provision_scratch_branch proceeds.
+    if "api" in argv and any("git/commits" in a for a in argv):
+        return _completed(argv=argv, stdout="b" * 40 + "\n")
+    # gh api .../git/ref(s)/... → main SHA. The DELETE / create-branch / PATCH
+    # outputs are unused by the recorder (it only checks the exit code).
     if "api" in argv and any("git/ref" in a for a in argv):
         return _completed(argv=argv, stdout=_MAIN_SHA)
-    # gh api .../git/refs (branch creation)
-    if "api" in argv and any("git/refs" in a for a in argv):
-        return _completed(argv=argv, stdout="{}\n")
     # gh issue create → issue URL
     if "issue" in argv and "create" in argv:
         return _completed(argv=argv, stdout=_ISSUE_URL)
@@ -524,6 +527,172 @@ def test_record_github_mutation_writes_merge_pr_cassette(tmp_path: Path) -> None
     assert cassette.output.exit_code == 0
     assert "pr_number" in cassette.normalizers
     assert not cassette.baseline_only
+
+
+def test_record_github_mutation_merge_pr_writes_stable_args(tmp_path: Path) -> None:
+    """merge_pr cassette must store the stable logical args (["42"]) — NOT the
+    live sandbox PR number (the fake returns /pull/7). ``input.args`` is compared
+    verbatim by the drift layer, so a live number would phantom-drift every tick.
+    """
+    with patch("contract_recording.subprocess.run", side_effect=_mutation_fake_run):
+        record_github_mutation(sandbox_repo=_SANDBOX, tmp_cassette_dir=tmp_path)
+
+    cassette = Cassette.model_validate(_load_yaml(tmp_path / "merge_pr.yaml"))
+    assert cassette.input.args == ["42"], (
+        f"merge_pr args must be stable ['42'], not the live PR number: "
+        f"{cassette.input.args}"
+    )
+    assert (
+        cassette.output.stdout == "merged pull request https://github.com/_/_/pull/42\n"
+    )
+    assert cassette.normalizers == ["pr_number"]
+
+
+def test_record_github_mutation_close_issue_writes_stable_args(tmp_path: Path) -> None:
+    """close_issue cassette must store the stable logical args (["42"]) even
+    though the freshly-created sandbox issue URL ends in a different number."""
+    with patch("contract_recording.subprocess.run", side_effect=_mutation_fake_run):
+        record_github_mutation(sandbox_repo=_SANDBOX, tmp_cassette_dir=tmp_path)
+
+    cassette = Cassette.model_validate(_load_yaml(tmp_path / "close_issue.yaml"))
+    assert cassette.input.args == ["42"], (
+        f"close_issue args must be stable ['42'], not the live issue number: "
+        f"{cassette.input.args}"
+    )
+
+
+def test_record_merge_pr_posts_synthetic_commit_before_pr_create(
+    tmp_path: Path,
+) -> None:
+    """The recorder must POST a tree-identical synthetic commit (with a
+    ``parents[]`` field) AND fast-forward the scratch ref (PATCH) BEFORE calling
+    ``gh pr create`` — otherwise GitHub rejects the no-diff branch."""
+    calls: list[list[str]] = []
+
+    def capture(argv: list[str], **kw: object) -> subprocess.CompletedProcess[str]:
+        calls.append(list(argv))
+        return _mutation_fake_run(argv)
+
+    with patch("contract_recording.subprocess.run", side_effect=capture):
+        record_github_mutation(sandbox_repo=_SANDBOX, tmp_cassette_dir=tmp_path)
+
+    commit_post = [
+        i
+        for i, c in enumerate(calls)
+        if any(str(a).startswith("parents[]=") for a in c)
+    ]
+    patch_ref = [
+        i
+        for i, c in enumerate(calls)
+        if "--method" in c
+        and "PATCH" in c
+        and any("git/refs/heads/contract-recorder-scratch" in a for a in c)
+    ]
+    pr_create = [i for i, c in enumerate(calls) if "pr" in c and "create" in c]
+
+    assert commit_post, "recorder must POST a synthetic commit (parents[]= field)"
+    assert patch_ref, "recorder must PATCH the scratch ref to the new commit"
+    assert pr_create, "recorder must call gh pr create"
+    assert commit_post[0] < pr_create[0], (
+        "synthetic commit POST must precede gh pr create"
+    )
+    assert patch_ref[0] < pr_create[0], "scratch ref PATCH must precede gh pr create"
+
+
+def test_record_merge_pr_pr_create_targets_scratch_branch_and_main(
+    tmp_path: Path,
+) -> None:
+    """``gh pr create`` must open the PR from the scratch branch against main."""
+    calls: list[list[str]] = []
+
+    def capture(argv: list[str], **kw: object) -> subprocess.CompletedProcess[str]:
+        calls.append(list(argv))
+        return _mutation_fake_run(argv)
+
+    with patch("contract_recording.subprocess.run", side_effect=capture):
+        record_github_mutation(sandbox_repo=_SANDBOX, tmp_cassette_dir=tmp_path)
+
+    pr_creates = [c for c in calls if "pr" in c and "create" in c]
+    assert len(pr_creates) == 1
+    argv = pr_creates[0]
+    assert (
+        "--head" in argv
+        and argv[argv.index("--head") + 1] == "contract-recorder-scratch"
+    )
+    assert "--base" in argv and argv[argv.index("--base") + 1] == "main"
+
+
+def test_record_merge_pr_best_effort_deletes_stale_scratch_branch(
+    tmp_path: Path,
+) -> None:
+    """A stale scratch branch (from a prior interrupted tick) is best-effort
+    deleted first, and a non-zero DELETE does not abort recording."""
+    calls: list[list[str]] = []
+
+    def capture(argv: list[str], **kw: object) -> subprocess.CompletedProcess[str]:
+        calls.append(list(argv))
+        # Simulate the DELETE failing (ref does not exist) — must be tolerated.
+        if "--method" in argv and "DELETE" in argv:
+            return _completed(argv=argv, returncode=1, stderr="Not Found\n")
+        return _mutation_fake_run(argv)
+
+    with patch("contract_recording.subprocess.run", side_effect=capture):
+        record_github_mutation(sandbox_repo=_SANDBOX, tmp_cassette_dir=tmp_path)
+
+    delete_calls = [
+        i
+        for i, c in enumerate(calls)
+        if "--method" in c
+        and "DELETE" in c
+        and any("git/refs/heads/contract-recorder-scratch" in a for a in c)
+    ]
+    assert delete_calls, "recorder must best-effort DELETE the stale scratch ref"
+    assert (tmp_path / "merge_pr.yaml").exists(), (
+        "a failing best-effort DELETE must not abort merge_pr recording"
+    )
+
+
+def test_record_merge_pr_still_merges_live_pr_number(tmp_path: Path) -> None:
+    """The side-effecting ``gh pr merge`` uses the LIVE PR number (7 from the
+    fake URL) even though the cassette records the stable ["42"]."""
+    calls: list[list[str]] = []
+
+    def capture(argv: list[str], **kw: object) -> subprocess.CompletedProcess[str]:
+        calls.append(list(argv))
+        return _mutation_fake_run(argv)
+
+    with patch("contract_recording.subprocess.run", side_effect=capture):
+        record_github_mutation(sandbox_repo=_SANDBOX, tmp_cassette_dir=tmp_path)
+
+    merge_calls = [c for c in calls if "pr" in c and "merge" in c]
+    assert len(merge_calls) == 1
+    assert "7" in merge_calls[0], (
+        f"gh pr merge must target the live PR number 7: {merge_calls[0]}"
+    )
+    cassette = Cassette.model_validate(_load_yaml(tmp_path / "merge_pr.yaml"))
+    assert cassette.input.args == ["42"], "cassette must still record the stable arg"
+
+
+def test_record_merge_pr_returns_none_when_synthetic_commit_fails(
+    tmp_path: Path,
+) -> None:
+    """When the synthetic-commit POST exits non-zero, no merge_pr cassette is
+    written and the recorder never raises into the loop (graceful failure)."""
+
+    def failing_commit_post(
+        argv: list[str], **_: object
+    ) -> subprocess.CompletedProcess[str]:
+        # The synthetic-commit POST is the git/commits call carrying parents[].
+        if any(str(a).startswith("parents[]=") for a in argv):
+            return _completed(argv=argv, returncode=1, stderr="422 Unprocessable\n")
+        return _mutation_fake_run(argv)
+
+    with patch("contract_recording.subprocess.run", side_effect=failing_commit_post):
+        paths = record_github_mutation(sandbox_repo=_SANDBOX, tmp_cassette_dir=tmp_path)
+
+    stems = {p.stem for p in paths}
+    assert "merge_pr" not in stems
+    assert not (tmp_path / "merge_pr.yaml").exists()
 
 
 def test_record_github_mutation_returns_empty_when_gh_missing(


### PR DESCRIPTION
## Problem (#9535)

Two defects in `_record_merge_pr`:
1. **No-diff PR** — the scratch branch was created at main's SHA with no commit, so `gh pr create` rejected it ("No commits between…"), the recorder returned None every ContractRefreshLoop tick, and `merge_pr.yaml` was never live-recorded. Self-wedging: the branch is only deleted on successful merge, so later ticks failed even earlier at branch-create.
2. **Volatile args** — recorded `args=[str(pr_number)]` (live number) drifts against the committed cassette's `args:["42"]`, phantom-filing spurious refresh PRs. `_record_close_issue` had the identical bug.

## Fix

`_provision_scratch_branch` (mirrors `push_synthetic_commit`): idempotent stale-ref delete → main SHA → branch → tree-identical empty-diff commit parented on main → ref patch, so the PR carries one accepted commit and merging leaves main's tree unchanged. Both recorders now write stable `args=["42"]` while the live number still drives the side-effecting `gh` call. New `_gh_api_scalar` helper collapses the repeated guard (kept within PLR0911 — no noqa).

## Tests

8 regression pins (TDD red-first) + contract-recording + contract suite + refresh loop/scenario green; `make quality` exit 0.

Closes #9535

🤖 Generated with [Claude Code](https://claude.com/claude-code)