### PR TITLE
fix(dashboard): event-driven workstream cards — push on label swap, poll for truth (#9842)

### DIFF
--- a/src/issue_store.py
+++ b/src/issue_store.py
@@ -451,6 +451,33 @@ class IssueStore:
         self._eagerly_transitioned[task.id] = stage
         self._publish_queue_update_nowait()
 
+    def apply_label_transition(self, issue_number: int, new_label: str) -> bool:
+        """Mirror a GitHub pipeline-label swap in-memory immediately (#9842).
+
+        Event-driven bridge for the dashboard board: ``service_registry``
+        injects this as ``PRManager``'s pipeline-label listener, so every
+        ``swap_pipeline_labels`` moves the card within the snapshot debounce
+        (~0.1s) instead of waiting for the ``data_poll_interval`` (300s)
+        refresh to re-read labels. The poll remains the reconciling backstop,
+        and :meth:`enqueue_transition`'s eager protection stops a stale poll
+        (labels up to one cache cycle old) from dragging the card backward.
+
+        Returns ``True`` when the transition was applied. Returns ``False``
+        — leaving reconciliation to the poll — when *new_label* is not a
+        pipeline-stage label (e.g. a dup/parked swap-out; the issue is
+        usually still ``_active`` then, and ``mark_complete`` closes the
+        card) or when the issue was never routed by this store (no cached
+        Task to place in a queue, e.g. right after a restart).
+        """
+        stage = self._build_label_map().get(new_label)
+        if stage is None:
+            return False
+        task = self._issue_cache.get(issue_number)
+        if task is None:
+            return False
+        self.enqueue_transition(task, stage.value)
+        return True
+
     # ------------------------------------------------------------------
     # Queue accessors (non-blocking, return available issues)
     # ------------------------------------------------------------------

--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -133,6 +133,40 @@ class PRManager:
         self._max_retries = config.gh_max_retries
         self._label_counts_cache: LabelCounts | None = None
         self._label_counts_ts: float = 0.0
+        # #9842: notified on every successful ``swap_pipeline_labels`` so the
+        # dashboard's in-memory pipeline moves in seconds, not at the 300s
+        # label poll. Wired by service_registry to
+        # ``IssueStore.apply_label_transition``; None outside full wiring.
+        self._pipeline_label_listener: Callable[[int, str], object] | None = None
+
+    def set_pipeline_label_listener(
+        self, listener: Callable[[int, str], object]
+    ) -> None:
+        """Register a ``(issue_number, new_label)`` callback fired after each
+        successful :meth:`swap_pipeline_labels` add (#9842).
+
+        Internal wiring plumbing (like ``IssueStore.set_crate_manager``) —
+        deliberately NOT on :class:`ports.PRPort`; service_registry gates the
+        call on attribute presence so port fakes stay untouched.
+        """
+        self._pipeline_label_listener = listener
+
+    def _notify_pipeline_label_listener(
+        self, issue_number: int, new_label: str
+    ) -> None:
+        """Best-effort listener dispatch — a board-push failure must never
+        fail the GitHub label swap itself."""
+        if self._pipeline_label_listener is None:
+            return
+        try:
+            self._pipeline_label_listener(issue_number, new_label)
+        except Exception:
+            logger.warning(
+                "pipeline label listener failed for issue #%d → %s",
+                issue_number,
+                new_label,
+                exc_info=True,
+            )
 
     def _assert_repo(self) -> None:
         """Raise ``RuntimeError`` if ``self._repo`` is empty or malformed."""
@@ -1982,6 +2016,11 @@ class PRManager:
         await self._add_labels_strict("issue", issue_number, [new_label])
         if pr_number is not None:
             await self._add_labels_strict("pr", pr_number, [new_label])
+
+        # The swap is now real on GitHub (add-first defines the new stage) —
+        # push it to the in-memory pipeline BEFORE the best-effort removal
+        # fan-out so the dashboard card moves in seconds (#9842).
+        self._notify_pipeline_label_listener(issue_number, new_label)
 
         # --- then remove stale labels (best-effort) ---
         all_labels = self._config.all_pipeline_labels

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -840,6 +840,18 @@ def build_services(
     if hasattr(store, "set_crate_manager"):
         store.set_crate_manager(crate_manager)
 
+    # #9842: event-driven workstream cards. Every successful
+    # ``swap_pipeline_labels`` is applied to the in-memory pipeline
+    # immediately, so the existing coalesced PIPELINE_SNAPSHOT push moves the
+    # board within ~1s instead of at the 300s ``data_poll_interval`` label
+    # re-read (which stays as the reconciling backstop). hasattr-gated like
+    # ``set_crate_manager``: sandbox fakes (FakeGitHub / FakeIssueStore) read
+    # labels live and need no bridge.
+    if hasattr(prs, "set_pipeline_label_listener") and hasattr(
+        store, "apply_label_transition"
+    ):
+        prs.set_pipeline_label_listener(store.apply_label_transition)
+
     # Local JSONL issue cache (append-only mirror; see src/issue_cache.py and #6422)
     issue_cache = IssueCache(
         config.data_path("cache"),

--- a/tests/regressions/regression_issue_9842.py
+++ b/tests/regressions/regression_issue_9842.py
@@ -1,0 +1,97 @@
+"""Regression pins for issue #9842 — event-driven workstream cards.
+
+Phase transitions swap the issue's GitHub pipeline label immediately
+(``PRManager.swap_pipeline_labels``), but the dashboard's board rendered from
+``IssueStore``'s label-derived queues, which only re-read GitHub at the
+``data_poll_interval`` refresh (300s, ``config.py``) — so a finished phase's
+card lagged up to ~5 minutes behind reality. The fix is "push on transition,
+poll for truth": ``swap_pipeline_labels`` notifies an injected listener
+(``IssueStore.apply_label_transition``), which applies the move to the
+in-memory pipeline eagerly and lets the existing coalesced PIPELINE_SNAPSHOT
+push (0.1s debounce) carry it over the WebSocket within ~1s. The 300s poll
+stays as the reconciling backstop; the eager-transition protection prevents a
+stale poll from dragging the card backward.
+
+Invariants pinned here:
+
+1. **A label swap moves the card without any store refresh.** With PRManager
+   and IssueStore wired the way ``service_registry.build_services`` wires
+   them, ``swap_pipeline_labels`` alone must produce a live PIPELINE_SNAPSHOT
+   frame showing the issue in its new stage — no ``refresh()`` (the 300s
+   poll) in between. If this pin fails, cards are poll-bound again.
+
+2. **The stale poll cannot undo the eager move.** The reconciling refresh may
+   run with pre-swap label data (the GitHub cache is up to 5 minutes old);
+   the issue must stay in the swapped stage.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "src"))
+
+from events import EventBus, EventType
+from issue_store import STAGE_READY, STAGE_REVIEW, IssueStore
+from tests.conftest import TaskFactory
+from tests.helpers import ConfigFactory, make_pr_manager
+
+
+def _make_wired_pair(event_bus: EventBus) -> tuple[IssueStore, object]:
+    """A real IssueStore + real PRManager wired like build_services does."""
+    config = ConfigFactory.create()
+    fetcher = AsyncMock()
+    fetcher.fetch_all = AsyncMock(return_value=[])
+    store = IssueStore(config, fetcher, event_bus)
+    mgr = make_pr_manager(config, event_bus)
+    # gh label mutations are not under test — stub the network edge only.
+    mgr._add_labels_strict = AsyncMock()
+    mgr._remove_label = AsyncMock()
+    mgr.set_pipeline_label_listener(store.apply_label_transition)
+    return store, mgr
+
+
+@pytest.mark.asyncio
+async def test_label_swap_pushes_the_new_stage_without_a_poll() -> None:
+    bus = EventBus()
+    store, mgr = _make_wired_pair(bus)
+    subscriber = bus.subscribe()
+    issue = TaskFactory.create(id=9842, tags=["test-label"])  # ready stage
+    store._route_issues([issue])
+
+    await mgr.swap_pipeline_labels(9842, "hydraflow-review")
+
+    # Drain the coalesced snapshot flush — the ONLY thing between the swap
+    # and the WS frame. Crucially: store.refresh() is never called.
+    flush = store._snapshot_flush_task
+    assert flush is not None, "label swap did not schedule a snapshot flush"
+    await flush
+
+    frames = []
+    while not subscriber.empty():
+        event = subscriber.get_nowait()
+        if event.type == EventType.PIPELINE_SNAPSHOT:
+            frames.append(event)
+    assert frames, "no live PIPELINE_SNAPSHOT frame after the label swap"
+    stages = frames[-1].data["stages"]
+    assert 9842 in [e["issue_number"] for e in stages["review"]]
+    assert 9842 not in [e["issue_number"] for e in stages["implement"]]
+
+
+@pytest.mark.asyncio
+async def test_stale_reconciling_poll_does_not_drag_the_card_backward() -> None:
+    bus = EventBus()
+    store, mgr = _make_wired_pair(bus)
+    issue = TaskFactory.create(id=9843, tags=["test-label"])  # ready stage
+    store._route_issues([issue])
+
+    await mgr.swap_pipeline_labels(9843, "hydraflow-review")
+    # The next poll serves 5-minute-old labels that still say "ready".
+    store._route_issues([TaskFactory.create(id=9843, tags=["test-label"])])
+
+    assert 9843 in store._queue_members[STAGE_REVIEW]
+    assert 9843 not in store._queue_members[STAGE_READY]

--- a/tests/test_issue_store.py
+++ b/tests/test_issue_store.py
@@ -818,6 +818,93 @@ class TestPipelineSnapshotPush:
         )
 
 
+# ── Label-driven eager transitions (#9842) ───────────────────────────
+
+
+class TestApplyLabelTransition:
+    """``apply_label_transition`` mirrors a GitHub label swap in-memory.
+
+    #9842: phase transitions swap GitHub labels immediately, but the board
+    only re-read labels at the ``data_poll_interval`` (300s) refresh — cards
+    lagged up to 5 minutes. ``apply_label_transition`` is the event-driven
+    bridge: PRManager notifies the store on every ``swap_pipeline_labels``,
+    the store applies the move eagerly, and the existing coalesced
+    PIPELINE_SNAPSHOT push carries it to the dashboard within ~1s.
+    """
+
+    def test_moves_cached_issue_to_the_swapped_stage(self) -> None:
+        store = _make_store()
+        issue = TaskFactory.create(id=11, tags=["hydraflow-find"])
+        store._route_issues([issue])
+
+        applied = store.apply_label_transition(11, "hydraflow-review")
+
+        assert applied is True
+        assert store._queue_members[STAGE_REVIEW] == {11}
+        assert 11 not in store._queue_members[STAGE_FIND]
+
+    def test_hitl_label_moves_issue_to_hitl_set(self) -> None:
+        store = _make_store()
+        issue = TaskFactory.create(id=12, tags=["hydraflow-review"])
+        store._route_issues([issue])
+
+        applied = store.apply_label_transition(12, "hydraflow-hitl")
+
+        assert applied is True
+        assert 12 in store.get_hitl_issues()
+        assert 12 not in store._queue_members[STAGE_REVIEW]
+
+    def test_non_stage_label_is_ignored(self) -> None:
+        store = _make_store()
+        issue = TaskFactory.create(id=13, tags=["hydraflow-find"])
+        store._route_issues([issue])
+
+        applied = store.apply_label_transition(13, "hydraflow-duplicate")
+
+        assert applied is False
+        assert store._queue_members[STAGE_FIND] == {13}
+
+    def test_uncached_issue_is_ignored(self) -> None:
+        store = _make_store()
+
+        applied = store.apply_label_transition(999, "hydraflow-review")
+
+        assert applied is False
+        assert store._queue_members[STAGE_REVIEW] == set()
+
+    @pytest.mark.asyncio
+    async def test_pushes_pipeline_snapshot_with_the_new_stage(self, event_bus) -> None:
+        store = _make_store(event_bus=event_bus)
+        capture = _SnapshotCapture(event_bus)
+        issue = TaskFactory.create(id=14, tags=["test-label"])
+        store._route_issues([issue])
+
+        store.apply_label_transition(14, "hydraflow-review")
+        await _drain_snapshot_flush(store)
+
+        snap = capture.snapshots()[-1]
+        review_numbers = [e["issue_number"] for e in snap.data["stages"]["review"]]
+        implement_numbers = [
+            e["issue_number"] for e in snap.data["stages"]["implement"]
+        ]
+        assert 14 in review_numbers
+        assert 14 not in implement_numbers
+
+    def test_stale_refresh_does_not_move_the_issue_backward(self) -> None:
+        """The reconciling poll may still carry pre-swap labels — the eager
+        transition must hold until GitHub labels catch up."""
+        store = _make_store()
+        issue = TaskFactory.create(id=15, tags=["test-label"])
+        store._route_issues([issue])
+
+        store.apply_label_transition(15, "hydraflow-review")
+        # Stale poll data: labels still say ready.
+        store._route_issues([TaskFactory.create(id=15, tags=["test-label"])])
+
+        assert store._queue_members[STAGE_REVIEW] == {15}
+        assert 15 not in store._queue_members[STAGE_READY]
+
+
 # ── Lifecycle ────────────────────────────────────────────────────────
 
 

--- a/tests/test_pr_manager_labels.py
+++ b/tests/test_pr_manager_labels.py
@@ -521,6 +521,99 @@ class TestSwapPipelineLabels:
 
 
 # ---------------------------------------------------------------------------
+# swap_pipeline_labels → pipeline-label listener (#9842)
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineLabelListener:
+    """Label swaps notify the injected listener so the dashboard's in-memory
+    pipeline moves in seconds instead of waiting for the 300s label poll."""
+
+    @pytest.mark.asyncio
+    async def test_listener_is_notified_after_a_successful_swap(
+        self, config, event_bus
+    ) -> None:
+        mgr = make_pr_manager(config, event_bus)
+        mgr._add_labels_strict = AsyncMock()
+        mgr._remove_label = AsyncMock()
+        calls: list[tuple[int, str]] = []
+        mgr.set_pipeline_label_listener(lambda n, lbl: calls.append((n, lbl)))
+
+        await mgr.swap_pipeline_labels(42, "hydraflow-review")
+
+        assert calls == [(42, "hydraflow-review")]
+
+    @pytest.mark.asyncio
+    async def test_listener_fires_before_stale_label_removals(
+        self, config, event_bus
+    ) -> None:
+        """The board push must not wait on the best-effort removal fan-out."""
+        mgr = make_pr_manager(config, event_bus)
+        order: list[str] = []
+        mgr._add_labels_strict = AsyncMock(
+            side_effect=lambda *a, **kw: order.append("add")
+        )
+        mgr._remove_label = AsyncMock(
+            side_effect=lambda *a, **kw: order.append("remove")
+        )
+        mgr.set_pipeline_label_listener(lambda n, lbl: order.append("notify"))
+
+        await mgr.swap_pipeline_labels(42, "hydraflow-review")
+
+        assert "notify" in order
+        assert order.index("notify") < order.index("remove")
+        assert order.index("add") < order.index("notify")
+
+    @pytest.mark.asyncio
+    async def test_listener_exception_does_not_break_the_swap(
+        self, config, event_bus, caplog
+    ) -> None:
+        mgr = make_pr_manager(config, event_bus)
+        mgr._add_labels_strict = AsyncMock()
+        mgr._remove_label = AsyncMock()
+
+        def _boom(n: int, lbl: str) -> None:
+            raise RuntimeError("listener exploded")
+
+        mgr.set_pipeline_label_listener(_boom)
+
+        with caplog.at_level(logging.WARNING):
+            await mgr.swap_pipeline_labels(42, "hydraflow-review")
+
+        # Swap completed: stale labels were still removed.
+        assert mgr._remove_label.call_count > 0
+        assert "listener" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_listener_not_called_when_the_add_fails(
+        self, config, event_bus
+    ) -> None:
+        """A failed swap left GitHub unchanged — the board must not move."""
+        mgr = make_pr_manager(config, event_bus)
+        mgr._add_labels_strict = AsyncMock(side_effect=RuntimeError("API down"))
+        mgr._remove_label = AsyncMock()
+        calls: list[tuple[int, str]] = []
+        mgr.set_pipeline_label_listener(lambda n, lbl: calls.append((n, lbl)))
+
+        with pytest.raises(RuntimeError, match="API down"):
+            await mgr.swap_pipeline_labels(42, "hydraflow-review")
+
+        assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_no_listener_configured_swaps_normally(
+        self, config, event_bus
+    ) -> None:
+        mgr = make_pr_manager(config, event_bus)
+        mgr._add_labels_strict = AsyncMock()
+        mgr._remove_label = AsyncMock()
+
+        await mgr.swap_pipeline_labels(42, "hydraflow-review")
+
+        mgr._add_labels_strict.assert_any_call("issue", 42, ["hydraflow-review"])
+
+
+# ---------------------------------------------------------------------------
 # TaskTransitioner protocol compliance
 # ---------------------------------------------------------------------------
 

--- a/tests/test_service_registry.py
+++ b/tests/test_service_registry.py
@@ -64,6 +64,27 @@ class TestBuildServices:
                 continue
             assert getattr(registry, field_name) is not None, f"{field_name} is None"
 
+    def test_pipeline_label_listener_is_wired_to_the_store(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """#9842: label swaps must reach the in-memory pipeline immediately.
+
+        The wiring is hasattr-gated (sandbox fakes read labels live and skip
+        it), so a rename on either side would silently sever the event-driven
+        card path and quietly reintroduce the 5-minute poll lag — pin it.
+        """
+        bus = EventBus()
+        state = StateTracker(config.state_file)
+        stop_event = asyncio.Event()
+        callbacks = _make_callbacks()
+
+        registry = build_services(config, bus, state, stop_event, callbacks)
+
+        listener = registry.prs._pipeline_label_listener
+        assert listener is not None, "pipeline label listener not wired"
+        assert listener.__func__ is type(registry.store).apply_label_transition
+        assert listener.__self__ is registry.store
+
     def test_agents_runner_is_shared(self, config: HydraFlowConfig) -> None:
         """Agents, planners, reviewers, and HITL runner should share the subprocess runner."""
         bus = EventBus()


### PR DESCRIPTION
## Summary

Workstream cards lagged up to ~5 min behind phase transitions because the board's data source (`IssueStore`'s label-derived queues) only re-read GitHub labels at the `data_poll_interval` refresh (300s, `config.py`), itself fed by the 300s `github_cache` cycle. The real-time push machinery already existed end-to-end — `IssueStore` mutations schedule a coalesced `PIPELINE_SNAPSHOT` (0.1s debounce) that the WS layer fans out and the UI reducer applies — but most transition sites only called `PRManager.swap_pipeline_labels`, which never told the store. Eager `enqueue_transition` calls covered some phase paths; escalations, route-backs, orphan requeues, diagnostic verdicts, label-drift reconciliation etc. were all poll-bound.

**Fix — push on transition, poll for truth (#9842):**

- `IssueStore.apply_label_transition(issue_number, new_label)`: maps a swapped pipeline label to its stage and applies it via the existing eager `enqueue_transition` path (which already publishes `QUEUE_UPDATE` + schedules the coalesced `PIPELINE_SNAPSHOT` push, and whose eager protection stops the stale reconciling poll from dragging the card backward).
- `PRManager.set_pipeline_label_listener(...)` + best-effort notify inside `swap_pipeline_labels`, fired after the strict add (the swap is real on GitHub) and before the best-effort stale-label removals. Listener failure never fails the swap.
- `service_registry.build_services` wires listener → store, `hasattr`-gated like `set_crate_manager`, so port fakes are untouched.

The 300s poll is unchanged and remains the reconciling backstop (no cache-layer changes; ADR-0041 sidecar model untouched). No new event type; no UI change — the reducer already consumes `PIPELINE_SNAPSHOT`.

**Latency:** label swap → listener (sync) → eager route → 0.1s debounce → WS push. Card movement goes from up to ~300–600s (poll-bound, worst case two stacked cache cycles) to ~0.1–0.3s after the swap.

## Test evidence

- `tests/test_issue_store.py::TestApplyLabelTransition` — stage moves, HITL, non-stage label ignored, uncached ignored, snapshot payload carries the new stage, stale-poll no-backward-movement.
- `tests/test_pr_manager_labels.py::TestPipelineLabelListener` — notify after successful add, before removals, exception-isolated, not notified when the add fails, no-listener path.
- `tests/test_service_registry.py` — wiring pin: `build_services` connects `PRManager._pipeline_label_listener` to the store's bound `apply_label_transition` (the `hasattr` gate is fail-open; a rename would silently reintroduce the lag).
- `tests/regressions/regression_issue_9842.py` (P10.6) — real `IssueStore` + real `PRManager` wired as in production: a label swap alone (no `refresh()`) produces a live `PIPELINE_SNAPSHOT` frame with the issue in its new stage; a stale poll afterward does not move it back.
- Foreground gate: server/events/websocket/event-reducer-coverage/issue-store/pr-manager/service-registry batteries — 425 passed. `ruff` clean, `pyright` 0 errors, UI vitest 65 files / 1182 tests passed (no UI delta needed).

**MockWorld/sandbox note:** the bridge is deliberately not wired under fakes — `FakeIssueStore` reads `FakeGitHub` labels live on a 1s loop, so MockWorld already exhibits the post-fix contract (swap → snapshot reflects the new stage within ~1s) natively; a scenario would pass with or without this change. The real glue is covered end-to-end by the regression test at the event-bus level plus the wiring pin.

Closes #9842

🤖 Generated with [Claude Code](https://claude.com/claude-code)
