### PR TITLE
fix(refinement): v1 follow-ups — not-planned closes, priority budget, fail-closed fake, inefficiency re-file (#10025)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,51 +1,51 @@
 {
-  "regenerated_at": "2026-07-20T14:32:07.980937+00:00",
-  "commit_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14",
+  "regenerated_at": "2026-07-20T15:48:17.088066+00:00",
+  "commit_sha": "660e926f1be9101006a75d519e8686a434a6e5d2",
   "artifacts": {
     "loops.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
     },
     "ports.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
     },
     "labels.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
     },
     "modules.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
     },
     "events.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
     },
     "adr_xref.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
     },
     "mockworld.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
     },
     "changelog.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
     },
     "coverage_matrix.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
     },
     "adr-conformance.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
     },
     "ai_system_inventory.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
     },
     "traceability_matrix.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
     },
     "functional_areas.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
     },
     "ubiquitous-language.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,9 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W30
 
-- `ba68d67` — feat(orchestration): v2 IssueDriver runtime phase spec + accept ADR-0099 (#10038) (#10038) *(2026-07-20)*
+- `1306712` — fix(fitness): cadence-derived min_samples — scorecards can finally score (#9841) (#10056) (#10056) *(2026-07-20)*
+- `8509ee0` — feat(orchestration): v2 IssueDriver runtime phase spec + accept ADR-0099 (#10038) (#10055) (#10055) *(2026-07-20)*
+- `d94945e` — fix(ul): one file per term — delete stale forks, hard-fail uniqueness lint, store-level dedupe (#9938) (#10051) (#10051) *(2026-07-20)*
 - `f4c0d38` — fix(stale-issue): branch-GC reconciler + unpushed-work boot check (#10011) (#10052) (#10052) *(2026-07-20)*
 - `9d6184d` — feat(liveness): external factory watchdog + boot-time down-detection (#10044) (#10044) *(2026-07-20)*
 - `9fa2966` — fix(health-monitor): stale-code dead-man-switch — host in HealthMonitorLoop (#9596) (#10035) (#10035) *(2026-07-20)*

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -28,7 +28,7 @@ graph LR
     src_telemetry["src.telemetry"]
     src -- "4" --> src_arch
     src -- "14" --> src_auto_tighten
-    src -- "29" --> src_contracts
+    src -- "30" --> src_contracts
     src -- "4" --> src_dashboard_routes
     src -- "5" --> src_disturbance
     src -- "1" --> src_observability

--- a/src/config.py
+++ b/src/config.py
@@ -406,6 +406,11 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
         604800,
     ),
     ("issue_refinement_pair_budget", "HYDRAFLOW_ISSUE_REFINEMENT_PAIR_BUDGET", 24),
+    (
+        "issue_refinement_priority_budget",
+        "HYDRAFLOW_ISSUE_REFINEMENT_PRIORITY_BUDGET",
+        50,
+    ),
     # Work-queue band-draw weights (#10037); see queue_strategy.BandWeights.
     ("queue_weight_p1", "HYDRAFLOW_QUEUE_WEIGHT_P1", 3),
     ("queue_weight_p2", "HYDRAFLOW_QUEUE_WEIGHT_P2", 2),
@@ -4053,6 +4058,16 @@ class HydraFlowConfig(BaseModel):
         description=(
             "Max duplicate-candidate pairs judged by an LLM call per "
             "IssueRefinementLoop tick."
+        ),
+    )
+    issue_refinement_priority_budget: int = Field(
+        default=50,
+        ge=0,
+        le=500,
+        description=(
+            "Max issues priority-scored by an LLM call per "
+            "IssueRefinementLoop tick — bounds full-sweep spend, where every "
+            "unguarded open issue is otherwise a scoring target (#10025)."
         ),
     )
     issue_refinement_model: str = Field(

--- a/src/contract_recording.py
+++ b/src/contract_recording.py
@@ -281,7 +281,21 @@ def _record_close_issue(sandbox_repo: str, tmp_dir: Path) -> Path | None:
         )
         return None
 
-    close = _run(["gh", "issue", "close", str(issue_number), "--repo", sandbox_repo])
+    # `--reason "not planned"` exercises the reason-threading path (#10025):
+    # PRManager.close_issue(reason=...) is how automated dedup closes record
+    # stateReason=NOT_PLANNED instead of gh's default COMPLETED.
+    close = _run(
+        [
+            "gh",
+            "issue",
+            "close",
+            str(issue_number),
+            "--repo",
+            sandbox_repo,
+            "--reason",
+            "not planned",
+        ]
+    )
     if not _require_success(close, label="gh issue close"):
         return None
     assert close is not None
@@ -291,7 +305,7 @@ def _record_close_issue(sandbox_repo: str, tmp_dir: Path) -> Path | None:
         interaction="close_issue",
         fixture_repo=sandbox_repo,
         command="close_issue",
-        args=[str(issue_number)],
+        args=[str(issue_number), "--reason", "not planned"],
         exit_code=close.returncode,
         # Fake-shaped: FakeGitHub.close_issue returns empty stdout/stderr.
         # Real gh CLI may print a confirmation line; we discard it so the

--- a/src/issue_refinement_loop.py
+++ b/src/issue_refinement_loop.py
@@ -32,7 +32,9 @@ Tick pipeline (spec §3, steps 1-6):
    call. An unparseable/failed verdict degrades to a low-confidence digest
    proposal and the pair is still cached (no re-spend next tick).
 3. Score priority for changed issues lacking a P-label (all issues on a full
-   sweep).
+   sweep), capped at ``issue_refinement_priority_budget`` calls per tick. The
+   index + judged-pair cache persist BEFORE this pass, so a watchdog-cancelled
+   tick never repeats its dup judgments (#10025).
 4. Tier the judged verdicts + priority scores into concrete actions, then
    apply them: exact-dup/high pairs auto-close, gating every side effect on a
    still-open re-check + a confirmed close (stale-guard → evidence comment →
@@ -47,8 +49,9 @@ Tick pipeline (spec §3, steps 1-6):
    closed (reopen if supported, else mint a fresh one) or if state lost the
    number but the create-once dedup key survives (adopt the open digest found
    by label).
-6. Persist index + judged-pair cache + full-sweep marker + open proposals, and
-   publish one ``ISSUE_REFINEMENT_UPDATE`` event for the dashboard.
+6. Persist the full-sweep marker (index + judged-pair cache already persisted
+   pre-priority-pass; open proposals in 4b), and publish one
+   ``ISSUE_REFINEMENT_UPDATE`` event for the dashboard.
 
 Kill-switch (ADR-0049): ``_enabled_cb`` AND ``issue_refinement_enabled`` both gate
 the tick at the top. An empty backlog, or no changes with no full sweep due, is
@@ -323,7 +326,18 @@ class IssueRefinementLoop(BaseBackgroundLoop):
                 )
             newly_judged.append(key)
 
-        # 3. Priority scoring for the changed set (all issues on a full sweep).
+        # 2b. Persist the change-detection index + judged-pair cache BEFORE
+        # the priority pass: a watchdog-cancelled tick (the priority pass is
+        # the long tail on a full sweep) must not lose the dup judgments
+        # already paid for — next tick they'd all re-spend (#10025). A pair
+        # whose auto-close later fails or goes stale is REMOVED again in
+        # step 4 (`remove_judged_pairs`) so it still re-judges next tick.
+        self._state.set_refinement_index(new_index)
+        if newly_judged:
+            self._state.add_judged_pairs(newly_judged)
+
+        # 3. Priority scoring for the changed set (all issues on a full
+        # sweep), bounded by `issue_refinement_priority_budget` per tick.
         priorities: dict[int, PriorityVerdict] = {}
         for issue in self._priority_targets(issues, changed, full_sweep=full_sweep):
             prompt = build_priority_prompt(issue)
@@ -348,8 +362,9 @@ class IssueRefinementLoop(BaseBackgroundLoop):
                 )
                 continue
 
-        # 4. Tier + apply. A failed/stale auto-close returns the pair so we do
-        # NOT cache it — it must re-judge next tick against fresh content.
+        # 4. Tier + apply. A failed/stale auto-close returns the pair so its
+        # (already-persisted) cache entry is dropped below — it must re-judge
+        # next tick against fresh content.
         actions = plan_actions(verdicts, priorities, issues_by_number, now)
         closed, relabeled, failures, uncache_pairs = await self._apply(actions)
         if uncache_pairs:
@@ -359,6 +374,9 @@ class IssueRefinementLoop(BaseBackgroundLoop):
                 if a in issues_by_number and b in issues_by_number
             }
             newly_judged = [k for k in newly_judged if k not in stale_keys]
+            # Already persisted in step 2b — drop the stale keys from the
+            # cache too, so a failed/stale close re-judges next tick.
+            self._state.remove_judged_pairs(stale_keys)
 
         # 4b. Accumulate open operator questions across ticks: merge this tick's
         # dup proposals + priority questions into the persisted set, prune the
@@ -395,10 +413,10 @@ class IssueRefinementLoop(BaseBackgroundLoop):
         }
         await self._write_digest(digest_actions, stats, failures)
 
-        # 6. Persist + publish.
-        self._state.set_refinement_index(new_index)
-        if newly_judged:
-            self._state.add_judged_pairs(newly_judged)
+        # 6. Persist + publish. Index + judged pairs were already persisted in
+        # step 2b (pre-priority-pass); only the sweep marker lands here — a
+        # cancelled sweep re-sweeps next tick to finish its priority pass,
+        # with the judged-pair cache absorbing the dup re-spend.
         if full_sweep:
             self._state.set_refinement_last_full_sweep(now)
 
@@ -494,7 +512,10 @@ class IssueRefinementLoop(BaseBackgroundLoop):
             close.duplicate,
             f"**Refinement (auto):** duplicate of #{close.canonical} — {close.evidence}",
         )
-        ok = await self._pr.close_issue(close.duplicate)
+        # "not planned": gh defaults closes to stateReason=COMPLETED, which
+        # every get_issue_state consumer reads as "resolved" — a deduped
+        # issue was retired, not fixed (#10025).
+        ok = await self._pr.close_issue(close.duplicate, reason="not planned")
         if not ok:
             msg = f"close_issue returned False for #{close.duplicate}"
             raise RuntimeError(msg)
@@ -651,9 +672,20 @@ class IssueRefinementLoop(BaseBackgroundLoop):
         ones). Incremental: changed, unguarded issues that lack a P-label —
         scoring an already-prioritised issue would only spend an LLM call for a
         no-op delta.
+
+        Always capped at ``issue_refinement_priority_budget`` — the priority
+        pass had no spend bound analogous to the dup pass's pair budget, so a
+        full sweep over a large backlog could score hundreds of issues in one
+        tick and blow the loop watchdog (#10025). Issues past the cap are
+        simply scored on a later tick: an unscored issue stays unchanged in
+        the index only if its content is unchanged, and the next full sweep
+        re-offers every issue anyway.
         """
+        budget = self._config.issue_refinement_priority_budget
         targets: list[RefinementIssue] = []
         for issue in issues:
+            if len(targets) >= budget:
+                break
             if is_guarded(issue):
                 continue
             if full_sweep:

--- a/src/mockworld/fakes/fake_github.py
+++ b/src/mockworld/fakes/fake_github.py
@@ -81,6 +81,11 @@ class FakeIssue:
     # Empty = "not explicitly seeded": the closed listing falls back to
     # updated_at, mirroring GitHub (closing an issue touches both).
     closed_at: str = ""
+    # Only meaningful once state == "closed"; mirrors gh's stateReason
+    # ("COMPLETED" | "NOT_PLANNED"). Empty = closed without an explicit
+    # reason — get_issue_state falls back to "COMPLETED", matching gh's
+    # default close reason (#10025).
+    state_reason: str = ""
 
 
 @dataclass
@@ -486,10 +491,16 @@ class FakeGitHub:
         if issue_number in self._issues:
             self._issues[issue_number].state = "closed"
 
-    async def close_issue(self, issue_number: int) -> bool:
+    async def close_issue(
+        self, issue_number: int, *, reason: str | None = None
+    ) -> bool:
         self._maybe_rate_limit()
         if issue_number in self._issues:
-            self._issues[issue_number].state = "closed"
+            issue = self._issues[issue_number]
+            issue.state = "closed"
+            # Mirror gh: `--reason "not planned"` -> stateReason NOT_PLANNED;
+            # no --reason -> COMPLETED (get_issue_state's empty fallback).
+            issue.state_reason = reason.upper().replace(" ", "_") if reason else ""
         return True
 
     async def close_pr(self, pr_number: int) -> bool:
@@ -689,21 +700,28 @@ class FakeGitHub:
 
     # --- Loop-required PRPort methods ---
 
-    async def list_issues_by_label(self, label: str) -> list[dict[str, Any]]:
-        """Return open issues carrying *label* as GitHubIssueSummary-style dicts.
+    @staticmethod
+    def _issue_summary(issue: FakeIssue) -> dict[str, Any]:
+        """GitHubIssueSummary-style projection of one issue.
 
-        ``labels`` mirrors the gh wire shape (#9943) so filters reading
-        ``lbl["name"]`` behave identically under the fake and the adapter.
+        Shared by ``list_issues_by_label`` / ``list_open_issues`` — previously
+        two byte-identical copies (#10025). ``labels`` mirrors the gh wire
+        shape (``{"name": ...}``, #9943) so filters reading ``lbl["name"]``
+        behave identically under the fake and the adapter.
         """
+        return {
+            "number": issue.number,
+            "title": issue.title,
+            "body": issue.body,
+            "updated_at": getattr(issue, "updated_at", "2026-01-01T00:00:00Z"),
+            "labels": [{"name": name} for name in issue.labels],
+        }
+
+    async def list_issues_by_label(self, label: str) -> list[dict[str, Any]]:
+        """Return open issues carrying *label* as GitHubIssueSummary-style dicts."""
         self._maybe_rate_limit()
         return [
-            {
-                "number": issue.number,
-                "title": issue.title,
-                "body": issue.body,
-                "updated_at": getattr(issue, "updated_at", "2026-01-01T00:00:00Z"),
-                "labels": [{"name": name} for name in issue.labels],
-            }
+            self._issue_summary(issue)
             for issue in self._issues.values()
             if issue.state == "open" and label in issue.labels
         ]
@@ -711,19 +729,11 @@ class FakeGitHub:
     async def list_open_issues(self) -> list[dict[str, Any]]:
         """Return ALL open issues (no label filter), mirroring the gh projection.
 
-        Used by IssueRefinementLoop's backlog-wide sweep (#9957). ``labels``
-        mirrors the gh wire shape (fake-fidelity), same as
-        ``list_issues_by_label``.
+        Used by IssueRefinementLoop's backlog-wide sweep (#9957).
         """
         self._maybe_rate_limit()
         return [
-            {
-                "number": issue.number,
-                "title": issue.title,
-                "body": issue.body,
-                "updated_at": getattr(issue, "updated_at", "2026-01-01T00:00:00Z"),
-                "labels": [{"name": name} for name in issue.labels],
-            }
+            self._issue_summary(issue)
             for issue in self._issues.values()
             if issue.state == "open"
         ]
@@ -918,12 +928,22 @@ class FakeGitHub:
         return ""
 
     async def get_issue_state(self, issue_number: int) -> str:
-        """Return issue state as GitHub GraphQL style (OPEN/COMPLETED)."""
+        """Return issue state as GitHub GraphQL style (OPEN/COMPLETED/NOT_PLANNED).
+
+        An unknown issue returns ``"UNKNOWN"`` — matching prod
+        ``PRManager.get_issue_state``, which fail-closes with ``"UNKNOWN"``
+        when the ``gh`` read errors. The fake previously fail-opened with
+        ``"OPEN"`` here, which made every still-open guard (e.g. the
+        refinement TOCTOU stale-close check) pass vacuously for issues the
+        fake never saw (#10025).
+        """
         self._maybe_rate_limit()
         if issue_number in self._issues:
-            state = self._issues[issue_number].state
-            return "COMPLETED" if state == "closed" else "OPEN"
-        return "OPEN"
+            issue = self._issues[issue_number]
+            if issue.state == "closed":
+                return issue.state_reason or "COMPLETED"
+            return "OPEN"
+        return "UNKNOWN"
 
     async def get_issue_labels(self, issue_number: int) -> list[str]:
         """Return the label names on an issue (empty list when unknown)."""

--- a/src/ports.py
+++ b/src/ports.py
@@ -304,8 +304,16 @@ class PRPort(Protocol):
 
     # --- Issue management ---
 
-    async def close_issue(self, issue_number: int) -> bool:
+    async def close_issue(
+        self, issue_number: int, *, reason: str | None = None
+    ) -> bool:
         """Close GitHub issue *issue_number*.
+
+        *reason* maps to ``gh issue close --reason`` (``"completed"`` |
+        ``"not planned"``); ``None`` keeps gh's default, which records
+        ``stateReason=COMPLETED``. Automated dedup/wontfix closes should
+        pass ``"not planned"`` so ``get_issue_state`` consumers don't read
+        them as resolved (#10025).
 
         Returns True when the close reached GitHub, False when the
         underlying call failed (fail-soft: no raise). Background callers

--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -14,7 +14,7 @@ import tempfile
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 from urllib.parse import quote
 
 import ci_sentinels
@@ -44,10 +44,53 @@ from subprocess_util import run_subprocess, run_subprocess_with_retry
 from telemetry.spans import port_span  # noqa: E402
 from traceability import append_req_trailer, extract_req_id
 
+if TYPE_CHECKING:
+    from contracts.boundary import BoundaryParseResult
+    from contracts.shapes import GhIssueListItem
+
 logger = logging.getLogger("hydraflow.pr_manager")
 
 # Cache TTL for label-count queries (seconds).
 _LABEL_CACHE_TTL: int = 30
+
+
+def _project_issue_summaries(
+    results: list[BoundaryParseResult[GhIssueListItem]],
+) -> list[GitHubIssueSummary]:
+    """Project lenient-parsed gh issue rows into ``GitHubIssueSummary`` dicts.
+
+    Shared by ``list_issues_by_label`` / ``list_open_issues`` — previously two
+    byte-identical copies (#10025). ``labels`` ride along in gh wire shape
+    (``{"name": ...}``, #9943) so consumers like the preflight human-required
+    filter see real data whether the row validated or fell back to the raw
+    payload.
+    """
+    # Local import keeps the module-load contract identical when the
+    # contracts subsystem isn't imported elsewhere yet.
+    from contracts.boundary import field_or  # noqa: PLC0415
+
+    summaries: list[GitHubIssueSummary] = []
+    for r in results:
+        if r.model_instance is not None:
+            labels = [{"name": lbl.name} for lbl in r.model_instance.labels if lbl.name]
+        else:
+            entry = r.payload if isinstance(r.payload, dict) else {}
+            labels = [
+                {"name": str(lbl.get("name", ""))}
+                for lbl in (entry.get("labels") or [])
+                if isinstance(lbl, dict) and lbl.get("name")
+            ]
+        summaries.append(
+            {
+                "number": field_or(r, "number", 0),
+                "title": field_or(r, "title", ""),
+                "body": field_or(r, "body", ""),
+                "updated_at": field_or(r, "updated_at", "", dict_key="updatedAt"),
+                "labels": labels,
+            }
+        )
+    return summaries
+
 
 _JSONValue = TypeVar("_JSONValue")
 
@@ -1479,36 +1522,8 @@ class PRManager:
             "--limit",
             "100",
         )
-        from contracts.boundary import field_or  # noqa: PLC0415
-
         results = parse_list_with_shape(output or "[]", GhIssueListItem)
-        summaries: list[GitHubIssueSummary] = []
-        for r in results:
-            # #9943: labels ride along in gh wire shape ({"name": ...}) so
-            # consumers like the preflight human-required filter see real
-            # data — the old projection omitted labels and the filter was
-            # a silent no-op.
-            if r.model_instance is not None:
-                labels = [
-                    {"name": lbl.name} for lbl in r.model_instance.labels if lbl.name
-                ]
-            else:
-                entry = r.payload if isinstance(r.payload, dict) else {}
-                labels = [
-                    {"name": str(lbl.get("name", ""))}
-                    for lbl in (entry.get("labels") or [])
-                    if isinstance(lbl, dict) and lbl.get("name")
-                ]
-            summaries.append(
-                {
-                    "number": field_or(r, "number", 0),
-                    "title": field_or(r, "title", ""),
-                    "body": field_or(r, "body", ""),
-                    "updated_at": field_or(r, "updated_at", "", dict_key="updatedAt"),
-                    "labels": labels,
-                }
-            )
-        return summaries
+        return _project_issue_summaries(results)
 
     async def list_open_issues(self) -> list[GitHubIssueSummary]:
         """Return ALL open issues (no label filter) as a list of dicts.
@@ -1535,31 +1550,8 @@ class PRManager:
             "--limit",
             "500",
         )
-        from contracts.boundary import field_or
-
         results = parse_list_with_shape(output or "[]", GhIssueListItem)
-        summaries: list[GitHubIssueSummary] = []
-        for r in results:
-            if r.model_instance is not None:
-                labels = [
-                    {"name": lbl.name} for lbl in r.model_instance.labels if lbl.name
-                ]
-            else:
-                entry = r.payload if isinstance(r.payload, dict) else {}
-                labels = [
-                    {"name": str(lbl.get("name", ""))}
-                    for lbl in (entry.get("labels") or [])
-                    if isinstance(lbl, dict) and lbl.get("name")
-                ]
-            summaries.append(
-                {
-                    "number": field_or(r, "number", 0),
-                    "title": field_or(r, "title", ""),
-                    "body": field_or(r, "body", ""),
-                    "updated_at": field_or(r, "updated_at", "", dict_key="updatedAt"),
-                    "labels": labels,
-                }
-            )
+        summaries = _project_issue_summaries(results)
         if len(summaries) == 500:
             logger.warning(
                 "list_open_issues returned exactly 500 rows — backlog may be"
@@ -1833,11 +1825,19 @@ class PRManager:
         url = parts[1] if len(parts) > 1 else ""
         return (conclusion, url)
 
-    async def close_issue(self, issue_number: int) -> bool:
-        """Close a GitHub issue. Returns False when the gh call failed (#9812)."""
+    async def close_issue(
+        self, issue_number: int, *, reason: str | None = None
+    ) -> bool:
+        """Close a GitHub issue. Returns False when the gh call failed (#9812).
+
+        *reason* maps to ``gh issue close --reason`` (``"completed"`` |
+        ``"not planned"``); ``None`` omits the flag, so gh records its
+        default ``stateReason=COMPLETED`` (#10025).
+        """
         self._assert_repo()
         if self._config.dry_run:
             return True
+        reason_args = ("--reason", reason) if reason else ()
         try:
             await self._run_gh(
                 "gh",
@@ -1846,6 +1846,7 @@ class PRManager:
                 str(issue_number),
                 "--repo",
                 self._repo,
+                *reason_args,
             )
         except RuntimeError as exc:
             logger.warning(

--- a/src/settings_registry.py
+++ b/src/settings_registry.py
@@ -134,7 +134,10 @@ SETTINGS: dict[str, SettingSpec] = {
     # --- Issue Refinement (backlog dedup + priority scoring, #9957) ----------
     "issue_refinement_enabled": SettingSpec("Issue Refinement", live=True, order=0),
     "issue_refinement_pair_budget": SettingSpec("Issue Refinement", live=True, order=1),
-    "issue_refinement_model": SettingSpec("Issue Refinement", live=True, order=2),
+    "issue_refinement_priority_budget": SettingSpec(
+        "Issue Refinement", live=True, order=2
+    ),
+    "issue_refinement_model": SettingSpec("Issue Refinement", live=True, order=3),
     # --- Prompt Refinement (skill-prompt self-refinement, #9724) ----------
     "skill_prompt_refine_enabled": SettingSpec("Prompt Refinement", live=True, order=0),
     "skill_prompt_refine_max_weekly": SettingSpec(

--- a/src/skill_prompt_eval_loop.py
+++ b/src/skill_prompt_eval_loop.py
@@ -85,6 +85,31 @@ def _escalation_subject(title: str) -> str | None:
     return m.group(1) if m else None
 
 
+# Marker label + dedup-key prefix for `prompt-inefficiency` filings (spec §5c).
+# Single-sourced so the filing path (`_file_inefficiency_issue`), the title
+# parser, and the closed-issue reconciler can never drift apart (#10025).
+_INEFFICIENCY_LABEL = "prompt-inefficiency"
+_INEFFICIENCY_KEY_PREFIX = "skill_prompt_eval:inefficiency"
+
+
+def _inefficiency_title(source: str) -> str:
+    return f"Prompt inefficiency: {source} cost-per-call regressed"
+
+
+# Parses `_inefficiency_title` back to the `source` subject. Non-greedy but
+# anchored on both sides — same rationale as `_ESCALATION_TITLE_RE`: sources
+# are machine-named today, and the anchored capture costs nothing if one ever
+# grows spaces.
+_INEFFICIENCY_TITLE_RE = re.compile(
+    r"^Prompt inefficiency: (.+?) cost-per-call regressed$"
+)
+
+
+def _inefficiency_subject(title: str) -> str | None:
+    m = _INEFFICIENCY_TITLE_RE.match(title)
+    return m.group(1) if m else None
+
+
 # Hard cap on the subprocess read. A wedged child must not hang the loop cycle
 # forever and freeze its heartbeat — the #9410 silent-stall failure class
 # (#9454 / #9508). ``make trust-adversarial`` drives an LLM eval harness so it
@@ -325,6 +350,20 @@ class SkillPromptEvalLoop(BaseBackgroundLoop):
             clear_attempts=state.clear_skill_prompt_attempts,
             subject_from_title=_escalation_subject,
         )
+        # Closed-issue reconcile for `prompt-inefficiency` filings: without it
+        # the dedup key set at filing time never clears, so a source that
+        # re-degrades after its issue was closed could never re-file (#10025).
+        # Only the closed path runs — a cost regression has no "no longer
+        # detected at HEAD" auto-close analog (the weekly window moves on),
+        # and there is no per-source attempt counter to clear.
+        self._inefficiencies = EscalationReconciler(
+            prs=pr_manager,
+            dedup=dedup,
+            key_prefix=_INEFFICIENCY_KEY_PREFIX,
+            stuck_label=_INEFFICIENCY_LABEL,
+            clear_attempts=lambda _subject: None,
+            subject_from_title=_inefficiency_subject,
+        )
 
     def _get_default_interval(self) -> int:
         return self._config.skill_prompt_eval_interval
@@ -473,6 +512,10 @@ class SkillPromptEvalLoop(BaseBackgroundLoop):
 
         t0 = time.perf_counter()
         await self._reconcile_closed_escalations()
+        # Same closed-path reconcile for `prompt-inefficiency` filings: a
+        # closed (triaged) inefficiency issue clears its dedup key so a
+        # re-degradation of the same source re-files fresh (#10025).
+        await self._inefficiencies.reconcile_closed()
 
         cases = await self._run_corpus()
         if not cases:
@@ -633,12 +676,17 @@ class SkillPromptEvalLoop(BaseBackgroundLoop):
         return ordered_cases, scorecard
 
     async def _file_inefficiency_issue(self, row: SkillEfficiencyRow) -> None:
-        """File a deduped `prompt-inefficiency` issue for a degraded source."""
+        """File a deduped `prompt-inefficiency` issue for a degraded source.
+
+        The dedup key is cleared when the filed issue closes (the
+        `_inefficiencies` reconciler in `_do_work`), so a source that
+        re-degrades after triage re-files fresh (#10025).
+        """
         dedup = self._dedup.get()
-        key = f"skill_prompt_eval:inefficiency:{row.source}"
+        key = f"{_INEFFICIENCY_KEY_PREFIX}:{row.source}"
         if key in dedup:
             return
-        title = f"Prompt inefficiency: {row.source} cost-per-call regressed"
+        title = _inefficiency_title(row.source)
         trend_pct = (
             f"{row.trend_vs_baseline:+.0%}"
             if row.trend_vs_baseline is not None
@@ -656,7 +704,7 @@ class SkillPromptEvalLoop(BaseBackgroundLoop):
             f"source._"
         )
         await self._pr.create_issue(
-            title, body, ["hydraflow-find", "prompt-inefficiency"]
+            title, body, ["hydraflow-find", _INEFFICIENCY_LABEL]
         )
         dedup.add(key)
         self._dedup.set_all(dedup)

--- a/src/state/_issue_refinement.py
+++ b/src/state/_issue_refinement.py
@@ -71,6 +71,24 @@ class IssueRefinementStateMixin:
         self._data.refinement_judged_pairs = merged
         self.save()
 
+    def remove_judged_pairs(self, keys: Iterable[str]) -> None:
+        """Drop *keys* from the judged-pair cache, preserving order; persist.
+
+        Used by the loop's failed/stale-close un-cache: the cache now
+        persists BEFORE the priority pass (#10025), so a pair whose
+        auto-close later fails must be removed again to re-judge next tick.
+        Unknown keys are ignored; a no-op removal skips the save.
+        """
+        drop = set(keys)
+        if not drop:
+            return
+        existing = self._data.refinement_judged_pairs
+        kept = [k for k in existing if k not in drop]
+        if len(kept) == len(existing):
+            return
+        self._data.refinement_judged_pairs = kept
+        self.save()
+
     # --- weekly full-sweep marker ---
 
     def get_refinement_last_full_sweep(self) -> datetime | None:

--- a/tests/regressions/test_issue_10025_refinement_followups.py
+++ b/tests/regressions/test_issue_10025_refinement_followups.py
@@ -1,0 +1,95 @@
+"""Regression: IssueRefinementLoop v1 follow-ups (#10025).
+
+Pins three bug shapes from the #9957 v1 build's final whole-branch review:
+
+- FakeGitHub.get_issue_state fail-OPENED for unknown issues (returned "OPEN"),
+  while prod PRManager.get_issue_state fail-CLOSES with "UNKNOWN" when the gh
+  read errors. The fake was fail-open exactly at the refinement TOCTOU
+  stale-close guard, making the still-open re-check pass vacuously for any
+  issue the fake never saw.
+- The refinement stale-close guard must therefore ABORT (not close) when
+  either side of a judged pair reads UNKNOWN.
+- gh defaults closes to stateReason=COMPLETED, so refinement auto-closes read
+  as "resolved" to every get_issue_state consumer. The close now threads
+  reason="not planned" through the port triplet and records NOT_PLANNED.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from base_background_loop import LoopDeps
+from config import HydraFlowConfig
+from dedup_store import DedupStore
+from events import EventBus
+from issue_refinement import AutoClose
+from issue_refinement_loop import _REFINEMENT_AUTO_LABEL, IssueRefinementLoop
+from mockworld.fakes.fake_github import FakeGitHub
+from state import StateTracker
+
+
+class _NeverCalledLLM:
+    async def complete(self, prompt: str) -> str:
+        raise AssertionError("no LLM call expected in this regression")
+
+
+def _make_loop(tmp_path: Path, gh: FakeGitHub) -> IssueRefinementLoop:
+    deps = LoopDeps(
+        event_bus=EventBus(),
+        stop_event=asyncio.Event(),
+        status_cb=lambda *a, **k: None,
+        enabled_cb=lambda _name: True,
+    )
+    return IssueRefinementLoop(
+        config=HydraFlowConfig(data_root=tmp_path, repo="hydra/hydraflow"),
+        state=StateTracker(state_file=tmp_path / "state.json"),
+        pr_manager=gh,
+        dedup=DedupStore("issue_refinement", tmp_path / "dedup.json"),
+        deps=deps,
+        refinement_llm=_NeverCalledLLM(),
+    )
+
+
+async def test_fake_github_unknown_issue_state_matches_prod_fail_closed() -> None:
+    """Unknown issue -> "UNKNOWN" (prod parity), never a vacuous "OPEN"."""
+    gh = FakeGitHub()
+    gh.add_issue(101, "Seeded issue", "body")
+
+    assert await gh.get_issue_state(101) == "OPEN"
+    assert await gh.get_issue_state(999) == "UNKNOWN"
+
+
+async def test_fake_github_close_reason_maps_to_state_reason() -> None:
+    """close_issue(reason="not planned") -> NOT_PLANNED; default -> COMPLETED."""
+    gh = FakeGitHub()
+    gh.add_issue(101, "Dedup victim", "body")
+    gh.add_issue(102, "Genuinely fixed", "body")
+
+    await gh.close_issue(101, reason="not planned")
+    await gh.close_issue(102)
+
+    assert await gh.get_issue_state(101) == "NOT_PLANNED"
+    assert await gh.get_issue_state(102) == "COMPLETED"
+
+
+async def test_stale_guard_aborts_close_when_issue_state_unknown(tmp_path) -> None:
+    """The TOCTOU stale-close guard fails CLOSED on an UNKNOWN read: before
+    the fake-fidelity fix it passed vacuously and the close went through."""
+    gh = FakeGitHub()
+    gh.add_issue(102, "The judged duplicate", "body")  # canonical 101 unknown
+    loop = _make_loop(tmp_path, gh)
+    close = AutoClose(
+        canonical=101, duplicate=102, evidence="judged earlier", confidence="high"
+    )
+
+    with pytest.raises(RuntimeError, match="stale judgment"):
+        await loop._apply_auto_close(close)
+
+    assert gh._issues[102].state == "open"
+    assert _REFINEMENT_AUTO_LABEL not in gh._issues[102].labels

--- a/tests/scenarios/test_issue_refinement_scenario.py
+++ b/tests/scenarios/test_issue_refinement_scenario.py
@@ -205,6 +205,9 @@ async def test_auto_close_path_closes_exactly_one_and_records_digest(
 
     duplicate = world.github.issue(102)
     assert duplicate.state == "closed"
+    # Closed as "not planned" (#10025): a deduped issue was retired, not
+    # resolved — get_issue_state consumers must not read it as COMPLETED.
+    assert await world.github.get_issue_state(102) == "NOT_PLANNED"
     assert _REFINEMENT_AUTO_LABEL in duplicate.labels
     assert any(
         c.body == "**Refinement (auto):** duplicate of #101 — "

--- a/tests/test_issue_refinement_loop.py
+++ b/tests/test_issue_refinement_loop.py
@@ -291,6 +291,74 @@ async def test_auto_close_applies_comment_label_and_close(tmp_path) -> None:
     assert _REFINEMENT_AUTO_LABEL not in gh._issues[101].labels
 
 
+async def test_auto_close_records_not_planned_state_reason(tmp_path) -> None:
+    """An auto-closed duplicate must read as NOT_PLANNED, not COMPLETED —
+    a deduped issue was retired, not resolved (#10025)."""
+    gh, state, dedup, bus = _env(tmp_path)
+    _near_dup_pair(gh)
+    llm = ScriptedRefinementLLM(
+        dup={frozenset({101, 102}): _dup_json("exact_dup", 101, "high")}
+    )
+    loop = _make_loop(_cfg(tmp_path), gh, state, dedup, bus, llm)
+
+    await loop._do_work()
+
+    assert gh._issues[102].state == "closed"
+    assert await gh.get_issue_state(102) == "NOT_PLANNED"
+
+
+async def test_priority_budget_caps_full_sweep_scoring(tmp_path) -> None:
+    """A full sweep scores at most `issue_refinement_priority_budget` issues —
+    the priority pass previously had no spend bound analog (#10025)."""
+    gh, state, dedup, bus = _env(tmp_path)
+    # Three dissimilar issues (no dup candidates), all priority targets.
+    gh.add_issue(501, "OAuth login flow returns a blank page", "b1", labels=[])
+    gh.add_issue(502, "Metrics dashboard chart renders upside down", "b2", labels=[])
+    gh.add_issue(503, "Webhook retries hammer the staging deploy hook", "b3", labels=[])
+    llm = ScriptedRefinementLLM()
+    loop = _make_loop(
+        _cfg(tmp_path, issue_refinement_priority_budget=2), gh, state, dedup, bus, llm
+    )
+
+    stats = await loop._do_work()  # first tick = full sweep (no marker)
+
+    assert stats["full_sweep"] is True
+    assert len(llm.priority_nums()) == 2
+
+
+async def test_judged_pairs_and_index_persist_before_priority_pass(tmp_path) -> None:
+    """A watchdog-cancelled tick (cancellation lands mid-priority-pass) must
+    keep the already-paid-for dup judgments: index + judged-pair cache persist
+    BEFORE the priority pass (#10025)."""
+    gh, state, dedup, bus = _env(tmp_path)
+    _near_dup_pair(gh)
+
+    class CancelOnPriorityLLM(ScriptedRefinementLLM):
+        async def complete(self, prompt: str) -> str:
+            if "for duplicates" not in prompt:
+                raise asyncio.CancelledError
+            return await super().complete(prompt)
+
+    llm = CancelOnPriorityLLM(
+        dup={frozenset({101, 102}): _dup_json("likely_dup", 101, "medium")}
+    )
+    loop = _make_loop(_cfg(tmp_path), gh, state, dedup, bus, llm)
+
+    with pytest.raises(asyncio.CancelledError):
+        await loop._do_work()
+
+    judged = state.get_judged_pairs()
+    assert len(judged) == 1
+    assert judged[0].startswith("101:102:")
+    assert set(state.get_refinement_index()) == {"101", "102"}
+
+    # Next tick (fresh LLM): ZERO dup calls — the persisted cache stands.
+    llm2 = ScriptedRefinementLLM(dup=llm.dup)
+    loop2 = _make_loop(_cfg(tmp_path), gh, state, dedup, bus, llm2)
+    await loop2._do_work()
+    assert llm2.dup_calls() == 0
+
+
 async def test_relabel_adds_new_and_removes_previous(tmp_path) -> None:
     gh, state, dedup, bus = _env(tmp_path)
     gh.add_issue(301, "Investigate the wedged planner phase", "body", labels=["P2"])

--- a/tests/test_issue_refinement_state.py
+++ b/tests/test_issue_refinement_state.py
@@ -34,6 +34,7 @@ class TestIssueRefinementConfigDefaults:
         assert cfg.issue_refinement_interval == 86400
         assert cfg.issue_refinement_full_sweep_interval == 604800
         assert cfg.issue_refinement_pair_budget == 24
+        assert cfg.issue_refinement_priority_budget == 50
         assert cfg.issue_refinement_model == ""
 
 
@@ -54,6 +55,22 @@ class TestIssueRefinementConfigBounds:
         with pytest.raises(ValidationError):
             HydraFlowConfig(repo="test/repo", issue_refinement_pair_budget=201)
 
+    def test_priority_budget_accepts_lower_bound(self) -> None:
+        cfg = HydraFlowConfig(repo="test/repo", issue_refinement_priority_budget=0)
+        assert cfg.issue_refinement_priority_budget == 0
+
+    def test_priority_budget_accepts_upper_bound(self) -> None:
+        cfg = HydraFlowConfig(repo="test/repo", issue_refinement_priority_budget=500)
+        assert cfg.issue_refinement_priority_budget == 500
+
+    def test_priority_budget_rejects_below_minimum(self) -> None:
+        with pytest.raises(ValidationError):
+            HydraFlowConfig(repo="test/repo", issue_refinement_priority_budget=-1)
+
+    def test_priority_budget_rejects_above_maximum(self) -> None:
+        with pytest.raises(ValidationError):
+            HydraFlowConfig(repo="test/repo", issue_refinement_priority_budget=501)
+
 
 class TestIssueRefinementConfigEnvOverrides:
     def test_enabled_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -73,6 +90,12 @@ class TestIssueRefinementConfigEnvOverrides:
     def test_pair_budget_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("HYDRAFLOW_ISSUE_REFINEMENT_PAIR_BUDGET", "10")
         assert HydraFlowConfig().issue_refinement_pair_budget == 10
+
+    def test_priority_budget_env_override(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HYDRAFLOW_ISSUE_REFINEMENT_PRIORITY_BUDGET", "5")
+        assert HydraFlowConfig().issue_refinement_priority_budget == 5
 
     def test_model_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("HYDRAFLOW_ISSUE_REFINEMENT_MODEL", "sonnet")
@@ -153,6 +176,26 @@ class TestJudgedPairs:
         assert len(kept) == 5000
         # The oldest 5 were dropped; the remainder keeps its original order.
         assert kept == keys[5:]
+
+    def test_remove_drops_named_keys_preserving_order(self, tmp_path: Path) -> None:
+        st = _tracker(tmp_path)
+        st.add_judged_pairs(["1:2:aaa:bbb", "3:4:ccc:ddd", "5:6:eee:fff"])
+        st.remove_judged_pairs({"3:4:ccc:ddd"})
+        assert st.get_judged_pairs() == ["1:2:aaa:bbb", "5:6:eee:fff"]
+
+    def test_remove_unknown_keys_is_a_noop(self, tmp_path: Path) -> None:
+        st = _tracker(tmp_path)
+        st.add_judged_pairs(["1:2:aaa:bbb"])
+        st.remove_judged_pairs({"9:9:zzz:zzz"})
+        st.remove_judged_pairs(set())
+        assert st.get_judged_pairs() == ["1:2:aaa:bbb"]
+
+    def test_remove_persists_across_reload(self, tmp_path: Path) -> None:
+        st = _tracker(tmp_path)
+        st.add_judged_pairs(["1:2:aaa:bbb", "3:4:ccc:ddd"])
+        st.remove_judged_pairs({"1:2:aaa:bbb"})
+        reloaded = _tracker(tmp_path)
+        assert reloaded.get_judged_pairs() == ["3:4:ccc:ddd"]
 
     def test_prune_applies_across_multiple_calls(self, tmp_path: Path) -> None:
         st = _tracker(tmp_path)

--- a/tests/test_pr_manager_core.py
+++ b/tests/test_pr_manager_core.py
@@ -2412,6 +2412,32 @@ class TestCloseIssue:
         assert config.repo in args
 
     @pytest.mark.asyncio
+    async def test_close_issue_without_reason_omits_flag(self, config, event_bus):
+        manager = make_pr_manager(config, event_bus)
+        mock_create = SubprocessMockBuilder().with_stdout("").build()
+
+        with patch("asyncio.create_subprocess_exec", mock_create):
+            await manager.close_issue(42)
+
+        args = mock_create.call_args[0]
+        assert "--reason" not in args
+
+    @pytest.mark.asyncio
+    async def test_close_issue_reason_passes_gh_reason_flag(self, config, event_bus):
+        """#10025: reason threads to `gh issue close --reason "not planned"` so
+        automated dedup closes record stateReason=NOT_PLANNED, not COMPLETED."""
+        manager = make_pr_manager(config, event_bus)
+        mock_create = SubprocessMockBuilder().with_stdout("").build()
+
+        with patch("asyncio.create_subprocess_exec", mock_create):
+            await manager.close_issue(42, reason="not planned")
+
+        args = mock_create.call_args[0]
+        assert "--reason" in args
+        assert "not planned" in args
+        assert args.index("--reason") + 1 == args.index("not planned")
+
+    @pytest.mark.asyncio
     async def test_close_issue_dry_run_skips_command(self, dry_config, event_bus):
         manager = make_pr_manager(dry_config, event_bus)
         mock_create = SubprocessMockBuilder().build()

--- a/tests/test_skill_prompt_eval_loop.py
+++ b/tests/test_skill_prompt_eval_loop.py
@@ -195,6 +195,86 @@ async def test_reconcile_closed_escalations(loop_env) -> None:
     state.clear_skill_prompt_attempts.assert_called_once_with("case_alpha")
 
 
+async def test_do_work_clears_inefficiency_key_when_issue_closed(
+    loop_env, monkeypatch
+) -> None:
+    """#10025: a closed `prompt-inefficiency` issue clears its dedup key on the
+    next tick (same closed-path reconcile as escalations), so a source that
+    re-degrades after triage re-files instead of hitting a dead dedup key."""
+    from skill_prompt_eval_loop import _INEFFICIENCY_LABEL, _inefficiency_title
+
+    cfg, state, pr, dedup = loop_env
+    key = "skill_prompt_eval:inefficiency:base_runner"
+    dedup.get.return_value = {key}
+
+    async def _closed(label: str, limit: int = 100) -> list[dict]:
+        if label == _INEFFICIENCY_LABEL:
+            return [
+                {
+                    "number": 9701,
+                    "title": _inefficiency_title("base_runner"),
+                    "body": "",
+                    "updated_at": "",
+                }
+            ]
+        return []
+
+    pr.list_closed_issues_by_label.side_effect = _closed
+    stop = asyncio.Event()
+    loop = SkillPromptEvalLoop(
+        config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=_deps(stop)
+    )
+    loop._run_corpus = AsyncMock(return_value=[])
+
+    await loop._do_work()
+
+    dedup.set_all.assert_called_once()
+    remaining = dedup.set_all.call_args.args[0]
+    assert key not in remaining
+    # Inefficiency filings have no per-source attempt counter to clear.
+    state.clear_skill_prompt_attempts.assert_not_called()
+
+
+async def test_inefficiency_refiles_after_key_cleared(loop_env) -> None:
+    """With the dedup key cleared, `_file_inefficiency_issue` files again for
+    the same source; with the key present it stays deduped (#10025)."""
+    from prompt_efficiency import SkillEfficiencyRow
+    from skill_prompt_eval_loop import _INEFFICIENCY_LABEL
+
+    cfg, state, pr, dedup = loop_env
+    stop = asyncio.Event()
+    loop = SkillPromptEvalLoop(
+        config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=_deps(stop)
+    )
+    row = SkillEfficiencyRow(
+        source="base_runner",
+        calls=120,
+        est_cost_usd=3.6,
+        anomalies=0,
+        cost_per_call=0.03,
+        trend_vs_baseline=0.42,
+    )
+
+    dedup.get.return_value = {"skill_prompt_eval:inefficiency:base_runner"}
+    await loop._file_inefficiency_issue(row)
+    pr.create_issue.assert_not_awaited()  # key present -> deduped
+
+    dedup.get.return_value = set()
+    await loop._file_inefficiency_issue(row)
+    pr.create_issue.assert_awaited_once()
+    labels = pr.create_issue.await_args.args[2]
+    assert _INEFFICIENCY_LABEL in labels
+
+
+def test_inefficiency_title_round_trips_through_subject_parser() -> None:
+    """The reconciler's title parser must invert the filing path's title
+    builder — drift between them orphans the dedup key forever (#10025)."""
+    from skill_prompt_eval_loop import _inefficiency_subject, _inefficiency_title
+
+    assert _inefficiency_subject(_inefficiency_title("base_runner")) == "base_runner"
+    assert _inefficiency_subject("Some operator-created issue title") is None
+
+
 _STALE_ESCALATION = {
     "number": 9618,
     "title": "HITL: skill prompt drift case_shrink_001 unresolved after 3",

--- a/tests/trust/contracts/cassettes/github/close_issue.yaml
+++ b/tests/trust/contracts/cassettes/github/close_issue.yaml
@@ -7,6 +7,8 @@ input:
   command: close_issue
   args:
     - "42"
+    - "--reason"
+    - "not planned"
   stdin: null
   env: {}
 output:

--- a/tests/trust/contracts/test_fake_github_contract.py
+++ b/tests/trust/contracts/test_fake_github_contract.py
@@ -46,8 +46,18 @@ async def _invoke_fake_github(cassette: Cassette) -> FakeOutput:  # noqa: PLR091
 
     if method == "close_issue":
         issue_number = int(args[0])
+        # Cassette shape (#10025): ["<number>", "--reason", "<reason>"] —
+        # thread the recorded reason through the fake's close, then assert
+        # the state-reason side effect the reason exists to produce.
+        reason = str(args[2]) if len(args) > 2 and args[1] == "--reason" else None
         fake.add_issue(issue_number, "Test Issue", "body")
-        await fake.close_issue(issue_number)
+        await fake.close_issue(issue_number, reason=reason)
+        expected_reason = reason.upper().replace(" ", "_") if reason else "COMPLETED"
+        state = await fake.get_issue_state(issue_number)
+        assert state == expected_reason, (
+            f"close_issue(reason={reason!r}) recorded state {state!r}; "
+            f"expected {expected_reason!r}"
+        )
         return FakeOutput(exit_code=0, stdout="", stderr="")
 
     if method == "close_task":


### PR DESCRIPTION
## Summary

Ships all five follow-ups from #10025 (PR #10024's final whole-branch review) in one PR:

1. **`close_issue` not-planned reason** — `PRPort.close_issue` gains keyword-only `reason` through the atomic triplet: port protocol docstring/signature, PRManager (`gh issue close --reason`), FakeGitHub (`FakeIssue.state_reason`, mirrored by `get_issue_state`). The close_issue cassette, contract dispatcher, and live recorder now exercise `--reason "not planned"`. `IssueRefinementLoop._apply_auto_close` passes it, so auto-closed duplicates record `stateReason=NOT_PLANNED` instead of reading as resolved to every `get_issue_state` consumer.
2. **Priority-pass spend cap + mid-tick persistence** — new triple-registered `issue_refinement_priority_budget` knob (default 50, ge=0 le=500) bounds per-tick priority LLM calls even on full sweeps; the change-detection index + judged-pair cache now persist BEFORE the priority pass so a watchdog-cancelled tick never repeats its dup judgments. New `StateTracker.remove_judged_pairs` drops a failed/stale close's key from the already-persisted cache so it still re-judges next tick.
3. **FakeGitHub `get_issue_state` fail-open fidelity** — unknown issue now returns `"UNKNOWN"` (prod fail-closed parity) instead of a vacuous `"OPEN"`; the fake was fail-open exactly at the refinement TOCTOU stale-close guard. Full fallout sweep: zero test breakage (all existing consumers seed their issues).
4. **Inefficiency dedup keys clear on close** — a second `EscalationReconciler` (closed path only) in `SkillPromptEvalLoop` with the `prompt-inefficiency` title/label/key-prefix single-sourced, so a source that re-degrades after triage re-files instead of hitting a dead dedup key.
5. **Projection-block extraction** — the byte-identical issue-summary projections in `PRManager.list_issues_by_label`/`list_open_issues` and their FakeGitHub twins now share one helper per side.

Known trade-off (documented in-code): with step-2b persistence, a cancellation landing between the early persist and the apply phase caches a judged pair whose close never ran; the pair re-judges only when either issue's content changes. Accepted — the priority budget cap makes mid-tick cancellation rare, and the alternative (losing all dup judgments) re-spends the whole pass.

## Test plan

- Unit: refinement loop/state (+7 new), pr_manager close_issue `--reason` (+2), skill_prompt_eval inefficiency reconcile (+3), `remove_judged_pairs` (+3)
- Regressions: `tests/regressions/test_issue_10025_refinement_followups.py` (fail-closed UNKNOWN parity, NOT_PLANNED mapping, TOCTOU guard aborts on UNKNOWN)
- MockWorld scenario: refinement auto-close now asserts `NOT_PLANNED`
- Contract: close_issue cassette carries `--reason "not planned"`; dispatcher asserts the state-reason side effect
- Full battery post-staging-merge: `pytest tests/` 19257 passed (exit 0) · scenario_loops 298 passed · ratchet+config-consistency 997 passed · ruff clean · pyright 0 errors

Closes #10025

🤖 Generated with [Claude Code](https://claude.com/claude-code)