### PR TITLE
feat(watchdog): thread-level event-loop freeze detector (#9552)

### DIFF
--- a/docs/adr/0106-thread-level-event-loop-freeze-detector.md
+++ b/docs/adr/0106-thread-level-event-loop-freeze-detector.md
@@ -1,0 +1,37 @@
+# ADR-0106: Thread-level event-loop freeze detector
+
+**Status:** Accepted
+**Date:** 2026-07-20
+**Enforcement:** enforced
+**Enforced by:** pytest:tests/regressions/test_issue_9552.py
+
+## Context
+
+HydraFlow's liveness story had three layers with a hole in the middle. The per-cycle asyncio watchdog (#9455 / #9556, `src/base_background_loop.py`) bounds every `_do_work()` cycle — but it is itself an `await asyncio.wait(...)`, so it can only cancel a cycle that is blocked *on an await*. The external liveness watchdog (#10009, `scripts/factory_liveness_watchdog.py`) runs outside the process via cron/launchd and catches whole-process death or a wedged `/healthz`. The hole (#9552): a **synchronous** block inside any loop's `_do_work` — a CPU spin, blocking file I/O, a non-async `subprocess.run` — freezes the entire event loop. Every asyncio-scheduled watcher freezes with it: the cycle watchdog, the health monitor's dead-man-switches, all of them run *on* the frozen loop. The process stays alive and may even keep accepting TCP, so the external watchdog's 15-minute stale-events check is the only backstop, it fires late, and it cannot say *what* blocked. This is the root-cause shape of the multi-hour silent stalls (#9486).
+
+Detecting "event loop alive as a process but frozen solid" requires an in-process observer that does not run on the event loop.
+
+## Decision
+
+`src/event_loop_watchdog.py` adds the missing layer: a daemon OS **thread** started by `HydraFlowOrchestrator.run()` in `src/orchestrator.py` alongside the loops.
+
+- **Beacon.** A trivial repeating asyncio task stamps a monotonic timestamp (`EventLoopBeacon`) every 1s. While the loop is synchronously blocked the task is simply never scheduled — which is exactly the signal. The stamp is a GIL-atomic float write; cost is negligible.
+- **Detector.** The daemon thread polls the beacon's age against the `event_loop_watchdog_stall_seconds` threshold (default 120s — generous; a true synchronous wedge is multi-minute). One trip per freeze episode, not per poll tick; a fresh beacon closes the episode.
+- **On trip (default-ON):** `faulthandler.dump_traceback(all_threads=True)` to a diagnostics file and stderr — the frozen loop thread's top Python frame in that dump *is* the offending call site — plus a stall marker on disk. The thread cannot file a GitHub issue itself (the async Ports run on the very loop that froze), so escalation is split: `HealthMonitorLoop._check_event_loop_stall` in `src/health_monitor_loop.py` consumes the marker on the next healthy cycle (in-place recovery or post-restart) and files one `hydraflow-find` + `loop-stalled` issue, file-then-clear.
+- **Hard recovery (default-OFF, opt-in):** with `event_loop_watchdog_hard_restart` enabled, the trip ends with `os._exit(75)` (`EX_TEMPFAIL`) so systemd/docker/launchd restarts a live process. Notify-default / restart-opt-in mirrors the branch-GC and external-liveness-watchdog precedent: automated process termination requires explicit operator consent and a supervisor with `Restart=always`; without one a hard exit turns a frozen process into a dead one.
+
+The three knobs are Pydantic fields in `src/config.py` surfaced through `src/settings_registry.py` (System tab; threshold and hard-restart are re-read live by the thread, enabled is captured at startup). They are deliberately *not* in the env-override tables — knobs go to the System tab, secrets stay in `.env`.
+
+One watchdog per process: in multi-repo mode every orchestrator calls `start()`, but they share one event loop, so a process-wide single-flight slot makes all but the first a passive no-op. `stop()` disarms promptly (stop event + bounded join) on any orchestrator exit path; the thread is a daemon regardless, so it can never wedge interpreter shutdown or test teardown.
+
+## Non-goals
+
+Preventing the freezes is out of scope — moving offenders off-loop (`run_in_executor`, `asyncio.create_subprocess_exec`) is a separate, diffuse refactor that this detector's stack dumps exist to prioritise. No meta-meta-watcher: the thread's own liveness is a trivial `Event.wait` poll loop backstopped by the external watchdog. Known limit, accepted: a C extension holding the GIL without release for the whole window defeats any in-process observer, including `faulthandler`; that residual class belongs to the external watchdog.
+
+## Testing boundary
+
+The MockWorld scenario layer is intentionally exempt: thread-level detection of a frozen event loop sits *below* MockWorld's seam (the same rationale that exempts subprocess-internal bounding — MockWorld replays through Ports on a healthy loop and cannot express "the loop itself stopped scheduling"). The behavioral layer is covered instead by `tests/test_event_loop_watchdog.py`, which freezes a real event loop in a child thread with `time.sleep` and asserts detection, dump content, and recovery-callback invocation; the escalation half is covered by `tests/test_health_monitor_event_loop_stall.py`; `tests/regressions/test_issue_9552.py` pins every runtime surface against silent non-delivery (the #9556 lesson).
+
+## Consequences
+
+A synchronous block anywhere in the fleet is now detected in ~2 minutes instead of ≥15 (external watchdog) or never (asyncio-level watchers), and every detection produces the one artifact that turns "the factory hung" into a one-line fix: the all-thread stack dump naming the blocking frame. The cost is one daemon thread, one 1s asyncio task, and a third liveness mechanism to keep conceptually distinct — the layering table at the top of `src/event_loop_watchdog.py` is the canonical statement of who catches what. Operators who want lights-off recovery flip one System-tab knob after confirming their supervisor restarts the process.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -143,6 +143,7 @@ cadence and files remediation issues on drift.
 | [0103](0103-continuous-human-steering-channel.md) | Continuous Human-on-the-Loop Steering Channel | Accepted |
 | [0104](0104-auto-tightening-ratchet.md) | Auto-tightening ratchet | Accepted |
 | [0105](0105-autonomous-convergence-via-decomposition.md) | Autonomous Convergence via Decomposition | Proposed |
+| [0106](0106-thread-level-event-loop-freeze-detector.md) | Thread-level event-loop freeze detector | Accepted |
 
 ## Adding a new ADR
 

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,51 +1,51 @@
 {
-  "regenerated_at": "2026-07-20T16:29:16.344616+00:00",
-  "commit_sha": "b1af3c56e2087cd4058ce891a69cfddf4a3427a2",
+  "regenerated_at": "2026-07-20T19:05:24.438237+00:00",
+  "commit_sha": "3f1f9c1145f2e482d5d8582c9b0d6fa74c484a16",
   "artifacts": {
     "loops.md": {
-      "source_sha": "b1af3c56e2087cd4058ce891a69cfddf4a3427a2"
+      "source_sha": "3f1f9c1145f2e482d5d8582c9b0d6fa74c484a16"
     },
     "ports.md": {
-      "source_sha": "b1af3c56e2087cd4058ce891a69cfddf4a3427a2"
+      "source_sha": "3f1f9c1145f2e482d5d8582c9b0d6fa74c484a16"
     },
     "labels.md": {
-      "source_sha": "b1af3c56e2087cd4058ce891a69cfddf4a3427a2"
+      "source_sha": "3f1f9c1145f2e482d5d8582c9b0d6fa74c484a16"
     },
     "modules.md": {
-      "source_sha": "b1af3c56e2087cd4058ce891a69cfddf4a3427a2"
+      "source_sha": "3f1f9c1145f2e482d5d8582c9b0d6fa74c484a16"
     },
     "events.md": {
-      "source_sha": "b1af3c56e2087cd4058ce891a69cfddf4a3427a2"
+      "source_sha": "3f1f9c1145f2e482d5d8582c9b0d6fa74c484a16"
     },
     "adr_xref.md": {
-      "source_sha": "b1af3c56e2087cd4058ce891a69cfddf4a3427a2"
+      "source_sha": "3f1f9c1145f2e482d5d8582c9b0d6fa74c484a16"
     },
     "mockworld.md": {
-      "source_sha": "b1af3c56e2087cd4058ce891a69cfddf4a3427a2"
+      "source_sha": "3f1f9c1145f2e482d5d8582c9b0d6fa74c484a16"
     },
     "changelog.md": {
-      "source_sha": "b1af3c56e2087cd4058ce891a69cfddf4a3427a2"
+      "source_sha": "3f1f9c1145f2e482d5d8582c9b0d6fa74c484a16"
     },
     "coverage_matrix.md": {
-      "source_sha": "b1af3c56e2087cd4058ce891a69cfddf4a3427a2"
+      "source_sha": "3f1f9c1145f2e482d5d8582c9b0d6fa74c484a16"
     },
     "adr-conformance.md": {
-      "source_sha": "b1af3c56e2087cd4058ce891a69cfddf4a3427a2"
+      "source_sha": "3f1f9c1145f2e482d5d8582c9b0d6fa74c484a16"
     },
     "ai_system_inventory.md": {
-      "source_sha": "b1af3c56e2087cd4058ce891a69cfddf4a3427a2"
+      "source_sha": "3f1f9c1145f2e482d5d8582c9b0d6fa74c484a16"
     },
     "traceability_matrix.md": {
-      "source_sha": "b1af3c56e2087cd4058ce891a69cfddf4a3427a2"
+      "source_sha": "3f1f9c1145f2e482d5d8582c9b0d6fa74c484a16"
     },
     "functional_areas.md": {
-      "source_sha": "b1af3c56e2087cd4058ce891a69cfddf4a3427a2"
+      "source_sha": "3f1f9c1145f2e482d5d8582c9b0d6fa74c484a16"
     },
     "ubiquitous-language.md": {
-      "source_sha": "b1af3c56e2087cd4058ce891a69cfddf4a3427a2"
+      "source_sha": "3f1f9c1145f2e482d5d8582c9b0d6fa74c484a16"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "b1af3c56e2087cd4058ce891a69cfddf4a3427a2"
+      "source_sha": "3f1f9c1145f2e482d5d8582c9b0d6fa74c484a16"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,51 +1,51 @@
 {
-  "regenerated_at": "2026-07-20T14:32:07.980937+00:00",
-  "commit_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14",
+  "regenerated_at": "2026-07-20T16:21:52.614834+00:00",
+  "commit_sha": "9b90a86761632859d435f1e4a6610255d8d616b6",
   "artifacts": {
     "loops.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "9b90a86761632859d435f1e4a6610255d8d616b6"
     },
     "ports.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "9b90a86761632859d435f1e4a6610255d8d616b6"
     },
     "labels.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "9b90a86761632859d435f1e4a6610255d8d616b6"
     },
     "modules.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "9b90a86761632859d435f1e4a6610255d8d616b6"
     },
     "events.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "9b90a86761632859d435f1e4a6610255d8d616b6"
     },
     "adr_xref.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "9b90a86761632859d435f1e4a6610255d8d616b6"
     },
     "mockworld.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "9b90a86761632859d435f1e4a6610255d8d616b6"
     },
     "changelog.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "9b90a86761632859d435f1e4a6610255d8d616b6"
     },
     "coverage_matrix.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "9b90a86761632859d435f1e4a6610255d8d616b6"
     },
     "adr-conformance.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "9b90a86761632859d435f1e4a6610255d8d616b6"
     },
     "ai_system_inventory.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "9b90a86761632859d435f1e4a6610255d8d616b6"
     },
     "traceability_matrix.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "9b90a86761632859d435f1e4a6610255d8d616b6"
     },
     "functional_areas.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "9b90a86761632859d435f1e4a6610255d8d616b6"
     },
     "ubiquitous-language.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "9b90a86761632859d435f1e4a6610255d8d616b6"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "ba68d675f3e56cd3e53d3f0cdd21519c91b61c14"
+      "source_sha": "9b90a86761632859d435f1e4a6610255d8d616b6"
     }
   }
 }

--- a/docs/arch/generated/adr-conformance.md
+++ b/docs/arch/generated/adr-conformance.md
@@ -78,6 +78,7 @@ Static structural map of ADR enforcement, derived purely from parsing Accepted A
 | ADR-0102 | enforced | `pytest:tests/test_review_phase_core.py` |
 | ADR-0103 | enforced | `pytest:tests/test_human_steering.py`, `pytest:tests/test_human_steering_loop.py`, `pytest:tests/test_human_steering_actuator.py`, `pytest:tests/test_human_steering_state.py`, `pytest:tests/test_orchestrator_human_steering.py`, `pytest:tests/test_config_env.py` |
 | ADR-0104 | enforced | `pytest:tests/test_auto_tighten_invariant.py` |
+| ADR-0106 | enforced | `pytest:tests/regressions/test_issue_9552.py` |
 
 ## Check → ADRs it protects
 
@@ -98,6 +99,7 @@ Static structural map of ADR enforcement, derived purely from parsing Accepted A
 | `pytest:tests/architecture/test_term_proposer_wiring.py` | ADR-0054 |
 | `pytest:tests/architecture/test_term_pruner_wiring.py` | ADR-0057 |
 | `pytest:tests/regressions/test_canonical_killswitch.py` | ADR-0049 |
+| `pytest:tests/regressions/test_issue_9552.py` | ADR-0106 |
 | `pytest:tests/regressions/test_otel_disabled_is_noop.py` | ADR-0055 |
 | `pytest:tests/sandbox_scenarios/scenarios/s50_convergence_review.py` | ADR-0094, ADR-0095 |
 | `pytest:tests/scenarios/fakes/test_prior_failure_propagation.py` | ADR-0024 |

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -112,6 +112,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | ADR-0103 | `src.agent`, `src.config`, `src.discover_completeness`, `src.discover_runner`, `src.hitl_runner`, `src.human_steering`, `src.human_steering_loop`, `src.models`, `src.orchestrator`, `src.planner`, `src.review_advisor`, `src.reviewer`, `src.service_registry`, `src.shape_coherence`, `src.shape_runner` | `pytest:tests/test_human_steering.py`, `pytest:tests/test_human_steering_loop.py`, `pytest:tests/test_human_steering_actuator.py`, `pytest:tests/test_human_steering_state.py`, `pytest:tests/test_orchestrator_human_steering.py`, `pytest:tests/test_config_env.py` |
 | ADR-0104 | — | `pytest:tests/test_auto_tighten_invariant.py` |
 | ADR-0105 | — | `'tests/test_issue_decomposer.py'; 'tests/test_decomposition_council.py'; 'tests/test_auto_agent_decompose_terminal.py'; 'tests/test_decomposition_depth_cap.py'; 'tests/scenarios/test_decompose_to_converge_scenario.py'; 'tests/sandbox_scenarios/scenarios/s54_decompose_to_converge.py'. Nested-lineage follow-up (#9757): 'tests/regressions/test_epic_lineage_nested_convergence.py'; 'tests/regressions/test_epic_sweeper_lineage_gate.py'; 'tests/regressions/test_epic_manager_lineage_propagation.py'; 'tests/sandbox_scenarios/scenarios/s55_nested_decompose.py'.` |
+| ADR-0106 | `src.base_background_loop`, `src.config`, `src.event_loop_watchdog`, `src.health_monitor_loop`, `src.orchestrator`, `src.settings_registry` | `pytest:tests/regressions/test_issue_9552.py` |
 
 ## Module → ADRs
 
@@ -133,7 +134,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.assumption_surfacer` | ADR-0064 |
 | `src.auto_agent_preflight_loop` | ADR-0050, ADR-0063, ADR-0084 |
 | `src.auto_pr` | ADR-0101 |
-| `src.base_background_loop` | ADR-0049, ADR-0055, ADR-0084, ADR-0093, ADR-0099 |
+| `src.base_background_loop` | ADR-0049, ADR-0055, ADR-0084, ADR-0093, ADR-0099, ADR-0106 |
 | `src.base_runner` | ADR-0004, ADR-0032, ADR-0055, ADR-0066, ADR-0099 |
 | `src.bg_worker_manager` | ADR-0049 |
 | `src.branch_protection_audit` | ADR-0082 |
@@ -141,7 +142,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.caching_issue_store` | ADR-0041 |
 | `src.code_grooming_loop` | ADR-0065 |
 | `src.complexity_gate` | ADR-0064 |
-| `src.config` | ADR-0002, ADR-0009, ADR-0010, ADR-0018, ADR-0021, ADR-0022, ADR-0031, ADR-0033, ADR-0034, ADR-0035, ADR-0036, ADR-0045, ADR-0050, ADR-0055, ADR-0065, ADR-0084, ADR-0094, ADR-0102, ADR-0103 |
+| `src.config` | ADR-0002, ADR-0009, ADR-0010, ADR-0018, ADR-0021, ADR-0022, ADR-0031, ADR-0033, ADR-0034, ADR-0035, ADR-0036, ADR-0045, ADR-0050, ADR-0055, ADR-0065, ADR-0084, ADR-0094, ADR-0102, ADR-0103, ADR-0106 |
 | `src.contract_diff` | ADR-0047, ADR-0052 |
 | `src.contract_recording` | ADR-0047, ADR-0052 |
 | `src.contract_refresh_loop` | ADR-0045, ADR-0047 |
@@ -179,6 +180,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.epic_monitor_loop` | ADR-0012, ADR-0080 |
 | `src.epic_sweeper_loop` | ADR-0081 |
 | `src.escalation_gate` | ADR-0015 |
+| `src.event_loop_watchdog` | ADR-0106 |
 | `src.events` | ADR-0006, ADR-0055, ADR-0064 |
 | `src.exception_classify` | ADR-0055 |
 | `src.fake_coverage_auditor_loop` | ADR-0045 |
@@ -189,7 +191,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.gate_activator_loop` | ADR-0082 |
 | `src.github_cache_loop` | ADR-0076 |
 | `src.harness_insights` | ADR-0099 |
-| `src.health_monitor_loop` | ADR-0045, ADR-0046 |
+| `src.health_monitor_loop` | ADR-0045, ADR-0046, ADR-0106 |
 | `src.hitl_runner` | ADR-0103 |
 | `src.human_steering` | ADR-0103 |
 | `src.human_steering_loop` | ADR-0103 |
@@ -209,7 +211,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.mockworld.fakes.fake_llm` | ADR-0059 |
 | `src.mockworld.sandbox_main` | ADR-0052 |
 | `src.models` | ADR-0011, ADR-0012, ADR-0013, ADR-0014, ADR-0015, ADR-0016, ADR-0025, ADR-0031, ADR-0037, ADR-0045, ADR-0050, ADR-0064, ADR-0084, ADR-0088, ADR-0094, ADR-0095, ADR-0098, ADR-0099, ADR-0103 |
-| `src.orchestrator` | ADR-0006, ADR-0009, ADR-0014, ADR-0044, ADR-0045, ADR-0103 |
+| `src.orchestrator` | ADR-0006, ADR-0009, ADR-0014, ADR-0044, ADR-0045, ADR-0103, ADR-0106 |
 | `src.pending_concerns` | ADR-0064 |
 | `src.plan_council` | ADR-0064 |
 | `src.plan_council_prompts` | ADR-0064 |
@@ -253,6 +255,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.sentry.reverse_lookup` | ADR-0050 |
 | `src.server` | ADR-0038, ADR-0055 |
 | `src.service_registry` | ADR-0045, ADR-0103 |
+| `src.settings_registry` | ADR-0106 |
 | `src.shape_challenger` | ADR-0064 |
 | `src.shape_coherence` | ADR-0103 |
 | `src.shape_expert_council` | ADR-0064 |

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,9 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W30
 
-- `ba68d67` — feat(orchestration): v2 IssueDriver runtime phase spec + accept ADR-0099 (#10038) (#10038) *(2026-07-20)*
+- `1306712` — fix(fitness): cadence-derived min_samples — scorecards can finally score (#9841) (#10056) (#10056) *(2026-07-20)*
+- `8509ee0` — feat(orchestration): v2 IssueDriver runtime phase spec + accept ADR-0099 (#10038) (#10055) (#10055) *(2026-07-20)*
+- `d94945e` — fix(ul): one file per term — delete stale forks, hard-fail uniqueness lint, store-level dedupe (#9938) (#10051) (#10051) *(2026-07-20)*
 - `f4c0d38` — fix(stale-issue): branch-GC reconciler + unpushed-work boot check (#10011) (#10052) (#10052) *(2026-07-20)*
 - `9d6184d` — feat(liveness): external factory watchdog + boot-time down-detection (#10044) (#10044) *(2026-07-20)*
 - `9fa2966` — fix(health-monitor): stale-code dead-man-switch — host in HealthMonitorLoop (#9596) (#10035) (#10035) *(2026-07-20)*

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,9 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W30
 
+- `9bf0a5d` — Merge remote-tracking branch 'origin/staging' into feat/9552-sync-block-watchdog *(2026-07-20)*
 - `b1af3c5` — feat(watchdog): thread-level event-loop freeze detector (#9552) (#9552) *(2026-07-20)*
+- `14f4a2e` — fix(refinement): v1 follow-ups — not-planned closes, priority budget, fail-closed fake, inefficiency re-file (#10025) (#10066) (#10066) *(2026-07-20)*
 - `1306712` — fix(fitness): cadence-derived min_samples — scorecards can finally score (#9841) (#10056) (#10056) *(2026-07-20)*
 - `8509ee0` — feat(orchestration): v2 IssueDriver runtime phase spec + accept ADR-0099 (#10038) (#10055) (#10055) *(2026-07-20)*
 - `d94945e` — fix(ul): one file per term — delete stale forks, hard-fail uniqueness lint, store-level dedupe (#9938) (#10051) (#10051) *(2026-07-20)*

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -36,7 +36,7 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 | `GateActivatorLoop` | ✅ [0082] | ❌ | ✅ loops.md | ❌ | ✅ `test_gate_activator_loop.py` | ✅ in catalog | ✅ `s45_gate_activator_no_proposals.py` |
 | `GateHealthLoop` | ❌ | ✅ [dark-factory.md] | ✅ loops.md | ✅ (caretaker loop) | ✅ `test_gate_health_loop.py` | ✅ in catalog | ❌ |
 | `GitHubCacheLoop` | ✅ [0076] | ✅ [git-hub-cache-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_github_cache_loop.py` | ✅ in catalog | ✅ `s44_github_cache_idle_poll.py` |
-| `HealthMonitorLoop` | ✅ [0045, 0046, 0093] | ✅ [testing.md] | ✅ loops.md | ✅ README.md | ✅ `test_health_monitor_loop_primary_cycle.py` | ✅ in catalog | ✅ `s48_health_monitor_idle_poll.py` |
+| `HealthMonitorLoop` | ✅ [0045, 0046, 0093, 0106] | ✅ [testing.md] | ✅ loops.md | ✅ README.md | ✅ `test_health_monitor_loop_primary_cycle.py` | ✅ in catalog | ✅ `s48_health_monitor_idle_poll.py` |
 | `HumanSteeringLoop` | ✅ [0103] | ✅ [human-steering-loop.md, steering-channel.md, steering-state.md] | ❌ | ❌ | ✅ `test_human_steering_loop.py` | ✅ in catalog | ✅ `s52_human_steering_directive.py` |
 | `IssueRefinementLoop` | ❌ | ❌ | ✅ loops.md | ✅ (caretaker loop) | ✅ `test_issue_refinement_loop.py` | ✅ in catalog | ✅ `s57_issue_refinement_digest.py` |
 | `LabelDriftWatcherLoop` | ✅ [0088] | ❌ | ✅ loops.md | ✅ README.md | ✅ `test_label_drift_watcher_loop.py` | ✅ in catalog | ❌ |

--- a/src/config.py
+++ b/src/config.py
@@ -2662,6 +2662,51 @@ class HydraFlowConfig(BaseModel):
             "Env: HYDRAFLOW_LOOP_WATCHDOG_LLM_SECONDS."
         ),
     )
+    # -- thread-level event-loop freeze detector (#9552) ----------------------
+    # The asyncio cycle watchdog above cannot see a SYNCHRONOUS block inside a
+    # cycle (CPU spin, blocking file I/O, non-async subprocess.run): such a
+    # block freezes the whole event loop, including every asyncio-scheduled
+    # watcher. EventLoopWatchdog (src/event_loop_watchdog.py) is the
+    # out-of-loop complement: a daemon thread wall-clocks a 1s asyncio beacon.
+    # Knobs are System-tab editable via settings_registry — deliberately NOT
+    # in the env-override tables (knobs→System; secrets stay .env).
+    event_loop_watchdog_enabled: bool = Field(
+        default=True,
+        description=(
+            "Enable the thread-level event-loop freeze detector (#9552). A "
+            "daemon watchdog thread checks a 1s asyncio liveness beacon; when "
+            "the beacon goes stale past event_loop_watchdog_stall_seconds it "
+            "dumps all thread stacks (faulthandler — names the blocking call "
+            "site) and leaves a stall marker the health monitor escalates as "
+            "a hydraflow-find issue. Detection + dump + notify only; process "
+            "restart is the separate opt-in hard-restart knob. Captured at "
+            "orchestrator startup (restart to apply)."
+        ),
+    )
+    event_loop_watchdog_stall_seconds: int = Field(
+        default=120,
+        ge=30,
+        le=3600,
+        description=(
+            "Beacon staleness (seconds) before the event loop is declared "
+            "frozen (default 120 ≈ 120 missed 1s beacons — generous, so a "
+            "briefly-blocking legitimate call never trips it; a true "
+            "synchronous wedge is multi-minute). Re-read by the watchdog "
+            "thread on every poll, so changes apply live."
+        ),
+    )
+    event_loop_watchdog_hard_restart: bool = Field(
+        default=False,
+        description=(
+            "OPT-IN hard recovery for a frozen event loop: after the stack "
+            "dump and stall marker, exit the process with code 75 "
+            "(EX_TEMPFAIL) so systemd/docker/launchd restarts it. Default "
+            "OFF — notify-default, restart-opt-in, mirroring branch-GC and "
+            "the external liveness watchdog (#10009). Enable only where a "
+            "supervisor with Restart=always is in place; without one this "
+            "turns a frozen process into a dead one. Re-read at trip time."
+        ),
+    )
     staging_bisect_flake_reruns: int = Field(
         default=2,
         ge=1,

--- a/src/event_loop_watchdog.py
+++ b/src/event_loop_watchdog.py
@@ -1,0 +1,372 @@
+"""Thread-level event-loop freeze detector (#9552).
+
+The per-cycle asyncio watchdog (#9455 / #9556, ``BaseBackgroundLoop.
+_execute_cycle``) can only cancel a cycle blocked on an *await*. A
+SYNCHRONOUS block inside ``_do_work`` — a CPU spin, blocking file I/O, a
+non-async ``subprocess.run`` — freezes the entire event loop, so every
+asyncio-scheduled watcher (the cycle watchdog, HealthMonitorLoop's
+dead-man-switches, any pacemaker task) freezes with it. Detecting this
+class requires an observer OUTSIDE the event loop.
+
+Liveness layering — this module complements, and must not duplicate, its
+siblings:
+
+- asyncio cycle watchdog (#9556): bounds one cycle's await; runs IN the loop.
+- THIS module: a daemon OS thread wall-clocks a 1s asyncio beacon the loop
+  stamps; catches "process alive but event loop frozen solid". IN-process,
+  out-of-loop.
+- ``scripts/factory_liveness_watchdog.py`` (#10009): external cron/launchd
+  check; catches whole-process death/hang from OUTSIDE the process.
+
+On a stale beacon (older than ``event_loop_watchdog_stall_seconds``), once
+per freeze episode, the thread:
+
+1. dumps ALL thread stacks via ``faulthandler`` to a diagnostics file and
+   stderr — the diagnostic gold: it names the exact blocking frame;
+2. writes a stall marker consumed by ``HealthMonitorLoop.
+   _check_event_loop_stall`` on the next healthy cycle (the thread cannot
+   file GitHub issues itself — Ports are async and run on the very loop
+   that froze), which files one ``hydraflow-find`` + ``loop-stalled`` issue;
+3. only when the default-OFF ``event_loop_watchdog_hard_restart`` knob is
+   enabled, hard-exits with ``EVENT_LOOP_STALL_EXIT_CODE`` so
+   systemd/docker/launchd restarts the process (notify-default,
+   restart-opt-in — the branch-GC / external-liveness-watchdog precedent).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import faulthandler
+import json
+import logging
+import os
+import sys
+import threading
+import time
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from config import HydraFlowConfig
+
+logger = logging.getLogger("hydraflow.event_loop_watchdog")
+
+#: ``EX_TEMPFAIL`` — "transient failure, retry me". Distinct from generic
+#: crash exit codes so supervisors/logs can attribute a restart to a frozen
+#: event loop specifically.
+EVENT_LOOP_STALL_EXIT_CODE = 75
+
+#: How often the asyncio beacon task stamps the heartbeat. Deliberately a
+#: constant, not a knob: the operator-facing dial is the stall threshold; a
+#: 1s beacon makes the threshold read directly as "seconds of frozen loop".
+BEACON_INTERVAL_SECONDS = 1.0
+
+#: Default watchdog-thread poll cadence. Also the bound on how long
+#: :meth:`EventLoopWatchdog.stop` can block joining the thread.
+DEFAULT_POLL_SECONDS = 1.0
+
+_MARKER_FILENAME = "event_loop_stall.json"
+
+# Process-wide single-flight slot: in multi-repo mode every orchestrator
+# calls start(), but all of them share ONE event loop — a second beacon +
+# thread would just duplicate detection (and multiply dumps). First start
+# wins; the rest become passive no-ops. One-element-list slot instead of a
+# rebindable global (the trace_collector._ACTIVE_CONFIG_SLOT pattern).
+_ACTIVE_LOCK = threading.Lock()
+_ACTIVE_SLOT: list[EventLoopWatchdog | None] = [None]
+
+
+def event_loop_stall_marker_path(config: HydraFlowConfig) -> Path:
+    """Canonical marker location — shared by the watchdog (writer) and
+    ``HealthMonitorLoop._check_event_loop_stall`` (reader/consumer)."""
+    return config.diagnostics_dir / _MARKER_FILENAME
+
+
+def read_stall_marker(path: Path) -> dict[str, Any] | None:
+    """Return the stall-marker payload, or ``None`` if absent/corrupt."""
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        logger.warning(
+            "Could not read event-loop stall marker %s — treating as absent", path
+        )
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def write_stall_marker(path: Path, payload: dict[str, Any]) -> None:
+    """Atomically persist *payload* (write-then-``os.replace``)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def clear_stall_marker(path: Path) -> None:
+    """Consume the marker. Missing file is fine (already consumed)."""
+    path.unlink(missing_ok=True)
+
+
+class EventLoopBeacon:
+    """Monotonic liveness stamp bridging the event loop and the thread.
+
+    The loop thread calls :meth:`stamp` (from the beacon task); the watchdog
+    thread calls :meth:`age`. A float attribute write/read is atomic under
+    the GIL, so no lock is needed. ``clock`` is injectable so tests never
+    monkeypatch global ``time.monotonic`` (the documented xdist/coverage
+    clock-patch flake trap).
+    """
+
+    def __init__(self, *, clock: Callable[[], float] = time.monotonic) -> None:
+        self._clock = clock
+        self._last: float = clock()
+
+    def stamp(self) -> None:
+        """Record 'the event loop was scheduling tasks at this instant'."""
+        self._last = self._clock()
+
+    def age(self) -> float:
+        """Seconds since the loop last proved liveness."""
+        return self._clock() - self._last
+
+
+class EventLoopWatchdog:
+    """Daemon-thread observer for a synchronously-frozen asyncio event loop.
+
+    Built by :func:`build_event_loop_watchdog` in production (which threads
+    the config knobs through as callables so System-tab edits apply live);
+    tests construct it directly with tiny thresholds and an injected
+    ``exit_fn`` so nothing ever actually kills the test runner.
+    """
+
+    def __init__(
+        self,
+        *,
+        stall_seconds_cb: Callable[[], float],
+        hard_restart_cb: Callable[[], bool],
+        diagnostics_dir: Path,
+        beacon_interval: float = BEACON_INTERVAL_SECONDS,
+        poll_seconds: float = DEFAULT_POLL_SECONDS,
+        clock: Callable[[], float] = time.monotonic,
+        exit_fn: Callable[[int], None] | None = None,
+        dump_fn: Callable[[Path], None] | None = None,
+    ) -> None:
+        self._stall_seconds_cb = stall_seconds_cb
+        self._hard_restart_cb = hard_restart_cb
+        self._diagnostics_dir = diagnostics_dir
+        self._marker_path = diagnostics_dir / _MARKER_FILENAME
+        self._beacon_interval = beacon_interval
+        self._poll_seconds = poll_seconds
+        self._beacon = EventLoopBeacon(clock=clock)
+        # os._exit, not sys.exit: a clean shutdown needs the (frozen) event
+        # loop to cooperate, which is exactly what it cannot do. Injectable
+        # so tests record the call instead of dying.
+        self._exit_fn: Callable[[int], None] = exit_fn or os._exit
+        self._dump_fn: Callable[[Path], None] = dump_fn or self._default_dump
+        self._thread_stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._beacon_task: asyncio.Task[None] | None = None
+        # Debounce: one dump + one marker per freeze episode, not one per
+        # poll tick. Cleared when the beacon goes fresh again (recovery).
+        self._episode_active = False
+        self._check_error_logged = False
+        self._owns_slot = False
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def start(self) -> bool:
+        """Arm the watchdog: beacon task on the running loop + daemon thread.
+
+        Must be called from a running event loop (the one to be watched).
+        Returns ``False`` (passive no-op) when another watchdog already owns
+        the process slot — multi-repo orchestrators share one loop and need
+        only one observer.
+        """
+        with _ACTIVE_LOCK:
+            active = _ACTIVE_SLOT[0]
+            if active is not None and active is not self:
+                logger.debug(
+                    "Event-loop watchdog already active in this process — "
+                    "this instance stays passive"
+                )
+                return False
+            _ACTIVE_SLOT[0] = self
+        self._owns_slot = True
+        self._thread_stop.clear()
+        self._beacon.stamp()
+        self._beacon_task = asyncio.get_running_loop().create_task(
+            self._beacon_loop(), name="hydraflow-event-loop-beacon"
+        )
+        self._thread = threading.Thread(
+            target=self._thread_main,
+            name="hydraflow-event-loop-watchdog",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.info(
+            "Event-loop freeze detector armed (stall threshold %.0fs, hard_restart=%s)",
+            float(self._stall_seconds_cb()),
+            bool(self._hard_restart_cb()),
+        )
+        return True
+
+    def stop(self) -> None:
+        """Disarm promptly: stop the thread (bounded join) + cancel the beacon.
+
+        Safe to call multiple times and on a passive (never-started) instance.
+        The thread is a daemon either way, so even a missed stop can never
+        wedge interpreter shutdown or test teardown.
+        """
+        self._thread_stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=self._poll_seconds + 1.0)
+            self._thread = None
+        if self._beacon_task is not None:
+            self._beacon_task.cancel()
+            self._beacon_task = None
+        if self._owns_slot:
+            with _ACTIVE_LOCK:
+                if _ACTIVE_SLOT[0] is self:
+                    _ACTIVE_SLOT[0] = None
+            self._owns_slot = False
+
+    # -- event-loop side ---------------------------------------------------
+
+    async def _beacon_loop(self) -> None:
+        """Stamp the beacon every ``beacon_interval`` seconds.
+
+        Trivially cheap (one monotonic read + float store per second). While
+        the loop is synchronously blocked this coroutine is simply never
+        scheduled — which is precisely the signal the thread reads.
+        """
+        while not self._thread_stop.is_set():
+            self._beacon.stamp()
+            await asyncio.sleep(self._beacon_interval)
+
+    # -- watchdog-thread side ----------------------------------------------
+
+    def _thread_main(self) -> None:
+        while not self._thread_stop.wait(self._poll_seconds):
+            try:
+                self._check_once()
+            except Exception:
+                # Watchdog must outlive its own bugs — log once, keep polling.
+                if not self._check_error_logged:
+                    self._check_error_logged = True
+                    logger.exception(
+                        "Event-loop watchdog check failed — logged once, "
+                        "the thread keeps polling"
+                    )
+
+    def _check_once(self) -> bool:
+        """One staleness check. Returns True only when a trip fired.
+
+        Episode semantics: the first poll past the threshold trips (dump +
+        marker + optional hard restart); subsequent polls of the SAME frozen
+        episode are silent; a fresh beacon closes the episode so a later
+        freeze trips again.
+        """
+        age = self._beacon.age()
+        threshold = float(self._stall_seconds_cb())
+        if age < threshold:
+            if self._episode_active:
+                self._episode_active = False
+                logger.warning(
+                    "Event loop recovered — beacon fresh again (age %.1fs) "
+                    "after a synchronous stall episode",
+                    age,
+                )
+            return False
+        if self._episode_active:
+            return False
+        self._episode_active = True
+        self._trip(age, threshold)
+        return True
+
+    def _trip(self, age: float, threshold: float) -> None:
+        detected_at = datetime.now(UTC)
+        dump_path = self._diagnostics_dir / (
+            f"event_loop_stall_{detected_at.strftime('%Y%m%dT%H%M%SZ')}.txt"
+        )
+        logger.critical(
+            "Event loop FROZEN: liveness beacon stale for %.1fs "
+            "(threshold %.0fs). A synchronous block is wedging the process — "
+            "dumping all thread stacks to %s",
+            age,
+            threshold,
+            dump_path,
+        )
+        try:
+            self._dump_fn(dump_path)
+        except Exception:
+            # Diagnostics must not kill the escalation that follows.
+            logger.exception("faulthandler stack dump failed")
+        prior = read_stall_marker(self._marker_path)
+        payload: dict[str, Any] = {
+            "detected_at": detected_at.isoformat(),
+            "stalled_for_seconds": round(age, 1),
+            "threshold_seconds": threshold,
+            "pid": os.getpid(),
+            "dump_path": str(dump_path),
+            "hard_restart": bool(self._hard_restart_cb()),
+            # Episodes that froze-and-recovered before the health monitor
+            # consumed the marker accumulate here instead of being lost.
+            "episode_count": (prior.get("episode_count", 0) if prior else 0) + 1,
+        }
+        try:
+            write_stall_marker(self._marker_path, payload)
+        except Exception:
+            # The marker is a best-effort breadcrumb, never fatal.
+            logger.exception("Could not write event-loop stall marker")
+        if self._hard_restart_cb():
+            logger.critical(
+                "event_loop_watchdog_hard_restart is enabled — exiting with "
+                "code %d so the process supervisor restarts a live instance",
+                EVENT_LOOP_STALL_EXIT_CODE,
+            )
+            self._exit_fn(EVENT_LOOP_STALL_EXIT_CODE)
+
+    def _default_dump(self, path: Path) -> None:
+        """All-thread stack dump to *path* and (best-effort) stderr.
+
+        The frozen loop thread's top Python frame in this dump IS the
+        offending synchronous call site — the one artifact that turns "the
+        factory hung" into a one-line fix.
+        """
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as fh:
+            faulthandler.dump_traceback(file=fh, all_threads=True)
+        with contextlib.suppress(Exception):
+            faulthandler.dump_traceback(file=sys.stderr, all_threads=True)
+
+
+def build_event_loop_watchdog(
+    config: HydraFlowConfig, *, force: bool = False
+) -> EventLoopWatchdog | None:
+    """Config-wired watchdog for orchestrator startup, or ``None``.
+
+    Returns ``None`` when the ``event_loop_watchdog_enabled`` knob is off, or
+    under pytest (mirroring ``server._init_sentry``: orchestrators spun up by
+    tests/MockWorld scenarios must not grow real observer threads).
+    ``force=True`` bypasses the pytest guard so the watchdog's own tests can
+    exercise the builder wiring.
+
+    The threshold/hard-restart knobs are threaded through as callables that
+    re-read the live config object each poll, so System-tab edits apply
+    without a restart (the control route mutates the config in place).
+    """
+    if not config.event_loop_watchdog_enabled:
+        return None
+    if not force and (os.environ.get("PYTEST_CURRENT_TEST") or "pytest" in sys.modules):
+        return None
+    return EventLoopWatchdog(
+        stall_seconds_cb=lambda: config.event_loop_watchdog_stall_seconds,
+        hard_restart_cb=lambda: config.event_loop_watchdog_hard_restart,
+        diagnostics_dir=config.diagnostics_dir,
+    )

--- a/src/health_monitor_loop.py
+++ b/src/health_monitor_loop.py
@@ -19,6 +19,11 @@ from audit_chain import AuditChain
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import Credentials, HydraFlowConfig
 from dedup_store import DedupStore
+from event_loop_watchdog import (
+    clear_stall_marker,
+    event_loop_stall_marker_path,
+    read_stall_marker,
+)
 from events import EventType, HydraFlowEvent
 from git_revision import get_commits_behind
 from subprocess_util import run_subprocess
@@ -459,6 +464,15 @@ class HealthMonitorLoop(BaseBackgroundLoop):
             await self._check_stale_code()
         except Exception:
             logger.debug("stale-code check failed", exc_info=True)
+
+        # Escalate a prior synchronous event-loop freeze recorded by the
+        # thread-level EventLoopWatchdog (#9552). The watchdog thread cannot
+        # file issues itself — Ports are async and run on the very loop that
+        # froze — so it leaves a marker this (now-healthy) loop consumes.
+        try:
+            await self._check_event_loop_stall()
+        except Exception:
+            logger.debug("event-loop stall check failed", exc_info=True)
 
         # Generic stall sweep: restart-first for any silent registry loop.
         # Deliberately unwrapped (unlike the grandfathered sibling checks
@@ -1377,6 +1391,63 @@ class HealthMonitorLoop(BaseBackgroundLoop):
             )
             keys = keys | {filed_key}
             dedup.set_all(keys)
+
+    async def _check_event_loop_stall(self) -> None:
+        """Escalate a synchronous event-loop freeze recorded by the watchdog.
+
+        ``EventLoopWatchdog`` (#9552) is a daemon THREAD: while the event
+        loop is frozen it can dump stacks and write a marker, but it cannot
+        file a GitHub issue — the async Ports run on the very loop that
+        froze. This check runs once the loop is healthy again (in-place
+        recovery, or the first cycles after a process restart), files one
+        ``hydraflow-find`` + ``loop-stalled`` issue per marker, then consumes
+        the marker. File-then-clear: a failed filing leaves the marker in
+        place so the next tick retries; the marker file itself is the dedup.
+        """
+        prs = self._prs
+        if prs is None:
+            return
+        marker_path = event_loop_stall_marker_path(self._config)
+        marker = read_stall_marker(marker_path)
+        if marker is None:
+            return
+        detected_at = marker.get("detected_at", "unknown")
+        stalled_for = marker.get("stalled_for_seconds", "?")
+        threshold = marker.get("threshold_seconds", "?")
+        dump_path = marker.get("dump_path", "unknown")
+        episodes = marker.get("episode_count", 1)
+        hard_restart = marker.get("hard_restart", False)
+        title = (
+            f"event-loop-stalled: process event loop froze synchronously "
+            f"for {stalled_for}s"
+        )
+        body = (
+            f"## Event-loop freeze detected by the thread-level watchdog "
+            f"(#9552)\n\n"
+            f"The asyncio event loop stopped scheduling tasks for "
+            f"`{stalled_for}s` (threshold `{threshold}s`) — a SYNCHRONOUS "
+            f"block (CPU spin, blocking file I/O, non-async subprocess.run) "
+            f"inside a loop's `_do_work` wedged the entire process. The "
+            f"per-cycle asyncio watchdog cannot see this class; the "
+            f"`EventLoopWatchdog` daemon thread caught it from outside the "
+            f"loop.\n\n"
+            f"- Detected at: `{detected_at}`\n"
+            f"- Freeze episodes before this escalation: `{episodes}`\n"
+            f"- All-thread stack dump: `{dump_path}`\n"
+            f"- Hard restart was enabled at trip time: `{hard_restart}`\n\n"
+            f"### Operator playbook\n"
+            f"1. Open the stack dump above — the frozen loop thread's top "
+            f"Python frame IS the offending synchronous call site.\n"
+            f"2. Move that call off-loop (`asyncio.create_subprocess_exec`, "
+            f"`run_in_executor`) and file/fix accordingly.\n"
+            f"3. For recovery-in-place next time, consider enabling "
+            f"`event_loop_watchdog_hard_restart` in the **System** tab "
+            f"(requires a process supervisor with Restart=always).\n\n"
+            f"_Auto-filed by HydraFlow `health_monitor` (event-loop freeze "
+            f"escalation, #9552)._"
+        )
+        await prs.create_issue(title, body, ["hydraflow-find", "loop-stalled"])
+        clear_stall_marker(marker_path)
 
     async def _check_wiki_freshness(self) -> None:
         """Dead-man-switch for `RepoWikiLoop` via `docs/wiki/log.jsonl` mtime.

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, cast
 from adr_utils import is_adr_issue_title
 from bg_worker_manager import BGWorkerManager
 from config import HydraFlowConfig
+from event_loop_watchdog import build_event_loop_watchdog
 from events import EventBus, EventType, HydraFlowEvent
 from hitl_controller import HITLController
 from human_steering import apply_steering, resolve_redo_phase
@@ -1053,6 +1054,14 @@ class HydraFlowOrchestrator:
         """
         self._stop_event.clear()
         self._running = True
+        # #9552: arm the thread-level event-loop freeze detector before any
+        # loop starts, so a synchronous block anywhere in the fleet is
+        # observable from OUTSIDE the (then-frozen) event loop. Builder
+        # returns None when disabled or under pytest; start() is a passive
+        # no-op when another orchestrator on this process already armed one.
+        event_loop_watchdog = build_event_loop_watchdog(self._config)
+        if event_loop_watchdog is not None:
+            event_loop_watchdog.start()
         try:
             self._restore_state()
             await self._publish_status()
@@ -1110,6 +1119,12 @@ class HydraFlowOrchestrator:
                 await self._publish_status()
                 logger.info("HydraFlow stopped")
         finally:
+            # #9552: disarm the freeze detector on ANY exit path — the thread
+            # exits within one poll tick of the stop event; a leaked daemon
+            # thread can't wedge teardown, but a prompt stop keeps restarts
+            # (and tests that force=True the builder) clean.
+            if event_loop_watchdog is not None:
+                event_loop_watchdog.stop()
             # Safety net: if run() is cancelled or raises during the setup
             # phase above (before the supervise-loops try-block), the inner
             # finally never executes and the line would stay stuck reporting

--- a/src/settings_registry.py
+++ b/src/settings_registry.py
@@ -96,6 +96,21 @@ SETTINGS: dict[str, SettingSpec] = {
     "gh_circuit_breaker_enabled": SettingSpec("Reliability", live=True, order=0),
     "merge_policy_enabled": SettingSpec("Reliability", live=True, order=1),
     "stale_code_alert_threshold": SettingSpec("Reliability", live=True, order=2),
+    # --- Event-Loop Watchdog (thread-level freeze detector, #9552) --------
+    # enabled gates thread startup (captured at orchestrator start) → restart
+    # badge; the other two are re-read by the watchdog thread on every poll /
+    # at trip time (the builder threads them through as live callables).
+    # hard_restart defaults False (notify-default, restart-opt-in) — flipping
+    # it is the operator's explicit consent to supervisor-driven restarts.
+    "event_loop_watchdog_enabled": SettingSpec(
+        "Event-Loop Watchdog", live=False, order=0
+    ),
+    "event_loop_watchdog_stall_seconds": SettingSpec(
+        "Event-Loop Watchdog", live=True, order=1
+    ),
+    "event_loop_watchdog_hard_restart": SettingSpec(
+        "Event-Loop Watchdog", live=True, order=2
+    ),
     # --- Branch GC (stale agent-branch reconciler, #10011) ----------------
     # Live: StaleIssueLoop re-reads these each tick, no restart needed.
     # delete_enabled defaults False (report/comment-only) since deletion is

--- a/tests/regressions/test_issue_9552.py
+++ b/tests/regressions/test_issue_9552.py
@@ -1,0 +1,93 @@
+"""Regression pin for #9552: the thread-level event-loop freeze detector.
+
+The #9556 lesson (its regression sibling in this directory) is that a
+watchdog can be designed, referenced by memory notes, and never actually
+delivered — silent non-delivery. These tests pin every runtime surface of
+the #9552 detector so it cannot quietly disappear:
+
+1. ``src/event_loop_watchdog.py`` exposes the public API;
+2. ``HydraFlowConfig`` carries the three knobs with the contract defaults
+   (detection ON, 120s threshold, hard-restart OFF — notify-default,
+   restart-opt-in);
+3. the knobs are System-tab editable (settings_registry), NOT env-table;
+4. the orchestrator arms the watchdog in ``run()``;
+5. the health monitor consumes the stall marker (the escalation half the
+   thread itself cannot perform while the loop is frozen).
+"""
+
+from __future__ import annotations
+
+import inspect
+
+
+def test_module_exposes_public_api() -> None:
+    import event_loop_watchdog as mod
+
+    for symbol in (
+        "EVENT_LOOP_STALL_EXIT_CODE",
+        "EventLoopBeacon",
+        "EventLoopWatchdog",
+        "build_event_loop_watchdog",
+        "event_loop_stall_marker_path",
+        "read_stall_marker",
+        "write_stall_marker",
+        "clear_stall_marker",
+    ):
+        assert hasattr(mod, symbol), (
+            f"event_loop_watchdog is missing `{symbol}` — the #9552 freeze "
+            "detector's public contract regressed"
+        )
+    assert mod.EVENT_LOOP_STALL_EXIT_CODE == 75  # EX_TEMPFAIL, documented
+
+
+def test_config_knobs_exist_with_contract_defaults() -> None:
+    from config import HydraFlowConfig
+
+    fields = HydraFlowConfig.model_fields
+    assert "event_loop_watchdog_enabled" in fields
+    assert "event_loop_watchdog_stall_seconds" in fields
+    assert "event_loop_watchdog_hard_restart" in fields
+    # Detection + dump + notify is default-ON; hard process restart is
+    # default-OFF (branch-GC / external-liveness-watchdog precedent). A
+    # flipped default here is a policy change, not a refactor.
+    assert fields["event_loop_watchdog_enabled"].default is True
+    assert fields["event_loop_watchdog_stall_seconds"].default == 120
+    assert fields["event_loop_watchdog_hard_restart"].default is False
+
+
+def test_knobs_are_settings_registry_entries_not_env() -> None:
+    from settings_registry import SETTINGS
+
+    for name in (
+        "event_loop_watchdog_enabled",
+        "event_loop_watchdog_stall_seconds",
+        "event_loop_watchdog_hard_restart",
+    ):
+        assert name in SETTINGS, (
+            f"`{name}` missing from settings_registry — the #9552 knobs are "
+            "System-tab-editable by contract (knobs→System, never .env)"
+        )
+
+
+def test_orchestrator_arms_the_watchdog_in_run() -> None:
+    from orchestrator import HydraFlowOrchestrator
+
+    source = inspect.getsource(HydraFlowOrchestrator.run)
+    assert "build_event_loop_watchdog" in source, (
+        "HydraFlowOrchestrator.run no longer arms the event-loop freeze "
+        "detector (#9552) — a synchronous block in any loop's _do_work "
+        "would again freeze the whole fleet undetected"
+    )
+    assert ".stop()" in source
+
+
+def test_health_monitor_consumes_the_stall_marker() -> None:
+    from health_monitor_loop import HealthMonitorLoop
+
+    assert hasattr(HealthMonitorLoop, "_check_event_loop_stall")
+    source = inspect.getsource(HealthMonitorLoop._do_work)
+    assert "_check_event_loop_stall" in source, (
+        "HealthMonitorLoop._do_work no longer runs the event-loop stall "
+        "escalation check (#9552) — freeze markers would rot on disk "
+        "unescalated"
+    )

--- a/tests/test_event_loop_watchdog.py
+++ b/tests/test_event_loop_watchdog.py
@@ -1,0 +1,379 @@
+"""Unit + behavioral tests for the thread-level event-loop freeze detector.
+
+Issue #9552. The deterministic core (`_check_once`) is driven with an
+injected stepping clock — no sleeping, no global ``time.monotonic``
+monkeypatching. The behavioral tests run a REAL event loop in a child
+thread, block it synchronously with ``time.sleep``, and assert the watchdog
+thread observes the freeze from outside — the exact class the asyncio cycle
+watchdog cannot see. ``exit_fn`` is always injected; ``os._exit`` never runs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from pathlib import Path
+
+from config import HydraFlowConfig
+from event_loop_watchdog import (
+    EVENT_LOOP_STALL_EXIT_CODE,
+    EventLoopBeacon,
+    EventLoopWatchdog,
+    build_event_loop_watchdog,
+    clear_stall_marker,
+    event_loop_stall_marker_path,
+    read_stall_marker,
+    write_stall_marker,
+)
+
+
+class SteppingClock:
+    """Deterministic monotonic clock — advanced explicitly by the test."""
+
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _make_watchdog(
+    tmp_path: Path,
+    *,
+    stall: float = 100.0,
+    hard_restart: bool = False,
+    clock: SteppingClock | None = None,
+    poll: float = 0.05,
+    beacon_interval: float = 0.05,
+    exit_calls: list[int] | None = None,
+    dump_calls: list[Path] | None = None,
+) -> EventLoopWatchdog:
+    return EventLoopWatchdog(
+        stall_seconds_cb=lambda: stall,
+        hard_restart_cb=lambda: hard_restart,
+        diagnostics_dir=tmp_path / "diagnostics",
+        beacon_interval=beacon_interval,
+        poll_seconds=poll,
+        clock=clock if clock is not None else time.monotonic,
+        exit_fn=exit_calls.append if exit_calls is not None else (lambda _c: None),
+        dump_fn=dump_calls.append if dump_calls is not None else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Beacon staleness math
+# ---------------------------------------------------------------------------
+
+
+def test_beacon_age_grows_with_clock_and_resets_on_stamp() -> None:
+    clock = SteppingClock()
+    beacon = EventLoopBeacon(clock=clock)
+    assert beacon.age() == 0.0
+    clock.advance(42.0)
+    assert beacon.age() == 42.0
+    beacon.stamp()
+    assert beacon.age() == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _check_once: detection core (deterministic, no threads, no sleeping)
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_beacon_does_not_trip(tmp_path: Path) -> None:
+    clock = SteppingClock()
+    exit_calls: list[int] = []
+    dump_calls: list[Path] = []
+    wd = _make_watchdog(
+        tmp_path, stall=100.0, clock=clock, exit_calls=exit_calls, dump_calls=dump_calls
+    )
+    clock.advance(99.0)
+    assert wd._check_once() is False
+    assert dump_calls == []
+    assert exit_calls == []
+    assert read_stall_marker(tmp_path / "diagnostics" / "event_loop_stall.json") is None
+
+
+def test_stale_beacon_trips_with_dump_and_marker_but_no_exit_by_default(
+    tmp_path: Path,
+) -> None:
+    clock = SteppingClock()
+    exit_calls: list[int] = []
+    dump_calls: list[Path] = []
+    wd = _make_watchdog(
+        tmp_path, stall=100.0, clock=clock, exit_calls=exit_calls, dump_calls=dump_calls
+    )
+    clock.advance(150.0)
+    assert wd._check_once() is True
+    assert len(dump_calls) == 1
+    assert dump_calls[0].name.startswith("event_loop_stall_")
+    # Recovery is OPT-IN and defaults OFF: detection must never exit.
+    assert exit_calls == []
+    marker = read_stall_marker(tmp_path / "diagnostics" / "event_loop_stall.json")
+    assert marker is not None
+    assert marker["stalled_for_seconds"] == 150.0
+    assert marker["threshold_seconds"] == 100.0
+    assert marker["episode_count"] == 1
+    assert marker["hard_restart"] is False
+    assert marker["dump_path"] == str(dump_calls[0])
+
+
+def test_one_trip_per_freeze_episode_not_per_poll(tmp_path: Path) -> None:
+    clock = SteppingClock()
+    dump_calls: list[Path] = []
+    wd = _make_watchdog(tmp_path, stall=100.0, clock=clock, dump_calls=dump_calls)
+    clock.advance(150.0)
+    assert wd._check_once() is True
+    clock.advance(50.0)  # still frozen — same episode
+    assert wd._check_once() is False
+    clock.advance(50.0)
+    assert wd._check_once() is False
+    assert len(dump_calls) == 1
+
+
+def test_recovery_closes_episode_and_a_second_freeze_trips_again(
+    tmp_path: Path,
+) -> None:
+    clock = SteppingClock()
+    dump_calls: list[Path] = []
+    wd = _make_watchdog(tmp_path, stall=100.0, clock=clock, dump_calls=dump_calls)
+    clock.advance(150.0)
+    assert wd._check_once() is True
+    # Loop recovers: beacon stamped fresh again.
+    wd._beacon.stamp()
+    assert wd._check_once() is False
+    # Second, distinct freeze episode.
+    clock.advance(200.0)
+    assert wd._check_once() is True
+    assert len(dump_calls) == 2
+    marker = read_stall_marker(tmp_path / "diagnostics" / "event_loop_stall.json")
+    assert marker is not None
+    # Unconsumed prior episode accumulates instead of being lost.
+    assert marker["episode_count"] == 2
+
+
+def test_hard_restart_knob_invokes_exit_fn_once_with_stall_code(
+    tmp_path: Path,
+) -> None:
+    clock = SteppingClock()
+    exit_calls: list[int] = []
+    dump_calls: list[Path] = []
+    wd = _make_watchdog(
+        tmp_path,
+        stall=100.0,
+        hard_restart=True,
+        clock=clock,
+        exit_calls=exit_calls,
+        dump_calls=dump_calls,
+    )
+    clock.advance(150.0)
+    assert wd._check_once() is True
+    assert exit_calls == [EVENT_LOOP_STALL_EXIT_CODE]
+    # Dump + marker land BEFORE the exit so diagnostics survive the restart.
+    assert len(dump_calls) == 1
+    marker = read_stall_marker(tmp_path / "diagnostics" / "event_loop_stall.json")
+    assert marker is not None
+    assert marker["hard_restart"] is True
+
+
+def test_default_dump_writes_all_thread_stacks(tmp_path: Path) -> None:
+    wd = _make_watchdog(tmp_path)
+    dump_path = tmp_path / "diagnostics" / "dump.txt"
+    wd._default_dump(dump_path)
+    text = dump_path.read_text(encoding="utf-8")
+    # faulthandler names threads and the current test frame.
+    assert "Current thread" in text or "Thread" in text
+    assert "test_default_dump_writes_all_thread_stacks" in text
+
+
+# ---------------------------------------------------------------------------
+# Marker helpers
+# ---------------------------------------------------------------------------
+
+
+def test_marker_roundtrip_and_clear(tmp_path: Path) -> None:
+    path = tmp_path / "diagnostics" / "event_loop_stall.json"
+    assert read_stall_marker(path) is None
+    write_stall_marker(path, {"episode_count": 3})
+    assert read_stall_marker(path) == {"episode_count": 3}
+    clear_stall_marker(path)
+    assert read_stall_marker(path) is None
+    clear_stall_marker(path)  # idempotent
+
+
+def test_corrupt_marker_reads_as_absent(tmp_path: Path) -> None:
+    path = tmp_path / "event_loop_stall.json"
+    path.write_text("{not json", encoding="utf-8")
+    assert read_stall_marker(path) is None
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle: thread start/stop + process-wide single-flight slot
+# ---------------------------------------------------------------------------
+
+
+async def test_stop_terminates_thread_promptly(tmp_path: Path) -> None:
+    wd = _make_watchdog(tmp_path, poll=0.05)
+    try:
+        assert wd.start() is True
+        thread = wd._thread
+        assert thread is not None
+        assert thread.is_alive()
+        assert thread.daemon is True  # can never wedge interpreter shutdown
+    finally:
+        wd.stop()
+    assert wd._thread is None
+    assert not thread.is_alive()
+    # Idempotent.
+    wd.stop()
+
+
+async def test_single_flight_one_watchdog_per_process(tmp_path: Path) -> None:
+    wd1 = _make_watchdog(tmp_path / "a")
+    wd2 = _make_watchdog(tmp_path / "b")
+    try:
+        assert wd1.start() is True
+        # Second orchestrator on the same process/loop: passive no-op.
+        assert wd2.start() is False
+        assert wd2._thread is None
+        # A passive instance's stop must NOT release the owner's slot.
+        wd2.stop()
+        wd3 = _make_watchdog(tmp_path / "c")
+        assert wd3.start() is False
+        wd3.stop()
+    finally:
+        wd1.stop()
+    wd4 = _make_watchdog(tmp_path / "d")
+    try:
+        assert wd4.start() is True
+    finally:
+        wd4.stop()
+
+
+# ---------------------------------------------------------------------------
+# Behavioral: a REAL event loop, synchronously frozen, in a child thread
+# ---------------------------------------------------------------------------
+
+
+def test_detects_synchronously_frozen_event_loop_and_invokes_recovery(
+    tmp_path: Path,
+) -> None:
+    """The headline #9552 scenario.
+
+    A real event loop runs in a CHILD thread; ``time.sleep`` on that thread
+    freezes it synchronously — the state no asyncio-level watchdog can see.
+    The watchdog thread must detect the stale beacon, write the faulthandler
+    dump naming the blocking frame, and (hard-restart knob ON) invoke the
+    injected recovery callable. Nothing here goes near ``os._exit``/killpg.
+    """
+    exit_calls: list[int] = []
+    wd = EventLoopWatchdog(
+        stall_seconds_cb=lambda: 0.5,
+        hard_restart_cb=lambda: True,
+        diagnostics_dir=tmp_path / "diagnostics",
+        beacon_interval=0.05,
+        poll_seconds=0.05,
+        exit_fn=exit_calls.append,
+    )
+
+    async def frozen_scenario() -> None:
+        wd.start()
+        await asyncio.sleep(0.2)  # beacon proves liveness while the loop pumps
+        time.sleep(1.2)  # SYNCHRONOUS block on the loop thread — the freeze
+        await asyncio.sleep(0.1)
+
+    thread = threading.Thread(
+        target=lambda: asyncio.run(frozen_scenario()), daemon=True
+    )
+    try:
+        thread.start()
+        thread.join(timeout=30)
+        assert not thread.is_alive()
+        assert exit_calls == [EVENT_LOOP_STALL_EXIT_CODE]
+        dumps = sorted((tmp_path / "diagnostics").glob("event_loop_stall_*.txt"))
+        assert dumps, "a trip must write a faulthandler dump"
+        dump_text = dumps[0].read_text(encoding="utf-8")
+        # The diagnostic gold: the frozen loop thread's top Python frame in
+        # the dump names the synchronous call site.
+        assert "frozen_scenario" in dump_text
+        marker = read_stall_marker(tmp_path / "diagnostics" / "event_loop_stall.json")
+        assert marker is not None
+        assert marker["episode_count"] == 1
+    finally:
+        wd.stop()
+
+
+def test_healthy_pumping_loop_never_trips(tmp_path: Path) -> None:
+    """No false positives: a loop that keeps scheduling never trips."""
+    exit_calls: list[int] = []
+    dump_calls: list[Path] = []
+    wd = EventLoopWatchdog(
+        stall_seconds_cb=lambda: 5.0,
+        hard_restart_cb=lambda: True,
+        diagnostics_dir=tmp_path / "diagnostics",
+        beacon_interval=0.05,
+        poll_seconds=0.05,
+        exit_fn=exit_calls.append,
+        dump_fn=dump_calls.append,
+    )
+
+    async def healthy_scenario() -> None:
+        wd.start()
+        for _ in range(10):
+            await asyncio.sleep(0.05)
+
+    thread = threading.Thread(
+        target=lambda: asyncio.run(healthy_scenario()), daemon=True
+    )
+    try:
+        thread.start()
+        thread.join(timeout=30)
+        assert not thread.is_alive()
+        assert exit_calls == []
+        assert dump_calls == []
+    finally:
+        wd.stop()
+
+
+# ---------------------------------------------------------------------------
+# Builder wiring
+# ---------------------------------------------------------------------------
+
+
+def test_builder_returns_none_when_disabled(tmp_path: Path) -> None:
+    cfg = HydraFlowConfig(data_root=tmp_path, event_loop_watchdog_enabled=False)
+    assert build_event_loop_watchdog(cfg, force=True) is None
+
+
+def test_builder_returns_none_under_pytest_without_force(tmp_path: Path) -> None:
+    # We ARE under pytest right now — the guard must keep orchestrators spun
+    # up by tests/MockWorld scenarios from growing real observer threads.
+    cfg = HydraFlowConfig(data_root=tmp_path)
+    assert cfg.event_loop_watchdog_enabled is True
+    assert build_event_loop_watchdog(cfg) is None
+
+
+def test_builder_wires_live_config_callbacks(tmp_path: Path) -> None:
+    cfg = HydraFlowConfig(
+        data_root=tmp_path,
+        event_loop_watchdog_stall_seconds=300,
+        event_loop_watchdog_hard_restart=True,
+    )
+    wd = build_event_loop_watchdog(cfg, force=True)
+    assert wd is not None
+    assert wd._stall_seconds_cb() == 300
+    assert wd._hard_restart_cb() is True
+    assert wd._diagnostics_dir == cfg.diagnostics_dir
+    assert event_loop_stall_marker_path(cfg) == (
+        cfg.diagnostics_dir / "event_loop_stall.json"
+    )
+    # LIVE knobs: the control route mutates the config object in place
+    # (object.__setattr__) and the thread re-reads via these callables.
+    object.__setattr__(cfg, "event_loop_watchdog_stall_seconds", 999)
+    object.__setattr__(cfg, "event_loop_watchdog_hard_restart", False)
+    assert wd._stall_seconds_cb() == 999
+    assert wd._hard_restart_cb() is False

--- a/tests/test_health_monitor_event_loop_stall.py
+++ b/tests/test_health_monitor_event_loop_stall.py
@@ -1,0 +1,106 @@
+"""HealthMonitor escalation for EventLoopWatchdog stall markers (#9552).
+
+The watchdog THREAD can only leave a marker on disk (Ports are async and run
+on the very event loop that froze); this suite covers the consumer side —
+``HealthMonitorLoop._check_event_loop_stall`` filing one ``hydraflow-find``
++ ``loop-stalled`` issue per marker and consuming it file-then-clear.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from config import HydraFlowConfig
+from event_loop_watchdog import (
+    event_loop_stall_marker_path,
+    read_stall_marker,
+    write_stall_marker,
+)
+from health_monitor_loop import HealthMonitorLoop
+
+_MARKER_PAYLOAD = {
+    "detected_at": "2026-07-20T00:00:00+00:00",
+    "stalled_for_seconds": 245.0,
+    "threshold_seconds": 120.0,
+    "pid": 4242,
+    "dump_path": "/data/diagnostics/event_loop_stall_20260720T000000Z.txt",
+    "hard_restart": False,
+    "episode_count": 2,
+}
+
+
+@pytest.fixture
+def hm_env(tmp_path: Path):
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    cfg = HydraFlowConfig(
+        data_root=tmp_path,
+        repo="hydra/hydraflow",
+        repo_root=repo_root,
+    )
+    prs = AsyncMock()
+    prs.create_issue = AsyncMock(return_value=42)
+    hm = HealthMonitorLoop.__new__(HealthMonitorLoop)
+    hm._config = cfg
+    hm._prs = prs
+    return hm, cfg, prs
+
+
+async def test_no_marker_is_silent_noop(hm_env) -> None:
+    hm, _cfg, prs = hm_env
+    await hm._check_event_loop_stall()
+    prs.create_issue.assert_not_awaited()
+
+
+async def test_marker_files_issue_and_is_consumed(hm_env) -> None:
+    hm, cfg, prs = hm_env
+    marker_path = event_loop_stall_marker_path(cfg)
+    write_stall_marker(marker_path, dict(_MARKER_PAYLOAD))
+
+    await hm._check_event_loop_stall()
+
+    prs.create_issue.assert_awaited_once()
+    title, body, labels = prs.create_issue.await_args.args
+    assert "event-loop-stalled" in title
+    assert "245.0" in title
+    assert labels == ["hydraflow-find", "loop-stalled"]
+    assert "event_loop_stall_20260720T000000Z.txt" in body
+    assert "#9552" in body
+    # Consumed: the marker file itself is the dedup — a second tick is a noop.
+    assert read_stall_marker(marker_path) is None
+    await hm._check_event_loop_stall()
+    prs.create_issue.assert_awaited_once()
+
+
+async def test_failed_filing_retains_marker_for_retry(hm_env) -> None:
+    hm, cfg, prs = hm_env
+    marker_path = event_loop_stall_marker_path(cfg)
+    write_stall_marker(marker_path, dict(_MARKER_PAYLOAD))
+    prs.create_issue.side_effect = RuntimeError("gh unavailable")
+
+    with pytest.raises(RuntimeError):
+        await hm._check_event_loop_stall()
+
+    # File-then-clear: the filing failed, so the marker must survive.
+    assert read_stall_marker(marker_path) is not None
+
+
+async def test_no_prs_dependency_is_silent_noop_and_retains_marker(hm_env) -> None:
+    hm, cfg, _prs = hm_env
+    hm._prs = None
+    marker_path = event_loop_stall_marker_path(cfg)
+    write_stall_marker(marker_path, dict(_MARKER_PAYLOAD))
+    await hm._check_event_loop_stall()
+    assert read_stall_marker(marker_path) is not None
+
+
+async def test_corrupt_marker_is_treated_as_absent(hm_env) -> None:
+    hm, cfg, prs = hm_env
+    marker_path = event_loop_stall_marker_path(cfg)
+    marker_path.parent.mkdir(parents=True, exist_ok=True)
+    marker_path.write_text("{not json", encoding="utf-8")
+    await hm._check_event_loop_stall()
+    prs.create_issue.assert_not_awaited()


### PR DESCRIPTION
## Summary

The asyncio cycle watchdog (#9556) can only cancel a cycle blocked on an `await`; a SYNCHRONOUS block in any loop's `_do_work` (CPU spin, blocking file I/O, non-async `subprocess.run`) freezes the whole event loop and every asyncio-scheduled watcher with it. This adds the missing in-process layer: `EventLoopWatchdog`, a daemon OS thread that wall-clocks a 1s asyncio beacon the loop stamps.

- **Beacon**: trivial 1s asyncio task stamping a GIL-atomic monotonic float (`EventLoopBeacon`); while the loop is synchronously blocked the task is never scheduled — which is the signal.
- **Detector**: daemon thread polls beacon age vs `event_loop_watchdog_stall_seconds` (default 120s); one trip per freeze episode, fresh beacon closes the episode.
- **On trip**: `faulthandler` all-thread stack dump (names the blocking frame) to diagnostics + stderr, plus a stall marker; `HealthMonitorLoop._check_event_loop_stall` consumes it on the next healthy cycle and files one `hydraflow-find` + `loop-stalled` issue (file-then-clear) — the thread cannot use the async Ports, they run on the very loop that froze.
- **Hard restart**: opt-in behind default-OFF `event_loop_watchdog_hard_restart` — `os._exit(75)` (EX_TEMPFAIL) for the supervisor. Notify-default, restart-opt-in, mirroring branch-GC and the external liveness watchdog (#10009), which this complements from inside the process.
- Knobs System-tab editable via `settings_registry`; threshold + hard-restart re-read live by the thread. Single-flight slot keeps multi-repo orchestrators to one watchdog per process; `stop()` disarms within one poll tick.
- ADR-0106 documents the liveness layering; MockWorld scenario layer intentionally exempt (thread-level freeze detection sits below MockWorld's seam — subprocess-internal-bounding precedent); behavioral layer freezes a REAL event loop in a child thread instead.

## Test plan

- `tests/test_event_loop_watchdog.py` — behavioral: real event loop frozen in a child thread; detection, dump content, recovery, episode debounce, single-flight, stop paths
- `tests/test_health_monitor_event_loop_stall.py` — escalation half (marker consume, issue filing, file-then-clear retry)
- `tests/regressions/test_issue_9552.py` — pins every runtime surface against silent non-delivery (the #9556 lesson)
- `make quality` green locally (19350 passed, exit 0); `make arch-regen` + `python -m arch.runner --check` green; `HYDRAFLOW_AUDIT_PR_BASE=staging make audit` 92 PASS / 0 WARN / 0 FAIL

Closes #9552

🤖 Generated with [Claude Code](https://claude.com/claude-code)
