### PR TITLE
fix(dashboard): /ws handlers end on client disconnect — no parked queue.get() orphans (#10071)

### DIFF
--- a/src/dashboard_routes/_routes.py
+++ b/src/dashboard_routes/_routes.py
@@ -319,11 +319,22 @@ async def _client_gone(ws: WebSocket) -> None:
     treated as "client gone" (fail-closed — a live client would reconnect,
     while the alternative is a permanent leak). ``CancelledError`` is never
     swallowed here.
+
+    The loop continues ONLY for a genuine client data frame
+    (``{"type": "websocket.receive"}``); anything else — disconnect, a
+    non-dict, an unknown type — returns immediately. Post-accept, real
+    Starlette only ever yields ``websocket.receive`` / ``websocket.disconnect``
+    dicts, so production behavior is unchanged; the guard exists because a
+    stubbed socket (``AsyncMock``) resolves ``receive()`` instantly with a
+    ``Mock``, and an unguarded loop then spins without ever suspending —
+    unbounded CPU plus unbounded mock call history (OOM-killed CI runners).
     """
     with contextlib.suppress(Exception):
         while True:
             message = await ws.receive()
-            if message["type"] == "websocket.disconnect":
+            if not isinstance(message, dict):
+                return
+            if message.get("type") != "websocket.receive":
                 return
 
 

--- a/src/dashboard_routes/_routes.py
+++ b/src/dashboard_routes/_routes.py
@@ -301,6 +301,72 @@ def _is_likely_disconnect(exc: BaseException) -> bool:
     }
 
 
+async def _client_gone(ws: WebSocket) -> None:
+    """Resolve once the WebSocket client has gone away.
+
+    The dashboard's ``/ws`` feeds are server-push only — a healthy client never
+    sends frames — so the streaming loop parks on ``queue.get()``. Without a
+    concurrent ``receive()`` the handler can never observe a vanished client on
+    a quiet bus: no events flow, so no send ever fails, and the ASGI task sits
+    on ``queue.get()`` forever. That leaks the bus subscription for every
+    closed browser tab, and in-process harnesses (browser scenarios) then
+    wedge at event-loop close: the orphaned handler survives shutdown, and
+    uvicorn's ``run_asgi`` swallows the loop-close ``CancelledError``
+    (``except BaseException``) before awaiting an event nobody will ever set
+    (#10071).
+
+    Stray client frames are drained and ignored; any receive failure is
+    treated as "client gone" (fail-closed — a live client would reconnect,
+    while the alternative is a permanent leak). ``CancelledError`` is never
+    swallowed here.
+    """
+    with contextlib.suppress(Exception):
+        while True:
+            message = await ws.receive()
+            if message["type"] == "websocket.disconnect":
+                return
+
+
+async def _stream_queue_to_ws(
+    ws: WebSocket, queue: asyncio.Queue[HydraFlowEvent]
+) -> None:
+    """Forward live *queue* events to *ws* until the client disconnects.
+
+    Races ``queue.get()`` against a disconnect watcher (``_client_gone``) so a
+    closed tab ends the handler promptly even when no events are flowing.
+    Returns on disconnect; send errors propagate to the caller's
+    disconnect-aware ``except`` blocks unchanged.
+
+    Cleanup awaits each child task individually rather than via
+    ``asyncio.gather``: a ``GatheringFuture`` whose members already finished
+    refuses cancellation (``cancel()`` returns ``False``), which corrupts the
+    cancellation bookkeeping that anyio's TestClient cancel-scope relies on to
+    absorb its own cancel. Both children cancel instantly (bare ``get`` /
+    ``receive`` awaits), so the per-task awaits are bounded; a pending outer
+    cancellation still propagates after the ``finally`` completes.
+    """
+    watcher = asyncio.create_task(_client_gone(ws))
+    getter: asyncio.Task[HydraFlowEvent] | None = None
+    try:
+        while True:
+            getter = asyncio.create_task(queue.get())
+            done, _ = await asyncio.wait(
+                {watcher, getter}, return_when=asyncio.FIRST_COMPLETED
+            )
+            if watcher in done:
+                return
+            event = getter.result()
+            getter = None
+            await ws.send_text(event.model_dump_json())
+    finally:
+        for task in (watcher, getter):
+            if task is None:
+                continue
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+
 # Per-bus subscriber queue depth; the merged ``repo=__all__`` socket sizes its
 # shared fan-in queue at ``N × this`` so a busy line can't starve the others.
 _WS_MERGED_PER_BUS_QUEUE = 500
@@ -402,9 +468,7 @@ async def _serve_merged_ws(ws: WebSocket, runtimes: list[_Runtime]) -> None:
         try:
             for event in history:
                 await ws.send_text(event.model_dump_json())
-            while True:
-                event = await out_queue.get()
-                await ws.send_text(event.model_dump_json())
+            await _stream_queue_to_ws(ws, out_queue)
         except WebSocketDisconnect:
             pass
         except Exception as exc:  # noqa: BLE001
@@ -420,11 +484,15 @@ async def _serve_merged_ws(ws: WebSocket, runtimes: list[_Runtime]) -> None:
                     exc_info=True,
                 )
         finally:
-            for task in forwarders:
-                task.cancel()
             # Await the cancellations so the buses are unsubscribed (AsyncExitStack
             # exit) only after their forwarders have actually stopped reading.
-            await asyncio.gather(*forwarders, return_exceptions=True)
+            # Per-task awaits, not asyncio.gather: a GatheringFuture whose members
+            # already finished refuses cancellation, which corrupts the outer
+            # cancel-scope bookkeeping (see _stream_queue_to_ws / #10071).
+            for task in forwarders:
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
 
 
 @dataclass
@@ -2450,11 +2518,11 @@ def create_router(
                         )
                     return
 
-            # Stream live events
+            # Stream live events until the client disconnects. A concurrent
+            # disconnect watcher (not a failing send) ends the loop for a
+            # vanished client on a quiet bus — see _stream_queue_to_ws (#10071).
             try:
-                while True:
-                    event: HydraFlowEvent = await queue.get()
-                    await ws.send_text(event.model_dump_json())
+                await _stream_queue_to_ws(ws, queue)
             except WebSocketDisconnect:
                 pass
             except Exception as exc:

--- a/tests/regressions/test_ws_disconnect_no_traffic_10071.py
+++ b/tests/regressions/test_ws_disconnect_no_traffic_10071.py
@@ -1,0 +1,127 @@
+"""Regression #10071: /ws handlers must end when the client disconnects with
+zero events flowing.
+
+Both dashboard WebSocket paths streamed with a bare ``await queue.get()`` loop
+and never called ``receive()``, so a handler whose client vanished on a quiet
+bus parked forever: no event ever arrived, no send ever failed. Every closed
+browser tab leaked one bus subscription plus one ASGI task, and in-process
+harnesses (the browser scenarios) then wedged at event-loop close — the
+orphaned task survives ``stop_dashboard`` and uvicorn's ``run_asgi`` swallows
+the loop-close ``CancelledError`` (``except BaseException``) before awaiting
+an event nobody sets, hanging pytest until the CI job timeout.
+
+These pins drive the real endpoint with a server-push-only fake client and
+assert the handler RETURNS (is not cancelled) once the client goes away.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from events import EventBus, EventType
+from tests.conftest import EventFactory
+from tests.helpers import find_endpoint, make_dashboard_router
+
+
+class _ServerPushClient:
+    """Starlette-WebSocket stand-in for the dashboard's push-only client."""
+
+    def __init__(self) -> None:
+        self.query_params: dict[str, str] = {}
+        self.accepted = False
+        self.sent: list[str] = []
+        self._frames: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def send_text(self, text: str) -> None:
+        self.sent.append(text)
+
+    async def receive(self) -> dict[str, Any]:
+        return await self._frames.get()
+
+    async def close(self, code: int = 1000, reason: str | None = None) -> None:
+        pass
+
+    def client_sends(self, text: str) -> None:
+        self._frames.put_nowait({"type": "websocket.receive", "text": text})
+
+    def client_disconnects(self) -> None:
+        self._frames.put_nowait({"type": "websocket.disconnect", "code": 1001})
+
+
+async def _drain_until(predicate, timeout: float = 5.0) -> None:
+    """Poll *predicate* until true (bounded), yielding to the loop."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not predicate():
+        assert asyncio.get_running_loop().time() < deadline, "condition never held"
+        await asyncio.sleep(0.01)
+
+
+def _ws_endpoint(config, event_bus, state, tmp_path):
+    router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+    endpoint = find_endpoint(router, "/ws")
+    assert endpoint is not None
+    return endpoint
+
+
+async def test_ws_handler_returns_on_disconnect_without_any_traffic(
+    config, event_bus: EventBus, state, tmp_path
+) -> None:
+    # The exact #10071 shape: connected, zero events flowing, client vanishes.
+    # The old code parked on queue.get() forever here (wait_for would time out).
+    endpoint = _ws_endpoint(config, event_bus, state, tmp_path)
+    client = _ServerPushClient()
+
+    task = asyncio.create_task(endpoint(client))
+    await _drain_until(lambda: event_bus._subscribers)
+
+    client.client_disconnects()
+    await asyncio.wait_for(task, timeout=5)
+
+    assert not task.cancelled(), "handler must END on disconnect, not need a cancel"
+    assert event_bus._subscribers == [], "bus subscription leaked after disconnect"
+
+
+async def test_ws_handler_ignores_stray_client_frames_but_ends_on_disconnect(
+    config, event_bus: EventBus, state, tmp_path
+) -> None:
+    # A stray client frame (nothing in the dashboard sends one) must not end
+    # the stream; the following disconnect must.
+    endpoint = _ws_endpoint(config, event_bus, state, tmp_path)
+    client = _ServerPushClient()
+
+    task = asyncio.create_task(endpoint(client))
+    await _drain_until(lambda: event_bus._subscribers)
+
+    client.client_sends("ping")
+    await event_bus.publish(
+        EventFactory.create(type=EventType.PHASE_CHANGE, data={"phase": "plan"})
+    )
+    await _drain_until(lambda: client.sent)  # stream still live after the frame
+
+    client.client_disconnects()
+    await asyncio.wait_for(task, timeout=5)
+
+    assert any('"phase_change"' in msg or "phase_change" in msg for msg in client.sent)
+
+
+async def test_merged_ws_returns_on_disconnect_without_any_traffic(
+    config, event_bus: EventBus, state, tmp_path
+) -> None:
+    # Same pin for the multi-repo ``repo=__all__`` fan-in path.
+    from dashboard_routes._routes import _serve_merged_ws
+
+    client = _ServerPushClient()
+    runtimes = [(config, state, event_bus, lambda: None, "repo-a")]
+
+    task = asyncio.create_task(_serve_merged_ws(client, runtimes))
+    await _drain_until(lambda: event_bus._subscribers)
+
+    client.client_disconnects()
+    await asyncio.wait_for(task, timeout=5)
+
+    assert not task.cancelled()
+    assert event_bus._subscribers == [], "merged path leaked its bus subscription"

--- a/tests/regressions/test_ws_disconnect_no_traffic_10071.py
+++ b/tests/regressions/test_ws_disconnect_no_traffic_10071.py
@@ -108,6 +108,52 @@ async def test_ws_handler_ignores_stray_client_frames_but_ends_on_disconnect(
     assert any('"phase_change"' in msg or "phase_change" in msg for msg in client.sent)
 
 
+async def test_watcher_is_bounded_on_garbage_receive_stub(
+    config, event_bus: EventBus, state, tmp_path
+) -> None:
+    # A stubbed socket (AsyncMock-style) resolves receive() instantly with a
+    # Mock, not a Starlette message dict. The watcher must read that as
+    # "client gone" and return after ONE call — the unguarded loop spun
+    # without ever suspending, growing mock call history until CI runners
+    # were OOM-killed (~7GB in 3 minutes locally).
+    from unittest.mock import MagicMock
+
+    endpoint = _ws_endpoint(config, event_bus, state, tmp_path)
+
+    class _GarbageSocket(_ServerPushClient):
+        def __init__(self) -> None:
+            super().__init__()
+            self.receive_calls = 0
+
+        async def receive(self) -> Any:
+            # Yield once so a regressed spin still trips wait_for instead of
+            # wedging the loop outright.
+            await asyncio.sleep(0)
+            self.receive_calls += 1
+            return MagicMock()
+
+    client = _GarbageSocket()
+    await asyncio.wait_for(endpoint(client), timeout=5)
+
+    assert client.receive_calls == 1, "watcher must stop on the FIRST garbage frame"
+    assert event_bus._subscribers == []
+
+
+async def test_watcher_treats_unknown_message_type_as_client_gone(
+    config, event_bus: EventBus, state, tmp_path
+) -> None:
+    # Dict messages with any type other than websocket.receive also end the
+    # stream (post-accept Starlette only yields receive/disconnect, so this is
+    # production-neutral and fail-closed).
+    endpoint = _ws_endpoint(config, event_bus, state, tmp_path)
+    client = _ServerPushClient()
+    client._frames.put_nowait({"type": "websocket.mystery"})
+
+    await asyncio.wait_for(asyncio.create_task(endpoint(client)), timeout=5)
+
+    assert event_bus._subscribers == []
+
+
 async def test_merged_ws_returns_on_disconnect_without_any_traffic(
     config, event_bus: EventBus, state, tmp_path
 ) -> None:

--- a/tests/test_error_visibility.py
+++ b/tests/test_error_visibility.py
@@ -212,6 +212,18 @@ class TestHistoryCacheWarmUpLogLevel:
 # ---------------------------------------------------------------------------
 
 
+async def _park_forever() -> dict:
+    """A quiet, still-connected client: receive() that never resolves.
+
+    Stands in for real Starlette receive() on tests that must exercise the
+    live-stream send path — a bare AsyncMock receive() resolves instantly with
+    a Mock, which the #10071 disconnect watcher correctly reads as "client
+    gone" before any event is sent.
+    """
+    await asyncio.Event().wait()
+    raise AssertionError("unreachable")
+
+
 class TestWebSocketDisconnectDifferentiation:
     """WebSocket handlers should log ERROR for bugs and WARNING for disconnects."""
 
@@ -337,6 +349,11 @@ class TestWebSocketDisconnectDifferentiation:
         await q2.put(event)
 
         mock_ws.send_text = AsyncMock(side_effect=BrokenPipeError("gone"))
+        # The live stream races queue.get() against a disconnect watcher
+        # (#10071). A bare AsyncMock receive() resolves instantly with a Mock,
+        # which reads as "client gone" before the event is ever sent — park it
+        # like a real quiet client so the send (and its logging) happens.
+        mock_ws.receive = _park_forever
 
         with (
             patch.object(event_bus, "subscription") as mock_sub,
@@ -377,6 +394,9 @@ class TestWebSocketDisconnectDifferentiation:
         mock_ws.send_text = AsyncMock(
             side_effect=ValueError("unexpected serialization error")
         )
+        # See test_websocket_live_stream_disconnect_logs_warning: park the
+        # disconnect watcher so the live-stream send path is exercised.
+        mock_ws.receive = _park_forever
 
         with (
             patch.object(event_bus, "subscription") as mock_sub,


### PR DESCRIPTION
## Problem

`Browser Scenarios (PR→staging fast subset)` intermittently wedges until the 20-minute job timeout (`##[error]The operation was canceled.`, zero failure output). It cancelled attempt 1 on #10069 and reproduces locally on plain `staging` at ~1-2 hangs per 20 suite runs — a pre-existing race, not any PR's regression. Closes #10071.

## Root cause

Two stacked defects:

1. **Both dashboard WS paths could never observe a vanished client.** `websocket_endpoint` and `_serve_merged_ws` (`src/dashboard_routes/_routes.py`) streamed with a bare `while True: await queue.get(); await ws.send_text(...)` and never called `receive()`. The feed is server-push only, so when the client goes away on a quiet bus no event ever arrives and no send ever fails — the handler parks on `queue.get()` **forever**. Production impact: one leaked bus subscription + one leaked ASGI task per closed browser tab. Harness impact: the parked task is not a child of uvicorn's serve task and survives `MockWorld.stop_dashboard`.
2. **The orphan eats its one cancellation.** pytest-asyncio's per-test `Runner.close()` → `_cancel_all_tasks()` cancels leftovers and gathers them. uvicorn's `WebSocketProtocol.run_asgi` wraps the app in `except BaseException:` — swallowing the loop-close `CancelledError` — then awaits `handshake_completed_event.wait()`; when that event is never set the task stays pending forever, the gather never returns, and pytest hangs with an idle loop until the CI timeout. Faulthandler stack from a hung run: `asyncio/runners.py:201 _cancel_all_tasks` ← `pytest_asyncio/plugin.py _scoped_runner`.

## Fix

- `_client_gone(ws)`: resolves when `receive()` yields `websocket.disconnect` (stray client frames drained/ignored; receive failure = gone, fail-closed; never swallows `CancelledError`).
- `_stream_queue_to_ws(ws, queue)`: races `queue.get()` against the watcher (`asyncio.wait FIRST_COMPLETED`); returns on disconnect; send errors propagate to the existing disconnect-aware `except` blocks unchanged. Used by both WS paths.
- Cleanup awaits child tasks **per-task**, not via `asyncio.gather`: a `GatheringFuture` whose members already finished refuses cancellation (`cancel()` → `False`), corrupting the cancel-scope bookkeeping starlette's TestClient relies on to absorb its own cancel. The same hazard existed in `_serve_merged_ws`'s pre-existing forwarder-cleanup gather — fixed identically.

## Evidence

- **Deterministic pins (red → green):** `tests/regressions/test_ws_disconnect_no_traffic_10071.py` — 3 tests, all fail on the old code (handler never returns; `wait_for` times out), all pass with the fix. Pins: handler returns (not cancelled) on disconnect with zero traffic; stray frames don't end the stream but disconnect does; merged `__all__` path same; bus subscription released.
- **Orphan-pool probe:** boot dashboard in-process, raw WS connect, hard-drop the client, `stop_dashboard()` — before: `WebSocketProtocol.run_asgi` remains in `asyncio.all_tasks()`; after: gone (only uvicorn's cancel-safe lifespan task remains).
- **Soak:** 40/40 consecutive local runs of the exact CI browser subset (smoke + happy + orchestrator-controls, `--reruns=1`) green on this branch, vs 2 hangs/20 runs (pre-fix branch) and 1 hang/30 runs (plain staging) baseline.
- Existing `tests/test_dashboard_websocket.py` (13) and `tests/test_dashboard_ws_merged_multirepo.py` (8) green; full `make quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
