### PR TITLE
feat(sandbox): active-trigger scenarios for six governance loops (s65-s70) (#9543)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,51 +1,51 @@
 {
-  "regenerated_at": "2026-07-20T15:48:17.088066+00:00",
-  "commit_sha": "660e926f1be9101006a75d519e8686a434a6e5d2",
+  "regenerated_at": "2026-07-20T19:38:39.784137+00:00",
+  "commit_sha": "87cbff0b360fe6c702d6b3194906b5e727be347d",
   "artifacts": {
     "loops.md": {
-      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
+      "source_sha": "87cbff0b360fe6c702d6b3194906b5e727be347d"
     },
     "ports.md": {
-      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
+      "source_sha": "87cbff0b360fe6c702d6b3194906b5e727be347d"
     },
     "labels.md": {
-      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
+      "source_sha": "87cbff0b360fe6c702d6b3194906b5e727be347d"
     },
     "modules.md": {
-      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
+      "source_sha": "87cbff0b360fe6c702d6b3194906b5e727be347d"
     },
     "events.md": {
-      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
+      "source_sha": "87cbff0b360fe6c702d6b3194906b5e727be347d"
     },
     "adr_xref.md": {
-      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
+      "source_sha": "87cbff0b360fe6c702d6b3194906b5e727be347d"
     },
     "mockworld.md": {
-      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
+      "source_sha": "87cbff0b360fe6c702d6b3194906b5e727be347d"
     },
     "changelog.md": {
-      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
+      "source_sha": "87cbff0b360fe6c702d6b3194906b5e727be347d"
     },
     "coverage_matrix.md": {
-      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
+      "source_sha": "87cbff0b360fe6c702d6b3194906b5e727be347d"
     },
     "adr-conformance.md": {
-      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
+      "source_sha": "87cbff0b360fe6c702d6b3194906b5e727be347d"
     },
     "ai_system_inventory.md": {
-      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
+      "source_sha": "87cbff0b360fe6c702d6b3194906b5e727be347d"
     },
     "traceability_matrix.md": {
-      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
+      "source_sha": "87cbff0b360fe6c702d6b3194906b5e727be347d"
     },
     "functional_areas.md": {
-      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
+      "source_sha": "87cbff0b360fe6c702d6b3194906b5e727be347d"
     },
     "ubiquitous-language.md": {
-      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
+      "source_sha": "87cbff0b360fe6c702d6b3194906b5e727be347d"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "660e926f1be9101006a75d519e8686a434a6e5d2"
+      "source_sha": "87cbff0b360fe6c702d6b3194906b5e727be347d"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W30
 
+- `14f4a2e` — fix(refinement): v1 follow-ups — not-planned closes, priority budget, fail-closed fake, inefficiency re-file (#10025) (#10066) (#10066) *(2026-07-20)*
 - `1306712` — fix(fitness): cadence-derived min_samples — scorecards can finally score (#9841) (#10056) (#10056) *(2026-07-20)*
 - `8509ee0` — feat(orchestration): v2 IssueDriver runtime phase spec + accept ADR-0099 (#10038) (#10055) (#10055) *(2026-07-20)*
 - `d94945e` — fix(ul): one file per term — delete stale forks, hard-fail uniqueness lint, store-level dedupe (#9938) (#10051) (#10051) *(2026-07-20)*
@@ -523,7 +524,6 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `39c6fc9` — feat(principles-audit): ADR-0044 + audit framework + P1 checks (#8386) (#8386) *(2026-04-22)*
 - `57157c8` — feat(audit): prompt audit report + scoring engine (sub-project 1 of 4) (#8376) (#8376) *(2026-04-21)*
 - `046f5fa` — refactor(agent-cli): scan /opt/plugins dynamically instead of hardcoding (#8375) (#8375) *(2026-04-21)*
-- `6b45f82` — feat(skills): boot-time install + prompt alignment + per-phase whitelist (#8374) (#8374) *(2026-04-21)*
 
 
 <!-- arch:generated -->

--- a/src/mockworld/fakes/fake_github.py
+++ b/src/mockworld/fakes/fake_github.py
@@ -177,6 +177,7 @@ class FakeGitHub:
                 title=issue_dict["title"],
                 body=issue_dict["body"],
                 labels=list(issue_dict.get("labels", [])),
+                state=issue_dict.get("state", "open"),
             )
         for issue_number, comment_dicts in seed.comments.items():
             for comment_dict in comment_dicts:
@@ -195,6 +196,7 @@ class FakeGitHub:
                 merged=pr_dict.get("merged", False),
                 author=pr_dict.get("author", "fake-author"),
                 is_bot=pr_dict.get("is_bot", False),
+                mergeable=pr_dict.get("mergeable", True),
             )
             for label in pr_dict.get("labels", []):
                 gh.add_pr_label(pr_dict["number"], label)
@@ -214,12 +216,20 @@ class FakeGitHub:
         title: str,
         body: str,
         labels: list[str] | None = None,
+        state: str = "open",
     ) -> None:
+        """Seed an issue. ``state`` accepts ``"open"`` (default) or ``"closed"``.
+
+        A closed seed issue reports ``COMPLETED`` from ``get_issue_state``
+        (close-reason defaulting mirrors gh, #10025) — the surface loops like
+        workspace_gc/epic_sweeper consult before acting (#9543).
+        """
         self._issues[number] = FakeIssue(
             number=number,
             title=title,
             body=body,
             labels=labels or [],
+            state=state,
         )
 
     def add_seeded_comment(
@@ -253,12 +263,14 @@ class FakeGitHub:
         merged: bool = False,
         author: str = "fake-author",
         is_bot: bool = False,
+        mergeable: bool = True,
     ) -> None:
         """Directly insert a PR record (sync helper for test seeding).
 
         The async ``create_pr`` handles the production path; this helper
         exists so scenario seeds can set up a fully-populated world
-        synchronously.
+        synchronously. ``mergeable=False`` seeds a CONFLICTING PR that
+        ``list_conflicting_prs`` surfaces to merge_state_watcher (#9543).
         """
         self._prs[number] = FakePR(
             number=number,
@@ -268,6 +280,7 @@ class FakeGitHub:
             ci_status=ci_status,
             author=author,
             is_bot=is_bot,
+            mergeable=mergeable,
         )
 
     def add_pr_label(self, pr_number: int, label: str) -> None:

--- a/src/mockworld/sandbox_main.py
+++ b/src/mockworld/sandbox_main.py
@@ -144,6 +144,14 @@ def _apply_sandbox_config_overrides(config: HydraFlowConfig) -> None:
     # Frozen-model bypass (the same write the runtime PATCH route uses) —
     # avoids adding another suppression to the disturbance ratchet.
     object.__setattr__(config, "auto_pr_preflight_gate_enabled", False)
+    # ``approval_records`` (#9543): MergeStateWatcherLoop's CH-2 reconciler
+    # tick reads merged PRs at the raw ``gh`` subprocess boundary
+    # (approval_records._list_recently_merged — deliberately not on PRPort, so
+    # FakeGitHub never sees it). Under the air-gapped network that read raises
+    # every cycle, so ``_do_work`` never returns its conflict-handling stats
+    # and the watcher's active outcome is unobservable. The reconciler has its
+    # own unit tests; the sandbox exercises the conflict watcher.
+    object.__setattr__(config, "approval_records_enabled", False)
 
 
 def _load_seed() -> MockWorldSeed:
@@ -312,6 +320,112 @@ def _build_caretaker_enabled_cb(
     return lambda name, *_a, **_kw: name in allowed
 
 
+def seed_stale_workspaces(
+    state: Any, config: HydraFlowConfig, seed: MockWorldSeed
+) -> None:
+    """Register seeded stale worktrees in StateTracker (#9543).
+
+    WorkspaceGCLoop's phase-1 sweep reads ``state.get_active_workspaces()``;
+    seeding an entry here (path derived from config, mirroring the production
+    WorkspaceManager layout) gives a GC cycle a tracked worktree to judge.
+    Empty ``stale_workspaces`` (every other scenario) touches nothing.
+    """
+    for entry in seed.stale_workspaces:
+        number = int(entry["number"])
+        branch = str(entry.get("branch") or f"agent/issue-{number}")
+        path = config.workspace_base / config.repo_slug / f"issue-{number}"
+        state.set_workspace(number, str(path))
+        state.set_branch(number, branch)
+
+
+def materialize_expired_runs(config: HydraFlowConfig, seed: MockWorldSeed) -> None:
+    """Create back-dated run-artifact dirs for RunsGCLoop to purge (#9543).
+
+    RunRecorder derives a run's age from its ``%Y%m%dT%H%M%SZ`` directory
+    name, so materializing ``<runs>/<issue>/<old-timestamp>/`` at boot is all
+    an expired artifact takes. Empty ``expired_run_dirs`` creates nothing.
+    """
+    from datetime import UTC, datetime, timedelta  # noqa: PLC0415
+
+    runs_dir = config.repo_data_path("runs")
+    for entry in seed.expired_run_dirs:
+        issue = int(entry["issue"])
+        age_days = int(entry.get("age_days", 90))
+        stamp = (datetime.now(UTC) - timedelta(days=age_days)).strftime(
+            "%Y%m%dT%H%M%SZ"
+        )
+        run_dir = runs_dir / str(issue) / stamp
+        run_dir.mkdir(parents=True, exist_ok=True)
+        # A marker file so the purged directory is a realistic non-empty run.
+        (run_dir / "transcript.log").write_text("seeded expired run (#9543)\n")
+
+
+def build_seeded_gate_detector(
+    gate_activations: list[dict[str, Any]],
+) -> Callable[[], Any]:
+    """Detector stand-in returning seed-scripted ActivationProposals (#9543).
+
+    The production detector reads the repo's real gates.toml / workflows /
+    Makefile — all steady-state (no planned gates) in the baked sandbox image,
+    so the file-a-proposal path could never fire. Swapping the loop's existing
+    ``detector=`` injection point for this closure at the composition root is
+    the same DI pattern as the ``_mockworld_fake_llm`` sentinel wiring.
+    """
+    from scripts.gates.activation import ActivationProposal  # noqa: PLC0415
+
+    proposals = [
+        ActivationProposal(
+            name=str(entry["name"]),
+            dimension=str(entry.get("dimension", "tests")),
+            required_on=tuple(entry.get("required_on", ("main",))),
+            workflow=str(entry.get("workflow", "test.yml")),
+            job=str(entry.get("job", "tests")),
+            make_target=str(entry.get("make_target", "")),
+        )
+        for entry in gate_activations
+    ]
+
+    async def _detect() -> list[ActivationProposal]:
+        return list(proposals)
+
+    return _detect
+
+
+def build_seeded_branch_protection_auditor(
+    config: HydraFlowConfig,
+    github: FakeGitHub,
+    canonical_dir: Path | None = None,
+) -> Callable[[], Any]:
+    """Auditor stand-in serving live rulesets from FakeGitHub (#9543/#9644).
+
+    Runs the REAL ``audit_repo`` diff against the repo's canonical ruleset
+    contract (baked into the image) — only the live-ruleset fetch is swapped
+    from the raw-``gh`` ``gh_fetch_rulesets`` (unreachable on the air-gapped
+    network) to ``FakeGitHub.fetch_rulesets``, which serves ``seed.rulesets``.
+
+    ``canonical_dir`` defaults to the contract location under
+    ``config.repo_root``; the in-process harness (whose config is tmp-rooted)
+    passes the real repo's contract dir explicitly.
+    """
+    import asyncio as _asyncio  # noqa: PLC0415
+
+    from branch_protection_audit import AuditReport, audit_repo  # noqa: PLC0415
+
+    if canonical_dir is None:
+        # Mirrors service_registry's ``_bp_canonical_dir`` (contract location).
+        canonical_dir = config.repo_root / "docs" / "standards" / "branch_protection"
+
+    async def _audit() -> AuditReport:
+        return await _asyncio.to_thread(
+            audit_repo,
+            config.repo,
+            canonical_dir,
+            fetch_rulesets=github.fetch_rulesets,
+        )
+
+    return _audit
+
+
 async def main() -> None:
     config = load_runtime_config()
     # Disable production code paths that reach services unreachable on the
@@ -378,6 +492,11 @@ async def main() -> None:
     for issue_number, count in seed.auto_agent_attempts.items():
         for _ in range(count):
             state.bump_auto_agent_attempts(int(issue_number))
+
+    # Stale-worktree + expired-run seeding (#9543). Both act on state/disk
+    # before the loops boot; empty seed fields are no-ops.
+    seed_stale_workspaces(state, config, seed)
+    materialize_expired_runs(config, seed)
 
     # Every async-touched ``subprocess.run`` site in production code now
     # specifies ``timeout=`` (PRs #8454, #8456, #8468 — enforced by
@@ -538,6 +657,27 @@ async def main() -> None:
         # the sanctioned seam here, mirroring ``_refine_loop._refine_llm`` above.
         svc.issue_refinement_loop._refinement_llm = _SeededRefinementLLM(
             list(seed.issue_refinement_verdicts)
+        )
+
+    # GateActivatorLoop (#9543) air-gap seam: when the scenario scripts
+    # activation proposals, swap the loop's existing ``detector=`` injection
+    # point for a closure returning them — the same composition-root DI as the
+    # ``_mockworld_fake_llm`` sentinel wiring. ``create_issue`` already routes
+    # through FakeGitHub. Empty seed: production detector untouched.
+    if seed.gate_activations:
+        svc.gate_activator_loop._detector = build_seeded_gate_detector(
+            seed.gate_activations
+        )
+
+    # BranchProtectionAuditorLoop (#9543/#9644) air-gap seam: when the
+    # scenario seeds live rulesets, rebind the auditor so the REAL
+    # ``audit_repo`` diff runs against ``FakeGitHub.fetch_rulesets`` instead
+    # of the raw-``gh`` ``gh_fetch_rulesets`` (which errors every cycle on the
+    # air-gapped network, reducing s41's heartbeat to an ``{'error': True}``
+    # tick). Empty seed: production auditor untouched.
+    if seed.rulesets:
+        svc.branch_protection_auditor_loop._auditor = (
+            build_seeded_branch_protection_auditor(config, shared_github)
         )
 
     orch = HydraFlowOrchestrator(

--- a/src/mockworld/sandbox_main.py
+++ b/src/mockworld/sandbox_main.py
@@ -11,13 +11,17 @@ imports this module — Fakes are unreachable from the production code path.
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import signal
 import sys
 from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
+from branch_protection_audit import AuditReport, audit_repo
 from dashboard import HydraFlowDashboard
 from events import EventBus
 from mockworld.fakes import (
@@ -345,7 +349,6 @@ def materialize_expired_runs(config: HydraFlowConfig, seed: MockWorldSeed) -> No
     name, so materializing ``<runs>/<issue>/<old-timestamp>/`` at boot is all
     an expired artifact takes. Empty ``expired_run_dirs`` creates nothing.
     """
-    from datetime import UTC, datetime, timedelta  # noqa: PLC0415
 
     runs_dir = config.repo_data_path("runs")
     for entry in seed.expired_run_dirs:
@@ -360,10 +363,30 @@ def materialize_expired_runs(config: HydraFlowConfig, seed: MockWorldSeed) -> No
         (run_dir / "transcript.log").write_text("seeded expired run (#9543)\n")
 
 
+@dataclass(frozen=True)
+class SeededActivationProposal:
+    """Duck-typed stand-in for ``scripts.gates.activation.ActivationProposal``.
+
+    GateActivatorLoop touches only these attributes (``_proposal_key`` /
+    ``_issue_body``); its own ``ActivationProposal`` import is
+    TYPE_CHECKING-only. A local mirror keeps the composition root off the
+    ``scripts`` package, which Dockerfile.agent does NOT ship into the
+    sandbox image (only ``src``/``tests``/``templates``/``static`` are
+    copied) — a real import would crash the entrypoint at boot.
+    """
+
+    name: str
+    dimension: str
+    required_on: tuple[str, ...]
+    workflow: str
+    job: str
+    make_target: str
+
+
 def build_seeded_gate_detector(
     gate_activations: list[dict[str, Any]],
 ) -> Callable[[], Any]:
-    """Detector stand-in returning seed-scripted ActivationProposals (#9543).
+    """Detector stand-in returning seed-scripted activation proposals (#9543).
 
     The production detector reads the repo's real gates.toml / workflows /
     Makefile — all steady-state (no planned gates) in the baked sandbox image,
@@ -371,10 +394,8 @@ def build_seeded_gate_detector(
     ``detector=`` injection point for this closure at the composition root is
     the same DI pattern as the ``_mockworld_fake_llm`` sentinel wiring.
     """
-    from scripts.gates.activation import ActivationProposal  # noqa: PLC0415
-
     proposals = [
-        ActivationProposal(
+        SeededActivationProposal(
             name=str(entry["name"]),
             dimension=str(entry.get("dimension", "tests")),
             required_on=tuple(entry.get("required_on", ("main",))),
@@ -385,10 +406,54 @@ def build_seeded_gate_detector(
         for entry in gate_activations
     ]
 
-    async def _detect() -> list[ActivationProposal]:
+    async def _detect() -> list[SeededActivationProposal]:
         return list(proposals)
 
     return _detect
+
+
+# Fixed canonical baseline served to the seeded auditor. Deliberately NOT the
+# repo's real contract: Dockerfile.agent ships no ``docs/`` into the sandbox
+# image, and a copy of the live contract in a seed would rot as gates.toml
+# evolves. The seam tests audit MECHANICS (normalize/diff/missing-ruleset
+# detection + issue filing) through the real ``audit_repo``; a scenario seeds
+# live rulesets against this stable baseline to produce drift (or cleanness).
+_CANONICAL_BASELINE: dict[str, dict[str, Any]] = {
+    "main protect": {
+        "name": "main protect",
+        "target": "branch",
+        "enforcement": "active",
+        "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}},
+        "rules": [{"type": "deletion"}, {"type": "non_fast_forward"}],
+    },
+    "staging protect": {
+        "name": "staging protect",
+        "target": "branch",
+        "enforcement": "active",
+        "conditions": {"ref_name": {"include": ["refs/heads/staging"], "exclude": []}},
+        "rules": [{"type": "deletion"}, {"type": "non_fast_forward"}],
+    },
+}
+
+
+def materialize_canonical_rulesets(config: HydraFlowConfig) -> Path:
+    """Write the fixed canonical ruleset baseline to disk; return its dir.
+
+    ``branch_protection_audit.load_canonical`` reads
+    ``main_ruleset.json``/``staging_ruleset.json`` from a directory; both
+    loaders materialize this one under the writable data root so the REAL
+    audit code runs unmodified with no dependency on repo ``docs/`` (absent
+    from the sandbox image). Idempotent.
+    """
+    canonical_dir = config.repo_data_path("sandbox_canonical_rulesets")
+    canonical_dir.mkdir(parents=True, exist_ok=True)
+    (canonical_dir / "main_ruleset.json").write_text(
+        json.dumps(_CANONICAL_BASELINE["main protect"], indent=2)
+    )
+    (canonical_dir / "staging_ruleset.json").write_text(
+        json.dumps(_CANONICAL_BASELINE["staging protect"], indent=2)
+    )
+    return canonical_dir
 
 
 def build_seeded_branch_protection_auditor(
@@ -398,25 +463,17 @@ def build_seeded_branch_protection_auditor(
 ) -> Callable[[], Any]:
     """Auditor stand-in serving live rulesets from FakeGitHub (#9543/#9644).
 
-    Runs the REAL ``audit_repo`` diff against the repo's canonical ruleset
-    contract (baked into the image) — only the live-ruleset fetch is swapped
-    from the raw-``gh`` ``gh_fetch_rulesets`` (unreachable on the air-gapped
-    network) to ``FakeGitHub.fetch_rulesets``, which serves ``seed.rulesets``.
-
-    ``canonical_dir`` defaults to the contract location under
-    ``config.repo_root``; the in-process harness (whose config is tmp-rooted)
-    passes the real repo's contract dir explicitly.
+    Runs the REAL ``audit_repo`` diff — only its two inputs are swapped: the
+    live-ruleset fetch moves from the raw-``gh`` ``gh_fetch_rulesets``
+    (unreachable on the air-gapped network) to ``FakeGitHub.fetch_rulesets``
+    serving ``seed.rulesets``, and ``canonical_dir`` defaults to the
+    materialized fixed baseline (see ``materialize_canonical_rulesets``).
     """
-    import asyncio as _asyncio  # noqa: PLC0415
-
-    from branch_protection_audit import AuditReport, audit_repo  # noqa: PLC0415
-
     if canonical_dir is None:
-        # Mirrors service_registry's ``_bp_canonical_dir`` (contract location).
-        canonical_dir = config.repo_root / "docs" / "standards" / "branch_protection"
+        canonical_dir = materialize_canonical_rulesets(config)
 
     async def _audit() -> AuditReport:
-        return await _asyncio.to_thread(
+        return await asyncio.to_thread(
             audit_repo,
             config.repo,
             canonical_dir,

--- a/src/mockworld/seed.py
+++ b/src/mockworld/seed.py
@@ -22,7 +22,11 @@ class MockWorldSeed:
     # List of (slug, path) pairs registered into RepoRegistryStore.
     repos: list[tuple[str, str]] = field(default_factory=list)
 
-    # Each issue is a dict with keys: number, title, body, labels[].
+    # Each issue is a dict with keys: number, title, body, labels[], and
+    # optionally state ("open" default / "closed"). A closed seed issue lets a
+    # scenario exercise closed-issue reads (e.g. workspace_gc's is-it-safe-to-GC
+    # check, epic_sweeper's are-all-children-done sweep) without driving the
+    # whole pipeline to close it first (#9543).
     issues: list[dict[str, Any]] = field(default_factory=list)
 
     # Per-issue seeded comments, keyed by issue number. Each entry is a dict
@@ -34,7 +38,9 @@ class MockWorldSeed:
     comments: dict[int, list[dict[str, Any]]] = field(default_factory=dict)
 
     # Each PR is a dict with keys: number, issue_number, branch,
-    # ci_status, merged, labels[].
+    # ci_status, merged, labels[], and optionally mergeable (True default).
+    # ``mergeable: false`` seeds a CONFLICTING PR so merge_state_watcher's
+    # rebase/escalate path has something to act on (#9543).
     prs: list[dict[str, Any]] = field(default_factory=list)
 
     # Per-phase scripted LLM responses. Outer key is phase name
@@ -151,6 +157,38 @@ class MockWorldSeed:
     # ``FakeGitHub.fetch_rulesets`` returns ``{}``, leaving every existing seed
     # payload unchanged.
     rulesets: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    # Stale worktrees pre-registered in StateTracker for the ``workspace_gc``
+    # loop (#9543). Each entry is a dict with keys ``number`` (issue number)
+    # and optionally ``branch`` (defaults to ``agent/issue-<number>``). Both
+    # loaders (sandbox_main + the in-process harness) register the worktree in
+    # ``state.active_workspaces``/``active_branches`` at boot, so a GC cycle
+    # sees a tracked workspace whose issue state decides collection. Pair each
+    # entry with a ``state: "closed"`` issue of the same number to drive the
+    # collect path. All values are JSON-native; default empty leaves every
+    # existing seed payload unchanged.
+    stale_workspaces: list[dict[str, Any]] = field(default_factory=list)
+
+    # Scripted gate-activation proposals for the ``gate_activator`` loop
+    # (#9543). Each entry carries ``ActivationProposal`` kwargs (``name`` /
+    # ``dimension`` / ``required_on`` / ``workflow`` / ``job`` /
+    # ``make_target``). In production the detector reads the repo's real
+    # ``gates.toml``/workflows/Makefile — all steady-state (no planned gates)
+    # in the baked sandbox image, so the file-a-proposal path can never fire.
+    # When non-empty, both loaders swap the loop's detector for one returning
+    # these proposals (composition-root DI on the existing ``detector=``
+    # injection point). Default empty: production detector untouched.
+    gate_activations: list[dict[str, Any]] = field(default_factory=list)
+
+    # Expired run-artifact directories materialized at boot for the
+    # ``runs_gc`` loop (#9543). Each entry is a dict with keys ``issue``
+    # (issue number) and optionally ``age_days`` (default 90 — far beyond any
+    # realistic ``artifact_retention_days``). Both loaders create
+    # ``<runs>/<issue>/<timestamp>/`` with the timestamp back-dated by
+    # ``age_days``, so a purge cycle has a genuinely expired artifact to
+    # delete (RunRecorder derives artifact age from the directory name).
+    # Default empty: no directories are created.
+    expired_run_dirs: list[dict[str, Any]] = field(default_factory=list)
 
     # IssueRefinementLoop (spec #9957) air-gap seam. The loop reads the WHOLE
     # open backlog via ``PRPort.list_open_issues`` (Faked) and then spends one

--- a/src/workspace_gc_loop.py
+++ b/src/workspace_gc_loop.py
@@ -205,17 +205,26 @@ class WorkspaceGCLoop(BaseBackgroundLoop):
         return bool(labels & pipeline_labels)
 
     async def _get_issue_state(self, issue_number: int) -> str:
-        """Query GitHub for the issue state ('open' or 'closed')."""
-        output = await run_subprocess(
-            "gh",
-            "api",
-            f"repos/{self._config.repo}/issues/{issue_number}",
-            "--jq",
-            ".state",
-            cwd=self._config.repo_root,
-            gh_token=self._credentials.gh_token,
-        )
-        return output.strip()
+        """Query the issue state ('open' / 'closed' / 'unknown') via PRPort.
+
+        Routed through ``PRPort.get_issue_state`` so the air-gapped sandbox
+        FakeGitHub can serve the read — the raw ``gh api`` call this replaces
+        failed on every cycle there, fail-closing every GC decision to "skip"
+        and making the closed-issue collect path unreachable in scenarios
+        (#9543; same class as the #9575 open-issue-path port routing).
+
+        The port speaks GitHub's GraphQL-style vocabulary
+        (``COMPLETED``/``NOT_PLANNED``/``OPEN``/``UNKNOWN``/``""``); map it to
+        the REST-style strings ``_is_safe_to_gc`` compares against. Anything
+        unrecognized maps to ``"unknown"``, preserving the fail-closed-on-
+        uncertainty contract (an unknown state is never collected).
+        """
+        port_state = await self._prs.get_issue_state(issue_number)
+        if port_state in ("COMPLETED", "NOT_PLANNED"):
+            return "closed"
+        if port_state == "OPEN":
+            return "open"
+        return "unknown"
 
     async def _has_open_pr(self, issue_number: int) -> bool:
         """Check whether an open PR exists for the issue's branch (via PRPort).

--- a/tests/architecture/test_sandbox_seam_completeness.py
+++ b/tests/architecture/test_sandbox_seam_completeness.py
@@ -72,7 +72,8 @@ GRANDFATHERED_SPAWN_BASELINE: dict[str, int] = {
     "src/trust_fleet_sanity_loop.py::TrustFleetSanityLoop._find_open_escalation::run_subprocess_result": 1,
     "src/trust_fleet_sanity_loop.py::TrustFleetSanityLoop._reconcile_closed_escalations::run_subprocess_result": 1,
     "src/workspace_gc_loop.py::WorkspaceGCLoop._collect_orphaned_branches::run_subprocess": 2,
-    "src/workspace_gc_loop.py::WorkspaceGCLoop._get_issue_state::run_subprocess": 1,
+    # _get_issue_state's raw ``gh api`` spawn was routed through
+    # PRPort.get_issue_state in #9543 — entry pruned per the shrink-only rule.
 }
 
 

--- a/tests/regressions/test_issue_9543_sandbox_no_scripts_import.py
+++ b/tests/regressions/test_issue_9543_sandbox_no_scripts_import.py
@@ -1,0 +1,81 @@
+"""#9543 — sandbox_main must not import the ``scripts`` package (any scope).
+
+Dockerfile.agent ships only ``src``/``tests``/``templates``/``static`` into
+the sandbox image; the repo-root ``scripts`` package does not exist there. A
+module-level import crashes ``python -m mockworld.sandbox_main`` at boot for
+EVERY scenario; a function-level one detonates at seam-wiring time for the
+scenario that hits it. Both are invisible to host-tier tests (where
+``scripts`` is importable) and only surface as a wedged docker lane — so the
+constraint is pinned here, at the AST level, where a reintroduction reddens
+in ``make quality``.
+
+The seeded gate detector uses the duck-typed ``SeededActivationProposal``
+mirror instead (GateActivatorLoop touches only the attributes; its own
+``ActivationProposal`` import is TYPE_CHECKING-only).
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+_SANDBOX_MAIN = (
+    Path(__file__).resolve().parents[2] / "src" / "mockworld" / "sandbox_main.py"
+)
+
+
+def _scripts_imports(tree: ast.AST) -> list[tuple[int, str]]:
+    offenders: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            offenders.extend(
+                (node.lineno, alias.name)
+                for alias in node.names
+                if alias.name == "scripts" or alias.name.startswith("scripts.")
+            )
+        elif isinstance(node, ast.ImportFrom) and node.level == 0:
+            module = node.module or ""
+            if module == "scripts" or module.startswith("scripts."):
+                offenders.append((node.lineno, module))
+    return offenders
+
+
+def test_sandbox_main_never_imports_scripts_package() -> None:
+    tree = ast.parse(_SANDBOX_MAIN.read_text(encoding="utf-8"))
+
+    offenders = _scripts_imports(tree)
+
+    assert offenders == [], (
+        f"src/mockworld/sandbox_main.py imports the `scripts` package at "
+        f"{offenders} — that package is NOT shipped into the sandbox docker "
+        "image (Dockerfile.agent copies only src/tests/templates/static), so "
+        "the import wedges the air-gapped sandbox at boot or seam-wiring "
+        "time. Use a duck-typed local stand-in instead (see "
+        "SeededActivationProposal)."
+    )
+
+
+def test_seeded_gate_detector_needs_no_scripts_package() -> None:
+    """The s66 seam builds proposals without the scripts package present."""
+    import asyncio
+
+    from mockworld.sandbox_main import build_seeded_gate_detector
+
+    detector = build_seeded_gate_detector(
+        [{"name": "g", "required_on": ["main"], "workflow": "t.yml", "job": "j"}]
+    )
+    was_loaded = {
+        name: sys.modules.pop(name)
+        for name in list(sys.modules)
+        if name == "scripts" or name.startswith("scripts.")
+    }
+    try:
+        proposals = asyncio.run(detector())
+    finally:
+        sys.modules.update(was_loaded)
+
+    assert [p.name for p in proposals] == ["g"]
+    assert proposals[0].required_on == ("main",)

--- a/tests/sandbox_scenarios/scenarios/s65_workspace_gc_collects_stale.py
+++ b/tests/sandbox_scenarios/scenarios/s65_workspace_gc_collects_stale.py
@@ -1,0 +1,74 @@
+"""s65 — WorkspaceGCLoop actively collects a seeded stale worktree.
+
+Active-trigger upgrade of the s46 idle poll (#9543): the seed registers a
+tracked worktree for an issue that FakeGitHub reports closed, so a GC cycle
+must actually collect it — not merely heartbeat. Proves the closed-issue GC
+decision runs end-to-end on the air-gapped network now that
+``WorkspaceGCLoop._get_issue_state`` routes through ``PRPort.get_issue_state``
+(served by FakeGitHub) instead of a raw ``gh api`` subprocess.
+
+s46 keeps covering the idle/steady-state path; per the active-trigger
+convention this scenario has its own NEW id and issue number.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s65_workspace_gc_collects_stale"
+DESCRIPTION = (
+    "WorkspaceGCLoop collects a seeded stale worktree whose issue is closed "
+    "(details.collected >= 1), not just a heartbeat."
+)
+
+# One constant issue number across the seed's issues / stale_workspaces and
+# the assertion — the seed-alignment convention for active scenario families.
+_ISSUE = 7301
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["workspace_gc"],
+        cycles_to_run=2,
+        # Closed and label-free: the pipeline's store refresh only pulls open
+        # ``hydraflow-*``-labelled issues, so only the GC loop sees this one.
+        issues=[
+            {
+                "number": _ISSUE,
+                "title": "Done issue with a leaked worktree",
+                "body": "Merged manually; the worktree leaked.",
+                "labels": [],
+                "state": "closed",
+            }
+        ],
+        stale_workspaces=[{"number": _ISSUE, "branch": f"agent/issue-{_ISSUE}"}],
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """A workspace_gc cycle reports at least one collected worktree."""
+
+    def _collected(payload: object) -> bool:
+        events = payload if isinstance(payload, list) else []
+        return any(
+            e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "workspace_gc"
+            and (e.get("data", {}).get("details") or {}).get("collected", 0) >= 1
+            for e in events
+        )
+
+    events_payload = await api.wait_until("/api/events", _collected, timeout=90.0)
+
+    gc_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "workspace_gc"
+    ]
+    assert any(
+        (e.get("data", {}).get("details") or {}).get("collected", 0) >= 1
+        for e in gc_events
+    ), (
+        f"Expected a workspace_gc cycle with details.collected >= 1 for the "
+        f"seeded stale worktree (issue #{_ISSUE}); worker events: {gc_events!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s66_gate_activator_files_proposal.py
+++ b/tests/sandbox_scenarios/scenarios/s66_gate_activator_files_proposal.py
@@ -1,0 +1,75 @@
+"""s66 — GateActivatorLoop actively files a gate-activation proposal issue.
+
+Active-trigger upgrade of the s45 idle poll (#9543): the seed scripts one
+activatable planned gate, the composition root swaps the loop's ``detector=``
+injection point for a closure returning it (the repo baked into the sandbox
+image is steady-state — every gate active — so the production detector can
+never propose), and the loop must actually file the proposal issue through
+``PRPort.create_issue`` (served by FakeGitHub).
+
+s45 keeps covering the idle/steady-state path; this scenario has its own NEW
+id per the active-trigger convention.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s66_gate_activator_files_proposal"
+DESCRIPTION = (
+    "GateActivatorLoop files an activation issue for a seeded planned-but-"
+    "enforceable gate (details.issue_created present), not just a heartbeat."
+)
+
+# One constant gate name across the seed and any debugging of the filed issue.
+_GATE = "mockworld-scenarios"
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["gate_activator"],
+        cycles_to_run=2,
+        gate_activations=[
+            {
+                "name": _GATE,
+                "dimension": "tests",
+                "required_on": ["main", "staging"],
+                "workflow": "test.yml",
+                "job": "scenario-tests",
+                "make_target": "scenario",
+            }
+        ],
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """A gate_activator cycle reports the filed proposal issue number."""
+
+    def _proposal_filed(payload: object) -> bool:
+        events = payload if isinstance(payload, list) else []
+        return any(
+            e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "gate_activator"
+            and (e.get("data", {}).get("details") or {}).get("status") == "proposals"
+            and (e.get("data", {}).get("details") or {}).get("issue_created")
+            for e in events
+        )
+
+    events_payload = await api.wait_until("/api/events", _proposal_filed, timeout=90.0)
+
+    activator_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "gate_activator"
+    ]
+    filed = [
+        (e.get("data", {}).get("details") or {}).get("issue_created")
+        for e in activator_events
+        if (e.get("data", {}).get("details") or {}).get("issue_created")
+    ]
+    assert filed, (
+        f"Expected gate_activator to file an activation issue for the seeded "
+        f"gate {_GATE!r} (details.issue_created); worker events: "
+        f"{activator_events!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s67_branch_protection_auditor_files_drift.py
+++ b/tests/sandbox_scenarios/scenarios/s67_branch_protection_auditor_files_drift.py
@@ -1,0 +1,78 @@
+"""s67 — BranchProtectionAuditorLoop actively files a ruleset-drift issue.
+
+Active-trigger upgrade of the s41 idle poll (#9543, unblocked by the #9644
+FakeGitHub ruleset seam): the seed stands up a drifted live ruleset (a
+non-canonical ``main protect``; ``staging protect`` absent entirely), the
+composition root rebinds the auditor so the REAL ``audit_repo`` diff runs
+against ``FakeGitHub.fetch_rulesets``, and the loop must actually file the
+drift issue via ``PRPort.create_issue``.
+
+This also retires the s41 blind spot: there the raw-``gh`` fetch errors under
+the air-gap, ``_do_work`` returns ``{'error': True}``, and the heartbeat-only
+assert passes anyway. Here the audit genuinely runs and its outcome is
+asserted. s41 keeps covering registry wiring; this scenario has its own NEW id.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s67_branch_protection_auditor_files_drift"
+DESCRIPTION = (
+    "BranchProtectionAuditorLoop files a drift issue when seeded live "
+    "rulesets diverge from the canonical contract (details.issue_created "
+    "present), not just a heartbeat."
+)
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["branch_protection_auditor"],
+        cycles_to_run=2,
+        # Deliberately drifted: enforcement disabled + no rules on ``main
+        # protect`` (canonical has enforcement active with required checks),
+        # and ``staging protect`` missing outright — two independent drift
+        # signals, so the audit reports drift regardless of how the canonical
+        # contract evolves.
+        rulesets={
+            "main protect": {
+                "name": "main protect",
+                "target": "branch",
+                "enforcement": "disabled",
+                "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"]}},
+                "rules": [],
+            }
+        },
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """An auditor cycle reports drift plus the filed drift-issue number."""
+
+    def _drift_filed(payload: object) -> bool:
+        events = payload if isinstance(payload, list) else []
+        return any(
+            e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "branch_protection_auditor"
+            and (e.get("data", {}).get("details") or {}).get("status") == "drift"
+            and (e.get("data", {}).get("details") or {}).get("issue_created")
+            for e in events
+        )
+
+    events_payload = await api.wait_until("/api/events", _drift_filed, timeout=90.0)
+
+    auditor_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "branch_protection_auditor"
+    ]
+    filed = [
+        (e.get("data", {}).get("details") or {}).get("issue_created")
+        for e in auditor_events
+        if (e.get("data", {}).get("details") or {}).get("issue_created")
+    ]
+    assert filed, (
+        "Expected branch_protection_auditor to file a ruleset-drift issue for "
+        f"the seeded drifted rulesets; worker events: {auditor_events!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s68_epic_sweeper_closes_completed_epic.py
+++ b/tests/sandbox_scenarios/scenarios/s68_epic_sweeper_closes_completed_epic.py
@@ -1,0 +1,82 @@
+"""s68 — EpicSweeperLoop actively closes an epic whose children are all done.
+
+Active-trigger upgrade of the s23 idle poll (#9543): the seed carries an open
+epic (checkbox body ref) whose single child issue is already closed, so a
+sweep cycle must actually close the epic — check the checkbox, label it
+fixed, comment, and ``close_issue`` through PRPort — not merely heartbeat.
+Everything routes through FakeIssueFetcher/FakeGitHub; no network reads.
+
+s23 keeps covering the idle/no-epics path; this scenario has its own NEW ids
+per the active-trigger convention.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s68_epic_sweeper_closes_completed_epic"
+DESCRIPTION = (
+    "EpicSweeperLoop auto-closes a seeded epic whose only sub-issue is closed "
+    "(details.swept >= 1), not just a heartbeat."
+)
+
+# One constant pair across the seed body's checkbox ref and the assertions.
+_CHILD = 7401
+_EPIC = 7402
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["epic_sweeper"],
+        cycles_to_run=2,
+        issues=[
+            {
+                # Closed, label-free child: only the sweeper's by-number fetch
+                # sees it; the pipeline's store refresh never picks it up.
+                "number": _CHILD,
+                "title": "Child work item (done)",
+                "body": "Completed and closed.",
+                "labels": [],
+                "state": "closed",
+            },
+            {
+                # ``hydraflow-epic`` is not a pipeline lifecycle label, so the
+                # epic is visible to the sweeper's label fetch only.
+                "number": _EPIC,
+                "title": "Epic: one-child rollup",
+                "body": f"## Sub-issues\n\n- [ ] #{_CHILD}\n",
+                "labels": ["hydraflow-epic"],
+                "state": "open",
+            },
+        ],
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """A sweep cycle reports the epic checked and swept (auto-closed)."""
+
+    def _swept(payload: object) -> bool:
+        events = payload if isinstance(payload, list) else []
+        return any(
+            e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "epic_sweeper"
+            and (e.get("data", {}).get("details") or {}).get("swept", 0) >= 1
+            for e in events
+        )
+
+    events_payload = await api.wait_until("/api/events", _swept, timeout=90.0)
+
+    sweep_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "epic_sweeper"
+    ]
+    assert any(
+        (e.get("data", {}).get("details") or {}).get("swept", 0) >= 1
+        for e in sweep_events
+    ), (
+        f"Expected epic_sweeper to auto-close epic #{_EPIC} (its only child "
+        f"#{_CHILD} is closed) with details.swept >= 1; worker events: "
+        f"{sweep_events!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s69_runs_gc_purges_expired_run.py
+++ b/tests/sandbox_scenarios/scenarios/s69_runs_gc_purges_expired_run.py
@@ -1,0 +1,63 @@
+"""s69 — RunsGCLoop actively purges an expired run artifact.
+
+Active-trigger upgrade of the s47 idle poll (#9543): the seed materializes a
+run-artifact directory back-dated far past ``artifact_retention_days``
+(RunRecorder derives artifact age from the ``%Y%m%dT%H%M%SZ`` directory
+name), so a GC cycle must actually delete it — not merely heartbeat. Pure
+local-disk work; nothing touches the air-gapped network.
+
+s47 keeps covering the idle/nothing-expired path; this scenario has its own
+NEW id and issue number per the active-trigger convention.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s69_runs_gc_purges_expired_run"
+DESCRIPTION = (
+    "RunsGCLoop purges a seeded, far-past-retention run directory "
+    "(details.expired_purged >= 1), not just a heartbeat."
+)
+
+# One constant issue number across the seeded run dir and the assertions.
+_ISSUE = 7501
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["runs_gc"],
+        cycles_to_run=2,
+        # 3650 days ≫ any realistic artifact_retention_days (default 30), so
+        # the seeded run is expired regardless of config drift.
+        expired_run_dirs=[{"issue": _ISSUE, "age_days": 3650}],
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """A runs_gc cycle reports at least one expired run purged."""
+
+    def _purged(payload: object) -> bool:
+        events = payload if isinstance(payload, list) else []
+        return any(
+            e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "runs_gc"
+            and (e.get("data", {}).get("details") or {}).get("expired_purged", 0) >= 1
+            for e in events
+        )
+
+    events_payload = await api.wait_until("/api/events", _purged, timeout=90.0)
+
+    gc_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "runs_gc"
+    ]
+    assert any(
+        (e.get("data", {}).get("details") or {}).get("expired_purged", 0) >= 1
+        for e in gc_events
+    ), (
+        f"Expected runs_gc to purge the seeded expired run for issue "
+        f"#{_ISSUE} (details.expired_purged >= 1); worker events: {gc_events!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s70_merge_state_watcher_rebases_conflict.py
+++ b/tests/sandbox_scenarios/scenarios/s70_merge_state_watcher_rebases_conflict.py
@@ -1,0 +1,72 @@
+"""s70 — MergeStateWatcherLoop actively rebases a conflicting PR.
+
+Active-trigger upgrade of the s49 idle poll (#9543): the seed carries a PR
+flagged ``mergeable: false`` (CONFLICTING), so a watcher cycle must actually
+act — ``list_conflicting_prs`` surfaces it, ``update_pr_branch`` rebases it,
+and the re-check reports it mergeable — not merely heartbeat. All PR I/O
+routes through PRPort/FakeGitHub; the CH-2 approval-record reconciler (a raw
+``gh`` boundary with no Fake seam) is config-disabled in the sandbox.
+
+s49 keeps covering the idle/no-conflicts path; this scenario has its own NEW
+ids per the active-trigger convention.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s70_merge_state_watcher_rebases_conflict"
+DESCRIPTION = (
+    "MergeStateWatcherLoop rebases a seeded CONFLICTING PR "
+    "(details.rebased >= 1), not just a heartbeat."
+)
+
+# One constant pair across the seeded PR and the assertions.
+_ISSUE = 8800
+_PR = 8801
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["merge_state_watcher"],
+        cycles_to_run=2,
+        # Label-free so neither the HITL label nor SKIP_LABELS applies and no
+        # other loop claims the PR; ``mergeable: false`` is the trigger.
+        prs=[
+            {
+                "number": _PR,
+                "issue_number": _ISSUE,
+                "branch": f"agent/issue-{_ISSUE}",
+                "mergeable": False,
+            }
+        ],
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """A watcher cycle reports the conflicting PR checked and rebased."""
+
+    def _rebased(payload: object) -> bool:
+        events = payload if isinstance(payload, list) else []
+        return any(
+            e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "merge_state_watcher"
+            and (e.get("data", {}).get("details") or {}).get("rebased", 0) >= 1
+            for e in events
+        )
+
+    events_payload = await api.wait_until("/api/events", _rebased, timeout=90.0)
+
+    watcher_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "merge_state_watcher"
+    ]
+    assert any(
+        (e.get("data", {}).get("details") or {}).get("rebased", 0) >= 1
+        for e in watcher_events
+    ), (
+        f"Expected merge_state_watcher to rebase seeded CONFLICTING PR "
+        f"#{_PR} (details.rebased >= 1); worker events: {watcher_events!r}"
+    )

--- a/tests/scenarios/fakes/mock_world.py
+++ b/tests/scenarios/fakes/mock_world.py
@@ -820,20 +820,12 @@ class MockWorld:
                 build_seeded_gate_detector(seed.gate_activations),
             )
         if seed.rulesets:
-            # The run_with_loops config is tmp-rooted; point the audit at the
-            # real repo's canonical ruleset contract, as the baked sandbox
-            # image does via config.repo_root.
-            repo_root = Path(__file__).resolve().parents[3]
+            # Default canonical_dir: the same fixed baseline sandbox_main
+            # materializes under the (tmp-rooted) data root — both tiers
+            # audit seeded live rulesets against one deterministic contract.
             self._loop_ports.setdefault(
                 "branch_protection_audit",
-                build_seeded_branch_protection_auditor(
-                    config,
-                    self._github,
-                    canonical_dir=repo_root
-                    / "docs"
-                    / "standards"
-                    / "branch_protection",
-                ),
+                build_seeded_branch_protection_auditor(config, self._github),
             )
         if seed.expired_run_dirs:
             from run_recorder import RunRecorder  # noqa: PLC0415

--- a/tests/scenarios/fakes/mock_world.py
+++ b/tests/scenarios/fakes/mock_world.py
@@ -250,6 +250,10 @@ class MockWorld:
         self._issues: dict[int, dict[str, Any]] = {}
         self._phase_hooks: list[tuple[str, Callable[[], None]]] = []
         self._ran = False
+        # Last seed given to apply_seed — run_with_loops wires the seed-seam
+        # loop overrides (stale worktrees, gate proposals, rulesets, expired
+        # runs) from it, mirroring sandbox_main's composition root (#9543).
+        self._applied_seed: MockWorldSeed | None = None
         self._dashboard: Any = None
         self._dashboard_url: str | None = None
 
@@ -356,6 +360,7 @@ class MockWorld:
         title: str,
         body: str,
         labels: list[str] | None = None,
+        state: str = "open",
     ) -> MockWorld:
         self._issues[number] = {
             "number": number,
@@ -363,7 +368,7 @@ class MockWorld:
             "body": body,
             "labels": labels or ["hydraflow-find"],
         }
-        self._github.add_issue(number, title, body, labels=labels)
+        self._github.add_issue(number, title, body, labels=labels, state=state)
         return self
 
     def add_repo(
@@ -467,6 +472,7 @@ class MockWorld:
         test code that wants to consume a sandbox scenario's seed() output
         without rewriting it as a fluent chain. Returns self for chaining.
         """
+        self._applied_seed = seed
         for repo_slug, repo_path in seed.repos:
             self.add_repo(repo_slug, repo_path)
         for issue_dict in seed.issues:
@@ -475,6 +481,7 @@ class MockWorld:
                 title=issue_dict["title"],
                 body=issue_dict["body"],
                 labels=list(issue_dict.get("labels", [])),
+                state=issue_dict.get("state", "open"),
             )
         for pr_dict in seed.prs:
             self._github.add_pr(
@@ -483,9 +490,12 @@ class MockWorld:
                 branch=pr_dict["branch"],
                 ci_status=pr_dict.get("ci_status", "pass"),
                 merged=pr_dict.get("merged", False),
+                mergeable=pr_dict.get("mergeable", True),
             )
             for label in pr_dict.get("labels", []):
                 self._github.add_pr_label(pr_dict["number"], label)
+        for name, cfg in seed.rulesets.items():
+            self._github.add_ruleset(name, cfg)
         for phase, by_issue in seed.scripts.items():
             for issue_number, results in by_issue.items():
                 for result in results:
@@ -758,6 +768,11 @@ class MockWorld:
             self._loop_ports["workspace"] = self._workspace
             self._loop_ports["state"] = self._harness.state
 
+        # Mirror sandbox_main's seed-seam composition wiring (#9543) so the
+        # in-process tier exercises the same active-trigger paths the docker
+        # tier does (dual-loader parity).
+        self._wire_seed_loop_seams(config)
+
         loop_instances = []
         for name in loops:
             instance = LoopCatalog.instantiate(
@@ -772,6 +787,72 @@ class MockWorld:
                 results[name] = stats
 
         return results
+
+    def _wire_seed_loop_seams(self, config: Any) -> None:
+        """Wire seed-seam loop overrides from the last applied seed (#9543).
+
+        The dual-loader parity contract: any composition-root seam
+        ``sandbox_main`` wires from a ``MockWorldSeed`` field must be wired
+        here too, so ``test_sandbox_parity`` runs every scenario's active
+        path in-process as well. Reuses sandbox_main's public builders — one
+        implementation, no drift. Empty seed fields (or no ``apply_seed``
+        call at all) leave every port default untouched.
+        """
+        seed = self._applied_seed
+        if seed is None:
+            return
+        from mockworld.sandbox_main import (  # noqa: PLC0415
+            build_seeded_branch_protection_auditor,
+            build_seeded_gate_detector,
+            materialize_expired_runs,
+            seed_stale_workspaces,
+        )
+
+        if seed.stale_workspaces:
+            # Register the worktrees in the REAL harness StateTracker and hand
+            # that tracker to the loop builder (its default is an empty-world
+            # MagicMock, which can never surface a tracked workspace).
+            seed_stale_workspaces(self._harness.state, config, seed)
+            self._loop_ports.setdefault("workspace_gc_state", self._harness.state)
+        if seed.gate_activations:
+            self._loop_ports.setdefault(
+                "gate_activation_detect",
+                build_seeded_gate_detector(seed.gate_activations),
+            )
+        if seed.rulesets:
+            # The run_with_loops config is tmp-rooted; point the audit at the
+            # real repo's canonical ruleset contract, as the baked sandbox
+            # image does via config.repo_root.
+            repo_root = Path(__file__).resolve().parents[3]
+            self._loop_ports.setdefault(
+                "branch_protection_audit",
+                build_seeded_branch_protection_auditor(
+                    config,
+                    self._github,
+                    canonical_dir=repo_root
+                    / "docs"
+                    / "standards"
+                    / "branch_protection",
+                ),
+            )
+        if seed.expired_run_dirs:
+            from run_recorder import RunRecorder  # noqa: PLC0415
+
+            materialize_expired_runs(config, seed)
+            self._loop_ports.setdefault("run_recorder", RunRecorder(config))
+        epic_labels = set(getattr(config, "epic_label", None) or ["hydraflow-epic"])
+        if any(epic_labels & set(i.get("labels", [])) for i in seed.issues):
+            # Give epic_sweeper a real fetcher over the shared FakeGitHub so a
+            # seeded epic (and its closed children) is actually swept; the
+            # builder default is an empty-world MagicMock.
+            from mockworld.fakes.fake_issue_fetcher import (  # noqa: PLC0415
+                FakeIssueFetcher,
+            )
+
+            self._loop_ports.setdefault(
+                "issue_fetcher", FakeIssueFetcher(github=self._github)
+            )
+            self._loop_ports.setdefault("epic_sweeper_state", self._harness.state)
 
     # --- Dashboard lifecycle ---
 

--- a/tests/scenarios/test_governance_active_trigger_scenarios.py
+++ b/tests/scenarios/test_governance_active_trigger_scenarios.py
@@ -1,0 +1,99 @@
+"""#9543 — governance active-trigger scenarios prove their outcome in Tier 1.
+
+``test_sandbox_parity`` only asserts each sandbox scenario produces *some*
+loop stats in-process; for the s59–s64 active-trigger family that would pass
+even if the seeded trigger never fired (the exact failure mode the family
+exists to catch). These tests run each scenario's real seed through the
+MockWorld loaders and assert the ACTIVE outcome — the worktree collected, the
+issue filed, the epic closed, the artifact purged, the PR rebased — so a
+regression in either loader's seam wiring reddens here, without docker.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.sandbox_scenarios.scenarios import (
+    s65_workspace_gc_collects_stale as s65,
+)
+from tests.sandbox_scenarios.scenarios import (
+    s66_gate_activator_files_proposal as s66,
+)
+from tests.sandbox_scenarios.scenarios import (
+    s67_branch_protection_auditor_files_drift as s67,
+)
+from tests.sandbox_scenarios.scenarios import (
+    s68_epic_sweeper_closes_completed_epic as s68,
+)
+from tests.sandbox_scenarios.scenarios import (
+    s69_runs_gc_purges_expired_run as s69,
+)
+from tests.sandbox_scenarios.scenarios import (
+    s70_merge_state_watcher_rebases_conflict as s70,
+)
+
+
+async def _run(mock_world, scenario):
+    seed = scenario.seed()
+    mock_world.apply_seed(seed)
+    stats = await mock_world.run_with_loops(seed.loops_enabled, cycles=1)
+    return seed, stats
+
+
+@pytest.mark.asyncio
+async def test_s65_workspace_gc_collects_seeded_stale_worktree(mock_world) -> None:
+    _seed, stats = await _run(mock_world, s65)
+
+    assert stats["workspace_gc"]["collected"] >= 1
+    # The world shows the side effect, not just the counter.
+    assert s65._ISSUE in mock_world._workspace.destroyed
+    assert s65._ISSUE not in mock_world._harness.state.get_active_workspaces()
+
+
+@pytest.mark.asyncio
+async def test_s66_gate_activator_files_activation_issue(mock_world) -> None:
+    _seed, stats = await _run(mock_world, s66)
+
+    assert stats["gate_activator"]["status"] == "proposals"
+    filed = stats["gate_activator"]["issue_created"]
+    issue = mock_world._github._issues[filed]
+    assert issue.title.startswith("[gate-activation]")
+    assert s66._GATE in issue.body
+
+
+@pytest.mark.asyncio
+async def test_s67_branch_protection_auditor_files_drift_issue(mock_world) -> None:
+    _seed, stats = await _run(mock_world, s67)
+
+    assert stats["branch_protection_auditor"]["status"] == "drift"
+    filed = stats["branch_protection_auditor"]["issue_created"]
+    issue = mock_world._github._issues[filed]
+    assert issue.title.startswith("[branch-protection] ruleset drift")
+
+
+@pytest.mark.asyncio
+async def test_s68_epic_sweeper_closes_completed_epic(mock_world) -> None:
+    _seed, stats = await _run(mock_world, s68)
+
+    assert stats["epic_sweeper"]["swept"] >= 1
+    epic = mock_world._github._issues[s68._EPIC]
+    assert epic.state == "closed"
+    assert f"- [x] #{s68._CHILD}" in epic.body
+
+
+@pytest.mark.asyncio
+async def test_s69_runs_gc_purges_expired_run(mock_world) -> None:
+    _seed, stats = await _run(mock_world, s69)
+
+    assert stats["runs_gc"]["expired_purged"] >= 1
+    runs_dir = mock_world._loop_ports["run_recorder"].runs_dir
+    assert not (runs_dir / str(s69._ISSUE)).exists()
+
+
+@pytest.mark.asyncio
+async def test_s70_merge_state_watcher_rebases_conflicting_pr(mock_world) -> None:
+    _seed, stats = await _run(mock_world, s70)
+
+    assert stats["merge_state_watcher"]["checked"] >= 1
+    assert stats["merge_state_watcher"]["rebased"] >= 1
+    assert mock_world._github._prs[s70._PR].mergeable is True

--- a/tests/scenarios/test_mock_world_apply_seed.py
+++ b/tests/scenarios/test_mock_world_apply_seed.py
@@ -53,3 +53,46 @@ async def test_apply_seed_builds_multi_runtime_registry(mock_world, tmp_path) ->
     beta = registry.get("owner-beta")
     assert alpha.event_bus is not beta.event_bus  # genuinely independent runtimes
     assert alpha.event_bus._active_repo == "owner-alpha"  # tagged via set_repo
+
+
+@pytest.mark.asyncio
+async def test_apply_seed_threads_issue_state_and_pr_mergeable(mock_world) -> None:
+    """#9543: closed issues and CONFLICTING PRs survive the Tier-1 loader."""
+    seed = MockWorldSeed(
+        issues=[
+            {
+                "number": 7301,
+                "title": "done",
+                "body": "b",
+                "labels": [],
+                "state": "closed",
+            }
+        ],
+        prs=[
+            {
+                "number": 8801,
+                "issue_number": 8800,
+                "branch": "agent/issue-8800",
+                "mergeable": False,
+            }
+        ],
+    )
+
+    mock_world.apply_seed(seed)
+
+    assert await mock_world._github.get_issue_state(7301) == "COMPLETED"
+    conflicting = await mock_world._github.list_conflicting_prs()
+    assert [pr.number for pr in conflicting] == [8801]
+
+
+@pytest.mark.asyncio
+async def test_apply_seed_threads_rulesets(mock_world) -> None:
+    """#9543: seeded rulesets reach FakeGitHub.fetch_rulesets in Tier 1 too."""
+    seed = MockWorldSeed(
+        rulesets={"main protect": {"name": "main protect", "enforcement": "active"}}
+    )
+
+    mock_world.apply_seed(seed)
+
+    live = mock_world._github.fetch_rulesets("owner/repo")
+    assert live["main protect"]["enforcement"] == "active"

--- a/tests/test_fake_github_from_seed.py
+++ b/tests/test_fake_github_from_seed.py
@@ -47,3 +47,51 @@ def test_from_seed_handles_empty_seed() -> None:
     gh = FakeGitHub.from_seed(MockWorldSeed())
     assert gh._issues == {}
     assert gh._prs == {}
+
+
+def test_from_seed_honors_issue_state() -> None:
+    """#9543: a ``state: closed`` seed issue reports COMPLETED from the port."""
+    import asyncio
+
+    seed = MockWorldSeed(
+        issues=[
+            {
+                "number": 7301,
+                "title": "done",
+                "body": "b",
+                "labels": [],
+                "state": "closed",
+            },
+            {"number": 7302, "title": "open one", "body": "b", "labels": []},
+        ],
+    )
+
+    gh = FakeGitHub.from_seed(seed)
+
+    assert asyncio.run(gh.get_issue_state(7301)) == "COMPLETED"
+    # Absent ``state`` key still defaults to open — back-compat preserved.
+    assert asyncio.run(gh.get_issue_state(7302)) == "OPEN"
+
+
+def test_from_seed_honors_pr_mergeable() -> None:
+    """#9543: ``mergeable: false`` seeds a CONFLICTING PR the watcher can act on."""
+    import asyncio
+
+    seed = MockWorldSeed(
+        prs=[
+            {
+                "number": 8801,
+                "issue_number": 8800,
+                "branch": "agent/issue-8800",
+                "mergeable": False,
+            },
+            {"number": 8802, "issue_number": 8803, "branch": "b2"},
+        ],
+    )
+
+    gh = FakeGitHub.from_seed(seed)
+
+    conflicting = asyncio.run(gh.list_conflicting_prs())
+    assert [pr.number for pr in conflicting] == [8801]
+    # Absent ``mergeable`` key still defaults to True — back-compat preserved.
+    assert gh._prs[8802].mergeable is True

--- a/tests/test_mockworld_seed.py
+++ b/tests/test_mockworld_seed.py
@@ -217,3 +217,54 @@ def test_seed_round_trips_issue_refinement_seam_through_json() -> None:
     assert parsed.issue_refinement_backlog[0]["number"] == 7101
     assert isinstance(parsed.issue_refinement_backlog[0]["number"], int)
     assert parsed.issue_refinement_verdicts[0].startswith('{"verdict"')
+
+
+def test_default_seed_has_empty_active_trigger_seams() -> None:
+    """#9543 governance active-trigger seed fields default empty (back-compat)."""
+    seed = MockWorldSeed()
+    assert seed.stale_workspaces == []
+    assert seed.gate_activations == []
+    assert seed.expired_run_dirs == []
+
+
+def test_seed_round_trips_active_trigger_seams_through_json() -> None:
+    original = MockWorldSeed(
+        issues=[
+            {
+                "number": 7301,
+                "title": "done",
+                "body": "b",
+                "labels": [],
+                "state": "closed",
+            }
+        ],
+        prs=[
+            {
+                "number": 8801,
+                "issue_number": 8800,
+                "branch": "agent/issue-8800",
+                "mergeable": False,
+            }
+        ],
+        stale_workspaces=[{"number": 7301, "branch": "agent/issue-7301"}],
+        gate_activations=[
+            {
+                "name": "mockworld-scenarios",
+                "dimension": "tests",
+                "required_on": ["main"],
+                "workflow": "test.yml",
+                "job": "scenario-tests",
+                "make_target": "scenario",
+            }
+        ],
+        expired_run_dirs=[{"issue": 7501, "age_days": 3650}],
+    )
+
+    restored = MockWorldSeed.from_json(original.to_json())
+
+    assert restored == original
+    assert restored.issues[0]["state"] == "closed"
+    assert restored.prs[0]["mergeable"] is False
+    assert restored.stale_workspaces == original.stale_workspaces
+    assert restored.gate_activations == original.gate_activations
+    assert restored.expired_run_dirs == original.expired_run_dirs

--- a/tests/test_sandbox_main_smoke.py
+++ b/tests/test_sandbox_main_smoke.py
@@ -76,3 +76,178 @@ def test_caretaker_enabled_cb_tolerates_extra_args() -> None:
     assert cb_all("workspace_gc", "extra", key="val") is True
     assert cb_subset("workspace_gc", "extra", key="val") is True
     assert cb_subset("other", "extra", key="val") is False
+
+
+# --- #9543 active-trigger seed seams -----------------------------------------
+
+
+def _seed_config(tmp_path):
+    from tests.helpers import make_bg_loop_deps
+
+    return make_bg_loop_deps(tmp_path).config
+
+
+def test_seed_stale_workspaces_populates_state(tmp_path) -> None:
+    from mockworld.seed import MockWorldSeed
+    from state import StateTracker
+
+    config = _seed_config(tmp_path)
+    state = StateTracker(config.state_file)
+    seed = MockWorldSeed(
+        stale_workspaces=[{"number": 7301, "branch": "agent/issue-7301"}]
+    )
+
+    sandbox_main.seed_stale_workspaces(state, config, seed)
+
+    workspaces = state.get_active_workspaces()
+    assert 7301 in workspaces
+    expected = config.workspace_base / config.repo_slug / "issue-7301"
+    assert workspaces[7301] == str(expected)
+    assert state.get_active_branches()[7301] == "agent/issue-7301"
+
+
+def test_seed_stale_workspaces_defaults_branch_and_noops_when_empty(
+    tmp_path,
+) -> None:
+    from mockworld.seed import MockWorldSeed
+    from state import StateTracker
+
+    config = _seed_config(tmp_path)
+    state = StateTracker(config.state_file)
+
+    sandbox_main.seed_stale_workspaces(state, config, MockWorldSeed())
+    assert state.get_active_workspaces() == {}
+
+    seed = MockWorldSeed(stale_workspaces=[{"number": 42}])
+    sandbox_main.seed_stale_workspaces(state, config, seed)
+    assert state.get_active_branches()[42] == "agent/issue-42"
+
+
+def test_materialize_expired_runs_creates_purgeable_dir(tmp_path) -> None:
+    from mockworld.seed import MockWorldSeed
+    from run_recorder import RunRecorder
+
+    config = _seed_config(tmp_path)
+    seed = MockWorldSeed(expired_run_dirs=[{"issue": 7501, "age_days": 3650}])
+
+    sandbox_main.materialize_expired_runs(config, seed)
+
+    issue_dir = config.repo_data_path("runs") / "7501"
+    run_dirs = list(issue_dir.iterdir())
+    assert len(run_dirs) == 1
+    # The materialized run is genuinely expired: a purge cycle removes it.
+    recorder = RunRecorder(config)
+    assert recorder.purge_expired(config.artifact_retention_days) == 1
+    assert not issue_dir.exists()
+
+
+def test_materialize_expired_runs_noops_when_empty(tmp_path) -> None:
+    from mockworld.seed import MockWorldSeed
+
+    config = _seed_config(tmp_path)
+    sandbox_main.materialize_expired_runs(config, MockWorldSeed())
+    assert not (config.repo_data_path("runs")).exists()
+
+
+def test_build_seeded_gate_detector_returns_proposals() -> None:
+    import asyncio
+
+    detector = sandbox_main.build_seeded_gate_detector(
+        [
+            {
+                "name": "mockworld-scenarios",
+                "dimension": "tests",
+                "required_on": ["main", "staging"],
+                "workflow": "test.yml",
+                "job": "scenario-tests",
+                "make_target": "scenario",
+            }
+        ]
+    )
+
+    proposals = asyncio.run(detector())
+
+    assert len(proposals) == 1
+    proposal = proposals[0]
+    assert proposal.name == "mockworld-scenarios"
+    assert proposal.required_on == ("main", "staging")  # tuple-coerced
+    assert proposal.workflow == "test.yml"
+    assert proposal.job == "scenario-tests"
+
+
+def _write_canonical(tmp_path):
+    import json
+
+    canonical = {
+        "name": "main protect",
+        "target": "branch",
+        "enforcement": "active",
+        "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}},
+        "rules": [{"type": "deletion"}],
+    }
+    staging = dict(canonical, name="staging protect")
+    canonical_dir = tmp_path / "canonical"
+    canonical_dir.mkdir()
+    (canonical_dir / "main_ruleset.json").write_text(json.dumps(canonical))
+    (canonical_dir / "staging_ruleset.json").write_text(json.dumps(staging))
+    return canonical_dir, canonical, staging
+
+
+def test_build_seeded_branch_protection_auditor_reports_drift(tmp_path) -> None:
+    import asyncio
+
+    from mockworld.fakes import FakeGitHub
+
+    config = _seed_config(tmp_path)
+    canonical_dir, _canonical, _staging = _write_canonical(tmp_path)
+    gh = FakeGitHub()
+    gh.add_ruleset(
+        "main protect",
+        {
+            "name": "main protect",
+            "target": "branch",
+            "enforcement": "disabled",  # drifted
+            "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"]}},
+            "rules": [],
+        },
+    )
+    auditor = sandbox_main.build_seeded_branch_protection_auditor(
+        config, gh, canonical_dir=canonical_dir
+    )
+
+    report = asyncio.run(auditor())
+
+    assert not report.clean
+    # Both drift signals: the divergent main ruleset and the missing staging one.
+    assert any("staging protect" in d and "missing" in d for d in report.drifts)
+
+
+def test_build_seeded_branch_protection_auditor_clean_when_matching(
+    tmp_path,
+) -> None:
+    import asyncio
+
+    from mockworld.fakes import FakeGitHub
+
+    config = _seed_config(tmp_path)
+    canonical_dir, canonical, staging = _write_canonical(tmp_path)
+    gh = FakeGitHub()
+    gh.add_ruleset("main protect", canonical)
+    gh.add_ruleset("staging protect", staging)
+    auditor = sandbox_main.build_seeded_branch_protection_auditor(
+        config, gh, canonical_dir=canonical_dir
+    )
+
+    report = asyncio.run(auditor())
+
+    assert report.clean
+
+
+def test_sandbox_overrides_disable_approval_records(tmp_path) -> None:
+    """#9543: the CH-2 reconciler's raw ``gh`` boundary is config-disabled."""
+    config = _seed_config(tmp_path)
+    assert config.approval_records_enabled is True  # production default
+
+    sandbox_main._apply_sandbox_config_overrides(config)
+
+    assert config.approval_records_enabled is False

--- a/tests/test_sandbox_main_smoke.py
+++ b/tests/test_sandbox_main_smoke.py
@@ -251,3 +251,35 @@ def test_sandbox_overrides_disable_approval_records(tmp_path) -> None:
     sandbox_main._apply_sandbox_config_overrides(config)
 
     assert config.approval_records_enabled is False
+
+
+def test_auditor_defaults_to_materialized_canonical_baseline(tmp_path) -> None:
+    """No canonical_dir: the fixed baseline is materialized under data root.
+
+    The sandbox image ships no repo ``docs/`` (Dockerfile.agent copies only
+    src/tests/templates/static), so the default must not depend on it.
+    """
+    import asyncio
+
+    from mockworld.fakes import FakeGitHub
+
+    config = _seed_config(tmp_path)
+    gh = FakeGitHub()
+    gh.add_ruleset(
+        "main protect",
+        {
+            "name": "main protect",
+            "target": "branch",
+            "enforcement": "disabled",
+            "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"]}},
+            "rules": [],
+        },
+    )
+    auditor = sandbox_main.build_seeded_branch_protection_auditor(config, gh)
+
+    report = asyncio.run(auditor())
+
+    canonical_dir = config.repo_data_path("sandbox_canonical_rulesets")
+    assert (canonical_dir / "main_ruleset.json").exists()
+    assert (canonical_dir / "staging_ruleset.json").exists()
+    assert not report.clean  # drifted main + missing staging vs the baseline

--- a/tests/test_workspace_gc_loop.py
+++ b/tests/test_workspace_gc_loop.py
@@ -377,19 +377,64 @@ class TestWorktreeGCOrphanedBranches:
 
 class TestWorktreeGCSubprocessArgs:
     @pytest.mark.asyncio
-    async def test_get_issue_state_args(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize(
+        ("port_state", "expected"),
+        [
+            ("COMPLETED", "closed"),
+            ("NOT_PLANNED", "closed"),
+            ("OPEN", "open"),
+            ("UNKNOWN", "unknown"),
+            ("", "unknown"),
+        ],
+    )
+    async def test_get_issue_state_maps_port_vocabulary(
+        self, tmp_path: Path, port_state: str, expected: str
+    ) -> None:
+        """#9543: issue state reads route via PRPort, not raw gh.
+
+        The port speaks GraphQL-style (COMPLETED/NOT_PLANNED/OPEN/UNKNOWN);
+        the mapping preserves the REST-style strings _is_safe_to_gc compares
+        against, and anything unrecognized fails closed to "unknown".
+        """
         loop, _s, _e = _make_loop(tmp_path)
+        loop._prs.get_issue_state = AsyncMock(return_value=port_state)
         with patch("workspace_gc_loop.run_subprocess", new_callable=AsyncMock) as m:
-            m.return_value = "closed\n"
             result = await loop._get_issue_state(42)
-        assert result == "closed"
-        args = m.call_args[0]
-        assert args[0] == "gh"
-        assert args[1] == "api"
-        assert "issues/42" in args[2]
-        assert "--jq" in args
-        assert ".state" in args
-        assert m.call_args[1]["cwd"] == loop._config.repo_root
+        m.assert_not_called()  # no raw subprocess
+        assert result == expected
+        loop._prs.get_issue_state.assert_awaited_once_with(42)
+
+    @pytest.mark.asyncio
+    async def test_gc_collects_closed_issue_via_fake_github(
+        self, tmp_path: Path
+    ) -> None:
+        """#9543 e2e slice: a FakeGitHub-closed issue's worktree is collected.
+
+        Exercises the real _get_issue_state → PRPort.get_issue_state chain
+        against FakeGitHub (the adapter the air-gapped sandbox serves), not a
+        mocked _get_issue_state — proving the seeded-closed-issue collect path
+        the s59 sandbox scenario asserts.
+        """
+        loop, state, _e = _make_loop(tmp_path, active_workspaces={7301: "/p/7301"})
+        gh = FakeGitHub()
+        gh.add_issue(7301, "done", "body", state="closed")
+        loop._prs = gh
+        result = await loop._do_work()
+        assert result is not None
+        assert result["collected"] == 1
+        assert 7301 not in state.get_active_workspaces()
+        loop._workspaces.destroy.assert_awaited_once_with(7301)
+
+    @pytest.mark.asyncio
+    async def test_gc_skips_issue_unknown_to_fake_github(self, tmp_path: Path) -> None:
+        """An issue FakeGitHub never saw reports UNKNOWN → fail-closed skip."""
+        loop, state, _e = _make_loop(tmp_path, active_workspaces={7301: "/p/7301"})
+        loop._prs = FakeGitHub()  # issue 7301 not seeded → UNKNOWN
+        result = await loop._do_work()
+        assert result is not None
+        assert result["collected"] == 0
+        assert result["skipped"] == 1
+        assert 7301 in state.get_active_workspaces()
 
     @pytest.mark.asyncio
     async def test_has_open_pr_queries_port_for_branch(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Part of #9543 — upgrades six of the eight heartbeat-only governance sandbox scenarios to active-trigger assertions. Each new scenario seeds a NEW triggering entity (new scenario IDs, new issue/PR numbers) and asserts the loop ACTS on it via the full `/api/events` history; the existing idle-poll scenarios are retained untouched for steady-state coverage.

## Scenarios added (Tier-2, docker)

| New | Upgrades | Active assertion |
|---|---|---|
| `s65_workspace_gc_collects_stale` | s46 idle | seeded stale worktree of a closed issue → `details.collected >= 1` |
| `s66_gate_activator_files_proposal` | s45 idle | seeded planned-gate proposal → `details.issue_created` (proposal issue filed) |
| `s67_branch_protection_auditor_files_drift` | s41 idle | seeded drifted live ruleset → `details.status == "drift"` + drift issue filed |
| `s68_epic_sweeper_closes_completed_epic` | s23 idle | seeded epic w/ closed child → `details.swept >= 1` (epic auto-closed) |
| `s69_runs_gc_purges_expired_run` | s47 idle | materialized far-past-retention run dir → `details.expired_purged >= 1` |
| `s70_merge_state_watcher_rebases_conflict` | s49 idle | seeded CONFLICTING PR → `details.rebased >= 1` |

## Production change

- `WorkspaceGCLoop._get_issue_state` now routes through `PRPort.get_issue_state` (GraphQL→REST vocabulary mapping, fail-closed to `"unknown"`) instead of a raw `gh api` subprocess — the last air-gap blocker on the closed-issue GC path (same class as #9575's open-issue-path routing). Seam-guard baseline entry pruned (shrink-only ratchet).
- `_apply_sandbox_config_overrides` additionally disables `approval_records` (CH-2 reconciler's raw `gh` boundary has no Fake seam; it keeps its own unit tests) so merge_state_watcher's `_do_work` stats are observable under the air gap.

## Seed surface (wired into BOTH loaders: sandbox_main and MockWorld.apply_seed/run_with_loops)

- `issues[].state` ("closed") and `prs[].mergeable` (false) honored by `FakeGitHub.add_issue/add_pr/from_seed` and the Tier-1 loader.
- New back-compatible fields (default empty, JSON round-trip pinned): `stale_workspaces`, `gate_activations`, `expired_run_dirs`.
- Existing `rulesets` seed (#9644) now actually reaches the auditor: composition roots rebind it to the REAL `audit_repo` diff over `FakeGitHub.fetch_rulesets`.
- Seam builders are public functions in `mockworld.sandbox_main`, reused by the Tier-1 harness — one implementation, no drift.

## Test pyramid

- **Unit**: port-vocabulary mapping + FakeGitHub-backed collect/skip for workspace_gc; seed defaults/round-trip; from_seed/apply_seed threading; every sandbox_main seam helper (incl. clean-vs-drift audit).
- **MockWorld scenario**: `tests/scenarios/test_governance_active_trigger_scenarios.py` runs each new scenario's real seed through the Tier-1 loaders and asserts the ACTIVE outcome (worktree destroyed, issues filed, epic closed, artifact purged, PR rebased) — `test_sandbox_parity` alone would pass even if the trigger never fired.
- **Sandbox e2e**: the six new s65–s70 modules; judged by CI's sandbox lane (docker unavailable in this local worktree — `/private/tmp` is not shared with Docker Desktop).

## Remainder of #9543 (commented on the issue)

- s27 epic_monitor + s48 health_monitor: blocked on #9643 (EpicState/JSONL seed materializer), still open.
- s41's own assertion stays heartbeat-only; its drift path is now genuinely covered by s67. A clean-path assert needs a seed that tracks the canonical contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
