### PR TITLE
feat(skills): hf.plan-review — adversarial panel gates a plan before implementation

### DIFF
--- a/.claude/commands/hf.plan-review.md
+++ b/.claude/commands/hf.plan-review.md
@@ -1,0 +1,55 @@
+# Plan Review — Adversarial Panel
+
+Run an adversarial panel of three senior reviewers over a **plan, spec, or design** *before* it is implemented, then pass the corrections back so the plan is revised first. This is a read-only review — it does not modify the plan; it produces the corrections to fold in.
+
+Use this at the gate between "plan written" (`superpowers:writing-plans` / a spec / a design issue) and "implement." It is the plan-stage complement to the code-stage advisor pattern (ADR-0059): multiple independent perspectives, before any code exists, when a design flaw is cheapest to fix.
+
+## When to Use
+
+- Before implementing a substantial feature (a new loop, a new runner, a spec → multi-task build)
+- After a spec or phase-plan is written but before the first task is dispatched
+- Whenever a design touches a load-bearing invariant (crash-safety, an Accepted ADR, factory-wide behaviour) — the higher the blast radius, the more a panel earns its keep
+
+Skip it for mechanical or single-file changes; the overhead isn't worth it there.
+
+## Instructions
+
+1. **Assemble the plan under review into one brief file.** The panel must review the *real artifact*, not a paraphrase. Gather into a single scratchpad file:
+   - the spec/plan/design doc itself (or the GitHub issue body + comments if that's the plan-of-record),
+   - the ADR(s) it implements or touches,
+   - any relevant already-landed scaffolding (so reviewers can check the plan matches what exists).
+
+   ```bash
+   {
+     echo "# PLAN UNDER REVIEW — <title>"
+     cat docs/superpowers/specs/<the-spec>.md    # or: gh issue view <N> --json title,body,comments --jq ...
+     echo "## ADRs it touches"; sed -n '1,80p' docs/adr/<relevant>.md
+   } > "$SCRATCH/plan-brief.md"
+   ```
+
+2. **Run the panel as a Workflow.** Three reviewers in parallel on a mid-tier model (Sonnet — plan critique is judgment-dense but not the hardest reasoning, and three of them should be cheap), then a synthesis pass on the main model (it holds the plan context and must adjudicate conflicts). The reviewers are **adversarial**: each is told to find what's *wrong*, not to bless it. The three lenses are deliberately non-overlapping — diversity is the whole point.
+
+   - **Principal Engineer** — is the abstraction right, and will it actually work? Correctness, the load-bearing invariant, is there a simpler design, does the mechanism buy what it claims.
+   - **VP Engineering** — should we build this, now, this way? Blast radius, sequencing, smallest de-risking increment, reversibility, opportunity cost, what existing behaviour it puts at risk.
+   - **Staff SRE / Reliability** — how does it fail unattended at 3am? Crash/resume, observability, rollback, preemption, backpressure, the on-call signal when it wedges.
+
+   Give every reviewer the project's real constraints as the attention lens (for HydraFlow: labels-as-truth / ADR-0002, lights-off operation, the six-phase pipeline, worker-per-phase concurrency). Have each return **structured findings** — `{concern, severity: blocking|major|minor, rationale, fix}` plus a one-line `overall_verdict` and `biggest_risk`. Barrier on all three (synthesis needs the full set), then synthesize.
+
+   The panel script lives at `scripts/workflows/adversarial-plan-review.js` in this repo if present; otherwise author it inline following the shape above. Pass the brief path via `args.briefPath`.
+
+3. **Verify the load-bearing claims in source before trusting them.** A reviewer's most valuable finding is also its most dangerous if hallucinated. In the synthesis prompt, require the synthesizer to **check the crux claims against the actual code/ADRs on `origin/staging`** (does the cited ADR really say that? is the primitive it names really non-atomic?) and to mark each as verified or unverified. Spot-check the single most important finding yourself before passing it on.
+
+4. **Produce the synthesis** for the plan's author to act on. It must contain:
+   - **Verdict** — ship-with-corrections / rework-before-implementing / do-not-build. Weigh the three; don't average.
+   - **Blocking corrections** — merged across reviewers, with duplicates noted (2+ reviewers independently hitting the same thing is the strongest signal). Each in imperative form: the exact change to make.
+   - **Cross-reviewer conflicts** — where fixes pull in opposite directions, and the adjudication.
+   - **Major (non-blocking) improvements.**
+   - **The one thing** — if the author fixes only one item, which and why.
+
+5. **Pass it along.** Post the synthesis as a comment on the plan's issue/PR (or write it beside the spec), framed as an adversarial-panel review with the source-verification note, so the plan is revised **before** implementation begins. Do not start implementing until the blocking corrections are resolved.
+
+## Notes
+
+- **This gates, it doesn't rubber-stamp.** If the panel returns "rework-before-implementing," the plan changes first. A panel whose output nobody acts on is wasted tokens.
+- **Cost:** ~3 Sonnet reviewers + 1 synthesis. Scale the panel to the stakes — three lenses for a normal feature; add a red-team/security lens for anything handling untrusted input or credentials.
+- **Personas are swappable.** Principal / VP / SRE is the default. For a data-migration plan, swap SRE for a "data-integrity / irreversibility" lens; for a user-facing feature, add a product-skeptic lens. The value is in non-overlapping, adversarial coverage — not these exact three titles.

--- a/scripts/workflows/adversarial-plan-review.js
+++ b/scripts/workflows/adversarial-plan-review.js
@@ -1,0 +1,116 @@
+// Reusable adversarial plan-review panel — the engine behind hf.plan-review.
+//
+// Runs three non-overlapping senior reviewers (Principal Engineer, VP Eng,
+// Staff SRE) over a plan in parallel on Sonnet, each told to FIND WHAT IS WRONG
+// rather than bless it, then a synthesis pass on the main model that verifies
+// the crux claims against source before ranking the corrections.
+//
+// Input: args.briefPath — a single file containing the plan/spec/issue under
+// review PLUS the ADRs and already-landed scaffolding it touches, so reviewers
+// can check the plan against what actually exists. Optionally args.context — a
+// short string of project-specific invariants to use as the attention lens
+// (defaults to HydraFlow's).
+//
+// Returns { reviews: [...structured findings per lens], synthesis: "..." }.
+export const meta = {
+  name: 'adversarial-plan-review',
+  description: 'Three adversarial senior reviewers (Principal, VP Eng, Staff SRE) critique a plan on Sonnet, then a synthesis pass (main model) verifies crux claims in source and ranks the corrections to fold in before implementation',
+  phases: [
+    { title: 'Review', detail: 'Principal / VP Eng / Staff SRE attack the plan in parallel (Sonnet)' },
+    { title: 'Synthesize', detail: 'verify crux claims in source, merge, rank, surface conflicts, go/no-go' },
+  ],
+}
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    lens: { type: 'string', description: 'which persona' },
+    overall_verdict: {
+      type: 'string',
+      enum: ['ship-the-plan', 'ship-with-corrections', 'rework-before-implementing', 'do-not-build'],
+    },
+    biggest_risk: { type: 'string', description: 'the single most important thing this plan gets wrong or omits, one sentence' },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          concern: { type: 'string', description: 'the specific defect/gap/risk in the plan' },
+          severity: { type: 'string', enum: ['blocking', 'major', 'minor'] },
+          rationale: { type: 'string', description: 'why it matters, grounded in the plan text or the codebase' },
+          fix: { type: 'string', description: 'the concrete correction to make to the plan before implementing' },
+        },
+        required: ['concern', 'severity', 'fix'],
+      },
+    },
+  },
+  required: ['lens', 'overall_verdict', 'biggest_risk', 'findings'],
+}
+
+const brief = args.briefPath
+const context =
+  args.context ||
+  `This is a HydraFlow plan. HydraFlow is a LIGHTS-OFF autonomous software factory. Its crash-safety rests on ADR-0002 (GitHub labels are the sole source of truth) — kill the process at any point and the labels tell the next boot exactly where every issue stands. It runs six pipeline phases with worker-per-phase concurrency (ADR-0001). Weigh any plan against those invariants.`
+
+const COMMON = `Read the plan at ${brief} in full — it is a real, not-yet-implemented design, together with the ADRs and existing scaffolding it touches.
+
+Project reality you must weigh every finding against:
+${context}
+
+You are an ADVERSARIAL reviewer. Your job is to find what is WRONG, missing, under-specified, or risky — NOT to bless it. Default to skepticism. A finding that names a concrete defect with a concrete fix is worth more than praise. Where the plan cites an ADR, a file, or a primitive, check whether it actually says/does what the plan claims. If the plan is genuinely sound on some axis, say so briefly, but spend your effort on what would bite us in production.`
+
+async function review(lens, charter) {
+  return agent(
+    `${COMMON}\n\n${charter}\n\nReturn structured findings, each grounded in the plan text or the codebase. Severity: 'blocking' = must fix or the plan is unsafe to implement; 'major' = will cause real pain/rework; 'minor' = worth noting.`,
+    { label: `review:${lens}`, phase: 'Review', model: 'sonnet', schema: FINDINGS_SCHEMA }
+  )
+}
+
+const reviews = (await parallel([
+  () => review('principal-engineer', `YOU ARE A SENIOR PRINCIPAL ENGINEER. Your lens: is the ABSTRACTION right and will it actually WORK?
+- Is this the correct decomposition, or complexity for its own sake? Is there a materially simpler design that gets the same outcome?
+- Does the core mechanism actually buy what the plan claims it does? Trace it — where does the claimed benefit come from, and does it survive the details?
+- Does the plan preserve the load-bearing invariants of the system, or quietly weaken one? Is that preservation stated as a hard constraint and demonstrated, or merely asserted?
+- Does the plan match the code/state that already exists? Cite the file where it doesn't.`),
+
+  () => review('vp-engineering', `YOU ARE A VP OF ENGINEERING. Your lens: should we build THIS, NOW, this WAY?
+- Blast radius: what does this change for everything already running? Is any "safe default / prove it first" migration story credible, or a fig leaf over a rewrite?
+- Sequencing: is this the right next step, or is there a missing intermediate (a spec, a shadow/canary mode, a metric) before it?
+- Scope: is this one plan or three? What is the smallest increment that de-risks the rest?
+- Reversibility & opportunity cost: if this is wrong, how expensive is it to unwind vs today? What existing behaviour does it put at risk?`),
+
+  () => review('staff-sre', `YOU ARE A STAFF SRE / RELIABILITY ENGINEER. Your lens: how does this FAIL, unattended, at 3am?
+- Crash & resume: what happens if the process dies mid-operation? Does the plan define the recovery path, or hand-wave it? Does its state model actually cover every mid-operation point, or only the tidy boundaries?
+- State divergence: if two sources of truth can disagree, how does the next boot reconcile them, and what is the failure mode when they don't?
+- Preemption & backpressure: what throttles the expensive work? Can high-priority work jump ahead, or does it wait behind something long-running with no bound?
+- Observability & rollback: what is the on-call signal when this wedges? Can an operator see progress and roll back without a deploy?`),
+])).filter(Boolean)
+
+log(`Collected ${reviews.length}/3 reviews`)
+
+phase('Synthesize')
+
+const synthesis = await agent(
+  `You are the staff+ engineer synthesizing an adversarial plan review before we commit to implementing it. Read the plan at ${brief} for context.
+
+Three senior reviewers attacked it independently. Their structured findings:
+
+${JSON.stringify(reviews, null, 2)}
+
+FIRST, verify the crux claims against source. Before trusting any blocking finding, check it against the actual code/ADRs on origin/staging — does the cited ADR really say that? is the named primitive really non-atomic / really absent? Mark each crux claim verified or unverified; a confidently-wrong finding is worse than none. Use the repo tools to check.
+
+THEN produce a synthesis for the plan's author to act on BEFORE writing/finishing the implementation plan:
+
+1. **Verdict** — one line: ship-with-corrections / rework-before-implementing / do-not-build. Weigh the three verdicts; don't just average them.
+2. **Blocking corrections** — the findings that MUST be resolved in the plan first. Merge duplicates across reviewers (note where 2+ reviewers independently hit the same thing — that convergence is the strongest signal). Each in imperative form: the exact change to make.
+3. **Cross-reviewer conflicts** — where reviewers disagree or their fixes pull in opposite directions, and your adjudication.
+4. **Major (non-blocking) improvements** — worth doing, not gating.
+5. **The one thing** — if the author fixes only a single item, which one and why.
+
+Be concrete and terse. This feeds directly back into the plan; it is not a status report. Do not soften findings to be diplomatic — the point of the panel is to catch what a single author misses.`,
+  { label: 'synthesis', phase: 'Synthesize' }
+)
+
+return { reviews, synthesis }


### PR DESCRIPTION
## What

A reusable `hf.plan-review` command that runs an **adversarial panel over a plan/spec/design before it is implemented**, then passes the corrections back so the plan is revised first. The plan-stage complement to ADR-0059's code-stage advisor pattern.

Three non-overlapping senior reviewers — **Principal Engineer** (is the abstraction right / will it work), **VP Engineering** (should we build this, now, this way), **Staff SRE** (how does it fail unattended at 3am) — run in parallel on **Sonnet**, each told to *find what's wrong, not bless it*. A synthesis pass on the main model **verifies the crux claims against source** (so a confidently-wrong finding doesn't propagate), then ranks the corrections: verdict, blocking fixes (with cross-reviewer convergence noted), conflicts + adjudication, and "the one thing."

## Why this shape

- **Adversarial, non-overlapping lenses** — the value is diverse coverage; identical reviewers are wasted tokens.
- **Sonnet reviewers, main-model synthesis** — plan critique is judgment-dense but not the hardest reasoning; the synthesizer needs the plan context and has to adjudicate conflicts.
- **Verify-in-source before passing along** — a reviewer's best finding is its most dangerous if hallucinated.
- **It gates, it doesn't rubber-stamp** — blocking corrections are resolved before implementation.

## Proven before shipping

Run live on #10038 (the v2 IssueDriver scheduler spec). It caught, and **verified in source**, two things a single author had missed:
- **ADR-0094 already evaluated and rejected this exact design** — verbatim: *"Blocking shepherd… one worker walks an issue stage-to-stage… Rejected in favor of requeue + ledger."* The spec never rebutted it.
- The spec's central "ADR-0002 survives intact" premise rests on `swap_pipeline_labels`, which is **add-first-then-best-effort-remove** — non-atomic, so a crash mid-swap leaves two pipeline labels and the "single unambiguous label" guarantee is false as written.

Verdict: rework-before-implementing, [posted back to #10038](https://github.com/T-rav/hydraflow/issues/10038#issuecomment-5027854352).

## Files
- `.claude/commands/hf.plan-review.md` — the command (when to use · assemble the brief · run the panel · verify in source · synthesize · pass it along).
- `scripts/workflows/adversarial-plan-review.js` — the reusable Workflow engine, parameterized by `args.briefPath` (+ optional `args.context` for non-HydraFlow invariants).

Prose-only addition (a command doc + a workflow script); no runtime code paths touched.