### PR TITLE
fix(workspace,state): HITL reset runbook residuals — main-repo core.worktree heal + attempt-counter close-to-clear (Fix J, #9723)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,51 +1,51 @@
 {
-  "regenerated_at": "2026-07-20T21:36:01.458340+00:00",
-  "commit_sha": "3130b1bb7c05e021961e1f32554c1160795390aa",
+  "regenerated_at": "2026-07-20T22:15:32.552972+00:00",
+  "commit_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4",
   "artifacts": {
     "loops.md": {
-      "source_sha": "3130b1bb7c05e021961e1f32554c1160795390aa"
+      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
     },
     "ports.md": {
-      "source_sha": "3130b1bb7c05e021961e1f32554c1160795390aa"
+      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
     },
     "labels.md": {
-      "source_sha": "3130b1bb7c05e021961e1f32554c1160795390aa"
+      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
     },
     "modules.md": {
-      "source_sha": "3130b1bb7c05e021961e1f32554c1160795390aa"
+      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
     },
     "events.md": {
-      "source_sha": "3130b1bb7c05e021961e1f32554c1160795390aa"
+      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
     },
     "adr_xref.md": {
-      "source_sha": "3130b1bb7c05e021961e1f32554c1160795390aa"
+      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
     },
     "mockworld.md": {
-      "source_sha": "3130b1bb7c05e021961e1f32554c1160795390aa"
+      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
     },
     "changelog.md": {
-      "source_sha": "3130b1bb7c05e021961e1f32554c1160795390aa"
+      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
     },
     "coverage_matrix.md": {
-      "source_sha": "3130b1bb7c05e021961e1f32554c1160795390aa"
+      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
     },
     "adr-conformance.md": {
-      "source_sha": "3130b1bb7c05e021961e1f32554c1160795390aa"
+      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
     },
     "ai_system_inventory.md": {
-      "source_sha": "3130b1bb7c05e021961e1f32554c1160795390aa"
+      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
     },
     "traceability_matrix.md": {
-      "source_sha": "3130b1bb7c05e021961e1f32554c1160795390aa"
+      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
     },
     "functional_areas.md": {
-      "source_sha": "3130b1bb7c05e021961e1f32554c1160795390aa"
+      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
     },
     "ubiquitous-language.md": {
-      "source_sha": "3130b1bb7c05e021961e1f32554c1160795390aa"
+      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "3130b1bb7c05e021961e1f32554c1160795390aa"
+      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,12 +6,10 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W30
 
-- `3130b1b` — Merge remote-tracking branch 'origin/staging' into feat/9546-adequacy-verifier *(2026-07-20)*
+- `ee15f26` — feat(test-adequacy): independent second-opinion verifier gated on explicit OK (#9546) (#10076) (#10076) *(2026-07-20)*
+- `fa5e02e` — feat(gh-load): cached CI-run + issue-list reads and first-tick stagger — cut direct-gh load (#9814) (#10075) (#10075) *(2026-07-20)*
 - `aee928c` — feat(sandbox): active-trigger scenarios for six governance loops (s65-s70) (#9543) (#10074) (#10074) *(2026-07-20)*
-- `27852d9` — Merge remote-tracking branch 'origin/staging' into feat/9546-adequacy-verifier *(2026-07-20)*
 - `64fc05d` — feat(watchdog): thread-level event-loop freeze detector (#9552) (#10070) (#10070) *(2026-07-20)*
-- `5ae0798` — chore(arch): regen artifacts after staging merge (#9546) (#9546) *(2026-07-20)*
-- `77772e0` — feat(test-adequacy): independent second-opinion verifier gated on explicit OK (#9546) (#9546) *(2026-07-20)*
 - `14f4a2e` — fix(refinement): v1 follow-ups — not-planned closes, priority budget, fail-closed fake, inefficiency re-file (#10025) (#10066) (#10066) *(2026-07-20)*
 - `1306712` — fix(fitness): cadence-derived min_samples — scorecards can finally score (#9841) (#10056) (#10056) *(2026-07-20)*
 - `8509ee0` — feat(orchestration): v2 IssueDriver runtime phase spec + accept ADR-0099 (#10038) (#10055) (#10055) *(2026-07-20)*

--- a/src/state/_gc.py
+++ b/src/state/_gc.py
@@ -28,11 +28,18 @@ logger = logging.getLogger("hydraflow.state")
 # field here is keyed by str(issue_number) via StateTracker._key. Fields
 # keyed by anything else (worker name, PR branch, stream name) must never
 # be listed.
+#
+# Attempt-cap close-to-clear contract (#9723 Fix J): a closed issue's burned
+# attempt budget must not leak into a reopened/re-filed issue. The three
+# attempt counters are covered here — ``issue_attempts`` directly,
+# review attempts inside ``convergence_ledgers`` stage state, and
+# ``hitl_summary_failures`` directly.
 _ISSUE_SCOPED_FIELDS = (
     "adversarial_states",
     "convergence_ledgers",
     "escalation_contexts",
     "hitl_summaries",
+    "hitl_summary_failures",
     "issue_attempts",
 )
 

--- a/src/workspace.py
+++ b/src/workspace.py
@@ -193,6 +193,11 @@ class WorkspaceManager:
         main = self._config.base_branch()
         gh = self._credentials.gh_token
 
+        # Fix J (#9723): heal main-checkout core.worktree corruption BEFORE
+        # any other git command — a corrupt entry makes the fetch below fail
+        # with "fatal: Invalid path '/workspace'".
+        await self._heal_repo_root_config()
+
         # Fetch latest main for worktree creation
         await self._fetch_origin_with_retry(repo, main)
 
@@ -232,26 +237,94 @@ class WorkspaceManager:
         await self._fetch_origin_with_retry(self._repo_root, self._config.base_branch())
 
     async def _heal_worktree_config(self, wt_path: Path, gh_token: str) -> None:
-        """Clear a stale ``core.worktree`` from a worktree's git config.
+        """Clear a stale ``core.worktree`` from a worktree's git config (WS-8).
 
         A docker container that runs git inside the worktree can write
         ``core.worktree=/workspace`` into ``<wt>/.git/config``. On the host that
         path doesn't exist, and git then refuses to run *any* command in the
-        worktree — including ``git config --unset core.worktree`` itself —
-        failing with "fatal: Invalid path '/workspace'". So we can't heal from
-        inside the worktree.
-
-        Instead, edit the config file directly via ``git config --file <path>
-        --unset`` run from OUTSIDE the worktree (``cwd=wt_path.parent``), where
-        git won't auto-discover and validate the broken worktree. Workspaces
+        worktree — failing with "fatal: Invalid path '/workspace'". Workspaces
         here are full local clones (see ``_create_unlocked``), so the config is
-        always ``<wt>/.git/config``. No-op when ``core.worktree`` is absent (git
-        exits non-zero, which we ignore) or the config file is missing.
+        always ``<wt>/.git/config``. Delegates to the guarded
+        :meth:`_heal_stale_core_worktree` predicate.
         """
-        config_path = wt_path / ".git" / "config"
-        if not config_path.exists():
-            return
-        # A non-zero exit just means core.worktree was not set — nothing to heal.
+        await self._heal_stale_core_worktree(
+            wt_path / ".git" / "config", wt_path, gh_token
+        )
+
+    async def _heal_repo_root_config(self) -> bool:
+        """Heal a stale ``core.worktree`` in the MAIN checkout's config (#9723).
+
+        The docker factory can corrupt the primary checkout the same way it
+        corrupts worktrees (WS-8): a container writes
+        ``core.worktree=/workspace`` into ``<repo>/.git/config`` and every
+        host-side git command then fails with "fatal: Invalid path
+        '/workspace'" — the manual HITL reset runbook step this automates.
+        Runs first in :meth:`sanitize_repo` (orchestrator startup, shutdown,
+        and deferred pipeline start). No-op when ``<repo>/.git/config`` is
+        missing — e.g. the primary checkout is itself a linked worktree whose
+        config lives elsewhere.
+
+        Returns ``True`` when a stale entry was unset.
+        """
+        return await self._heal_stale_core_worktree(
+            self._repo_root / ".git" / "config",
+            self._repo_root,
+            self._credentials.gh_token,
+        )
+
+    async def _heal_stale_core_worktree(
+        self, config_path: Path, root: Path, gh_token: str
+    ) -> bool:
+        """Unset ``core.worktree`` in *config_path* when it points outside *root*.
+
+        Fail-safe predicate (#9723): only a value that resolves OUTSIDE
+        *root* — the container-corruption signature, e.g. ``/workspace`` on a
+        host where that path is not this checkout — is ever unset. A value
+        that resolves to *root* (or inside it) is a legitimately-configured
+        worktree checkout and is never touched; git resolves relative values
+        against the ``.git`` directory, so ``..`` is legitimate too. When the
+        value cannot be read, nothing is unset.
+
+        All git calls use ``--file`` and run from OUTSIDE the checkout
+        (``cwd=root.parent``): from inside, git auto-discovers the repo and
+        re-validates the bogus ``core.worktree`` before it ever processes
+        ``--file``, re-triggering the same fatal error.
+
+        Returns ``True`` when a stale entry was unset.
+        """
+        if not config_path.is_file():
+            return False
+        try:
+            value = (
+                await run_subprocess(
+                    "git",
+                    "config",
+                    "--file",
+                    str(config_path),
+                    "--get",
+                    "core.worktree",
+                    cwd=root.parent,
+                    gh_token=gh_token,
+                )
+            ).strip()
+        except RuntimeError:
+            # Exit 1 = key absent — nothing to heal. Any other read failure:
+            # fail safe by leaving the config untouched.
+            return False
+        if not value:
+            return False
+        raw = Path(value)
+        # git resolves a relative core.worktree against the .git directory.
+        resolved = (raw if raw.is_absolute() else config_path.parent / raw).resolve()
+        root_resolved = root.resolve()
+        if resolved == root_resolved or resolved.is_relative_to(root_resolved):
+            logger.debug(
+                "core.worktree=%s in %s resolves inside %s — legitimate, keeping",
+                value,
+                config_path,
+                root,
+            )
+            return False
         with contextlib.suppress(RuntimeError):
             await run_subprocess(
                 "git",
@@ -260,12 +333,17 @@ class WorkspaceManager:
                 str(config_path),
                 "--unset",
                 "core.worktree",
-                # Run from outside the worktree: from inside, git auto-discovers
-                # the repo and re-validates the bogus core.worktree before it
-                # ever processes --file, re-triggering the same fatal error.
-                cwd=wt_path.parent,
+                cwd=root.parent,
                 gh_token=gh_token,
             )
+            logger.warning(
+                "Healed stale core.worktree=%s in %s (points outside %s)",
+                value,
+                config_path,
+                root,
+            )
+            return True
+        return False
 
     async def _salvage_uncommitted(self, issue_number: int) -> None:
         """Commit and push any uncommitted changes in the worktree before destroying it.

--- a/tests/regressions/test_issue_9723_hitl_reset_residual.py
+++ b/tests/regressions/test_issue_9723_hitl_reset_residual.py
@@ -1,0 +1,184 @@
+"""Regression: HITL reset runbook residuals — Fix J (#9723).
+
+Two manual runbook steps are automated; these pins hold them.
+
+1. Main-repo ``core.worktree`` heal. A docker factory run can write
+   ``core.worktree=/workspace`` into the MAIN checkout's ``.git/config``
+   (not just a worktree's — that was WS-8). Every host-side git command
+   then dies with "fatal: Invalid path '/workspace'" — including
+   ``sanitize_repo``'s own fetch — so the factory could not start until an
+   operator ran the documented out-of-repo ``git config --unset``.
+   ``sanitize_repo`` now heals this before its first git call, behind a
+   fail-safe predicate: only a ``core.worktree`` that resolves OUTSIDE the
+   checkout root is ever unset. A value resolving to the root itself is a
+   legitimately-configured worktree checkout and must never be touched.
+
+2. Attempt-counter close-to-clear. ``issue_attempts``, review attempts
+   (inside ``convergence_ledgers`` stage state), and
+   ``hitl_summary_failures`` survived issue close, so a reopened or
+   re-filed issue inherited a burned attempt budget. The StaleIssueGC
+   state prune (#9905) now also sweeps ``hitl_summary_failures``; the
+   pins below hold the close-to-clear contract for all three counters —
+   and that counters for still-open issues are never cleared.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from models import ConvergenceLedger, StageRecord
+from state import StateTracker
+from tests.helpers import ConfigFactory
+from workspace import WorkspaceManager
+
+_GIT_ENV = {
+    "GIT_AUTHOR_NAME": "Test",
+    "GIT_AUTHOR_EMAIL": "test@test.com",
+    "GIT_COMMITTER_NAME": "Test",
+    "GIT_COMMITTER_EMAIL": "test@test.com",
+}
+
+
+def _git(repo: Path, *args: str) -> str:
+    env = {**os.environ, **_GIT_ENV}
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+    )
+    return result.stdout.strip()
+
+
+def _make_repo(base: Path, name: str, branch: str) -> Path:
+    repo = base / name
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init", "-b", branch)
+    (repo / "README.md").write_text("# Test\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "init")
+    return repo
+
+
+class TestMainRepoCoreWorktreeHeal:
+    """Pin 1: ``sanitize_repo`` heals main-checkout ``core.worktree``
+    corruption, and only ever unsets a value pointing outside the root."""
+
+    def _make_cloned_manager(self, tmp_path: Path) -> tuple[WorkspaceManager, Path]:
+        """A WorkspaceManager over a clone of a local origin.
+
+        The origin's branch matches ``config.base_branch()`` so
+        ``sanitize_repo``'s fetch succeeds offline.
+        """
+        clone = tmp_path / "repo"
+        config = ConfigFactory.create(
+            repo_root=clone,
+            workspace_base=tmp_path / "worktrees",
+            execution_mode="host",
+        )
+        origin = _make_repo(tmp_path, "origin", config.base_branch())
+        env = {**os.environ, **_GIT_ENV}
+        subprocess.run(
+            ["git", "clone", str(origin), str(clone)],
+            capture_output=True,
+            text=True,
+            check=True,
+            env=env,
+        )
+        return WorkspaceManager(config), clone
+
+    @pytest.mark.asyncio
+    async def test_sanitize_repo_heals_corrupt_main_checkout(
+        self, tmp_path: Path
+    ) -> None:
+        """The runbook residual: a container path in the MAIN checkout's
+        config must be healed by sanitize_repo, not left for an operator."""
+        mgr, clone = self._make_cloned_manager(tmp_path)
+        config_file = clone / ".git" / "config"
+        _git(clone, "config", "core.worktree", "/nonexistent/workspace")
+        # Pre-condition: the corruption breaks host git in the main checkout.
+        broken = subprocess.run(
+            ["git", "status", "--porcelain"],
+            check=False,
+            cwd=clone,
+            capture_output=True,
+            text=True,
+        )
+        assert broken.returncode != 0
+
+        await mgr.sanitize_repo()
+
+        assert "/nonexistent/workspace" not in config_file.read_text()
+        assert _git(clone, "status", "--porcelain") == ""
+
+    @pytest.mark.asyncio
+    async def test_sanitize_repo_leaves_legitimate_core_worktree(
+        self, tmp_path: Path
+    ) -> None:
+        """Fail-safe predicate: a core.worktree resolving to the checkout
+        root is a legitimately-configured worktree — never unset."""
+        mgr, clone = self._make_cloned_manager(tmp_path)
+        _git(clone, "config", "core.worktree", str(clone))
+
+        await mgr.sanitize_repo()
+
+        assert _git(clone, "config", "--get", "core.worktree") == str(clone)
+        assert _git(clone, "status", "--porcelain") == ""
+
+
+class TestAttemptCounterCloseToClear:
+    """Pin 2: closing an issue clears its attempt counters via the
+    StaleIssueGC state prune; open issues keep theirs."""
+
+    def _tracker(self, tmp_path: Path) -> StateTracker:
+        tracker = StateTracker(tmp_path / "state.json")
+        tracker._data.issue_attempts = {"100": 2, "999": 3}
+        open_ledger = ConvergenceLedger(issue_number=100)
+        open_ledger.stage_state["review"] = StageRecord(attempts=1)
+        closed_ledger = ConvergenceLedger(issue_number=999)
+        closed_ledger.stage_state["review"] = StageRecord(attempts=2)
+        tracker._data.convergence_ledgers = {"100": open_ledger, "999": closed_ledger}
+        tracker.set_hitl_summary_failure(100, "summary llm failed")
+        tracker.set_hitl_summary_failure(999, "summary llm failed")
+        return tracker
+
+    def test_closed_issue_attempt_counters_are_cleared(self, tmp_path: Path) -> None:
+        tracker = self._tracker(tmp_path)
+
+        removed = tracker.prune_issue_scoped_state({100})
+
+        assert removed["hitl_summary_failures"] == 1
+        assert set(tracker._data.hitl_summary_failures) == {"100"}
+        # issue_attempts + review attempts (ledger) follow the same contract.
+        assert set(tracker._data.issue_attempts) == {"100"}
+        assert set(tracker._data.convergence_ledgers) == {"100"}
+
+    def test_open_issue_counters_survive_sweep(self, tmp_path: Path) -> None:
+        tracker = self._tracker(tmp_path)
+
+        removed = tracker.prune_issue_scoped_state({100, 999})
+
+        assert removed == {}
+        assert set(tracker._data.hitl_summary_failures) == {"100", "999"}
+        assert set(tracker._data.issue_attempts) == {"100", "999"}
+        assert set(tracker._data.convergence_ledgers) == {"100", "999"}
+
+    def test_cleared_counters_persist_to_disk(self, tmp_path: Path) -> None:
+        """A reopened issue must see fresh budget even across a restart."""
+        tracker = self._tracker(tmp_path)
+        tracker.save()
+
+        tracker.prune_issue_scoped_state({100})
+
+        reloaded = StateTracker(tmp_path / "state.json")
+        assert set(reloaded._data.hitl_summary_failures) == {"100"}
+        assert set(reloaded._data.issue_attempts) == {"100"}

--- a/tests/test_integration_worktree.py
+++ b/tests/test_integration_worktree.py
@@ -104,6 +104,62 @@ class TestWorktreeConfigHealing:
         assert _git(repo, "status", "--porcelain") == ""
 
     @pytest.mark.asyncio
+    async def test_heal_leaves_absolute_core_worktree_inside_root(
+        self, tmp_path: Path
+    ) -> None:
+        """Fail-safe predicate (#9723): a ``core.worktree`` resolving to the
+        checkout root is a legitimately-configured worktree — never unset."""
+        repo = _make_repo(tmp_path, "repo")
+        _git(repo, "config", "core.worktree", str(repo))
+        mgr = self._make_manager(tmp_path, repo)
+
+        await mgr._heal_worktree_config(repo, "")
+
+        assert _git(repo, "config", "--get", "core.worktree") == str(repo)
+        assert _git(repo, "status", "--porcelain") == ""
+
+    @pytest.mark.asyncio
+    async def test_heal_leaves_relative_core_worktree_inside_root(
+        self, tmp_path: Path
+    ) -> None:
+        """git resolves a relative ``core.worktree`` against the ``.git``
+        dir; ``..`` therefore points at the checkout root and is legitimate."""
+        repo = _make_repo(tmp_path, "repo")
+        _git(repo, "config", "core.worktree", "..")
+        mgr = self._make_manager(tmp_path, repo)
+
+        await mgr._heal_worktree_config(repo, "")
+
+        assert _git(repo, "config", "--get", "core.worktree") == ".."
+        assert _git(repo, "status", "--porcelain") == ""
+
+    @pytest.mark.asyncio
+    async def test_repo_root_heal_unsets_container_path(self, tmp_path: Path) -> None:
+        """Fix J (#9723): the MAIN checkout gets the same guarded heal the
+        worktrees got in WS-8 — a container path is unset, git works again."""
+        repo = _make_repo(tmp_path, "repo")
+        _git(repo, "config", "core.worktree", "/nonexistent/workspace")
+        mgr = self._make_manager(tmp_path, repo)
+
+        healed = await mgr._heal_repo_root_config()
+
+        assert healed is True
+        assert "/nonexistent/workspace" not in (repo / ".git" / "config").read_text()
+        assert _git(repo, "status", "--porcelain") == ""
+
+    @pytest.mark.asyncio
+    async def test_repo_root_heal_is_noop_without_corruption(
+        self, tmp_path: Path
+    ) -> None:
+        repo = _make_repo(tmp_path, "repo")
+        mgr = self._make_manager(tmp_path, repo)
+
+        healed = await mgr._heal_repo_root_config()
+
+        assert healed is False
+        assert _git(repo, "status", "--porcelain") == ""
+
+    @pytest.mark.asyncio
     async def test_salvage_heals_corruption_then_commits(self, tmp_path: Path) -> None:
         repo = _make_repo(tmp_path, "repo")
         mgr = self._make_manager(tmp_path, repo)


### PR DESCRIPTION
## Summary

Automates the two residual manual steps of the HITL reset runbook (Fix J of the dark-factory hardening roadmap). Closes #9723

### 1. Main-repo `core.worktree` heal

The docker factory can corrupt the MAIN checkout's `.git/config` with `core.worktree=/workspace` (not just worktrees' — that was WS-8), after which every host-side git command dies with `fatal: Invalid path '/workspace'` — including `sanitize_repo`'s own fetch, so the factory could not start without an operator running the documented out-of-repo `git config --unset`.

- `WorkspaceManager._heal_repo_root_config()` runs first in `sanitize_repo()` (orchestrator startup, deferred pipeline start, shutdown — all existing call sites), before any other git command.
- Shared guarded core `_heal_stale_core_worktree(config_path, root, gh_token)`: reads the value via `git config --file <cfg> --get` from OUTSIDE the checkout (in-repo git re-validates the bogus path before processing `--file`), then **only unsets a value that resolves outside the checkout root**. A value resolving to the root (absolute, or relative like `..` resolved against the `.git` dir — git's semantics) is a legitimately-configured worktree checkout and is never touched. Unreadable value → fail-safe no-op.
- The existing WS-8 worktree heal (`_heal_worktree_config`) now delegates to the same guarded predicate, so worktree heals get the same fail-safe.

### 2. Attempt-counter close-to-clear on issue close

`hitl_summary_failures` survived issue close, so a reopened/re-filed issue inherited burned attempt-cap state. Added it to `_ISSUE_SCOPED_FIELDS` in the StaleIssueGC state prune (#9905) — the caretaker sweep the issue names as the natural home. The other two counters named by the issue were already covered by the sweep: `issue_attempts` directly, review attempts inside `convergence_ledgers` stage state. The prune stays fail-closed (empty/failed open-issue listing skips the sweep) and is governed by the existing `state_prune_enabled` kill-switch + `stale_issue_gc_interval`; no new knobs.

## Tests

- `tests/regressions/test_issue_9723_hitl_reset_residual.py` — pins: `sanitize_repo` heals a corrupt main checkout end-to-end over a real local clone (red before this change: the fetch itself raised); legit `core.worktree` pointing at the checkout root survives `sanitize_repo`; all three attempt counters cleared for closed issues, retained for open issues, persisted across restart.
- `tests/test_integration_worktree.py::TestWorktreeConfigHealing` — predicate units: absolute and relative (`..`) legitimate values are never unset; container path is unset via `_heal_repo_root_config` (returns True); no-corruption no-op (returns False). Existing WS-8 tests unchanged and green.
- MockWorld: N/A by design — `sanitize_repo` is a concrete-only real-git bootstrap op (Fakes explicitly don't implement it), and the prune-field addition sits behind the already-scenario-stubbed `prune_issue_scoped_state` seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
