### PR TITLE
test(arch): ratchet guard for unguarded Quality-only-CLI (rg) shell-outs (#9411)

### DIFF
--- a/tests/architecture/quality_only_cli_scan.py
+++ b/tests/architecture/quality_only_cli_scan.py
@@ -1,0 +1,259 @@
+"""AST enumeration of Quality-only-CLI shell-out sites in ``src/``.
+
+Support code for the Quality-only CLI guard (#9411). Pure functions only —
+no repo mutation, no subprocesses. The guard test
+(``test_quality_only_cli_guard.py``) imports from here.
+
+Background: the GitHub **Quality** workflow runs on a runner image that ships
+ripgrep (``rg``); the leaner **CI / Tests** runner does not. ``src/`` code
+that shells out to a Quality-only CLI without a ``shutil.which(...)`` guard
+passes local ``make quality`` and the Quality runner, then crashes only on
+the CI/Tests runner — invisible until CI (#9403→#9404). This scan finds those
+call sites so the guard can red at PR time.
+
+The scan is lexical (call sites by shape, per module), deliberately
+line-number-free so refactors that move code within a function do not churn
+the baseline, mirroring ``sandbox_seam_scan.py`` / ``disturbance.models``.
+
+A **site** is a Quality-only CLI name (``QUALITY_ONLY_CLIS``) appearing in
+command position — either the first element of a command list/tuple literal
+(``["rg", ...]`` — the executable-first idiom) or a positional string arg to
+a subprocess primitive call (``run_subprocess_result("rg", ...)``). A site is
+**guarded** iff its nearest enclosing function references
+``shutil.which("<tool>")`` (or ``which("<tool>")``) for that same tool — the
+enclosing-function scope check that
+``FakeCoverageAuditorLoop._grep_scenario_for_helper`` satisfies. Shell-string
+forms (``os.system("rg ...")``) are out of scope by design: HydraFlow shells
+out via list-form bounded helpers, and the #9403 failure was list-form.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Mapping
+from pathlib import Path
+from typing import NamedTuple
+
+# Curated set of external CLIs present on the Quality runner but NOT the
+# leaner CI/Tests runner. Start with ripgrep; extend by adding a name here.
+QUALITY_ONLY_CLIS: frozenset[str] = frozenset({"rg", "ripgrep"})
+
+# Call names through which ``src/`` reaches a raw subprocess. Covers the
+# HydraFlow bounded helpers (``run_subprocess`` / ``run_subprocess_result``),
+# asyncio, and the stdlib ``subprocess`` surface — so a Quality-only CLI
+# passed as a bare positional arg (not wrapped in a list) is still caught.
+SUBPROCESS_PRIMITIVES: frozenset[str] = frozenset(
+    {
+        "run_subprocess",
+        "run_subprocess_result",
+        "create_subprocess_exec",
+        "create_subprocess_shell",
+        "run",
+        "call",
+        "check_call",
+        "check_output",
+        "getoutput",
+        "getstatusoutput",
+        "Popen",
+    }
+)
+
+
+class CliSite(NamedTuple):
+    """One Quality-only-CLI shell-out signature's aggregate state.
+
+    ``guarded`` is a function-level property (the whole enclosing function is
+    scanned for a ``shutil.which`` guard), so every physical site collapsed
+    into one signature shares it.
+    """
+
+    count: int
+    guarded: bool
+
+
+def quality_only_target_files(repo_root: Path) -> list[Path]:
+    """Every ``.py`` module under ``src/`` (recursive)."""
+    return sorted((repo_root / "src").glob("**/*.py"))
+
+
+def _which_guarded_tool(node: ast.Call) -> str | None:
+    """Return the CLI name a ``shutil.which("<tool>")`` call guards, if any.
+
+    Accepts both ``shutil.which("rg")`` (Attribute) and a bare
+    ``which("rg")`` (``from shutil import which``).
+    """
+    callee = node.func
+    if isinstance(callee, ast.Attribute):
+        is_which = callee.attr == "which"
+    elif isinstance(callee, ast.Name):
+        is_which = callee.id == "which"
+    else:
+        is_which = False
+    if not is_which or not node.args:
+        return None
+    arg = node.args[0]
+    if isinstance(arg, ast.Constant) and arg.value in QUALITY_ONLY_CLIS:
+        return arg.value
+    return None
+
+
+def _guarded_tools(func: ast.AST) -> frozenset[str]:
+    """CLI names guarded by a ``shutil.which(...)`` anywhere in ``func``."""
+    tools: set[str] = set()
+    for sub in ast.walk(func):
+        if isinstance(sub, ast.Call):
+            tool = _which_guarded_tool(sub)
+            if tool is not None:
+                tools.add(tool)
+    return frozenset(tools)
+
+
+class _CliSiteVisitor(ast.NodeVisitor):
+    """Collects Quality-only-CLI shell-out sites with guard status.
+
+    Maintains a scope stack (for the ``Class.method`` qualname) and a
+    function stack (for the nearest-enclosing-function guard scope).
+    """
+
+    def __init__(self, relpath: str) -> None:
+        self._relpath = relpath
+        self._scope: list[str] = []
+        self._func_stack: list[ast.AST] = []
+        self._guard_cache: dict[int, frozenset[str]] = {}
+        # signature -> [count, guarded]
+        self.sites: dict[str, list[object]] = {}
+
+    # -- scope tracking -------------------------------------------------
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._scope.append(node.name)
+        self.generic_visit(node)
+        self._scope.pop()
+
+    def _enter_func(self, node: ast.AST, name: str) -> None:
+        self._scope.append(name)
+        self._func_stack.append(node)
+        self.generic_visit(node)
+        self._func_stack.pop()
+        self._scope.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._enter_func(node, node.name)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._enter_func(node, node.name)
+
+    # -- site detection -------------------------------------------------
+
+    def visit_List(self, node: ast.List) -> None:
+        self._check_command_seq(node.elts)
+        self.generic_visit(node)
+
+    def visit_Tuple(self, node: ast.Tuple) -> None:
+        self._check_command_seq(node.elts)
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        callee = node.func
+        name: str | None = None
+        if isinstance(callee, ast.Name):
+            name = callee.id
+        elif isinstance(callee, ast.Attribute):
+            name = callee.attr
+        if name in SUBPROCESS_PRIMITIVES:
+            for arg in node.args:
+                if isinstance(arg, ast.Constant) and arg.value in QUALITY_ONLY_CLIS:
+                    self._record(arg.value)
+        self.generic_visit(node)
+
+    # -- helpers --------------------------------------------------------
+
+    def _check_command_seq(self, elts: list[ast.expr]) -> None:
+        if not elts:
+            return
+        first = elts[0]
+        if isinstance(first, ast.Constant) and first.value in QUALITY_ONLY_CLIS:
+            self._record(first.value)
+
+    def _current_guarded(self, tool: str) -> bool:
+        if not self._func_stack:
+            return False
+        func = self._func_stack[-1]
+        key = id(func)
+        guarded = self._guard_cache.get(key)
+        if guarded is None:
+            guarded = _guarded_tools(func)
+            self._guard_cache[key] = guarded
+        return tool in guarded
+
+    def _record(self, tool: str) -> None:
+        guarded = self._current_guarded(tool)
+        qual = ".".join(self._scope) or "<module>"
+        signature = f"{self._relpath}::{qual}::{tool}"
+        entry = self.sites.get(signature)
+        if entry is None:
+            self.sites[signature] = [1, guarded]
+        else:
+            entry[0] = int(entry[0]) + 1
+            entry[1] = bool(entry[1]) or guarded
+
+
+def scan_source(source: str, relpath: str = "<memory>") -> dict[str, CliSite]:
+    """Scan one source string. Returns ``{signature: CliSite}``.
+
+    ``signature`` is ``"{posix relpath}::{enclosing qualname}::{tool}"``.
+    """
+    visitor = _CliSiteVisitor(relpath)
+    visitor.visit(ast.parse(source, filename=relpath))
+    return {
+        signature: CliSite(count=int(count), guarded=bool(guarded))
+        for signature, (count, guarded) in visitor.sites.items()
+    }
+
+
+def scan_cli_sites(repo_root: Path) -> dict[str, CliSite]:
+    """Scan every ``src/`` module. Returns ``{signature: CliSite}``.
+
+    Signatures embed the posix relpath, so they are unique across files.
+    """
+    sites: dict[str, CliSite] = {}
+    for path in quality_only_target_files(repo_root):
+        rel = path.relative_to(repo_root).as_posix()
+        sites.update(scan_source(path.read_text(encoding="utf-8"), rel))
+    return sites
+
+
+def signature_tool(signature: str) -> str:
+    """The CLI tool a signature targets (its trailing ``::<tool>`` field)."""
+    return signature.rsplit("::", 1)[1]
+
+
+def unguarded_signatures(sites: Mapping[str, CliSite]) -> dict[str, int]:
+    """Signatures (with counts) whose enclosing function has no ``which`` guard."""
+    return {
+        signature: site.count for signature, site in sites.items() if not site.guarded
+    }
+
+
+def ratchet_diff(
+    current: Mapping[str, int], baseline: Mapping[str, int]
+) -> tuple[dict[str, int], dict[str, int]]:
+    """Compare unguarded site counts to the grandfathered baseline.
+
+    Returns ``(new, resolved)`` — mirrors ``sandbox_seam_scan.ratchet_diff``
+    / ``disturbance.baseline.diff``: ``new`` maps signature -> excess over
+    baseline (guard reddens); ``resolved`` maps signature -> shortfall under
+    baseline (baseline must be pruned in the same change so the ratchet only
+    shrinks).
+    """
+    new: dict[str, int] = {}
+    resolved: dict[str, int] = {}
+    for signature, count in current.items():
+        allowed = baseline.get(signature, 0)
+        if count > allowed:
+            new[signature] = count - allowed
+    for signature, allowed in baseline.items():
+        count = current.get(signature, 0)
+        if count < allowed:
+            resolved[signature] = allowed - count
+    return new, resolved

--- a/tests/architecture/test_quality_only_cli_guard.py
+++ b/tests/architecture/test_quality_only_cli_guard.py
@@ -1,0 +1,169 @@
+"""Quality-only CLI guard (#9411) — the Quality-vs-CI-runner wedge class.
+
+The GitHub **Quality** workflow runs on a runner image that ships ripgrep
+(``rg``); the leaner **CI / Tests** runner does not. Code in ``src/`` that
+shells out to a Quality-only CLI without a ``shutil.which(...)`` guard passes
+local ``make quality`` and the Quality runner, then crashes only on the
+CI/Tests runner — invisible until CI. #9403→#9404 was exactly this
+(``FakeCoverageAuditorLoop._grep_scenario_for_helper`` shelled out to ``rg``
+unguarded and blew up on the CI/Tests runner).
+
+This guard turns the next one into a red unit test at PR time: it AST-scans
+every ``src/`` module for subprocess call sites that invoke a Quality-only
+CLI and asserts each one is protected by a nearby ``shutil.which("<tool>")``
+guard (or sits in the grandfathered baseline). The baseline only shrinks
+(ratchet, mirroring ``tests/test_disturbance_ratchet.py`` and
+``tests/architecture/test_sandbox_seam_completeness.py``): a NEW unguarded
+Quality-only-CLI shell-out reddens, and covering a grandfathered one requires
+pruning its entry in the same change so the baseline stays honest.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+from tests.architecture.quality_only_cli_scan import (
+    QUALITY_ONLY_CLIS,
+    ratchet_diff,
+    scan_cli_sites,
+    scan_source,
+    signature_tool,
+    unguarded_signatures,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The load-bearing real site: it exists as long as HydraFlow's fake-coverage
+# auditor greps its scenario tree with ``rg``. Pinned by the anti-vacuity
+# canary so a broken scan (scope regression, primitive-set typo) cannot pass
+# every assertion here vacuously on an empty result.
+_KNOWN_GUARDED_SITE = (
+    "src/fake_coverage_auditor_loop.py::"
+    "FakeCoverageAuditorLoop._grep_scenario_for_helper::rg"
+)
+
+# Grandfathered UNGUARDED Quality-only-CLI shell-outs, keyed ``{signature:
+# count}`` (see quality_only_cli_scan.scan_cli_sites). EMPTY by design: the
+# only real ``rg`` shell-out in ``src/`` is already guarded with
+# ``shutil.which("rg")`` (#9404). The guard is preventive. DO NOT ADD
+# ENTRIES: a new Quality-only-CLI shell-out must be guarded with
+# ``shutil.which("<tool>")`` and a fallback, the way
+# ``FakeCoverageAuditorLoop._grep_scenario_for_helper`` is. Remove entries as
+# sites gain guards — the ratchet only shrinks.
+GRANDFATHERED_UNGUARDED_BASELINE: dict[str, int] = {}
+
+
+def test_quality_only_cli_set_is_curated() -> None:
+    """The curated set is a small named constant, trivially extensible."""
+    assert "rg" in QUALITY_ONLY_CLIS
+    assert "ripgrep" in QUALITY_ONLY_CLIS
+
+
+def test_scanner_flags_unguarded_command_list() -> None:
+    """A ``rg`` command list with no ``shutil.which`` guard is unguarded."""
+    source = dedent(
+        """
+        import subprocess
+
+        def scan(pattern):
+            return subprocess.run(["rg", "-n", pattern])
+        """
+    )
+    sites = scan_source(source, "src/synthetic.py")
+    sig = "src/synthetic.py::scan::rg"
+    assert sig in sites
+    assert sites[sig].guarded is False
+    assert sig in unguarded_signatures(sites)
+
+
+def test_scanner_flags_unguarded_direct_arg() -> None:
+    """The direct-arg idiom (``run_subprocess_result("rg", ...)``) is caught."""
+    source = dedent(
+        """
+        def scan(pattern):
+            return run_subprocess_result("rg", "-l", pattern)
+        """
+    )
+    sites = scan_source(source, "src/synthetic.py")
+    sig = "src/synthetic.py::scan::rg"
+    assert sig in sites
+    assert sites[sig].guarded is False
+
+
+def test_scanner_treats_which_guarded_site_as_guarded() -> None:
+    """The same command list becomes guarded once ``shutil.which`` protects it."""
+    source = dedent(
+        """
+        import shutil
+        import subprocess
+
+        def scan(pattern):
+            if shutil.which("rg") is not None:
+                return subprocess.run(["rg", "-n", pattern])
+            return grep_fallback(pattern)
+        """
+    )
+    sites = scan_source(source, "src/synthetic.py")
+    sig = "src/synthetic.py::scan::rg"
+    assert sig in sites
+    assert sites[sig].guarded is True
+    assert sig not in unguarded_signatures(sites)
+
+
+def test_which_call_is_not_itself_a_site() -> None:
+    """``shutil.which("rg")`` alone is a guard, not a shell-out site."""
+    source = dedent(
+        """
+        import shutil
+
+        def probe():
+            return shutil.which("rg") is not None
+        """
+    )
+    assert scan_source(source, "src/synthetic.py") == {}
+
+
+def test_scan_finds_real_rg_site_and_marks_it_guarded() -> None:
+    """Anti-vacuity canary on the live ``src/`` tree.
+
+    The one real ``rg`` shell-out — ``FakeCoverageAuditorLoop.
+    _grep_scenario_for_helper`` — must be detected AND classified as guarded
+    (it wraps the ``rg`` command list in ``if shutil.which("rg") is not
+    None:`` with a stdlib fallback). If the scan scope or primitive set
+    regresses, this reddens instead of letting the ratchet pass vacuously.
+    """
+    sites = scan_cli_sites(REPO_ROOT)
+    assert _KNOWN_GUARDED_SITE in sites, (
+        "scanner no longer detects the known rg shell-out in "
+        "fake_coverage_auditor_loop.py — scan scope or CLI set regressed"
+    )
+    assert sites[_KNOWN_GUARDED_SITE].guarded is True
+    assert signature_tool(_KNOWN_GUARDED_SITE) == "rg"
+
+
+def test_no_new_unguarded_quality_only_cli_shellouts() -> None:
+    """The ratchet: no unguarded Quality-only-CLI shell-out beyond baseline."""
+    unguarded = unguarded_signatures(scan_cli_sites(REPO_ROOT))
+    new, _resolved = ratchet_diff(unguarded, GRANDFATHERED_UNGUARDED_BASELINE)
+    assert not new, (
+        f"Unguarded Quality-only-CLI shell-outs in src/ (beyond baseline): "
+        f"{new}. The Quality runner has these CLIs (e.g. `rg`); the CI/Tests "
+        "runner does not, so this crashes only on CI/Tests — invisible to "
+        'local `make quality`. Guard the call with `shutil.which("<tool>")` '
+        "and a fallback, the way "
+        "FakeCoverageAuditorLoop._grep_scenario_for_helper does. Do NOT grow "
+        "GRANDFATHERED_UNGUARDED_BASELINE — the ratchet only shrinks."
+    )
+
+
+def test_grandfathered_baseline_only_shrinks() -> None:
+    """Covering a grandfathered site requires pruning its baseline entry."""
+    unguarded = unguarded_signatures(scan_cli_sites(REPO_ROOT))
+    _new, resolved = ratchet_diff(unguarded, GRANDFATHERED_UNGUARDED_BASELINE)
+    assert not resolved, (
+        f"Baseline lists unguarded shell-outs no longer present or now "
+        f"guarded: {resolved}. Prune them from "
+        "GRANDFATHERED_UNGUARDED_BASELINE in this change so the baseline "
+        "stays honest."
+    )


### PR DESCRIPTION
Closes #9411. Preventive shrink-only ratchet guard: AST-scans src/ for subprocess shell-outs to Quality-only CLIs (rg/ripgrep — present on the Quality runner but not the leaner CI/Tests runner) and reddens any lacking a shutil.which() guard. Closes the Quality-vs-CI runner blind spot behind #9403→#9404. The one real rg site (fake_coverage_auditor_loop) already which-guards, so the baseline is empty and no src/ change was needed. Mirrors the sandbox-seam guard (scanner module + test + ratchet_diff). `make quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)