### PR TITLE
test(guard): spawn-side reap guard — raw-spawn containment + reap-pairing ratchets (#9623)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,51 +1,51 @@
 {
-  "regenerated_at": "2026-07-20T22:15:32.552972+00:00",
-  "commit_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4",
+  "regenerated_at": "2026-07-21T00:15:48.531031+00:00",
+  "commit_sha": "982cec56380abe87e45ec1f28c7cef9027d90ede",
   "artifacts": {
     "loops.md": {
-      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
+      "source_sha": "982cec56380abe87e45ec1f28c7cef9027d90ede"
     },
     "ports.md": {
-      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
+      "source_sha": "982cec56380abe87e45ec1f28c7cef9027d90ede"
     },
     "labels.md": {
-      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
+      "source_sha": "982cec56380abe87e45ec1f28c7cef9027d90ede"
     },
     "modules.md": {
-      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
+      "source_sha": "982cec56380abe87e45ec1f28c7cef9027d90ede"
     },
     "events.md": {
-      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
+      "source_sha": "982cec56380abe87e45ec1f28c7cef9027d90ede"
     },
     "adr_xref.md": {
-      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
+      "source_sha": "982cec56380abe87e45ec1f28c7cef9027d90ede"
     },
     "mockworld.md": {
-      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
+      "source_sha": "982cec56380abe87e45ec1f28c7cef9027d90ede"
     },
     "changelog.md": {
-      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
+      "source_sha": "982cec56380abe87e45ec1f28c7cef9027d90ede"
     },
     "coverage_matrix.md": {
-      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
+      "source_sha": "982cec56380abe87e45ec1f28c7cef9027d90ede"
     },
     "adr-conformance.md": {
-      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
+      "source_sha": "982cec56380abe87e45ec1f28c7cef9027d90ede"
     },
     "ai_system_inventory.md": {
-      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
+      "source_sha": "982cec56380abe87e45ec1f28c7cef9027d90ede"
     },
     "traceability_matrix.md": {
-      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
+      "source_sha": "982cec56380abe87e45ec1f28c7cef9027d90ede"
     },
     "functional_areas.md": {
-      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
+      "source_sha": "982cec56380abe87e45ec1f28c7cef9027d90ede"
     },
     "ubiquitous-language.md": {
-      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
+      "source_sha": "982cec56380abe87e45ec1f28c7cef9027d90ede"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "1d7ffa0b5b3d13016f5f45077321c7f21060f1e4"
+      "source_sha": "982cec56380abe87e45ec1f28c7cef9027d90ede"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W30
 
+- `982cec5` — fix(workspace,state): automate HITL reset runbook residuals — main-repo core.worktree heal + attempt-counter close-to-clear (#9723) (#10082) (#10082) *(2026-07-20)*
 - `ee15f26` — feat(test-adequacy): independent second-opinion verifier gated on explicit OK (#9546) (#10076) (#10076) *(2026-07-20)*
 - `fa5e02e` — feat(gh-load): cached CI-run + issue-list reads and first-tick stagger — cut direct-gh load (#9814) (#10075) (#10075) *(2026-07-20)*
 - `aee928c` — feat(sandbox): active-trigger scenarios for six governance loops (s65-s70) (#9543) (#10074) (#10074) *(2026-07-20)*
@@ -526,7 +527,6 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `8de17bf` — docs(adr): backfill real Enforced-by refs for 14 ADRs (B1) (#8404) (#8404) *(2026-04-23)*
 - `1b79b45` — feat(adr): require Enforced-by linkage on Accepted ADRs (P3) (#8398) (#8398) *(2026-04-23)*
 - `39c6fc9` — feat(principles-audit): ADR-0044 + audit framework + P1 checks (#8386) (#8386) *(2026-04-22)*
-- `57157c8` — feat(audit): prompt audit report + scoring engine (sub-project 1 of 4) (#8376) (#8376) *(2026-04-21)*
 
 
 <!-- arch:generated -->

--- a/tests/architecture/subprocess_reap_scan.py
+++ b/tests/architecture/subprocess_reap_scan.py
@@ -1,0 +1,333 @@
+"""AST enumeration of raw subprocess spawns and reap-on-cancel pairing (#9623).
+
+Support code for the spawn-side reap guard
+(``tests/architecture/test_subprocess_reap_guard.py``) and its regression
+story (``tests/regressions/test_issue_9623.py``). Pure functions only — no
+repo mutation, no subprocesses.
+
+Two orthogonal scans over ``src/**/*.py``:
+
+1. **Raw-spawn containment** (:func:`scan_raw_spawn_signatures`): every call
+   site of a *live-child* spawn primitive (``asyncio.create_subprocess_exec``
+   / ``create_subprocess_shell``, ``subprocess.Popen``, the ``os.spawn*`` /
+   ``posix_spawn*`` family), keyed line-number-free as
+   ``"{relpath}::{qualname}::{primitive}"`` with call counts — the same
+   drift-immune signature shape as ``sandbox_seam_scan``. The guard confines
+   these to the sanctioned reap-aware implementations
+   (``HostRunner.run_simple`` / ``HostRunner.create_streaming_process`` —
+   everything else must route through ``subprocess_util.run_subprocess`` /
+   ``run_subprocess_result`` or ``runner_utils.stream_claude_process``).
+
+   The synchronous run-to-completion family (``subprocess.run`` /
+   ``check_output`` / …) is deliberately out of scope: those calls cannot be
+   abandoned by asyncio cancellation mid-flight — they are the subject of the
+   ``communicate``-timeout guards, a different failure class.
+
+2. **Reap pairing** (:func:`scan_reap_violations`): every function whose own
+   body spawns a session leader — ``create_subprocess_exec``/``_shell`` with
+   literal ``start_new_session=True``, or any ``create_streaming_process``
+   call not passing literal ``start_new_session=False`` (its default is
+   ``True``) — must contain BOTH an ``except asyncio.CancelledError`` and an
+   ``except TimeoutError`` handler, each calling the guarded primitive
+   ``process_group.kill_process_group`` (directly, or via a module-local
+   one-hop wrapper such as ``execution._reap_process_group`` /
+   ``runner_utils._kill_proc_group``). A session leader reaped with a bare
+   ``proc.kill()`` orphans every grandchild in its group — the #9648/#9553
+   defect class this guard fences statically.
+
+Scope notes (deliberate):
+
+* Attribution is per enclosing function (nested defs are attributed to
+  themselves, never their parent), so handlers and spawns must live in the
+  same function scope.
+* ``start_new_session`` threaded as a *variable* (the
+  ``HostRunner.create_streaming_process`` factory signature) is out of reap
+  scope by construction — the containment scan is what fences new raw spawn
+  sites regardless of keyword shape.
+* Wrapper resolution is exactly one hop deep: a module-local function whose
+  own body calls ``kill_process_group`` counts as a reaper alias; deeper
+  indirection must be flattened (or the site baselined) — a fixpoint walk
+  would wrongly bless e.g. ``run_simple`` itself as a "reaper".
+* Handlers that catch strictly wider types still count where the runtime
+  semantics cover the requirement: bare ``except:`` / ``BaseException``
+  catch ``CancelledError``; those plus ``Exception`` catch ``TimeoutError``.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Iterator
+from pathlib import Path
+
+#: Call names that create a live child process at the OS level. ``Popen`` and
+#: the ``os.spawn*``/``posix_spawn*`` family are included so a regression to a
+#: non-asyncio spawn cannot dodge the guard. ``os.fork``/``forkpty`` are
+#: excluded on purpose: "fork" is a GitHub-domain verb in this codebase and a
+#: bare fork is not a subprocess-helper concern.
+RAW_SPAWN_PRIMITIVES: frozenset[str] = frozenset(
+    {
+        "create_subprocess_exec",
+        "create_subprocess_shell",
+        "Popen",
+        "posix_spawn",
+        "posix_spawnp",
+        "spawnl",
+        "spawnle",
+        "spawnlp",
+        "spawnlpe",
+        "spawnv",
+        "spawnve",
+        "spawnvp",
+        "spawnvpe",
+    }
+)
+
+#: The single sanctioned group-reap primitive (#10017); see
+#: ``src/process_group.py`` and ``tests/architecture/test_process_group_kill_guard.py``.
+REAP_PRIMITIVE = "kill_process_group"
+
+_SESSION_SPAWNERS = frozenset({"create_subprocess_exec", "create_subprocess_shell"})
+_STREAMING_FACTORY = "create_streaming_process"
+
+# Exception-name sets that satisfy each required handler. ``CancelledError``
+# derives from BaseException (3.8+), so ``except Exception`` does NOT cover
+# the cancel path and is deliberately absent from _CANCEL_NAMES.
+_CANCEL_NAMES = frozenset({"CancelledError", "BaseException"})
+_TIMEOUT_NAMES = frozenset({"TimeoutError", "Exception", "BaseException"})
+
+_MISSING_CANCEL = (
+    "no `except asyncio.CancelledError` handler calling kill_process_group"
+)
+_MISSING_TIMEOUT = "no `except TimeoutError` handler calling kill_process_group"
+
+
+def _callee_name(func: ast.expr) -> str | None:
+    """Simple callee name for ``f(...)`` or ``mod.f(...)``."""
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _own_nodes(root: ast.AST) -> Iterator[ast.AST]:
+    """Descendants of *root* without descending into nested function scopes.
+
+    Keeps spawns/handlers attributed to the function that owns them: a nested
+    def's body belongs to the nested def (which the scoped visitors analyze
+    separately), never to its parent.
+    """
+    stack = list(ast.iter_child_nodes(root))
+    while stack:
+        node = stack.pop()
+        yield node
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda):
+            stack.extend(ast.iter_child_nodes(node))
+
+
+def _src_files(repo_root: Path) -> list[Path]:
+    return sorted((repo_root / "src").rglob("*.py"))
+
+
+# ---------------------------------------------------------------------------
+# Scan 1 — raw-spawn containment
+# ---------------------------------------------------------------------------
+
+
+class _RawSpawnVisitor(ast.NodeVisitor):
+    """Collects (enclosing qualname, primitive) for every raw spawn call."""
+
+    def __init__(self) -> None:
+        self._stack: list[str] = []
+        self.hits: list[tuple[str, str]] = []
+
+    def _visit_scoped(self, node: ast.AST, name: str) -> None:
+        self._stack.append(name)
+        self.generic_visit(node)
+        self._stack.pop()
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._visit_scoped(node, node.name)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_scoped(node, node.name)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_scoped(node, node.name)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        name = _callee_name(node.func)
+        if name in RAW_SPAWN_PRIMITIVES:
+            qualname = ".".join(self._stack) or "<module>"
+            self.hits.append((qualname, name))
+        self.generic_visit(node)
+
+
+def scan_raw_spawn_signatures(repo_root: Path) -> dict[str, int]:
+    """``{signature: count}`` for every raw spawn call site under ``src/``.
+
+    ``signature`` is ``"{posix relpath}::{enclosing qualname}::{primitive}"``
+    — line-number-free so in-function refactors do not churn the baseline;
+    counts catch a second spawn call added to an already-listed function.
+    """
+    counts: dict[str, int] = {}
+    for path in _src_files(repo_root):
+        rel = path.relative_to(repo_root).as_posix()
+        visitor = _RawSpawnVisitor()
+        visitor.visit(ast.parse(path.read_text(), filename=rel))
+        for qualname, primitive in visitor.hits:
+            signature = f"{rel}::{qualname}::{primitive}"
+            counts[signature] = counts.get(signature, 0) + 1
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Scan 2 — reap pairing for session-leader spawns
+# ---------------------------------------------------------------------------
+
+
+def _module_reaper_names(tree: ast.Module) -> frozenset[str]:
+    """``kill_process_group`` plus its module-local one-hop wrappers."""
+    names = {REAP_PRIMITIVE}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and any(
+            isinstance(sub, ast.Call) and _callee_name(sub.func) == REAP_PRIMITIVE
+            for sub in _own_nodes(node)
+        ):
+            names.add(node.name)
+    return frozenset(names)
+
+
+def _session_leader_spawns(fn: ast.AST) -> list[str]:
+    """Primitive names of in-reap-scope spawn calls in *fn*'s own body."""
+    hits: list[str] = []
+    for node in _own_nodes(fn):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _callee_name(node.func)
+        if name in _SESSION_SPAWNERS:
+            if any(
+                kw.arg == "start_new_session"
+                and isinstance(kw.value, ast.Constant)
+                and kw.value.value is True
+                for kw in node.keywords
+            ):
+                hits.append(name)
+        elif name == _STREAMING_FACTORY:
+            opted_out = any(
+                kw.arg == "start_new_session"
+                and isinstance(kw.value, ast.Constant)
+                and kw.value.value is False
+                for kw in node.keywords
+            )
+            if not opted_out:
+                hits.append(name)
+    return hits
+
+
+def _handler_exception_names(handler: ast.ExceptHandler) -> set[str] | None:
+    """``None`` for a bare ``except:`` (catches everything); else the names."""
+    if handler.type is None:
+        return None
+    nodes = (
+        list(handler.type.elts)
+        if isinstance(handler.type, ast.Tuple)
+        else [handler.type]
+    )
+    names: set[str] = set()
+    for node in nodes:
+        if isinstance(node, ast.Name):
+            names.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            names.add(node.attr)
+    return names
+
+
+def _handler_reaps(handler: ast.ExceptHandler, reaper_names: frozenset[str]) -> bool:
+    return any(
+        isinstance(node, ast.Call) and _callee_name(node.func) in reaper_names
+        for node in _own_nodes(handler)
+    )
+
+
+def _reap_deficits(fn: ast.AST, reaper_names: frozenset[str]) -> list[str]:
+    cancel_ok = False
+    timeout_ok = False
+    for node in _own_nodes(fn):
+        if not isinstance(node, ast.ExceptHandler):
+            continue
+        names = _handler_exception_names(node)
+        catches_cancel = names is None or bool(names & _CANCEL_NAMES)
+        catches_timeout = names is None or bool(names & _TIMEOUT_NAMES)
+        if (catches_cancel or catches_timeout) and _handler_reaps(node, reaper_names):
+            cancel_ok = cancel_ok or catches_cancel
+            timeout_ok = timeout_ok or catches_timeout
+    deficits: list[str] = []
+    if not cancel_ok:
+        deficits.append(_MISSING_CANCEL)
+    if not timeout_ok:
+        deficits.append(_MISSING_TIMEOUT)
+    return deficits
+
+
+class _ReapVisitor(ast.NodeVisitor):
+    """Per-function session-leader spawn scope and handler deficits."""
+
+    def __init__(self, reaper_names: frozenset[str]) -> None:
+        self._stack: list[str] = []
+        self._reapers = reaper_names
+        self.in_scope: dict[str, list[str]] = {}
+        self.deficits: dict[str, list[str]] = {}
+
+    def _visit_scoped(self, node: ast.AST, name: str) -> None:
+        self._stack.append(name)
+        self.generic_visit(node)
+        self._stack.pop()
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._visit_scoped(node, node.name)
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        spawns = _session_leader_spawns(node)
+        if spawns:
+            qualname = ".".join([*self._stack, node.name])
+            self.in_scope[qualname] = spawns
+            missing = _reap_deficits(node, self._reapers)
+            if missing:
+                self.deficits[qualname] = missing
+        self._visit_scoped(node, node.name)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function(node)
+
+
+def _scan_reap(
+    repo_root: Path,
+) -> tuple[dict[str, list[str]], dict[str, str]]:
+    in_scope: dict[str, list[str]] = {}
+    violations: dict[str, str] = {}
+    for path in _src_files(repo_root):
+        rel = path.relative_to(repo_root).as_posix()
+        tree = ast.parse(path.read_text(), filename=rel)
+        visitor = _ReapVisitor(_module_reaper_names(tree))
+        visitor.visit(tree)
+        for qualname, spawns in visitor.in_scope.items():
+            in_scope[f"{rel}::{qualname}"] = spawns
+        for qualname, missing in visitor.deficits.items():
+            violations[f"{rel}::{qualname}"] = "; ".join(missing)
+    return in_scope, violations
+
+
+def scan_reap_scope(repo_root: Path) -> dict[str, list[str]]:
+    """``{"relpath::qualname": [spawn primitives]}`` for in-reap-scope fns."""
+    in_scope, _violations = _scan_reap(repo_root)
+    return in_scope
+
+
+def scan_reap_violations(repo_root: Path) -> dict[str, str]:
+    """``{"relpath::qualname": deficit description}`` for non-conforming fns."""
+    _in_scope, violations = _scan_reap(repo_root)
+    return violations

--- a/tests/architecture/test_subprocess_reap_guard.py
+++ b/tests/architecture/test_subprocess_reap_guard.py
@@ -1,0 +1,522 @@
+"""Spawn-side reap guard (#9623) — the orphaned-grandchild defect class.
+
+The reap family is behavioral-complete: ``process_group.kill_process_group``
+is the single guarded primitive (#10017, location-gated by
+``test_process_group_kill_guard.py``), ``HostRunner.run_simple`` and
+``stream_claude_process`` reap their process group on timeout AND
+cancellation (#9648/#9911), and ``tests/regressions/test_issue_9553.py``
+pins the zero-orphan end-to-end story. What was still missing (#9623) is the
+STRUCTURAL fence: a NEW spawn site with a dropped cancel handler — or a new
+raw spawn that bypasses the reap-aware helpers entirely — was only caught
+behaviorally, if its author happened to write the behavioral test.
+
+Two ratchets, both shrink-only (mirroring
+``test_sandbox_seam_completeness.py``):
+
+1. **Raw-spawn containment** — a raw live-child spawn primitive
+   (``create_subprocess_exec``/``_shell``, ``subprocess.Popen``,
+   ``os.spawn*``) may appear only inside the sanctioned reap-aware
+   implementations (``HostRunner.run_simple``,
+   ``HostRunner.create_streaming_process``) or the grandfathered baseline.
+   Everything else routes through ``subprocess_util.run_subprocess`` /
+   ``run_subprocess_result`` (one-shot; bounded + registry-reaped) or
+   ``runner_utils.stream_claude_process`` (streaming agents).
+2. **Reap pairing** — every function spawning a session leader
+   (``start_new_session=True``, or a ``create_streaming_process`` call not
+   opting out) must call ``kill_process_group`` inside BOTH an
+   ``except asyncio.CancelledError`` and an ``except TimeoutError`` handler.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from tests.architecture.sandbox_seam_scan import ratchet_diff
+from tests.architecture.subprocess_reap_scan import (
+    scan_raw_spawn_signatures,
+    scan_reap_scope,
+    scan_reap_violations,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The only two places in src/ allowed to call a raw spawn primitive: the
+# SubprocessRunner host implementations that every sanctioned helper
+# (run_subprocess / run_subprocess_result via _run_gated -> run_simple;
+# stream_claude_process via create_streaming_process) funnels into. Both
+# carry the reap machinery: process-group registry (#9911/#10019) and
+# group-kill on timeout/cancel.
+SANCTIONED_RAW_SPAWNERS: frozenset[str] = frozenset(
+    {
+        "src/execution.py::HostRunner.run_simple::create_subprocess_exec",
+        "src/execution.py::HostRunner.create_streaming_process::create_subprocess_exec",
+    }
+)
+
+# Raw spawn sites that predate this guard, keyed ``{signature: count}``
+# (see subprocess_reap_scan.scan_raw_spawn_signatures). DO NOT ADD ENTRIES:
+# a new spawn goes through run_subprocess / run_subprocess_result /
+# stream_claude_process instead. Remove entries as sites migrate — the
+# ratchet only shrinks.
+#
+# * dashboard_routes / preflight: interactive UI/boot one-shots (git/gh
+#   plumbing) that predate the #9554/#10060 migration wave.
+# * staging_bisect_loop._run_git: deliberately excluded from that migration —
+#   cooperative kill-switch cancellation needs its own deadline-poll loop
+#   (part of #10028).
+# * subprocess_util.probe_auth_availability: the fail-open `gh auth status`
+#   probe; cannot route through _run_gated without recursing into the very
+#   machinery it corroborates.
+GRANDFATHERED_RAW_SPAWN_BASELINE: dict[str, int] = {
+    "src/dashboard_routes/_onboarding_routes.py::_run_checked::create_subprocess_exec": 1,
+    "src/dashboard_routes/_routes.py::_run_dialog_command::create_subprocess_exec": 1,
+    "src/dashboard_routes/_state_routes.py::register._detect_repo_slug_from_path::create_subprocess_exec": 1,
+    "src/dashboard_routes/_state_routes.py::register.add_repo_by_path::create_subprocess_exec": 1,
+    "src/dashboard_routes/_state_routes.py::register.clone_github_repo::create_subprocess_exec": 1,
+    "src/dashboard_routes/_state_routes.py::register.list_github_repos::create_subprocess_exec": 1,
+    "src/preflight/__init__.py::_check_gh_auth::create_subprocess_exec": 1,
+    "src/staging_bisect_loop.py::StagingBisectLoop._run_git::create_subprocess_exec": 1,
+    "src/subprocess_util.py::probe_auth_availability::create_subprocess_exec": 1,
+}
+
+# Session-leader spawn sites that do not reap via except-handlers, keyed
+# ``relpath::qualname``. DO NOT ADD ENTRIES; prune when the site conforms.
+#
+# * staging_bisect_loop._run_git: reaps the group inline from a cooperative
+#   deadline-poll loop (kill-switch cancellation, #9579) rather than from
+#   except handlers — the known deliberate exclusion, part of #10028.
+GRANDFATHERED_REAP_BASELINE: frozenset[str] = frozenset(
+    {
+        "src/staging_bisect_loop.py::StagingBisectLoop._run_git",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Live-tree ratchets
+# ---------------------------------------------------------------------------
+
+
+def test_scan_finds_the_sanctioned_spawn_implementations() -> None:
+    """Anti-vacuity canary for the containment scan.
+
+    If the scan scope or primitive set regresses (rename, glob typo), the
+    containment assertions pass vacuously on an empty scan. The two
+    sanctioned HostRunner sites exist as long as HydraFlow spawns anything.
+    """
+    current = scan_raw_spawn_signatures(REPO_ROOT)
+    missing = SANCTIONED_RAW_SPAWNERS - set(current)
+    assert not missing, (
+        f"Sanctioned spawn implementations not seen by the scan: {sorted(missing)}. "
+        "Either the scanner scope regressed or the HostRunner spawn sites "
+        "moved — update SANCTIONED_RAW_SPAWNERS in the same change."
+    )
+
+
+def test_no_new_raw_spawn_sites_outside_reap_aware_helpers() -> None:
+    current = scan_raw_spawn_signatures(REPO_ROOT)
+    unsanctioned = {
+        signature: count
+        for signature, count in current.items()
+        if signature not in SANCTIONED_RAW_SPAWNERS
+    }
+    new, _resolved = ratchet_diff(unsanctioned, GRANDFATHERED_RAW_SPAWN_BASELINE)
+    assert not new, (
+        f"Raw subprocess spawn sites outside the reap-aware helpers: {new}. "
+        "A raw spawn bypasses reap-on-cancel/timeout and the process-group "
+        "registry — its children orphan on cancellation (#9623, the "
+        "#9648/#9553 defect class). Route one-shot commands through "
+        "subprocess_util.run_subprocess / run_subprocess_result and "
+        "streaming agent spawns through runner_utils.stream_claude_process. "
+        "Do NOT grow GRANDFATHERED_RAW_SPAWN_BASELINE — the ratchet only "
+        "shrinks."
+    )
+
+
+def test_raw_spawn_baseline_only_shrinks() -> None:
+    current = scan_raw_spawn_signatures(REPO_ROOT)
+    unsanctioned = {
+        signature: count
+        for signature, count in current.items()
+        if signature not in SANCTIONED_RAW_SPAWNERS
+    }
+    _new, resolved = ratchet_diff(unsanctioned, GRANDFATHERED_RAW_SPAWN_BASELINE)
+    assert not resolved, (
+        f"Baseline lists raw spawn sites no longer present: {resolved}. "
+        "Prune them from GRANDFATHERED_RAW_SPAWN_BASELINE in this change so "
+        "the baseline stays honest."
+    )
+
+
+def test_reap_scan_sees_the_load_bearing_spawn_paths() -> None:
+    """Anti-vacuity canary for the reap-pairing scan."""
+    in_scope = scan_reap_scope(REPO_ROOT)
+    assert "src/execution.py::HostRunner.run_simple" in in_scope
+    assert "src/runner_utils.py::stream_claude_process" in in_scope
+
+
+def test_session_leader_spawns_reap_in_both_cancel_and_timeout_handlers() -> None:
+    violations = scan_reap_violations(REPO_ROOT)
+    new = {
+        signature: deficit
+        for signature, deficit in violations.items()
+        if signature not in GRANDFATHERED_REAP_BASELINE
+    }
+    assert not new, (
+        f"Session-leader spawn sites missing reap handlers: {new}. A process "
+        "spawned with start_new_session=True is its own group leader; only "
+        "process_group.kill_process_group reaps its whole tree, and it must "
+        "be called from BOTH an `except asyncio.CancelledError` and an "
+        "`except TimeoutError` handler — a bare proc.kill() (or a dropped "
+        "handler) silently orphans grandchildren (#9623, #9648). Do NOT grow "
+        "GRANDFATHERED_REAP_BASELINE — the ratchet only shrinks."
+    )
+
+
+def test_reap_baseline_only_shrinks() -> None:
+    violations = scan_reap_violations(REPO_ROOT)
+    stale = GRANDFATHERED_REAP_BASELINE - set(violations)
+    assert not stale, (
+        f"Baseline lists reap sites that now conform or no longer spawn: "
+        f"{sorted(stale)}. Prune them from GRANDFATHERED_REAP_BASELINE in "
+        "this change so the baseline stays honest."
+    )
+
+
+def test_reap_baseline_entries_are_not_raw_spawn_sanctioned() -> None:
+    """The two allowlists must stay disjoint.
+
+    A site cannot be both a sanctioned reap-aware implementation and a
+    grandfathered reap violation — that would grant it a permanent pass.
+    """
+    sanctioned_functions = {
+        signature.rsplit("::", 1)[0] for signature in SANCTIONED_RAW_SPAWNERS
+    }
+    conflicted = GRANDFATHERED_REAP_BASELINE & sanctioned_functions
+    assert not conflicted, (
+        f"Sites in both SANCTIONED_RAW_SPAWNERS and "
+        f"GRANDFATHERED_REAP_BASELINE: {sorted(conflicted)}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scanner unit tests against inline fixtures
+# ---------------------------------------------------------------------------
+
+
+class TestRawSpawnScanner:
+    """Containment-scan mechanics on synthetic trees."""
+
+    def test_flags_raw_spawn_primitives(
+        self, fixture_src_tree: Callable[[dict[str, str]], Path]
+    ) -> None:
+        root = fixture_src_tree(
+            {
+                "src/rogue.py": """
+                    import asyncio
+                    import os
+                    import subprocess
+
+
+                    async def exec_site() -> None:
+                        await asyncio.create_subprocess_exec("git", "status")
+
+
+                    def popen_site() -> None:
+                        subprocess.Popen(["ls"])
+
+
+                    def spawn_site() -> None:
+                        os.spawnv(os.P_NOWAIT, "/bin/ls", ["ls"])
+                    """,
+            }
+        )
+        assert scan_raw_spawn_signatures(root) == {
+            "src/rogue.py::exec_site::create_subprocess_exec": 1,
+            "src/rogue.py::popen_site::Popen": 1,
+            "src/rogue.py::spawn_site::spawnv": 1,
+        }
+
+    def test_sanctioned_helper_calls_are_not_raw_spawns(
+        self, fixture_src_tree: Callable[[dict[str, str]], Path]
+    ) -> None:
+        root = fixture_src_tree(
+            {
+                "src/clean.py": """
+                    async def helper_users(runner) -> None:
+                        await run_subprocess("gh", "pr", "view")
+                        await run_subprocess_result("git", "status")
+                        await stream_claude_process(cmd=["claude", "-p"], prompt="hi")
+                        await runner.run_simple(["git", "status"])
+                    """,
+            }
+        )
+        assert scan_raw_spawn_signatures(root) == {}
+
+    def test_counts_pin_multiplicity_per_function(
+        self, fixture_src_tree: Callable[[dict[str, str]], Path]
+    ) -> None:
+        root = fixture_src_tree(
+            {
+                "src/twice.py": """
+                    import asyncio
+
+
+                    async def double_spawn() -> None:
+                        await asyncio.create_subprocess_exec("a")
+                        await asyncio.create_subprocess_exec("b")
+                    """,
+            }
+        )
+        signature = "src/twice.py::double_spawn::create_subprocess_exec"
+        current = scan_raw_spawn_signatures(root)
+        assert current[signature] == 2
+        new, _resolved = ratchet_diff(current, {signature: 1})
+        assert new == {signature: 1}
+
+
+_CONFORMING_SPAWN = """
+    import asyncio
+    import contextlib
+
+    from process_group import kill_process_group
+
+
+    async def run_agent(cmd: list[str]) -> None:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd, start_new_session=True
+        )
+        try:
+            await asyncio.wait_for(proc.communicate(), timeout=5.0)
+        except TimeoutError:
+            kill_process_group(proc)
+            with contextlib.suppress(ProcessLookupError, OSError):
+                await proc.wait()
+            raise
+        except asyncio.CancelledError:
+            kill_process_group(proc)
+            raise
+    """
+
+
+class TestReapPairingScanner:
+    """Reap-pairing mechanics on synthetic trees."""
+
+    def test_conforming_site_is_in_scope_and_clean(
+        self, fixture_src_tree: Callable[[dict[str, str]], Path]
+    ) -> None:
+        root = fixture_src_tree({"src/agent.py": _CONFORMING_SPAWN})
+        assert scan_reap_scope(root) == {
+            "src/agent.py::run_agent": ["create_subprocess_exec"]
+        }
+        assert scan_reap_violations(root) == {}
+
+    def test_bare_proc_kill_in_handlers_is_a_violation(
+        self, fixture_src_tree: Callable[[dict[str, str]], Path]
+    ) -> None:
+        root = fixture_src_tree(
+            {
+                "src/agent.py": """
+                    import asyncio
+
+
+                    async def run_agent(cmd: list[str]) -> None:
+                        proc = await asyncio.create_subprocess_exec(
+                            *cmd, start_new_session=True
+                        )
+                        try:
+                            await asyncio.wait_for(proc.communicate(), timeout=5.0)
+                        except TimeoutError:
+                            proc.kill()
+                            raise
+                        except asyncio.CancelledError:
+                            proc.kill()
+                            raise
+                    """,
+            }
+        )
+        violations = scan_reap_violations(root)
+        assert set(violations) == {"src/agent.py::run_agent"}
+        assert "CancelledError" in violations["src/agent.py::run_agent"]
+        assert "TimeoutError" in violations["src/agent.py::run_agent"]
+
+    def test_dropped_cancel_handler_is_a_violation(
+        self, fixture_src_tree: Callable[[dict[str, str]], Path]
+    ) -> None:
+        root = fixture_src_tree(
+            {
+                "src/agent.py": """
+                    import asyncio
+
+                    from process_group import kill_process_group
+
+
+                    async def run_agent(cmd: list[str]) -> None:
+                        proc = await asyncio.create_subprocess_exec(
+                            *cmd, start_new_session=True
+                        )
+                        try:
+                            await asyncio.wait_for(proc.communicate(), timeout=5.0)
+                        except TimeoutError:
+                            kill_process_group(proc)
+                            raise
+                    """,
+            }
+        )
+        violations = scan_reap_violations(root)
+        assert set(violations) == {"src/agent.py::run_agent"}
+        assert "CancelledError" in violations["src/agent.py::run_agent"]
+        assert "TimeoutError" not in violations["src/agent.py::run_agent"]
+
+    def test_module_local_reaper_wrapper_conforms(
+        self, fixture_src_tree: Callable[[dict[str, str]], Path]
+    ) -> None:
+        root = fixture_src_tree(
+            {
+                "src/agent.py": """
+                    import asyncio
+
+                    from process_group import kill_process_group
+
+
+                    def _reap(proc) -> None:
+                        kill_process_group(proc)
+
+
+                    async def run_agent(cmd: list[str]) -> None:
+                        proc = await asyncio.create_subprocess_exec(
+                            *cmd, start_new_session=True
+                        )
+                        try:
+                            await asyncio.wait_for(proc.communicate(), timeout=5.0)
+                        except TimeoutError:
+                            _reap(proc)
+                            raise
+                        except asyncio.CancelledError:
+                            _reap(proc)
+                            raise
+                    """,
+            }
+        )
+        assert scan_reap_violations(root) == {}
+
+    def test_tuple_handler_counts_for_timeout(
+        self, fixture_src_tree: Callable[[dict[str, str]], Path]
+    ) -> None:
+        root = fixture_src_tree(
+            {
+                "src/agent.py": """
+                    import asyncio
+
+                    from process_group import kill_process_group
+
+
+                    async def run_agent(cmd: list[str]) -> None:
+                        proc = await asyncio.create_subprocess_exec(
+                            *cmd, start_new_session=True
+                        )
+                        try:
+                            await asyncio.wait_for(proc.communicate(), timeout=5.0)
+                        except (TimeoutError, OSError):
+                            kill_process_group(proc)
+                            raise
+                        except asyncio.CancelledError:
+                            kill_process_group(proc)
+                            raise
+                    """,
+            }
+        )
+        assert scan_reap_violations(root) == {}
+
+    def test_non_session_leader_spawns_are_out_of_scope(
+        self, fixture_src_tree: Callable[[dict[str, str]], Path]
+    ) -> None:
+        """No literal True keyword -> out of reap scope (containment still
+        fences the raw site). Covers the HostRunner.create_streaming_process
+        factory, which threads start_new_session as a variable."""
+        root = fixture_src_tree(
+            {
+                "src/agent.py": """
+                    import asyncio
+
+
+                    async def no_keyword(cmd: list[str]) -> None:
+                        await asyncio.create_subprocess_exec(*cmd)
+
+
+                    async def literal_false(cmd: list[str]) -> None:
+                        await asyncio.create_subprocess_exec(
+                            *cmd, start_new_session=False
+                        )
+
+
+                    async def variable_threaded(cmd, start_new_session: bool) -> None:
+                        await asyncio.create_subprocess_exec(
+                            *cmd, start_new_session=start_new_session
+                        )
+                    """,
+            }
+        )
+        assert scan_reap_scope(root) == {}
+        assert scan_reap_violations(root) == {}
+
+    def test_streaming_factory_calls_are_in_scope_unless_opted_out(
+        self, fixture_src_tree: Callable[[dict[str, str]], Path]
+    ) -> None:
+        root = fixture_src_tree(
+            {
+                "src/streamer.py": """
+                    import asyncio
+
+
+                    async def defaulted(runner) -> None:
+                        await runner.create_streaming_process(["claude", "-p"])
+
+
+                    async def opted_out(runner) -> None:
+                        await runner.create_streaming_process(
+                            ["claude", "-p"], start_new_session=False
+                        )
+                    """,
+            }
+        )
+        scope = scan_reap_scope(root)
+        assert set(scope) == {"src/streamer.py::defaulted"}
+        violations = scan_reap_violations(root)
+        assert set(violations) == {"src/streamer.py::defaulted"}
+
+    def test_nested_function_spawns_attribute_to_the_nested_scope(
+        self, fixture_src_tree: Callable[[dict[str, str]], Path]
+    ) -> None:
+        """A parent with conforming handlers cannot launder a nested def's
+        spawn — the nested function owns (and lacks) its own handlers."""
+        root = fixture_src_tree(
+            {
+                "src/nested.py": """
+                    import asyncio
+
+                    from process_group import kill_process_group
+
+
+                    async def outer(cmd: list[str]) -> None:
+                        async def inner() -> None:
+                            await asyncio.create_subprocess_exec(
+                                *cmd, start_new_session=True
+                            )
+
+                        try:
+                            await inner()
+                        except TimeoutError:
+                            kill_process_group(None)
+                            raise
+                        except asyncio.CancelledError:
+                            kill_process_group(None)
+                            raise
+                    """,
+            }
+        )
+        assert set(scan_reap_violations(root)) == {"src/nested.py::outer.inner"}

--- a/tests/regressions/test_issue_9623.py
+++ b/tests/regressions/test_issue_9623.py
@@ -1,0 +1,204 @@
+"""Regression: a spawn site that drops its reap-on-cancel handler is red.
+
+Issue #9623: the reap family (kill_process_group #10017, run_simple /
+stream_claude_process group-reap #9648/#9911, the zero-orphan e2e pin
+#9553) enforced reap-on-cancel only BEHAVIORALLY — a new spawn site with a
+dropped ``except asyncio.CancelledError`` handler, or a raw
+``create_subprocess_exec`` bypassing the reap-aware helpers entirely,
+shipped silently unless its author wrote the behavioral test. This pins the
+spawn-side scanner mechanics on synthetic trees: the exact
+dropped-cancel-handler and rogue-raw-spawn shapes must stay red, and the
+conforming shape (including the module-local wrapper aliases the live tree
+uses, ``execution._reap_process_group`` / ``runner_utils._kill_proc_group``)
+must stay green. If any of these regress, the guard in
+``tests/architecture/test_subprocess_reap_guard.py`` goes vacuously green
+and the next orphaned-grandchild regression ships without a red CI signal.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+from tests.architecture.sandbox_seam_scan import ratchet_diff
+from tests.architecture.subprocess_reap_scan import (
+    scan_raw_spawn_signatures,
+    scan_reap_scope,
+    scan_reap_violations,
+)
+
+_CONFORMING = """
+    import asyncio
+    import contextlib
+
+    from process_group import kill_process_group
+
+
+    async def run_agent(cmd: list[str]) -> None:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd, start_new_session=True
+        )
+        try:
+            await asyncio.wait_for(proc.communicate(), timeout=5.0)
+        except TimeoutError:
+            with contextlib.suppress(ProcessLookupError, OSError):
+                kill_process_group(proc)
+                await proc.wait()
+            raise
+        except asyncio.CancelledError:
+            kill_process_group(proc)
+            raise
+    """
+
+# The same site after the exact regression #9623 fears: the cancel handler
+# is gone (timeout still reaps), so a watchdog-cancelled cycle orphans the
+# whole grandchild tree.
+_DROPPED_CANCEL = """
+    import asyncio
+    import contextlib
+
+    from process_group import kill_process_group
+
+
+    async def run_agent(cmd: list[str]) -> None:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd, start_new_session=True
+        )
+        try:
+            await asyncio.wait_for(proc.communicate(), timeout=5.0)
+        except TimeoutError:
+            with contextlib.suppress(ProcessLookupError, OSError):
+                kill_process_group(proc)
+                await proc.wait()
+            raise
+    """
+
+
+def _write_tree(root: Path, spec: dict[str, str]) -> None:
+    for rel, body in spec.items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(dedent(body).lstrip("\n"))
+
+
+def test_conforming_spawn_site_stays_green(tmp_path: Path) -> None:
+    _write_tree(tmp_path, {"src/agent.py": _CONFORMING})
+    assert scan_reap_scope(tmp_path) == {
+        "src/agent.py::run_agent": ["create_subprocess_exec"]
+    }
+    assert scan_reap_violations(tmp_path) == {}
+
+
+def test_dropped_cancel_handler_reddens(tmp_path: Path) -> None:
+    """The canonical #9623 regression: cancel handler deleted, timeout kept."""
+    _write_tree(tmp_path, {"src/agent.py": _DROPPED_CANCEL})
+    violations = scan_reap_violations(tmp_path)
+    assert set(violations) == {"src/agent.py::run_agent"}
+    assert "CancelledError" in violations["src/agent.py::run_agent"]
+    assert "TimeoutError" not in violations["src/agent.py::run_agent"]
+
+
+def test_wrapper_alias_reap_stays_green(tmp_path: Path) -> None:
+    """The live tree reaps via one-hop wrappers; scanner must honor them.
+
+    If alias resolution regresses, run_simple / stream_claude_process would
+    flag as violations (loud), but this pins the mechanic so a scanner
+    refactor cannot quietly change what "conforming" means.
+    """
+    _write_tree(
+        tmp_path,
+        {
+            "src/agent.py": """
+                import asyncio
+
+                from process_group import kill_process_group
+
+
+                def _reap_process_group(proc) -> None:
+                    kill_process_group(proc)
+
+
+                async def run_agent(cmd: list[str]) -> None:
+                    proc = await asyncio.create_subprocess_exec(
+                        *cmd, start_new_session=True
+                    )
+                    try:
+                        await asyncio.wait_for(proc.communicate(), timeout=5.0)
+                    except TimeoutError:
+                        _reap_process_group(proc)
+                        raise
+                    except asyncio.CancelledError:
+                        _reap_process_group(proc)
+                        raise
+                """,
+        },
+    )
+    assert scan_reap_violations(tmp_path) == {}
+
+
+def test_bare_proc_kill_never_counts_as_a_reap(tmp_path: Path) -> None:
+    """proc.kill() reaps the leader only — grandchildren survive (#9648)."""
+    _write_tree(
+        tmp_path,
+        {
+            "src/agent.py": """
+                import asyncio
+
+
+                async def run_agent(cmd: list[str]) -> None:
+                    proc = await asyncio.create_subprocess_exec(
+                        *cmd, start_new_session=True
+                    )
+                    try:
+                        await asyncio.wait_for(proc.communicate(), timeout=5.0)
+                    except TimeoutError:
+                        proc.kill()
+                        raise
+                    except asyncio.CancelledError:
+                        proc.kill()
+                        raise
+                """,
+        },
+    )
+    violations = scan_reap_violations(tmp_path)
+    assert set(violations) == {"src/agent.py::run_agent"}
+
+
+def test_new_raw_spawn_site_reddens_the_containment_ratchet(
+    tmp_path: Path,
+) -> None:
+    """A rogue Popen/create_subprocess_exec outside the helpers is flagged."""
+    _write_tree(
+        tmp_path,
+        {
+            "src/rogue_loop.py": """
+                import subprocess
+
+
+                def shell_out() -> None:
+                    subprocess.Popen(["make", "quality"])
+                """,
+        },
+    )
+    current = scan_raw_spawn_signatures(tmp_path)
+    new, resolved = ratchet_diff(current, {})
+    assert new == {"src/rogue_loop.py::shell_out::Popen": 1}
+    assert not resolved
+
+
+def test_migrated_raw_spawn_demands_baseline_prune(tmp_path: Path) -> None:
+    """The ratchet only shrinks: a stale baseline entry must fail loudly."""
+    _write_tree(
+        tmp_path,
+        {
+            "src/clean.py": """
+                async def helper_user() -> str:
+                    return await run_subprocess("git", "status")
+                """,
+        },
+    )
+    current = scan_raw_spawn_signatures(tmp_path)
+    stale_baseline = {"src/clean.py::helper_user::create_subprocess_exec": 1}
+    new, resolved = ratchet_diff(current, stale_baseline)
+    assert not new
+    assert resolved == stale_baseline


### PR DESCRIPTION
## Summary

Closes #9623 — source-level (AST) guard preventing subprocess spawn paths from regressing reap-on-cancel, closing the structural gap left after the behavioral reap family landed (kill_process_group #10017, run_simple / stream_claude_process group-reap #9648/#9911, zero-orphan e2e pin #9553).

Two shrink-only ratchets over `src/**/*.py` (mirroring `test_sandbox_seam_completeness.py`):

1. **Raw-spawn containment** (`scan_raw_spawn_signatures`) — every call site of a live-child spawn primitive (`asyncio.create_subprocess_exec`/`_shell`, `subprocess.Popen`, the `os.spawn*`/`posix_spawn*` family), keyed line-number-free as `relpath::qualname::primitive` with call counts. Only the two sanctioned reap-aware HostRunner implementations (`run_simple`, `create_streaming_process`) plus a 9-entry grandfathered baseline may spawn raw; everything else must route through `run_subprocess` / `run_subprocess_result` / `stream_claude_process`. The synchronous `subprocess.run` family is deliberately out of scope (cannot be abandoned mid-flight by asyncio cancellation — that's the communicate-timeout guards' beat).
2. **Reap pairing** (`scan_reap_violations`) — every function spawning a session leader (`start_new_session=True` literal, or a `create_streaming_process` call not opting out) must call `process_group.kill_process_group` (directly or via a module-local one-hop wrapper) inside BOTH an `except asyncio.CancelledError` and an `except TimeoutError` handler. Single grandfathered entry: `staging_bisect_loop._run_git` (reaps inline from a cooperative deadline-poll loop; deliberate exclusion, part of #10028).

Anti-vacuity canaries pin that both scans still see the sanctioned/load-bearing sites; both baselines fail loudly when stale (ratchets only shrink); a disjointness test keeps the sanctioned list and the reap baseline from ever granting a site a permanent pass.

## Files

- `tests/architecture/subprocess_reap_scan.py` — pure AST scanner (containment + reap pairing)
- `tests/architecture/test_subprocess_reap_guard.py` — live-tree ratchets + scanner unit tests on synthetic trees
- `tests/regressions/test_issue_9623.py` — pins the dropped-cancel-handler / rogue-raw-spawn shapes red and the conforming + wrapper-alias shapes green

## Test evidence

- `pytest tests/architecture/test_subprocess_reap_guard.py tests/regressions/test_issue_9623.py -q` — 24 passed (exit 0)
- `pytest tests/architecture/ -q` — 226 passed (exit 0)
- `make arch-regen` + `python -m arch.runner --check` — exit 0
- Disturbance ratchet suite — passed (exit 0)
- `make quality` — full gate green (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
