### PR TITLE
refactor(ui): shared pipeline-track split + fork renderer for Header and StreamView (#9564)

### DIFF
--- a/src/ui/src/components/Header.jsx
+++ b/src/ui/src/components/Header.jsx
@@ -1,19 +1,12 @@
 import React, { useCallback, useState } from 'react'
 import { theme } from '../theme'
 import { useHydraFlow } from '../context/HydraFlowContext'
-import { PIPELINE_STAGES, PRODUCT_TRACK_KEYS, SENSITIVE_SELECTORS } from '../constants'
+import { PIPELINE_STAGES, SENSITIVE_SELECTORS } from '../constants'
+import { splitPipelineTracks } from '../utils/pipelineTracks'
+import { ProductFork, TerminalFork } from './PipelineFork'
 import { BugReportPanel } from './BugReportPanel'
 import { ReportIssueModal } from './ReportIssueModal'
 import html2canvasLib from 'html2canvas'
-
-// Terminal end-states = main-track stages with no processing role and no config
-// knob (hitl, merged). After REVIEW an issue forks to a human OR gets merged —
-// never both — so these render as parallel arms of a fork, not a linear chain
-// (#9224). Derived from PIPELINE_STAGES so adding/removing a terminal needs no
-// edit here; mirrors StreamView's PipelineFlow.
-const TERMINAL_STAGE_KEYS = new Set(
-  PIPELINE_STAGES.filter(s => !s.role && !s.configKey).map(s => s.key)
-)
 
 function isCrossOriginImage(el) {
   if (!el || el.tagName !== 'IMG') return false
@@ -252,8 +245,7 @@ export function Header({ connected, orchestratorStatus }) {
         <div style={styles.sessionBox} data-testid="session-box" aria-label="Session pipeline statistics">
           <div style={styles.pipelineRow} data-testid="session-pipeline">
             {(() => {
-              const mainTrack = sessionStages.filter(s => !PRODUCT_TRACK_KEYS.has(s.key))
-              const productTrack = sessionStages.filter(s => PRODUCT_TRACK_KEYS.has(s.key))
+              const { triage, product, postTriage, terminal } = splitPipelineTracks(sessionStages)
               const renderPill = (stage) => (
                 <div
                   key={stage.key}
@@ -267,56 +259,27 @@ export function Header({ connected, orchestratorStatus }) {
                 </div>
               )
               const arrow = <span style={styles.pipelineArrow}>→</span>
-              const triageStage = mainTrack.find(s => s.key === 'triage')
-              // Post-triage main-track stages minus the terminal end-states
-              // (hitl, merged): those fork off REVIEW rather than chaining
-              // linearly after it (#9224).
-              const postTriage = mainTrack.filter(
-                s => s.key !== 'triage' && !TERMINAL_STAGE_KEYS.has(s.key)
-              )
-              const terminalStages = mainTrack.filter(s => TERMINAL_STAGE_KEYS.has(s.key))
               return (
                 <>
-                  {triageStage && renderPill(triageStage)}
-                  {productTrack.length > 0 && (
-                    <>
-                      <span style={styles.pipelineFork}>
-                        <span style={styles.forkTop}>
-                          {productTrack.map((s, i) => (
-                            <React.Fragment key={s.key}>
-                              {i === 0 && <span style={styles.forkArrow}>↗</span>}
-                              {i > 0 && arrow}
-                              {renderPill(s)}
-                            </React.Fragment>
-                          ))}
-                          <span style={styles.forkArrow}>↘</span>
-                        </span>
-                        <span style={styles.forkBottom}>
-                          <span style={styles.forkDirect}>direct →</span>
-                        </span>
-                      </span>
-                    </>
-                  )}
+                  {triage && renderPill(triage)}
+                  <ProductFork
+                    items={product}
+                    renderItem={renderPill}
+                    separator={arrow}
+                    styles={forkStyles}
+                  />
                   {postTriage.map((stage) => (
                     <React.Fragment key={stage.key}>
                       {arrow}
                       {renderPill(stage)}
                     </React.Fragment>
                   ))}
-                  {terminalStages.length > 0 && (
-                    <span style={styles.pipelineFork} data-testid="review-terminal-fork">
-                      <span style={styles.forkTop}>
-                        <span style={styles.forkArrow}>↗</span>
-                        {renderPill(terminalStages[0])}
-                      </span>
-                      {terminalStages.slice(1).map((stage) => (
-                        <span style={styles.forkBottom} key={stage.key}>
-                          <span style={styles.forkArrow}>↘</span>
-                          {renderPill(stage)}
-                        </span>
-                      ))}
-                    </span>
-                  )}
+                  <TerminalFork
+                    items={terminal}
+                    renderItem={renderPill}
+                    styles={forkStyles}
+                    testId="review-terminal-fork"
+                  />
                 </>
               )
             })()}
@@ -529,6 +492,17 @@ const styles = {
     cursor: 'pointer',
     transition: 'opacity 0.15s',
   },
+}
+
+// Canonical fork-slot → Header-style map fed to the shared ProductFork /
+// TerminalFork so the compact pipeline row shares StreamView's fork topology
+// while keeping its own compact styling (#9564).
+const forkStyles = {
+  fork: styles.pipelineFork,
+  forkTop: styles.forkTop,
+  forkBottom: styles.forkBottom,
+  forkArrow: styles.forkArrow,
+  forkDirect: styles.forkDirect,
 }
 
 // Pre-computed pipeline stage style maps (avoids object spread in render loops)

--- a/src/ui/src/components/PipelineFork.jsx
+++ b/src/ui/src/components/PipelineFork.jsx
@@ -1,0 +1,79 @@
+import React from 'react'
+
+/**
+ * Shared pipeline fork visuals for the Header pipeline row and StreamView's
+ * PipelineFlow (#9564). Both components render the SAME fork topology — the
+ * discover→shape product fork off triage, and the hitl/merged terminal fork off
+ * REVIEW — so it can no longer drift between the two.
+ *
+ * Only the topology + arrows live here. Each caller keeps its OWN sizing and
+ * compactness by passing a `styles` bundle plus render-props for the per-stage
+ * body (compact pills in Header, larger flow stages in StreamView). The
+ * `styles` bundle maps the canonical fork-slot names to the caller's own
+ * styles:
+ *   - fork:       the vertical fork container
+ *   - forkTop:    a top/branch row (product arm, terminal arm)
+ *   - forkBottom: the "direct →" row (product fork only)
+ *   - forkArrow:  the diagonal branch arrow (↗ / ↘)
+ *   - forkDirect: the "direct →" label
+ */
+
+/**
+ * Product-discovery fork: triage branches UP into the product track
+ * (discover→shape, top row) or proceeds straight through ("direct →", bottom
+ * row). Renders nothing when there are no product stages.
+ *
+ * @param {Array} items  Product-track items, in pipeline order.
+ * @param {(item:any)=>string} keyOf  Maps an item to its React key / stage key.
+ * @param {(item:any)=>React.ReactNode} renderItem  Renders one stage body.
+ * @param {React.ReactNode} separator  Element placed between adjacent product
+ *   stages (a → arrow in Header, a connector line in StreamView).
+ * @param {object} styles  Canonical fork-slot → caller-style map (see above).
+ * @param {string} [directLabel]  The bottom-arm label. Canonical: "direct →".
+ */
+export function ProductFork({ items, keyOf = (i) => i.key, renderItem, separator, styles, directLabel = 'direct →' }) {
+  if (!items || items.length === 0) return null
+  return (
+    <span style={styles.fork}>
+      <span style={styles.forkTop}>
+        {items.map((item, idx) => (
+          <React.Fragment key={keyOf(item)}>
+            {idx === 0 && <span style={styles.forkArrow}>↗</span>}
+            {idx > 0 && separator}
+            {renderItem(item)}
+          </React.Fragment>
+        ))}
+        <span style={styles.forkArrow}>↘</span>
+      </span>
+      <span style={styles.forkBottom}>
+        <span style={styles.forkDirect}>{directLabel}</span>
+      </span>
+    </span>
+  )
+}
+
+/**
+ * Terminal fork off REVIEW: each end-state (hitl, merged) is a parallel arm —
+ * the first takes the ↗ arrow, the rest take ↘ — because after REVIEW an issue
+ * goes to a human OR gets merged, never both. Renders nothing when there are no
+ * terminal stages.
+ *
+ * @param {Array} items  Terminal items, in pipeline order (hitl before merged).
+ * @param {(item:any)=>string} keyOf  Maps an item to its React key / stage key.
+ * @param {(item:any)=>React.ReactNode} renderItem  Renders one stage body.
+ * @param {object} styles  Canonical fork-slot → caller-style map (see above).
+ * @param {string} [testId]  data-testid for the fork container.
+ */
+export function TerminalFork({ items, keyOf = (i) => i.key, renderItem, styles, testId }) {
+  if (!items || items.length === 0) return null
+  return (
+    <span style={styles.fork} data-testid={testId}>
+      {items.map((item, idx) => (
+        <span style={styles.forkTop} key={keyOf(item)}>
+          <span style={styles.forkArrow}>{idx === 0 ? '↗' : '↘'}</span>
+          {renderItem(item)}
+        </span>
+      ))}
+    </span>
+  )
+}

--- a/src/ui/src/components/StreamView.jsx
+++ b/src/ui/src/components/StreamView.jsx
@@ -2,7 +2,9 @@ import React, { useMemo, useCallback, useState } from 'react'
 import { theme } from '../theme'
 import { useHydraFlow, workerKey } from '../context/HydraFlowContext'
 import { StreamCard } from './StreamCard'
-import { PIPELINE_STAGES, PRODUCT_TRACK_KEYS, PULSE_ANIMATION } from '../constants'
+import { PIPELINE_STAGES, PULSE_ANIMATION } from '../constants'
+import { splitPipelineTracks } from '../utils/pipelineTracks'
+import { ProductFork, TerminalFork } from './PipelineFork'
 import { STAGE_KEYS } from '../hooks/useTimeline'
 import {
   sectionHeaderStyles,
@@ -24,14 +26,6 @@ const NO_ROLE_DOT_COLORS = {
   merged: theme.green,
   hitl: theme.red,
 }
-
-// Terminal end-states = pipeline stages with no processing role and no config
-// knob (hitl, merged). After REVIEW an issue forks to a human OR gets merged —
-// never both — so these render as parallel arms of a fork, not a linear chain.
-// Derived from PIPELINE_STAGES so adding/removing a terminal needs no edit here.
-const TERMINAL_STAGE_KEYS = new Set(
-  PIPELINE_STAGES.filter(s => !s.role && !s.configKey).map(s => s.key)
-)
 
 // Human-readable labels for the work-queue strategy badge (#10067).
 const QUEUE_STRATEGY_LABELS = {
@@ -105,15 +99,9 @@ function PipelineFlow({ stageGroups, queueStrategy }) {
     </div>
   )
 
-  const mainGroups = stageGroups.filter(g => !PRODUCT_TRACK_KEYS.has(g.stage.key))
-  const productGroups = stageGroups.filter(g => PRODUCT_TRACK_KEYS.has(g.stage.key))
-  const triageGroup = mainGroups.find(g => g.stage.key === 'triage')
-  // Post-triage main-track stages, minus the terminal end-states (hitl, merged):
-  // those fork off REVIEW rather than chaining linearly after it.
-  const postTriageGroups = mainGroups.filter(
-    g => g.stage.key !== 'triage' && !TERMINAL_STAGE_KEYS.has(g.stage.key)
-  )
-  const terminalGroups = mainGroups.filter(g => TERMINAL_STAGE_KEYS.has(g.stage.key))
+  const { triage: triageGroup, product: productGroups, postTriage: postTriageGroups, terminal: terminalGroups } =
+    splitPipelineTracks(stageGroups, g => g.stage.key)
+  const groupKey = g => g.stage.key
 
   return (
     <div style={styles.flowContainer} data-testid="pipeline-flow">
@@ -129,41 +117,26 @@ function PipelineFlow({ stageGroups, queueStrategy }) {
       )}
       <div style={styles.flowConnector} />
       {triageGroup && renderFlowStage(triageGroup)}
-      {productGroups.length > 0 && (
-        <>
-          <div style={styles.flowFork}>
-            <div style={styles.flowForkTop}>
-              {productGroups.map((group, idx) => (
-                <React.Fragment key={group.stage.key}>
-                  {idx === 0 && <span style={styles.flowForkArrow}>↗</span>}
-                  {idx > 0 && <div style={styles.flowConnectorShort} />}
-                  {renderFlowStage(group)}
-                </React.Fragment>
-              ))}
-              <span style={styles.flowForkArrow}>↘</span>
-            </div>
-            <div style={styles.flowForkBottom}>
-              <span style={styles.flowForkDirect}>direct →</span>
-            </div>
-          </div>
-        </>
-      )}
-      {postTriageGroups.map((group, idx) => (
+      <ProductFork
+        items={productGroups}
+        keyOf={groupKey}
+        renderItem={renderFlowStage}
+        separator={<div style={styles.flowConnectorShort} />}
+        styles={forkStyles}
+      />
+      {postTriageGroups.map((group) => (
         <React.Fragment key={group.stage.key}>
           <div style={styles.flowConnector} />
           {renderFlowStage(group)}
         </React.Fragment>
       ))}
-      {terminalGroups.length > 0 && (
-        <div style={styles.flowFork} data-testid="flow-terminal-fork">
-          {terminalGroups.map((group, idx) => (
-            <div style={styles.flowForkTop} key={group.stage.key}>
-              <span style={styles.flowForkArrow}>{idx === 0 ? '↗' : '↘'}</span>
-              {renderFlowStage(group)}
-            </div>
-          ))}
-        </div>
-      )}
+      <TerminalFork
+        items={terminalGroups}
+        keyOf={groupKey}
+        renderItem={renderFlowStage}
+        styles={forkStyles}
+        testId="flow-terminal-fork"
+      />
       {(mergedCount > 0 || failedCount > 0) && (
         <span style={styles.flowSummary} data-testid="flow-summary">
           {mergedCount > 0 && <span style={flowSummaryMergedStyle}>{mergedCount} merged</span>}
@@ -872,6 +845,17 @@ const styles = {
     color: theme.textMuted,
     flexShrink: 0,
   },
+}
+
+// Canonical fork-slot → PipelineFlow-style map fed to the shared ProductFork /
+// TerminalFork so the large flow diagram shares the Header pipeline row's fork
+// topology while keeping its own larger styling (#9564).
+const forkStyles = {
+  fork: styles.flowFork,
+  forkTop: styles.flowForkTop,
+  forkBottom: styles.flowForkBottom,
+  forkArrow: styles.flowForkArrow,
+  forkDirect: styles.flowForkDirect,
 }
 
 const epicContainerStyles = {

--- a/src/ui/src/components/__tests__/Header.test.jsx
+++ b/src/ui/src/components/__tests__/Header.test.jsx
@@ -313,6 +313,28 @@ describe('Header component', () => {
         expect(pill.style.borderColor).toBe(stage.color)
       })
     })
+
+    it('renders the shared product fork with a "direct →" bypass arm', () => {
+      // Header renders the discover→shape product fork via the shared ProductFork
+      // component; the "direct →" bottom arm is StreamView's canonical treatment
+      // (#9564), so the compact row and the flow diagram cannot drift.
+      render(<Header {...defaultProps} />)
+      const pipelineRow = screen.getByTestId('session-pipeline')
+      expect(pipelineRow.textContent).toContain('direct →')
+      // Both product stages sit inside the fork's top arm.
+      expect(screen.getByTestId('session-stage-discover')).toBeInTheDocument()
+      expect(screen.getByTestId('session-stage-shape')).toBeInTheDocument()
+    })
+
+    it('renders the shared terminal fork with hitl and merged as parallel arms', () => {
+      // hitl/merged fork off REVIEW (never both) via the shared TerminalFork —
+      // the same topology StreamView's flow-terminal-fork renders (#9564).
+      render(<Header {...defaultProps} />)
+      const fork = screen.getByTestId('review-terminal-fork')
+      expect(fork).toBeInTheDocument()
+      expect(fork).toContainElement(screen.getByTestId('session-stage-hitl'))
+      expect(fork).toContainElement(screen.getByTestId('session-stage-merged'))
+    })
   })
 
   describe('Report button', () => {

--- a/src/ui/src/components/__tests__/StreamView.test.jsx
+++ b/src/ui/src/components/__tests__/StreamView.test.jsx
@@ -618,6 +618,30 @@ describe('PipelineFlow visualization', () => {
     expect(activeDot.style.animation).toContain('stream-pulse')
     expect(queuedDot.style.animation).toBe('')
   })
+
+  it('renders the shared product fork with a "direct →" bypass arm', () => {
+    // PipelineFlow renders the discover→shape product fork via the shared
+    // ProductFork component — the same topology Header's pipeline row uses
+    // (#9564). PIPELINE_STAGES always contains discover/shape, so the fork
+    // renders regardless of issue counts.
+    mockUseHydraFlow.mockReturnValue(defaultHydraFlowContext())
+    render(<StreamView {...defaultProps} />)
+    const flow = screen.getByTestId('pipeline-flow')
+    expect(flow.textContent).toContain('direct →')
+    expect(flow.textContent).toContain('Discover')
+    expect(flow.textContent).toContain('Shape')
+  })
+
+  it('renders the shared terminal fork with hitl and merged as parallel arms', () => {
+    // hitl/merged fork off REVIEW via the shared TerminalFork — the same
+    // topology Header's review-terminal-fork renders (#9564).
+    mockUseHydraFlow.mockReturnValue(defaultHydraFlowContext())
+    render(<StreamView {...defaultProps} />)
+    const fork = screen.getByTestId('flow-terminal-fork')
+    expect(fork).toBeInTheDocument()
+    expect(fork.textContent).toContain('Needs Human')
+    expect(fork.textContent).toContain('Merged')
+  })
 })
 
 describe('Merged stage rendering', () => {

--- a/src/ui/src/utils/__tests__/pipelineTracks.test.js
+++ b/src/ui/src/utils/__tests__/pipelineTracks.test.js
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest'
+import { PIPELINE_STAGES, PRODUCT_TRACK_KEYS } from '../../constants'
+import {
+  splitPipelineTracks,
+  isProductStage,
+  isTerminalStage,
+  TERMINAL_TRACK_KEYS,
+} from '../pipelineTracks'
+
+// This is the anti-drift lock (#9564): Header's compact pipeline row and
+// StreamView's PipelineFlow both derive their triage / product-fork / linear /
+// terminal-fork layout from splitPipelineTracks. Asserting the split against the
+// REAL constants means the two renderers can no longer diverge silently.
+
+describe('TERMINAL_TRACK_KEYS', () => {
+  it('is exactly the no-role, no-configKey end-states (hitl, merged)', () => {
+    expect([...TERMINAL_TRACK_KEYS].sort()).toEqual(['hitl', 'merged'])
+  })
+
+  it('derives from PIPELINE_STAGES (role null AND configKey null)', () => {
+    const derived = PIPELINE_STAGES.filter(s => !s.role && !s.configKey).map(s => s.key)
+    expect([...TERMINAL_TRACK_KEYS]).toEqual(derived)
+  })
+})
+
+describe('isProductStage / isTerminalStage', () => {
+  it('isProductStage matches PRODUCT_TRACK_KEYS (discover, shape)', () => {
+    expect(isProductStage('discover')).toBe(true)
+    expect(isProductStage('shape')).toBe(true)
+    expect([...PRODUCT_TRACK_KEYS].sort()).toEqual(['discover', 'shape'])
+  })
+
+  it('isProductStage is false for main/terminal stages', () => {
+    expect(isProductStage('triage')).toBe(false)
+    expect(isProductStage('plan')).toBe(false)
+    expect(isProductStage('merged')).toBe(false)
+  })
+
+  it('isTerminalStage matches TERMINAL_TRACK_KEYS (hitl, merged)', () => {
+    expect(isTerminalStage('hitl')).toBe(true)
+    expect(isTerminalStage('merged')).toBe(true)
+  })
+
+  it('isTerminalStage is false for worker-bearing stages', () => {
+    expect(isTerminalStage('triage')).toBe(false)
+    expect(isTerminalStage('review')).toBe(false)
+    expect(isTerminalStage('discover')).toBe(false)
+  })
+})
+
+describe('splitPipelineTracks with the real PIPELINE_STAGES', () => {
+  const tracks = splitPipelineTracks(PIPELINE_STAGES)
+
+  it('puts the triage junction on the triage track', () => {
+    expect(tracks.triage).not.toBeNull()
+    expect(tracks.triage.key).toBe('triage')
+  })
+
+  it('routes discover→shape into the product fork, in order', () => {
+    expect(tracks.product.map(s => s.key)).toEqual(['discover', 'shape'])
+  })
+
+  it('routes plan→implement→review into the linear post-triage track', () => {
+    expect(tracks.postTriage.map(s => s.key)).toEqual(['plan', 'implement', 'review'])
+  })
+
+  it('routes hitl/merged into the terminal fork, hitl before merged', () => {
+    expect(tracks.terminal.map(s => s.key)).toEqual(['hitl', 'merged'])
+  })
+
+  it('main = every non-product stage, in pipeline order', () => {
+    expect(tracks.main.map(s => s.key)).toEqual([
+      'triage', 'plan', 'implement', 'review', 'hitl', 'merged',
+    ])
+  })
+
+  it('partitions every stage into exactly one of product / postTriage / terminal / triage', () => {
+    const covered = [
+      tracks.triage.key,
+      ...tracks.product.map(s => s.key),
+      ...tracks.postTriage.map(s => s.key),
+      ...tracks.terminal.map(s => s.key),
+    ]
+    expect(covered.sort()).toEqual(PIPELINE_STAGES.map(s => s.key).sort())
+    expect(new Set(covered).size).toBe(PIPELINE_STAGES.length)
+  })
+})
+
+describe('splitPipelineTracks with a custom getKey (StreamView group shape)', () => {
+  // StreamView feeds {stage, issues} groups through the same splitter.
+  const groups = PIPELINE_STAGES.map(stage => ({ stage, issues: [] }))
+  const tracks = splitPipelineTracks(groups, g => g.stage.key)
+
+  it('splits the {stage,issues} shape identically to the {key} shape', () => {
+    expect(tracks.triage.stage.key).toBe('triage')
+    expect(tracks.product.map(g => g.stage.key)).toEqual(['discover', 'shape'])
+    expect(tracks.postTriage.map(g => g.stage.key)).toEqual(['plan', 'implement', 'review'])
+    expect(tracks.terminal.map(g => g.stage.key)).toEqual(['hitl', 'merged'])
+  })
+})
+
+describe('splitPipelineTracks edge cases', () => {
+  it('returns empty tracks and null triage for an empty array', () => {
+    const tracks = splitPipelineTracks([])
+    expect(tracks.triage).toBeNull()
+    expect(tracks.product).toEqual([])
+    expect(tracks.postTriage).toEqual([])
+    expect(tracks.terminal).toEqual([])
+    expect(tracks.main).toEqual([])
+  })
+
+  it('tolerates null/undefined input', () => {
+    expect(splitPipelineTracks(null).main).toEqual([])
+    expect(splitPipelineTracks(undefined).triage).toBeNull()
+  })
+})

--- a/src/ui/src/utils/pipelineTracks.js
+++ b/src/ui/src/utils/pipelineTracks.js
@@ -1,0 +1,52 @@
+import { PIPELINE_STAGES, PRODUCT_TRACK_KEYS } from '../constants'
+
+// Terminal end-states = pipeline stages with no processing role and no config
+// knob (hitl, merged). After REVIEW an issue forks to a human OR gets merged —
+// never both — so these render as parallel arms of a fork, not a linear chain
+// (#9224). Derived from PIPELINE_STAGES so adding/removing a terminal needs no
+// edit at any call site. Single source of truth for BOTH the Header pipeline
+// row and StreamView's PipelineFlow (#9564).
+export const TERMINAL_TRACK_KEYS = new Set(
+  PIPELINE_STAGES.filter(s => !s.role && !s.configKey).map(s => s.key)
+)
+
+/** True if `key` is a product-discovery track stage (branches off triage). */
+export function isProductStage(key) {
+  return PRODUCT_TRACK_KEYS.has(key)
+}
+
+/** True if `key` is a terminal end-state (forks off REVIEW: hitl / merged). */
+export function isTerminalStage(key) {
+  return TERMINAL_TRACK_KEYS.has(key)
+}
+
+/**
+ * Split an array of stage-bearing items (in PIPELINE_STAGES order) into the
+ * pipeline's topology tracks. This is the ONE place that owns the
+ * triage / product-fork / linear / terminal-fork partition — both Header's
+ * compact pipeline row and StreamView's larger PipelineFlow derive their layout
+ * from this, so the two renderers can no longer drift (#9564).
+ *
+ * Returns:
+ *   - triage:     the single triage junction item, or null if absent
+ *   - product:    the discover→shape product-fork branch (top arm off triage)
+ *   - postTriage: linear main-track items after triage, excluding terminals
+ *   - terminal:   the hitl/merged fork off REVIEW
+ *   - main:       every non-product item (triage + postTriage + terminal), in order
+ *
+ * @param {Array} items  Stage-bearing items in PIPELINE_STAGES order.
+ * @param {(item: any) => string} getKey  Maps an item to its stage key.
+ *   Defaults to `item.key` (Header's {key,count} shape); StreamView passes
+ *   `g => g.stage.key` for its {stage,issues} groups.
+ */
+export function splitPipelineTracks(items, getKey = (item) => item.key) {
+  const safeItems = items || []
+  const main = safeItems.filter(item => !isProductStage(getKey(item)))
+  const product = safeItems.filter(item => isProductStage(getKey(item)))
+  const triage = main.find(item => getKey(item) === 'triage') ?? null
+  const postTriage = main.filter(
+    item => getKey(item) !== 'triage' && !isTerminalStage(getKey(item))
+  )
+  const terminal = main.filter(item => isTerminalStage(getKey(item)))
+  return { triage, product, postTriage, terminal, main }
+}

--- a/tests/regressions/test_issue_9224.py
+++ b/tests/regressions/test_issue_9224.py
@@ -39,6 +39,15 @@ import pytest
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _HEADER_JSX = _REPO_ROOT / "src" / "ui" / "src" / "components" / "Header.jsx"
 _CONSTANTS_JS = _REPO_ROOT / "src" / "ui" / "src" / "constants.js"
+# #9564 extracted the fork topology out of Header.jsx into a shared renderer
+# (``PipelineFork.jsx``) + a pure track-splitter (``pipelineTracks.js``); Header
+# and StreamView now both render from these. The #9224 invariants therefore live
+# in the shared modules now — the structure checks below read them, plus Header
+# as the consumer, rather than expecting the fork JSX inline in Header.
+_PIPELINE_FORK_JSX = (
+    _REPO_ROOT / "src" / "ui" / "src" / "components" / "PipelineFork.jsx"
+)
+_PIPELINE_TRACKS_JS = _REPO_ROOT / "src" / "ui" / "src" / "utils" / "pipelineTracks.js"
 
 # Rightward / branch arrow glyphs that can represent a flow edge. The diagram
 # currently uses U+2192 (->), U+2197 (^/up-right) and U+2198 (down-right).
@@ -136,33 +145,33 @@ def test_review_forks_to_two_terminal_endstates_not_linear_chain() -> None:
     review fork analogous to the product-track fork so the terminals render as
     two parallel arms with no trailing arrow.
     """
+    fork_src = _read(_PIPELINE_FORK_JSX)
+    tracks_src = _read(_PIPELINE_TRACKS_JS)
     header_src = _read(_HEADER_JSX)
-    terminals = _terminal_stage_keys(_read(_CONSTANTS_JS))
 
-    # The product-track fork is the only fork present today (single
-    # `styles.pipelineFork` usage). A correct fix adds a second fork for the
-    # review terminals -- detectable via any of these mutually-tolerant signals
-    # so the test accepts either a data-driven or a hardcoded implementation.
-    second_fork_block = header_src.count("styles.pipelineFork") >= 2
-    terminal_track = ("'terminal'" in header_src) or ('"terminal"' in header_src)
-    terminal_set_import = "TERMINAL_STAGE_KEYS" in header_src
-    explicit_terminal_keys = all(
-        re.search(rf"['\"]{re.escape(key)}['\"]", header_src) for key in terminals
+    # Post-#9564 the review terminals fork via the shared ``TerminalFork``
+    # component off a first-class ``terminal`` track, rather than a flat
+    # post-triage chain. The invariant holds iff: the terminal fork exists as a
+    # distinct component, the terminal track is a first-class concept, and Header
+    # actually renders the fork (not a linear chain).
+    terminal_fork_component = "TerminalFork" in fork_src
+    terminal_track_concept = ("TERMINAL_TRACK_KEYS" in tracks_src) or (
+        "isTerminalStage" in tracks_src
     )
+    terminal_fork_rendered = "TerminalFork" in header_src
 
     review_fork_present = (
-        second_fork_block
-        or terminal_track
-        or terminal_set_import
-        or explicit_terminal_keys
+        terminal_fork_component and terminal_track_concept and terminal_fork_rendered
     )
 
     assert review_fork_present, (
-        "Header.jsx renders the REVIEW terminals (hitl, merged) in the flat "
-        "post-triage linear chain instead of forking REVIEW into two terminal "
-        "arms. Expected a second fork block (styles.pipelineFork), a "
-        "track:'terminal' / TERMINAL_STAGE_KEYS concept, or explicit handling "
-        f"of the terminal keys {terminals}. Found none -- issue #9224 bug 1."
+        "The REVIEW terminals (hitl, merged) must fork into two parallel arms, "
+        "not a flat linear chain. Expected the shared TerminalFork component "
+        "(PipelineFork.jsx), a first-class terminal track "
+        "(TERMINAL_TRACK_KEYS/isTerminalStage in pipelineTracks.js), and Header "
+        "rendering <TerminalFork>. "
+        f"component={terminal_fork_component} track={terminal_track_concept} "
+        f"rendered={terminal_fork_rendered} -- issue #9224 bug 1."
     )
 
 
@@ -173,24 +182,35 @@ def test_triage_fork_has_explicit_direct_arrow_to_plan() -> None:
     -- a text label with no arrow. The fix adds an explicit arrow representing
     the TRIAGE -> PLAN bypass, parallel to the ``^ discover -> shape v`` arc.
     """
-    header_src = _read(_HEADER_JSX)
+    fork_src = _read(_PIPELINE_FORK_JSX)
 
-    direct_arm = _extract_balanced_span(header_src, "styles.forkBottom")
+    direct_arm = _extract_balanced_span(fork_src, "styles.forkBottom")
     assert direct_arm is not None, (
         "Could not locate the product-track fork's direct arm "
-        "(styles.forkBottom) in Header.jsx."
+        "(styles.forkBottom) in the shared ProductFork (PipelineFork.jsx)."
     )
 
+    # The direct arm renders ``{directLabel}``; the explicit arrow lives in the
+    # canonical default (``directLabel = 'direct →'``). Accept an inline glyph,
+    # an arrow element, or the arrow carried by the directLabel default.
+    direct_label_has_arrow = bool(
+        re.search(
+            rf"directLabel\s*=\s*['\"][^'\"]*[{re.escape(_ARROW_GLYPHS)}][^'\"]*['\"]",
+            fork_src,
+        )
+    )
     has_arrow = (
         any(glyph in direct_arm for glyph in _ARROW_GLYPHS)
         or "{arrow}" in direct_arm
         or "forkArrow" in direct_arm
         or "pipelineArrow" in direct_arm
+        or ("directLabel" in direct_arm and direct_label_has_arrow)
     )
 
     assert has_arrow, (
-        "The TRIAGE -> PLAN direct path in Header.jsx is rendered as a bare "
-        "text label ('direct') with no arrow. Expected an explicit arrow "
-        "(glyph or arrow element) in the fork's direct arm pointing to plan. "
-        f"Direct-arm content was: {direct_arm.strip()!r} -- issue #9224 bug 2."
+        "The TRIAGE -> PLAN direct path must render an explicit arrow, not a "
+        "bare 'direct' label. Expected an arrow glyph/element in the shared "
+        "ProductFork's direct arm, or the arrow carried by the directLabel "
+        f"default. Direct-arm content: {direct_arm.strip()!r}; "
+        f"directLabel-has-arrow={direct_label_has_arrow} -- issue #9224 bug 2."
     )


### PR DESCRIPTION
Closes #9564. The dashboard rendered the same pipeline topology twice (Header row + StreamView PipelineFlow), independently re-deriving the triage/product-fork/terminal split from PIPELINE_STAGES+PRODUCT_TRACK_KEYS — already drifted. Extracts a pure `splitPipelineTracks` helper (`src/ui/src/utils/pipelineTracks.js`) + shared `PipelineFork.jsx` (ProductFork/TerminalFork) consumed by both, so the forks can't diverge again. Each caller keeps its own compact/large styling via props.

Adopts StreamView's canonical treatment (direct→ bypass + idx-based ↗/↘ terminal fork); **Header's merged terminal arm gains a ~4px gap** (now same row style as the hitl arm) — the one visual change. Stage set/order/track assignments otherwise unchanged. Full UI vitest suite green (1210 tests, +19 new); the #9224 source-structure regression tests were retargeted to the shared renderer (invariants preserved at the new location). `make quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)