### PR TITLE
fix(mockworld): bound stop_dashboard orchestrator.stop with diagnostic dump on timeout (#10073)

### DIFF
--- a/tests/regressions/test_stop_dashboard_bounded_10073.py
+++ b/tests/regressions/test_stop_dashboard_bounded_10073.py
@@ -1,0 +1,130 @@
+"""Regression #10073: MockWorld.stop_dashboard must bound orchestrator.stop().
+
+stop_dashboard awaited ``orchestrator.stop()`` with no timeout. Any task that
+survives shutdown — or a real-orchestrator scenario whose stop path blocks —
+wedged the in-process harness at event-loop close: pytest hung until the CI
+job's 20-minute timeout with zero output (#10071's orphan probe showed
+``WebSocketProtocol.run_asgi`` surviving stop_dashboard pre-fix).
+
+These pins inject a deterministic hanging ``stop()`` fake with a tiny timeout
+(no real sleeps near the timeout value) and assert the teardown fails LOUDLY —
+a TimeoutError naming the live tasks — instead of hanging. The happy path pins
+that a completing stop() produces no diagnostic and no error.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import pytest
+
+from tests.scenarios.fakes.mock_world import MockWorld
+
+
+class _HangingOrchestrator:
+    """Orchestrator whose stop() parks forever (the #10073 wedge shape)."""
+
+    running = True
+
+    def __init__(self) -> None:
+        self.stop_calls = 0
+
+    async def stop(self) -> None:
+        self.stop_calls += 1
+        await asyncio.Event().wait()  # never set — deterministic hang
+
+
+class _PromptOrchestrator:
+    """Orchestrator whose stop() completes immediately (happy path)."""
+
+    running = True
+
+    def __init__(self) -> None:
+        self.stop_calls = 0
+
+    async def stop(self) -> None:
+        self.stop_calls += 1
+
+
+class _FakeDashboard:
+    """Just enough dashboard surface for stop_dashboard: _orchestrator + stop()."""
+
+    def __init__(self, orchestrator: object) -> None:
+        self._orchestrator = orchestrator
+        self._uvicorn_server = None
+        self.stopped = False
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+def _world_with_dashboard(
+    tmp_path, orchestrator: object
+) -> tuple[MockWorld, _FakeDashboard]:
+    world = MockWorld(tmp_path)
+    dashboard = _FakeDashboard(orchestrator)
+    world._dashboard = dashboard
+    world._dashboard_url = "http://127.0.0.1:1"
+    return world, dashboard
+
+
+async def test_hung_orchestrator_stop_raises_loud_timeout_with_task_names(
+    tmp_path,
+) -> None:
+    # The exact #10073 shape: stop() never returns. Teardown must convert the
+    # silent wedge into a bounded TimeoutError that names the live tasks —
+    # the #10071 orphan-probe technique, applied to the timeout diagnostic.
+    orchestrator = _HangingOrchestrator()
+    world, _ = _world_with_dashboard(tmp_path, orchestrator)
+
+    probe = asyncio.create_task(asyncio.Event().wait(), name="orphan-probe-10073")
+    try:
+        # Outer wait_for pins "no hang": a regressed unbounded await would
+        # trip it with a bare TimeoutError that fails the match below.
+        with pytest.raises(TimeoutError, match="orphan-probe-10073"):
+            await asyncio.wait_for(
+                world.stop_dashboard(orchestrator_stop_timeout=0.05), timeout=5
+            )
+    finally:
+        probe.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await probe
+
+    assert orchestrator.stop_calls == 1
+    # The finally block must still clear the handles so a retried teardown
+    # cannot double-stop a half-dead dashboard.
+    assert world._dashboard is None
+    assert world.dashboard_url is None
+
+
+async def test_hung_orchestrator_stop_diagnostic_reaches_stderr(
+    tmp_path, capsys
+) -> None:
+    # The attributed dump (task names) must land on stderr, where a CI log
+    # shows it even if the exception is swallowed by an outer harness.
+    world, _ = _world_with_dashboard(tmp_path, _HangingOrchestrator())
+
+    with pytest.raises(TimeoutError):
+        await world.stop_dashboard(orchestrator_stop_timeout=0.05)
+
+    err = capsys.readouterr().err
+    assert "orchestrator.stop() timed out" in err
+    assert "live tasks" in err
+
+
+async def test_completing_orchestrator_stop_is_quiet_and_clean(
+    tmp_path, capsys
+) -> None:
+    # Happy path: stop() completes -> no TimeoutError, no diagnostic output,
+    # dashboard fully torn down.
+    orchestrator = _PromptOrchestrator()
+    world, dashboard = _world_with_dashboard(tmp_path, orchestrator)
+
+    await asyncio.wait_for(world.stop_dashboard(), timeout=5)
+
+    assert orchestrator.stop_calls == 1
+    assert dashboard.stopped is True
+    assert world._dashboard is None
+    assert world.dashboard_url is None
+    assert "orchestrator.stop() timed out" not in capsys.readouterr().err

--- a/tests/scenarios/fakes/mock_world.py
+++ b/tests/scenarios/fakes/mock_world.py
@@ -7,6 +7,9 @@ run the pipeline, and assert on the world's final state.
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import faulthandler
+import sys
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -32,6 +35,12 @@ from tests.scenarios.catalog import (
     loop_registrations as _loop_registrations,  # noqa: F401
 )
 from tests.scenarios.fakes.scenario_result import IssueOutcome, ScenarioResult
+
+#: Upper bound for ``orchestrator.stop()`` during teardown (#10073). Generous —
+#: a healthy stop path finishes in well under a second; the bound exists only to
+#: convert a wedged shutdown into a loud, attributed failure instead of a silent
+#: 20-minute CI cancel at event-loop close.
+_ORCHESTRATOR_STOP_TIMEOUT = 60.0
 
 
 class _SafeProxy:
@@ -921,13 +930,36 @@ class MockWorld:
         self._dashboard_url = f"http://127.0.0.1:{port}"
         return self._dashboard_url
 
-    async def stop_dashboard(self) -> None:
-        """Shut down uvicorn task, stop orchestrator if present."""
+    async def stop_dashboard(
+        self, *, orchestrator_stop_timeout: float = _ORCHESTRATOR_STOP_TIMEOUT
+    ) -> None:
+        """Shut down uvicorn task, stop orchestrator if present.
+
+        ``orchestrator.stop()`` is bounded (#10073): a stop path that blocks —
+        or any task surviving shutdown — used to wedge the in-process harness
+        at event-loop close, hanging pytest until the CI job's 20-minute
+        timeout with zero output. On timeout we dump live asyncio task names
+        and faulthandler stacks to stderr, then raise a TimeoutError naming
+        the survivors, so the failure is loud and attributed.
+        """
         if self._dashboard is None:
             return
         try:
             if self._dashboard._orchestrator and self._dashboard._orchestrator.running:
-                await self._dashboard._orchestrator.stop()
+                try:
+                    await asyncio.wait_for(
+                        self._dashboard._orchestrator.stop(),
+                        timeout=orchestrator_stop_timeout,
+                    )
+                except TimeoutError:
+                    live = self._dump_stuck_teardown_diagnostics(
+                        orchestrator_stop_timeout
+                    )
+                    raise TimeoutError(
+                        "MockWorld.stop_dashboard: orchestrator.stop() did not "
+                        f"complete within {orchestrator_stop_timeout}s (#10073); "
+                        f"live tasks: {live}"
+                    ) from None
 
             uv_server = getattr(self._dashboard, "_uvicorn_server", None)
             if uv_server is not None:
@@ -943,6 +975,34 @@ class MockWorld:
         finally:
             self._dashboard = None
             self._dashboard_url = None
+
+    @staticmethod
+    def _dump_stuck_teardown_diagnostics(timeout: float) -> list[str]:
+        """Dump live task names + faulthandler stacks to stderr; return the names.
+
+        Called when ``orchestrator.stop()`` exceeds its bound (#10073). The
+        task-name dump attributes the wedge (the #10071 orphan-probe
+        technique); the faulthandler dump adds thread stacks. Both are
+        best-effort diagnostics — the load-bearing signal is the TimeoutError
+        the caller raises with the returned names.
+        """
+        current = asyncio.current_task()
+        live = sorted(
+            task.get_name()
+            for task in asyncio.all_tasks()
+            if task is not current and not task.done()
+        )
+        print(
+            f"MockWorld.stop_dashboard: orchestrator.stop() timed out after {timeout}s; "
+            f"live tasks: {live}",
+            file=sys.stderr,
+            flush=True,
+        )
+        # capsys-style captures replace sys.stderr with a fileno-less buffer,
+        # which faulthandler rejects — never let diagnostics mask the timeout.
+        with contextlib.suppress(Exception):
+            faulthandler.dump_traceback(file=sys.stderr)
+        return live
 
     async def _await_dashboard_port(self, dashboard: Any, timeout: float = 5.0) -> int:
         """Poll ``dashboard._uvicorn_server`` for the bound port up to ``timeout`` seconds."""


### PR DESCRIPTION
Closes #10073.

`MockWorld.stop_dashboard` awaited `orchestrator.stop()` unbounded — any task surviving shutdown (or a real-orchestrator scenario whose stop path blocks) wedged the in-process harness at event-loop close, so pytest hung until the CI job's 20-minute timeout with zero output (the cancelled-at-timeout bucket #10010 flags).

**Fix:** wrap the stop in `asyncio.wait_for` (default 60s, injectable per-call); on timeout, dump live `asyncio.all_tasks()` names + `faulthandler` traceback to stderr, then raise `TimeoutError` naming the stuck tasks — turning a silent 20-min cancel into a loud, attributed local failure. The `finally` still clears dashboard handles on the raise path.

**Tests:** 3 regression pins under `tests/regressions/test_stop_dashboard_bounded_10073.py` (deterministic hanging fake, injected 0.05s timeout — no real sleeps): hung stop → loud TimeoutError naming an `orphan-probe-10073` task + handles cleared; diagnostic reaches stderr; happy path stays quiet and tears down cleanly. Full `make quality` green (19,791 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)