### PR TITLE
fix(convergence): 2b/2c/2d deferred minors — DRY triage helper, conditional quality_fix write, oscillation-interval + stage guards (#9685)

### DIFF
--- a/docker-compose.sandbox.yml
+++ b/docker-compose.sandbox.yml
@@ -36,15 +36,15 @@ services:
       # disable it explicitly here.  Sandbox scenarios assert lifecycle
       # outcomes, never summarizer comment text.
       HYDRAFLOW_TRANSCRIPT_SUMMARIZATION_ENABLED: "false"
-      # ConvergenceOscillationLoop interval (s51). Intent: tick every 5 s for
-      # fast sandbox validation. NOTE: the pydantic field enforces ge=300 (5 min
-      # minimum); _apply_env_overrides raises ValueError (suppressed) so the
-      # config field stays at its default 3600. This is harmless in sandbox
-      # because WorkerRegistryCallbacks(get_interval=lambda *_: 60) overrides
-      # every caretaker loop's interval to 60 s via LoopDeps.interval_cb,
-      # which takes precedence over _get_default_interval(). Effective interval
-      # is 60 s regardless of this env var.
-      HYDRAFLOW_CONVERGENCE_OSCILLATION_INTERVAL: "5"
+      # ConvergenceOscillationLoop interval (s51). Deliberately NOT set here:
+      # the pydantic field enforces ge=300 (5 min minimum), so a fast-tick
+      # value like "5" fails validation and is silently ignored by
+      # _apply_env_overrides (ValueError suppressed), leaving the config
+      # field at its default 3600 — a misleading no-op. Sandbox already gets
+      # a fast tick regardless: WorkerRegistryCallbacks(get_interval=lambda
+      # *_: 60) overrides every caretaker loop's interval to 60 s via
+      # LoopDeps.interval_cb, which takes precedence over
+      # _get_default_interval(). Effective interval is 60 s.
       HYDRAFLOW_CONVERGENCE_OSCILLATION_LOOP_ENABLED: "true"
       # HumanSteeringLoop (ADR-0099 #4, s52). human_steering_enabled is
       # already default-on (src/config.py) but is set explicitly here for

--- a/src/convergence_oscillation_loop.py
+++ b/src/convergence_oscillation_loop.py
@@ -27,6 +27,7 @@ from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import HydraFlowConfig
 from exception_classify import reraise_on_credit_or_bug
 from loop_fitness import Confidence, FitnessContext, FitnessKind, LoopFitness
+from models import CONVERGENCE_BOUNDARY_STAGES
 
 if TYPE_CHECKING:
     from ports import PRPort
@@ -100,8 +101,13 @@ class ConvergenceOscillationLoop(BaseBackgroundLoop):
             # stage record. Skip ledgers that lack any such stage — this guards
             # against non-issue ledgers (e.g. sandbox_fix rows from
             # state/_sandbox_failure_fixer.py) even if the number-namespace
-            # invariant were ever to break.
-            if not (set(ledger.stage_state) & {"triage", "shape", "plan", "review"}):
+            # invariant were ever to break. Built from CONVERGENCE_BOUNDARY_STAGES
+            # (the same ubiquitous-language stage names the detector below and
+            # the escalation-issue-body lookup use) plus "review" (not itself a
+            # cross-boundary stage, but its own stage record also marks a real
+            # issue ledger).
+            relevant_stages = set(CONVERGENCE_BOUNDARY_STAGES) | {"review"}
+            if not (set(ledger.stage_state) & relevant_stages):
                 continue
 
             scanned += 1
@@ -126,11 +132,14 @@ class ConvergenceOscillationLoop(BaseBackgroundLoop):
 
             if fires:
                 # Identify which boundary stages are currently LOOP_BACK so the
-                # body gives operators a quick read on where the churn is.
-                boundary_stages = {"triage", "shape", "plan"}
+                # body gives operators a quick read on where the churn is. Reads
+                # the SAME CONVERGENCE_BOUNDARY_STAGES constant that
+                # detect_cross_boundary_oscillation() uses above — a future
+                # stage rename updates both call-sites at once instead of
+                # silently leaving this issue-body text stale (#9685).
                 loopback_stages = [
                     stage
-                    for stage in sorted(boundary_stages)
+                    for stage in sorted(CONVERGENCE_BOUNDARY_STAGES)
                     if ledger.stage_state.get(stage) is not None
                     and ledger.stage_state[stage].last_verdict == "LOOP_BACK"
                 ]

--- a/src/implement_phase.py
+++ b/src/implement_phase.py
@@ -613,7 +613,14 @@ class ImplementPhase:
                 f"Error: {result.error or 'none'}",
                 stage=PipelineStage.IMPLEMENT,
             )
-        self._state.set_quality_fix_attempts(issue.id, result.quality_fix_attempts)
+        # Only write a quality_fix stage record when a fix round actually
+        # happened. Writing unconditionally (including count == 0) created an
+        # empty stage_state["quality_fix"] entry for every issue; retrospective
+        # reads via ConvergenceLedger.get_attempts() already default to 0 for
+        # a missing stage, so skipping the zero-count write is a no-op for
+        # readers.
+        if result.quality_fix_attempts > 0:
+            self._state.set_quality_fix_attempts(issue.id, result.quality_fix_attempts)
         meta: WorkerResultMeta = {
             "pre_quality_review_attempts": result.pre_quality_review_attempts,
             "duration_seconds": result.duration_seconds,

--- a/src/models.py
+++ b/src/models.py
@@ -1864,6 +1864,20 @@ class PolicyEvent(BaseModel):
     counters: dict[str, int] = Field(default_factory=dict)
 
 
+# Ubiquitous-language boundary-stage names (ADR-0096 boundary verdict
+# recording). These MUST match the ``stage=`` literals passed to
+# ``record_stage_verdict``/``convergence_recording.record_stage_verdict`` at
+# each phase's boundary call-site: src/triage_phase.py (stage="triage"),
+# src/shape_phase.py (stage="shape"), src/plan_phase.py (stage="plan"). Both
+# ``ConvergenceLedger.detect_cross_boundary_oscillation`` below and
+# ``ConvergenceOscillationLoop``'s escalation-issue-body stage lookup
+# (src/convergence_oscillation_loop.py) read this single constant so a future
+# stage rename can't leave one of the two call-sites silently stale — a
+# literal-string drift there would still parse and run, just silently stop
+# matching either the detector or the issue body.
+CONVERGENCE_BOUNDARY_STAGES: tuple[str, ...] = ("triage", "shape", "plan")
+
+
 class ConvergenceLedger(BaseModel):
     """Single source of truth for one issue's two-level convergence state.
 
@@ -1962,7 +1976,7 @@ class ConvergenceLedger(BaseModel):
             identical findings across review laps.  Evaluated only when
             *include_temporal* is True.
         (b) Snapshot: at least ``min_loopback_stages`` DISTINCT stages among
-            ``{"triage", "shape", "plan"}`` currently have
+            ``CONVERGENCE_BOUNDARY_STAGES`` currently have
             ``last_verdict == "LOOP_BACK"`` — pre-review cross-boundary churn.
 
         Pass ``include_temporal=False`` to suppress the temporal arm and check
@@ -1973,10 +1987,9 @@ class ConvergenceLedger(BaseModel):
         """
         if include_temporal and self.detect_outer_oscillation(window):
             return True
-        boundary_stages = {"triage", "shape", "plan"}
         loopback_count = sum(
             1
-            for stage in boundary_stages
+            for stage in CONVERGENCE_BOUNDARY_STAGES
             if self.stage_state.get(stage, StageRecord()).last_verdict == "LOOP_BACK"
         )
         return loopback_count >= min_loopback_stages

--- a/src/triage_phase.py
+++ b/src/triage_phase.py
@@ -107,6 +107,25 @@ class TriagePhase:
         self._issue_cache = issue_cache
         self._bug_reproducer = bug_reproducer
 
+    def _record_triage_verdict(self, issue_id: int, routing_outcome: str) -> None:
+        """Record the ConvergenceLedger boundary verdict for a routing outcome.
+
+        Looks up ``routing_outcome`` in ``_TRIAGE_VERDICT_MAP`` and records the
+        verdict via :func:`record_stage_verdict` when a mapping exists.
+        Outcomes with no mapping (e.g. ``"unknown"``) are silently skipped —
+        matching the previous inline behavior at both call-sites.
+        """
+        verdict = _TRIAGE_VERDICT_MAP.get(routing_outcome)
+        if verdict is None:
+            return
+        record_stage_verdict(
+            self._state,
+            issue_number=issue_id,
+            stage="triage",
+            decision=verdict,
+            signatures=[],
+        )
+
     def _enrich_parent_epic(self, issue: Task) -> None:
         """Set the parent_epic field if this issue belongs to a tracked epic."""
         if self._epic_manager is None:
@@ -482,15 +501,7 @@ class TriagePhase:
                         issue.id,
                         evidence,
                     )
-                    _verdict = _TRIAGE_VERDICT_MAP.get(routing_outcome)
-                    if _verdict is not None:
-                        record_stage_verdict(
-                            self._state,
-                            issue_number=issue.id,
-                            stage="triage",
-                            decision=_verdict,
-                            signatures=[],
-                        )
+                    self._record_triage_verdict(issue.id, routing_outcome)
                     return 1
                 if str(repro.outcome) == "unable":
                     logger.warning(
@@ -518,15 +529,7 @@ class TriagePhase:
             await self._transitioner.transition(issue.id, "plan")
             self._state.increment_session_counter("triaged")
 
-        _verdict = _TRIAGE_VERDICT_MAP.get(routing_outcome)
-        if _verdict is not None:
-            record_stage_verdict(
-                self._state,
-                issue_number=issue.id,
-                stage="triage",
-                decision=_verdict,
-                signatures=[],
-            )
+        self._record_triage_verdict(issue.id, routing_outcome)
 
         return 1
 

--- a/tests/sandbox_scenarios/scenarios/s51_convergence_oscillation.py
+++ b/tests/sandbox_scenarios/scenarios/s51_convergence_oscillation.py
@@ -69,17 +69,19 @@ PIPELINE ROUTE THAT PRODUCES BOTH LOOP_BACKs SIMULTANEOUSLY
 ----------------------------------------------------------------------
 OSCILLATION LOOP INTERVAL IN SANDBOX
 ----------------------------------------------------------------------
-``HYDRAFLOW_CONVERGENCE_OSCILLATION_INTERVAL: "5"`` is set in
-docker-compose.sandbox.yml as a signal of intent (short interval for testing).
-However, the pydantic field enforces ``ge=300`` (5 minutes minimum); the
-``_apply_env_overrides`` function raises ``ValueError`` which is suppressed by
-``contextlib.suppress(ValueError)`` — the config field remains at its default of
-3600.  This is harmless: the sandbox bootstraps all caretaker loops with
-``WorkerRegistryCallbacks(get_interval=lambda *_a, **_kw: 60)``, which wires as
-``LoopDeps.interval_cb`` and takes precedence over ``_get_default_interval()`` in
-``BaseBackgroundLoop._get_interval()``.  The effective interval is therefore
-60 seconds in every sandbox run, independent of the config field.  The assertion
-timeout (120 s) comfortably accommodates one full tick margin.
+docker-compose.sandbox.yml deliberately does NOT set
+``HYDRAFLOW_CONVERGENCE_OSCILLATION_INTERVAL``. A short value like ``"5"``
+would fail the pydantic field's ``ge=300`` (5 minutes minimum) validation;
+``_apply_env_overrides`` raises ``ValueError`` which is suppressed by
+``contextlib.suppress(ValueError)``, so the config field silently stays at its
+default of 3600 — a misleading no-op that looked like a fast-tick override but
+wasn't (#9685). It isn't needed: the sandbox bootstraps all caretaker loops
+with ``WorkerRegistryCallbacks(get_interval=lambda *_a, **_kw: 60)``, which
+wires as ``LoopDeps.interval_cb`` and takes precedence over
+``_get_default_interval()`` in ``BaseBackgroundLoop._get_interval()``.  The
+effective interval is therefore 60 seconds in every sandbox run, independent
+of the config field.  The assertion timeout (120 s) comfortably accommodates
+one full tick margin.
 """
 
 from __future__ import annotations

--- a/tests/scenarios/test_convergence_counter_migration_mockworld.py
+++ b/tests/scenarios/test_convergence_counter_migration_mockworld.py
@@ -14,6 +14,11 @@ Rationale: Tasks 1-3 (committed on phase2c) migrated the per-issue counters
 for auto_agent, sandbox_fix, and quality_fix stages out of bespoke StateData
 dicts into the shared ConvergenceLedger. This test is the integration proof
 that the live loop code (not just the mixin unit tests) uses the new path.
+
+TestAutoAgentAttemptsLandInLedger below (#9685, deferred from the 2c
+convergence review) closes the coverage gap for the third migrated counter:
+``auto_agent``, bumped by AutoAgentPreflightLoop._process_one() via
+``state.bump_auto_agent_attempts()`` at auto_agent_preflight_loop.py.
 """
 
 from __future__ import annotations
@@ -23,6 +28,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from auto_agent_preflight_loop import AutoAgentPreflightLoop
+from preflight.agent import PreflightSpawn
 from sandbox_failure_fixer_loop import SandboxFailureFixerLoop
 from state import StateTracker
 from tests.helpers import make_bg_loop_deps
@@ -30,6 +37,7 @@ from tests.helpers import make_bg_loop_deps
 pytestmark = pytest.mark.scenario
 
 PR_NUMBER = 42
+AUTO_AGENT_ISSUE_NUMBER = 7
 
 
 def _make_loop_with_real_tracker(
@@ -119,4 +127,111 @@ class TestSandboxFixCounterLandsInLedger:
         assert ledger.stage_state["sandbox_fix"].attempts >= 1, (
             f"expected sandbox_fix.attempts >= 1, got "
             f"{ledger.stage_state.get('sandbox_fix')}"
+        )
+
+
+def _make_auto_agent_loop_with_real_tracker(tmp_path, *, prs, audit):
+    """Build an AutoAgentPreflightLoop wired to a real StateTracker.
+
+    Mirrors ``_make_loop`` from tests/scenarios/test_auto_agent_preflight.py
+    but substitutes the MagicMock state with a real StateTracker backed by a
+    temp-dir state.json, so ``bump_auto_agent_attempts`` writes through the
+    production accessor into a real ConvergenceLedger instead of a mock call
+    record.
+    """
+    tracker = StateTracker(state_file=tmp_path / "state.json")
+    deps = make_bg_loop_deps(tmp_path, enabled=True)
+    loop = AutoAgentPreflightLoop(
+        config=deps.config,
+        state=tracker,
+        pr_manager=prs,
+        wiki_store=None,
+        audit_store=audit,
+        deps=deps.loop_deps,
+    )
+    return loop, tracker
+
+
+def _stub_spawn(loop, output: str, *, cost: float = 1.0, crashed: bool = False):
+    async def _spawn(prompt: str, worktree_path: str) -> PreflightSpawn:
+        return PreflightSpawn(
+            process=None,
+            output_text=output,
+            cost_usd=cost,
+            tokens=100,
+            crashed=crashed,
+        )
+
+    loop._build_spawn_fn = lambda issue: _spawn
+
+
+class TestAutoAgentAttemptsLandInLedger:
+    """Full _do_work() drive: bump reaches the real ledger via real loop code.
+
+    Closes the #9685 (2c) gap in the Phase 2c counter-migration coverage —
+    this file previously proved ``sandbox_fix`` lands in the ledger via a
+    real StateTracker, but the third migrated counter (``auto_agent``,
+    bumped by AutoAgentPreflightLoop._process_one() before it spawns the
+    preflight agent) had no equivalent MockWorld-style integration scenario.
+    """
+
+    @pytest.mark.asyncio
+    async def test_do_work_increments_auto_agent_stage_in_ledger(
+        self, tmp_path
+    ) -> None:
+        """After one _do_work() cycle the ledger records auto_agent.attempts >= 1.
+
+        Non-vacuity probe: the 'ledger is not None' assert carries a message
+        that names the exact wiring regression so a future failure is
+        immediately actionable.
+        """
+        pr_port = AsyncMock()
+        pr_port.list_closed_issues_by_label = AsyncMock(return_value=[])
+        pr_port.list_issues_by_label = AsyncMock(
+            return_value=[
+                {
+                    "number": AUTO_AGENT_ISSUE_NUMBER,
+                    "body": "x",
+                    "labels": [
+                        {"name": "hitl-escalation"},
+                        {"name": "flaky-test-stuck"},
+                    ],
+                },
+            ]
+        )
+        audit = MagicMock()
+        audit.append = MagicMock()
+        audit.entries_for_issue = MagicMock(return_value=[])
+
+        loop, tracker = _make_auto_agent_loop_with_real_tracker(
+            tmp_path, prs=pr_port, audit=audit
+        )
+        _stub_spawn(
+            loop,
+            "<status>resolved</status><pr_url>https://x/pr/1</pr_url>"
+            "<diagnosis>fixed</diagnosis>",
+        )
+
+        result = await loop._do_work()
+
+        assert result is not None
+        assert result.get("status") == "ok", (
+            f"_do_work returned unexpected status: {result}"
+        )
+        assert result.get("result_status") == "resolved", (
+            f"_do_work returned unexpected result_status: {result}"
+        )
+
+        # --- non-vacuity probe ---
+        ledger = tracker.get_convergence_ledger(AUTO_AGENT_ISSUE_NUMBER)
+        assert ledger is not None, (
+            "no ledger after _do_work — "
+            "bump_auto_agent_attempts did not reach the ledger "
+            "(Phase 2c counter migration wiring regression)"
+        )
+
+        # --- integration assertion: counter flowed through real code ---
+        assert ledger.stage_state["auto_agent"].attempts >= 1, (
+            f"expected auto_agent.attempts >= 1, got "
+            f"{ledger.stage_state.get('auto_agent')}"
         )

--- a/tests/test_convergence_ledger.py
+++ b/tests/test_convergence_ledger.py
@@ -187,6 +187,36 @@ class TestDetectCrossBoundaryOscillation:
         ledger = ConvergenceLedger(issue_number=7)
         assert ledger.oscillation_escalated is False
 
+    def test_legacy_ledger_dict_missing_oscillation_escalated_loads_false(
+        self,
+    ) -> None:
+        """A pre-#9693 persisted ledger dict has no ``oscillation_escalated`` key.
+
+        Regression for #9685 (2d): ``oscillation_escalated`` was added to the
+        ConvergenceLedger model after the field already had live on-disk
+        state.json ledgers. Deserializing one of those legacy dicts (as
+        StateTracker.load() does on every boot) must not raise and must
+        default the field to False rather than requiring the key to be
+        present.
+        """
+        legacy_data = {
+            "issue_number": 7,
+            "laps": 2,
+            "blast_radius": "medium",
+            "stage_state": {
+                "triage": {"last_verdict": "LOOP_BACK", "attempts": 1},
+            },
+            # No "oscillation_escalated" key — simulates a ledger persisted
+            # before the field existed.
+        }
+        assert "oscillation_escalated" not in legacy_data
+        ledger = ConvergenceLedger.model_validate(legacy_data)
+        assert ledger.oscillation_escalated is False
+        # Sanity: the rest of the legacy data still loaded correctly.
+        assert ledger.issue_number == 7
+        assert ledger.laps == 2
+        assert ledger.stage_state["triage"].last_verdict == "LOOP_BACK"
+
     def test_oscillation_escalated_round_trips(self) -> None:
         ledger = ConvergenceLedger(issue_number=7)
         ledger.oscillation_escalated = True

--- a/tests/test_implement_phase.py
+++ b/tests/test_implement_phase.py
@@ -1103,6 +1103,51 @@ class TestWorkerResultMetaPersistence:
         assert led.stage_state["quality_fix"].attempts == 2
 
     @pytest.mark.asyncio
+    async def test_zero_quality_fix_attempts_writes_no_stage_record(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """count == 0 must not create an empty quality_fix stage record.
+
+        Regression for #9685 (2c): implement_phase previously called
+        ``set_quality_fix_attempts`` unconditionally, writing an empty
+        ``stage_state["quality_fix"]`` entry for every issue even when no
+        fix round happened. The retrospective reader
+        (``ConvergenceLedger.get_attempts``) already defaults to 0 for a
+        missing stage, so the write is conditionalized to count > 0 and the
+        retrospective-read behavior (0) is unchanged either way.
+        """
+        issue = TaskFactory.create(id=42)
+
+        async def agent_no_qf(
+            issue: Task,
+            wt_path: Path,
+            branch: str,
+            worker_id: int = 0,
+            review_feedback: str = "",
+            prior_failure: str = "",
+        ) -> WorkerResult:
+            return WorkerResultFactory.create(
+                issue_number=issue.id,
+                branch=branch,
+                success=True,
+                workspace_path=str(wt_path),
+                quality_fix_attempts=0,
+            )
+
+        phase, _, _ = make_implement_phase(config, [issue], agent_run=agent_no_qf)
+        await phase.run_batch()
+
+        led = phase._state.get_convergence_ledger(42)
+        # No fix round happened and nothing else in this flow touches the
+        # ledger, so no ConvergenceLedger is created for the issue at all.
+        assert led is None or "quality_fix" not in led.stage_state
+        # Retrospective read behavior is unchanged either way: retrospective.py
+        # reads `led.get_attempts("quality_fix") if led else 0`, which is 0
+        # whether the ledger is absent or present without the stage.
+        quality_fix_rounds = led.get_attempts("quality_fix") if led else 0
+        assert quality_fix_rounds == 0
+
+    @pytest.mark.asyncio
     async def test_worker_result_meta_no_longer_has_quality_fix_attempts(
         self, config: HydraFlowConfig
     ) -> None:


### PR DESCRIPTION
Closes #9685.

Non-blocking Minors deferred from the two-level convergence reviews (2b/2c/2d). Each item verified against staging first — the #9678-already-shipped ones (bug_not_present / discover / sentry_noise_closed ledger tests) were skipped.

**2b:** extracted the two duplicated Triage recording call-sites into `TriagePhase._record_triage_verdict()`.
**2c:** `implement_phase` no longer writes an empty `quality_fix` stage record when count==0 (guarded `if quality_fix_attempts > 0`; retrospective reads still default to 0). Added the missing auto_agent-migration MockWorld scenario.
**2d:** dropped the silently-ignored `HYDRAFLOW_CONVERGENCE_OSCILLATION_INTERVAL: "5"` (below config ge=300) from docker-compose.sandbox.yml; added `CONVERGENCE_BOUNDARY_STAGES=(triage,shape,plan)` constant so the escalation stage lookup can't silently drift on a rename; added a legacy-ledger deserialization test (missing `oscillation_escalated` → defaults False).

Convergence gate flag untouched (rollout out of scope). Full `tests/regressions` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)