### PR TITLE
fix(wiki-rot): consume structured WikiEntry/WikiIndex instead of raw-markdown regex (#9936)

### DIFF
--- a/src/repo_wiki.py
+++ b/src/repo_wiki.py
@@ -652,6 +652,25 @@ class WikiEntry(BaseModel):
             "the ingest-path dedup/corroboration logic in wiki_compiler."
         ),
     )
+    fixed_in_pr: str | None = Field(
+        default=None,
+        description=(
+            "PR reference (e.g. '#8713') asserting this entry's underlying "
+            "fix has shipped. Hand-authored gotcha/manual entries carry "
+            "this alongside code_refs; WikiRotDetectorLoop's shipped-claim "
+            "pass (issue #9598) verifies the claim against them. Previously "
+            "dropped as an unmodeled extra field on parse (issue #9936)."
+        ),
+    )
+    code_refs: tuple[str, ...] = Field(
+        default=(),
+        description=(
+            "path.py:symbol (or bare-file) references corroborating "
+            "fixed_in_pr — resolved against checked-out source by the "
+            "shipped-claim verifier. Previously dropped as an unmodeled "
+            "extra field on parse (issue #9936)."
+        ),
+    )
 
     @model_validator(mode="after")
     def _default_valid_from(self) -> WikiEntry:
@@ -701,6 +720,80 @@ def annotate_entries_with_temporal_tags(
             base = f"{base} (+{entry.corroborations})"
         annotated.append((entry, base))
     return annotated
+
+
+def parse_topic_page(topic_path: Path) -> list[WikiEntry]:
+    """Parse a topic markdown file into its ``WikiEntry`` objects.
+
+    Schema-slim layout: each entry is rendered as a `## Title`
+    section followed by prose, an optional `_Source: #N (kind)_`
+    footer, and a `json:entry` code block carrying metadata WITHOUT
+    the `content` field. The reader reconstructs ``WikiEntry.content``
+    from the prose section above the metadata block.
+
+    Legacy entries that still embed ``content`` in the JSON continue
+    to load — the prose section overrides if present, otherwise the
+    JSON-embedded copy is used.
+
+    Parsing strategy: split the file at line-start ``## `` boundaries
+    into entry sections, then within each section locate the LAST
+    ``json:entry`` code block as the metadata block. This is robust
+    against (a) prose containing embedded ```` ```json:entry ```` fences
+    (e.g., wiki entries about the wiki schema itself), and (b) free-form
+    ``## Heading`` sections without a metadata block (silently skipped
+    rather than eating the next entry).
+
+    Module-level (not a ``RepoWikiStore`` method) so callers that only
+    need the authoritative, read-only parse — e.g. ``WikiRotDetectorLoop``
+    (issue #9936) — can share it without a live store instance. Returns
+    ``[]``, never raises, for files that aren't in this shape (no ``## ``
+    sections, or none carrying a ``json:entry`` block) — callers treat
+    an empty result as "not a topic page" and fall back accordingly.
+    """
+    if not topic_path.exists():
+        return []
+
+    text = topic_path.read_text()
+    # Split at line-start "## " — first chunk is the file preamble.
+    sections = re.split(r"(?:^|\n)## ", text)
+    entries: list[WikiEntry] = []
+
+    for section in sections[1:]:
+        title, _, body = section.partition("\n")
+        title = title.strip()
+        if not title:
+            continue
+        meta_matches = list(
+            re.finditer(r"```json:entry\n(.+?)\n```", body, re.DOTALL),
+        )
+        if not meta_matches:
+            continue  # free-form section without metadata — skip silently
+        meta_match = meta_matches[-1]  # always the LAST block
+        try:
+            metadata = json.loads(meta_match.group(1))
+            prose = _strip_prose_chrome(body[: meta_match.start()])
+            if prose:
+                metadata["content"] = prose
+            elif "content" not in metadata:
+                metadata["content"] = ""
+            if not metadata.get("title"):
+                metadata["title"] = title
+            entries.append(WikiEntry.model_validate(metadata))
+        except Exception as exc:  # noqa: BLE001
+            # Surface the offending entry id and the validation reason so
+            # drift is diagnosable from the log alone (the bare path is not).
+            try:
+                entry_id = str(json.loads(meta_match.group(1)).get("id", ""))
+            except Exception:  # noqa: BLE001
+                entry_id = "<invalid-json>"
+            logger.warning(
+                "Skipping malformed entry %s in %s: %s",
+                entry_id or "<no-id>",
+                topic_path,
+                exc,
+            )
+
+    return entries
 
 
 class WikiIndex(BaseModel):
@@ -1546,68 +1639,12 @@ class RepoWikiStore:
     def _load_topic_entries(self, topic_path: Path) -> list[WikiEntry]:
         """Parse a topic markdown file back into entries.
 
-        Schema-slim layout: each entry is rendered as a `## Title`
-        section followed by prose, an optional `_Source: #N (kind)_`
-        footer, and a `json:entry` code block carrying metadata WITHOUT
-        the `content` field. The reader reconstructs ``WikiEntry.content``
-        from the prose section above the metadata block.
-
-        Legacy entries that still embed ``content`` in the JSON continue
-        to load — the prose section overrides if present, otherwise the
-        JSON-embedded copy is used.
-
-        Parsing strategy: split the file at line-start ``## `` boundaries
-        into entry sections, then within each section locate the LAST
-        ``json:entry`` code block as the metadata block. This is robust
-        against (a) prose containing embedded ```` ```json:entry ```` fences
-        (e.g., wiki entries about the wiki schema itself), and (b) free-form
-        ``## Heading`` sections without a metadata block (silently skipped
-        rather than eating the next entry).
+        Thin delegator to the module-level :func:`parse_topic_page` — that
+        function is the single source of truth so other callers (e.g.
+        ``WikiRotDetectorLoop``, issue #9936) can share the identical parse
+        without needing a live ``RepoWikiStore`` instance.
         """
-        if not topic_path.exists():
-            return []
-
-        text = topic_path.read_text()
-        # Split at line-start "## " — first chunk is the file preamble.
-        sections = re.split(r"(?:^|\n)## ", text)
-        entries: list[WikiEntry] = []
-
-        for section in sections[1:]:
-            title, _, body = section.partition("\n")
-            title = title.strip()
-            if not title:
-                continue
-            meta_matches = list(
-                re.finditer(r"```json:entry\n(.+?)\n```", body, re.DOTALL),
-            )
-            if not meta_matches:
-                continue  # free-form section without metadata — skip silently
-            meta_match = meta_matches[-1]  # always the LAST block
-            try:
-                metadata = json.loads(meta_match.group(1))
-                prose = _strip_prose_chrome(body[: meta_match.start()])
-                if prose:
-                    metadata["content"] = prose
-                elif "content" not in metadata:
-                    metadata["content"] = ""
-                if not metadata.get("title"):
-                    metadata["title"] = title
-                entries.append(WikiEntry.model_validate(metadata))
-            except Exception as exc:  # noqa: BLE001
-                # Surface the offending entry id and the validation reason so
-                # drift is diagnosable from the log alone (the bare path is not).
-                try:
-                    entry_id = str(json.loads(meta_match.group(1)).get("id", ""))
-                except Exception:  # noqa: BLE001
-                    entry_id = "<invalid-json>"
-                logger.warning(
-                    "Skipping malformed entry %s in %s: %s",
-                    entry_id or "<no-id>",
-                    topic_path,
-                    exc,
-                )
-
-        return entries
+        return parse_topic_page(topic_path)
 
     def _write_topic_page(
         self,

--- a/src/wiki_rot_detector_loop.py
+++ b/src/wiki_rot_detector_loop.py
@@ -11,16 +11,31 @@ fences — hints only), and verifies each hard cite against:
   AST verification across every managed repo is out of scope for v1
   and noted below as a follow-up.
 
+Wiki entries are read via the same authoritative parse ``RepoWikiStore``
+uses for itself (:func:`repo_wiki.parse_topic_page`, issue #9936): each
+``.md`` file under the wiki root is parsed into its per-entry ``WikiEntry``
+objects — one row per ``## Title`` section, carrying that entry's own
+``content``, ``source_type``, and ``source_issue`` — instead of a single
+regex pass over the whole file mislabeled under the file's ``# Heading``.
+A file that yields no structured entries (glossary/feedback mirrors that
+aren't in the topic-page shape, or hand-edited pages missing a
+``json:entry`` block) falls back to the legacy whole-file regex parse so
+non-``WikiEntry`` markdown keeps working unchanged.
+
 A second **shipped-claim pass** (issue #9598) verifies structured
-``fixed_in_pr`` assertions in ``json:entry`` blocks: a claim that a fix
-shipped in ``#NNNN`` is corroborated iff at least one of its ``code_refs``
-resolves against the checked-out source. An uncorroborated claim is the
-#9455-shape drift ("shipped" asserted, no surviving code) and files an
-entry-level finding naming the PR; its dead refs are suppressed from the
-per-cite pass so each stale claim yields one finding, not N. Verifying the
-cited PR actually *merged* (network ``get_pr_merge_state``) is the split-out
-follow-up #9664; auto-memory notes outside the repo are out of CI scope
-(#9935). Self-repo only — corroboration needs AST over real source.
+``fixed_in_pr`` assertions: for structured entries this reads
+``WikiEntry.fixed_in_pr`` / ``WikiEntry.code_refs`` directly (issue #9936
+added these as modeled fields — previously silently dropped as unmodeled
+extras on parse); the raw-fallback path still regexes embedded
+``json:entry`` blocks via :func:`wiki_rot_citations.extract_shipped_claims`.
+A claim that a fix shipped in ``#NNNN`` is corroborated iff at least one of
+its ``code_refs`` resolves against the checked-out source. An uncorroborated
+claim is the #9455-shape drift ("shipped" asserted, no surviving code) and
+files an entry-level finding naming the PR; its dead refs are suppressed
+from the per-cite pass so each stale claim yields one finding, not N.
+Verifying the cited PR actually *merged* (network ``get_pr_merge_state``) is
+the split-out follow-up #9664; auto-memory notes outside the repo are out of
+CI scope (#9935). Self-repo only — corroboration needs AST over real source.
 
 For each broken cite the loop files a ``hydraflow-find`` + ``wiki-rot``
 issue through :class:`PRManager` with a fuzzy-match suggestion (via
@@ -36,6 +51,7 @@ Kill-switch: :meth:`LoopDeps.enabled_cb` with ``worker_name="wiki_rot_detector"`
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 
@@ -43,6 +59,7 @@ from base_background_loop import BaseBackgroundLoop, LoopDeps
 from escalation_reconcile import EscalationReconciler
 from exception_classify import reraise_on_credit_or_bug
 from models import WorkCycleResult
+from repo_wiki import parse_topic_page
 from wiki_rot_citations import (
     Cite,
     ShippedClaim,
@@ -70,6 +87,25 @@ class _TickResult(TypedDict):
     filed: int
     escalated: int
     broken_subjects: set[str]
+
+
+@dataclass(frozen=True)
+class _WikiScanEntry:
+    """One cite-checkable unit produced by :meth:`_load_wiki_entries`.
+
+    Either an authoritative per-entry ``WikiEntry`` parse (``source_type``
+    is not ``None``) or a raw-file fallback row for markdown that isn't in
+    the ``WikiEntry`` topic-page shape (``source_type`` is ``None``) —
+    callers key behavior off that distinction (issue #9936).
+    """
+
+    title: str
+    body: str
+    path: Path
+    source_type: str | None
+    source_issue: int | None
+    fixed_in_pr: str | None
+    code_refs: tuple[str, ...]
 
 
 _MAX_ATTEMPTS = 3
@@ -246,7 +282,10 @@ class WikiRotDetectorLoop(BaseBackgroundLoop):
         repo_root = Path(self._config.repo_root)
         dedup_seen = self._dedup.get()
 
-        for title, body, entry_path in entries:
+        for scan_entry in entries:
+            title = scan_entry.title
+            body = scan_entry.body
+            entry_path = scan_entry.path
             cites = extract_cites(body)
             hints = extract_fenced_hints(body)
 
@@ -259,7 +298,7 @@ class WikiRotDetectorLoop(BaseBackgroundLoop):
             uncorroborated: list[ShippedClaim] = []
             suppressed_refs: set[str] = set()
             if is_self:
-                for claim in extract_shipped_claims(body):
+                for claim in self._shipped_claims_for(scan_entry, body):
                     if self._shipped_claim_corroborated(claim, repo_root):
                         continue
                     uncorroborated.append(claim)
@@ -288,6 +327,8 @@ class WikiRotDetectorLoop(BaseBackgroundLoop):
                     cite=cite,
                     suggestion=suggestion,
                     hints=hints,
+                    source_type=scan_entry.source_type,
+                    source_issue=scan_entry.source_issue,
                 )
                 dedup_seen.add(dedup_key)
 
@@ -316,6 +357,8 @@ class WikiRotDetectorLoop(BaseBackgroundLoop):
                     entry_path=str(entry_path),
                     body=body,
                     claim=claim,
+                    source_type=scan_entry.source_type,
+                    source_issue=scan_entry.source_issue,
                 )
                 dedup_seen.add(dedup_key)
 
@@ -340,11 +383,25 @@ class WikiRotDetectorLoop(BaseBackgroundLoop):
     def _load_wiki_entries(
         self,
         slug: str,
-    ) -> list[tuple[str, str, Path]]:
-        """Return ``[(title, body, path), ...]`` for every markdown entry
-        in the repo's wiki — supports both the legacy topic-file layout
-        and the Phase 3 per-entry layout.  Title defaults to the file
-        stem when no ``# Heading`` is present.
+    ) -> list[_WikiScanEntry]:
+        """Return one row per cite-checkable unit in the repo's wiki —
+        supports both the legacy topic-file layout and the Phase 3
+        per-entry layout.
+
+        Topic pages are parsed via :func:`repo_wiki.parse_topic_page` —
+        the same authoritative parse ``RepoWikiStore`` uses on itself
+        (issue #9936) — yielding one row per ``## Title`` entry with its
+        own ``content``/``source_type``/``source_issue``/``fixed_in_pr``/
+        ``code_refs``, instead of one row per FILE keyed under the file's
+        ``# Heading`` (which misattributed every finding in a topic page to
+        the same title and let cross-entry fenced-code hints leak into
+        unrelated findings).
+
+        Any ``.md`` file that doesn't parse into at least one structured
+        entry — glossary/feedback mirrors nested under the wiki root, or
+        hand-edited pages without a ``json:entry`` block — falls back to
+        the legacy whole-file regex row so that markdown keeps working
+        exactly as before.
         """
         try:
             repo_dir = self._wiki.repo_dir(slug)
@@ -355,17 +412,82 @@ class WikiRotDetectorLoop(BaseBackgroundLoop):
         if not repo_dir.is_dir():
             return []
 
-        out: list[tuple[str, str, Path]] = []
+        out: list[_WikiScanEntry] = []
         for md_path in sorted(repo_dir.rglob("*.md")):
             if md_path.name in {"index.md", "log.md"}:
+                continue
+            structured = self._load_structured_entries(md_path)
+            if structured:
+                out.extend(structured)
                 continue
             try:
                 text = md_path.read_text(encoding="utf-8", errors="replace")
             except OSError:
                 continue
             title = _first_heading(text) or md_path.stem
-            out.append((title, text, md_path))
+            out.append(
+                _WikiScanEntry(
+                    title=title,
+                    body=text,
+                    path=md_path,
+                    source_type=None,
+                    source_issue=None,
+                    fixed_in_pr=None,
+                    code_refs=(),
+                )
+            )
         return out
+
+    def _load_structured_entries(self, md_path: Path) -> list[_WikiScanEntry]:
+        """Parse *md_path* via the authoritative ``WikiEntry`` model.
+
+        Returns ``[]`` (never raises) for files that aren't in the
+        topic-page shape — the caller falls back to raw-file parsing.
+        """
+        try:
+            entries = parse_topic_page(md_path)
+        except Exception as exc:  # noqa: BLE001
+            reraise_on_credit_or_bug(exc)
+            logger.debug("parse_topic_page(%s) failed", md_path, exc_info=True)
+            return []
+        return [
+            _WikiScanEntry(
+                title=entry.title,
+                body=entry.content,
+                path=md_path,
+                source_type=entry.source_type,
+                source_issue=entry.source_issue,
+                fixed_in_pr=entry.fixed_in_pr,
+                code_refs=entry.code_refs,
+            )
+            for entry in entries
+        ]
+
+    def _shipped_claims_for(
+        self,
+        scan_entry: _WikiScanEntry,
+        body: str,
+    ) -> list[ShippedClaim]:
+        """Return shipped-claim candidates for one scanned entry.
+
+        Structured entries (``source_type is not None``) carry
+        ``fixed_in_pr`` / ``code_refs`` as authoritative ``WikiEntry``
+        fields (issue #9936) — no need to re-parse the ``json:entry`` block
+        RepoWikiStore already parsed once. The raw-fallback path (markdown
+        that isn't in the topic-page shape) still regexes *body* for
+        embedded ``json:entry`` blocks, unchanged from before #9936.
+        """
+        if scan_entry.source_type is not None:
+            if not scan_entry.fixed_in_pr:
+                return []
+            return [
+                ShippedClaim(
+                    pr_ref=scan_entry.fixed_in_pr,
+                    code_refs=scan_entry.code_refs,
+                    raw=scan_entry.body,
+                )
+            ]
+        return extract_shipped_claims(body)
 
     def _check_cite(
         self,
@@ -440,6 +562,8 @@ class WikiRotDetectorLoop(BaseBackgroundLoop):
         cite: Cite,
         suggestion: str | None,
         hints: list[Cite],
+        source_type: str | None = None,
+        source_issue: int | None = None,
     ) -> None:
         title = f"Wiki rot: {entry_title} cites missing {cite.raw}"
         excerpt = _excerpt_around(body, cite.raw, _EXCERPT_CHARS)
@@ -450,6 +574,9 @@ class WikiRotDetectorLoop(BaseBackgroundLoop):
             f"- Entry: `{entry_path}` — *{entry_title}*",
             f"- Broken cite: `{cite.raw}` ({cite.style})",
         ]
+        provenance = _entry_provenance(source_type, source_issue)
+        if provenance:
+            lines.append(f"- Entry source: {provenance}")
         if suggestion:
             lines.append(f"- Did you mean: {suggestion}?")
         if hints:
@@ -506,6 +633,8 @@ class WikiRotDetectorLoop(BaseBackgroundLoop):
         entry_path: str,
         body: str,
         claim: ShippedClaim,
+        source_type: str | None = None,
+        source_issue: int | None = None,
     ) -> None:
         """File a finding for an uncorroborated ``fixed_in_pr`` claim.
 
@@ -526,6 +655,11 @@ class WikiRotDetectorLoop(BaseBackgroundLoop):
             f"- Entry: `{entry_path}` — *{entry_title}*",
             f"- Shipped claim: `fixed_in_pr = {claim.pr_ref}`",
             f"- Code references that no longer resolve: {refs}",
+        ]
+        provenance = _entry_provenance(source_type, source_issue)
+        if provenance:
+            lines.append(f"- Entry source: {provenance}")
+        lines += [
             "",
             "This entry claims a fix shipped in "
             f"{claim.pr_ref}, but none of its code references exist at HEAD. "
@@ -643,6 +777,20 @@ def _parse_escalation_subject(title: str, body: str) -> str | None:
     if not slug or not cite:
         return None
     return f"{slug}:{cite}"
+
+
+def _entry_provenance(source_type: str | None, source_issue: int | None) -> str | None:
+    """Render ``#N (source_type)`` for a structured entry, or ``None``.
+
+    ``source_type`` is only populated for entries parsed via the
+    authoritative :func:`repo_wiki.parse_topic_page` (issue #9936) — the
+    raw-fallback row for non-``WikiEntry`` markdown has no provenance to
+    report, so callers must skip the line entirely in that case.
+    """
+    if source_type is None:
+        return None
+    issue_tag = f"#{source_issue}" if source_issue is not None else "no issue"
+    return f"{issue_tag} ({source_type})"
 
 
 def _first_heading(text: str) -> str | None:

--- a/src/wiki_rot_detector_loop.py
+++ b/src/wiki_rot_detector_loop.py
@@ -446,8 +446,7 @@ class WikiRotDetectorLoop(BaseBackgroundLoop):
         """
         try:
             entries = parse_topic_page(md_path)
-        except Exception as exc:  # noqa: BLE001
-            reraise_on_credit_or_bug(exc)
+        except (OSError, ValueError, KeyError, IndexError):
             logger.debug("parse_topic_page(%s) failed", md_path, exc_info=True)
             return []
         return [

--- a/tests/regressions/test_issue_9936_wikirot_structured_entry.py
+++ b/tests/regressions/test_issue_9936_wikirot_structured_entry.py
@@ -1,0 +1,32 @@
+"""Regression pin for #9936.
+
+WikiRotDetectorLoop used to walk ``rglob("*.md")`` and regex each file as one
+raw blob, ignoring the structured ``WikiEntry`` parse — so it misattributed a
+multi-entry topic page's findings to the file heading and couldn't key on
+provenance. The fix has the loop import the module-level ``parse_topic_page``
+so PR-claim and cite verification share the authoritative parse. This pins that
+the module-level function matches the store's own read and carries the
+structured ``source_type`` / ``source_issue`` the loop now keys on.
+"""
+
+from pathlib import Path
+
+from repo_wiki import RepoWikiStore, WikiEntry, parse_topic_page
+
+_REPO = "acme/widget"
+
+
+def test_parse_topic_page_matches_store_read_with_provenance(tmp_path: Path) -> None:
+    store = RepoWikiStore(tmp_path)
+    entry = WikiEntry(title="X", content="Y", source_type="plan", source_issue=1)
+    store.ingest(_REPO, [entry])
+    topic_path = store._repo_dir(_REPO) / f"{store._classify_topic(entry)}.md"
+
+    via_function = parse_topic_page(topic_path)
+    via_store = store._load_topic_entries(topic_path)
+
+    # Same authoritative parse via the module-level function and the store.
+    assert [e.model_dump() for e in via_function] == [e.model_dump() for e in via_store]
+    # Structured provenance survives the round-trip (what the loop keys on).
+    assert via_function[0].source_issue == 1
+    assert via_function[0].source_type == "plan"

--- a/tests/test_repo_wiki.py
+++ b/tests/test_repo_wiki.py
@@ -966,3 +966,83 @@ def test_load_topic_entries_is_public_api(store):
     private_entries = store._load_topic_entries(topic_path)
     assert len(public_entries) == 1
     assert public_entries == private_entries
+
+
+# ---------------------------------------------------------------------------
+# fixed_in_pr / code_refs (issue #9936)
+# ---------------------------------------------------------------------------
+#
+# WikiRotDetectorLoop's shipped-claim pass (#9598) needs a claim's
+# fixed_in_pr + code_refs. Before #9936 these were unmodeled extra fields
+# on WikiEntry — pydantic's default extra="ignore" silently dropped them
+# on every model_validate, so any caller reading the structured model
+# (rather than regexing the raw json:entry block) never saw them.
+
+
+def test_wiki_entry_captures_fixed_in_pr_and_code_refs_from_manual_gotcha_shape():
+    """Hand-authored 'manual' gotcha entries (rule/anti_pattern/code_refs/
+    fixed_in_pr/tags — the real on-disk shape in docs/wiki/gotchas.md)
+    must not lose fixed_in_pr/code_refs on parse."""
+    e = WikiEntry.model_validate(
+        {
+            "id": "swap-pipeline-labels",
+            "source_type": "manual",
+            "topic": "label_state_machine",
+            "tags": ["state-machine"],
+            "rule": "Swap issue/PR with separate calls.",
+            "anti_pattern": "swap_pipeline_labels(...) across the boundary",
+            "code_refs": ["src/pr_unsticker.py:_resolve_or_release_back_to_hitl"],
+            "fixed_in_pr": "#8715",
+            "title": "Swap boundary",
+            "content": "prose",
+        }
+    )
+    assert e.fixed_in_pr == "#8715"
+    assert e.code_refs == ("src/pr_unsticker.py:_resolve_or_release_back_to_hitl",)
+    # Fields with no WikiEntry counterpart are still ignored, unaffected.
+    assert not hasattr(e, "rule")
+
+
+def test_wiki_entry_fixed_in_pr_and_code_refs_default_empty():
+    e = WikiEntry(title="t", content="c", source_type="plan")
+    assert e.fixed_in_pr is None
+    assert e.code_refs == ()
+
+
+def test_entries_round_trip_fixed_in_pr_and_code_refs(store: RepoWikiStore) -> None:
+    original = WikiEntry(
+        title="Shipped claim round trip",
+        content="Some gotcha prose.",
+        source_type="manual",
+        source_issue=42,
+        fixed_in_pr="#9000",
+        code_refs=("src/foo.py:bar", "src/baz.py:qux"),
+    )
+    store.ingest(REPO, [original])
+
+    repo_dir = store._repo_dir(REPO)
+    topic = store._classify_topic(original)
+    topic_path = repo_dir / f"{topic}.md"
+    entries = store._load_topic_entries(topic_path)
+    assert len(entries) == 1
+    assert entries[0].fixed_in_pr == "#9000"
+    assert entries[0].code_refs == ("src/foo.py:bar", "src/baz.py:qux")
+
+
+def test_parse_topic_page_module_level_function_matches_store_method(
+    store: RepoWikiStore,
+) -> None:
+    """WikiRotDetectorLoop (issue #9936) imports ``parse_topic_page``
+    directly so it can share the authoritative parse without needing a
+    live ``RepoWikiStore`` instance — it must match the store's own read."""
+    from repo_wiki import parse_topic_page
+
+    entry = WikiEntry(title="X", content="Y", source_type="plan", source_issue=1)
+    store.ingest(REPO, [entry])
+    repo_dir = store._repo_dir(REPO)
+    topic = store._classify_topic(entry)
+    topic_path = repo_dir / f"{topic}.md"
+
+    via_function = parse_topic_page(topic_path)
+    via_store = store._load_topic_entries(topic_path)
+    assert [e.model_dump() for e in via_function] == [e.model_dump() for e in via_store]

--- a/tests/test_wiki_rot_detector_loop.py
+++ b/tests/test_wiki_rot_detector_loop.py
@@ -257,6 +257,198 @@ async def test_tick_repo_escalates_on_third_attempt(
     assert set(labels_escalate) == {"hitl-escalation", "wiki-rot-stuck"}
 
 
+# ---------------------------------------------------------------------------
+# Structured WikiEntry consumption (issue #9936)
+# ---------------------------------------------------------------------------
+#
+# Before #9936, ``_load_wiki_entries`` walked every ``.md`` file and treated
+# the WHOLE FILE as one blob, titled under the file's ``# Heading``. Two
+# regex-driven false positives fell out of that: (1) every broken cite in a
+# multi-entry topic page was misattributed to the file heading instead of
+# the entry that actually cited it, and (2) fenced-code "hints" from an
+# unrelated entry sharing the file leaked into a finding that had nothing
+# to do with them. Both are fixed by parsing the authoritative per-entry
+# ``WikiEntry`` (``repo_wiki.parse_topic_page``) instead.
+
+
+async def test_tick_repo_structured_entries_attribute_title_correctly(
+    tmp_path: Path, loop_env
+) -> None:
+    """A broken cite in one entry of a multi-entry topic page must be filed
+    under THAT entry's own title, not the topic file's ``# Heading``."""
+    from repo_wiki import RepoWikiStore, WikiEntry
+
+    cfg, state, pr, dedup, wiki_store = loop_env
+    slug = "hydra/hydraflow"
+
+    real_store = RepoWikiStore(tmp_path / "real_wiki", self_slug=slug)
+    real_store.ingest(
+        slug,
+        [
+            WikiEntry(
+                title="Alpha broken cite",
+                content="See src/foo.py:missing_symbol for the guard.",
+                source_type="manual",
+                source_issue=101,
+            ),
+            WikiEntry(
+                title="Beta unrelated hint",
+                content=("```python\ndef totally_unrelated_hint():\n    pass\n```\n"),
+                source_type="manual",
+                source_issue=102,
+            ),
+        ],
+    )
+    wiki_dir = real_store._repo_dir(slug)
+    wiki_store.repo_dir.return_value = wiki_dir
+    wiki_store.list_repos.return_value = [slug]
+
+    (tmp_path / "src").mkdir(exist_ok=True)
+    (tmp_path / "src" / "foo.py").write_text("def other():\n    return 1\n")
+    cfg.repo_root = tmp_path  # type: ignore[misc]
+
+    loop = _loop((cfg, state, pr, dedup, wiki_store))
+    loop._reconcile_closed_escalations = AsyncMock(return_value=None)
+    stats = await loop._do_work()
+
+    assert stats["issues_filed"] == 1, stats
+    title, body, labels = pr.create_issue.await_args.args
+    # Fixed: attributed to the originating entry, not the topic file's H1
+    # ("Patterns" — the old regex-whole-file behavior would have used it
+    # for every finding in the file, regardless of which entry cited it).
+    assert "Alpha broken cite" in title
+    assert "Patterns cites missing" not in title
+    # Fixed: Beta's fenced-code hint must not leak into Alpha's finding —
+    # under the old whole-file parse, extract_fenced_hints ran over BOTH
+    # entries concatenated and would have surfaced this as "context".
+    assert "totally_unrelated_hint" not in body
+    # New: structured provenance is now available and surfaced.
+    assert "#101 (manual)" in body
+    assert set(labels) == {"hydraflow-find", "wiki-rot"}
+
+
+async def test_shipped_claim_fires_via_structured_wiki_entry_fields(
+    tmp_path: Path, loop_env
+) -> None:
+    """Structured entries carry ``fixed_in_pr``/``code_refs`` as authoritative
+    ``WikiEntry`` fields (issue #9936 added them — previously silently
+    dropped as unmodeled pydantic extras). The shipped-claim pass must read
+    them directly rather than re-parsing the ``json:entry`` block
+    RepoWikiStore already parsed once — this must work even though
+    ``entry.content`` (the scanned ``body``) never contains that block."""
+    from repo_wiki import RepoWikiStore, WikiEntry
+
+    cfg, state, pr, dedup, wiki_store = loop_env
+    slug = "hydra/hydraflow"
+
+    real_store = RepoWikiStore(tmp_path / "real_wiki", self_slug=slug)
+    real_store.ingest(
+        slug,
+        [
+            WikiEntry(
+                title="Swap boundary",
+                content="Prose about the swap boundary gotcha.",
+                source_type="manual",
+                source_issue=6295,
+                fixed_in_pr="#8715",
+                code_refs=("src/gone.py:vanished",),
+            ),
+        ],
+    )
+    wiki_dir = real_store._repo_dir(slug)
+    wiki_store.repo_dir.return_value = wiki_dir
+    wiki_store.list_repos.return_value = [slug]
+
+    (tmp_path / "src").mkdir(exist_ok=True)  # module absent → code_ref dead
+    cfg.repo_root = tmp_path  # type: ignore[misc]
+
+    loop = _loop((cfg, state, pr, dedup, wiki_store))
+    loop._reconcile_closed_escalations = AsyncMock(return_value=None)
+    stats = await loop._do_work()
+
+    assert stats["issues_filed"] == 1, stats
+    title, body, labels = pr.create_issue.await_args.args
+    assert "#8715" in title
+    assert "#8715" in body
+    assert "#6295 (manual)" in body
+    assert set(labels) == {"hydraflow-find", "wiki-rot"}
+
+
+async def test_shipped_claim_clean_via_structured_fields_when_ref_resolves(
+    tmp_path: Path, loop_env
+) -> None:
+    """A structured entry's ``fixed_in_pr`` claim with a live code_ref must
+    not fire — mirrors the raw-fallback corroboration test but exercises
+    the structured (``WikiEntry.fixed_in_pr``) path."""
+    from repo_wiki import RepoWikiStore, WikiEntry
+
+    cfg, state, pr, dedup, wiki_store = loop_env
+    slug = "hydra/hydraflow"
+
+    real_store = RepoWikiStore(tmp_path / "real_wiki", self_slug=slug)
+    real_store.ingest(
+        slug,
+        [
+            WikiEntry(
+                title="Half-state on skill failure",
+                content="Prose about the guard.",
+                source_type="manual",
+                source_issue=6295,
+                fixed_in_pr="#8713",
+                code_refs=("src/live.py:present", "src/gone.py:vanished"),
+            ),
+        ],
+    )
+    wiki_dir = real_store._repo_dir(slug)
+    wiki_store.repo_dir.return_value = wiki_dir
+    wiki_store.list_repos.return_value = [slug]
+
+    (tmp_path / "src").mkdir(exist_ok=True)
+    (tmp_path / "src" / "live.py").write_text("def present():\n    return 1\n")
+    cfg.repo_root = tmp_path  # type: ignore[misc]
+
+    loop = _loop((cfg, state, pr, dedup, wiki_store))
+    loop._reconcile_closed_escalations = AsyncMock(return_value=None)
+    await loop._do_work()
+
+    assert not any("#8713" in c.args[0] for c in pr.create_issue.await_args_list), (
+        pr.create_issue.await_args_list
+    )
+
+
+async def test_load_wiki_entries_falls_back_to_raw_for_non_topic_page_markdown(
+    tmp_path: Path, loop_env
+) -> None:
+    """Markdown that isn't in the WikiEntry topic-page shape (no ``## ``
+    sections, or none carrying a ``json:entry`` block) must still be
+    scanned via the legacy whole-file path — preserving existing behavior
+    for entries that still need it (glossary/feedback-style pages)."""
+    cfg, state, pr, dedup, wiki_store = loop_env
+    slug = "hydra/hydraflow"
+    wiki_dir = tmp_path / "wiki" / slug
+    wiki_dir.mkdir(parents=True)
+    (wiki_dir / "terms" / "actuator.md").parent.mkdir(parents=True, exist_ok=True)
+    (wiki_dir / "terms" / "actuator.md").write_text(
+        "---\ncode_anchor: src/foo.py:bar\n---\n\n## Definition\n\nProse.\n"
+    )
+    wiki_store.repo_dir.return_value = wiki_dir
+    wiki_store.list_repos.return_value = [slug]
+
+    (tmp_path / "src").mkdir(exist_ok=True)
+    (tmp_path / "src" / "foo.py").write_text("def other():\n    return 1\n")
+    cfg.repo_root = tmp_path  # type: ignore[misc]
+
+    loop = _loop((cfg, state, pr, dedup, wiki_store))
+    loop._reconcile_closed_escalations = AsyncMock(return_value=None)
+    stats = await loop._do_work()
+
+    assert stats["issues_filed"] == 1, stats
+    title, body, labels = pr.create_issue.await_args.args
+    assert "src/foo.py:bar" in title
+    # No structured provenance for a raw-fallback row.
+    assert "Entry source:" not in body
+
+
 def _shipped_entry(pr_ref: str, code_refs: list[str]) -> str:
     """A wiki entry with a structured ``fixed_in_pr`` shipped claim."""
     import json


### PR DESCRIPTION
Closes #9936.

`WikiRotDetectorLoop._load_wiki_entries` walked `rglob("*.md")` and regexed each file as one raw blob, ignoring the structured `WikiEntry` model — so it misattributed findings in multi-entry topic pages to the file heading, leaked one entry's fenced hints into another's finding, and couldn't key on provenance.

**Fix:** `_load_wiki_entries` now returns one entry per `WikiEntry` via a new module-level `parse_topic_page()` (extracted from `RepoWikiStore._load_topic_entries` so callers share the authoritative parse), carrying `source_type`/`source_issue`/`fixed_in_pr`/`code_refs`. `WikiEntry` gained `fixed_in_pr`/`code_refs` (previously unmodeled — pydantic `extra=ignore` was silently dropping them, which would have broken the shipped-claim pass on a naive switch). Falls back to the old whole-file regex for non-topic-page markdown (glossary/feedback mirrors). Findings now show `Entry source: #N (source_type)` provenance.

8 new tests (TDD, verified red on old code first); full `tests/regressions` + existing wiki-rot MockWorld scenario green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)