### PR TITLE
feat(pr-manager): base-freshness guard — refuse/update-branch a stale merge-base before implementer PR open (#10101)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -329,6 +329,7 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
         "HYDRAFLOW_AUTO_PR_PREFLIGHT_STAGE_TIMEOUT_S",
         600,
     ),
+    ("pr_base_max_age_days", "HYDRAFLOW_PR_BASE_MAX_AGE_DAYS", 3),
     ("flake_tracker_interval", "HYDRAFLOW_FLAKE_TRACKER_INTERVAL", 14400),
     ("flake_threshold", "HYDRAFLOW_FLAKE_THRESHOLD", 3),
     ("skill_prompt_eval_interval", "HYDRAFLOW_SKILL_PROMPT_EVAL_INTERVAL", 604800),
@@ -644,6 +645,11 @@ _ENV_BOOL_OVERRIDES: list[tuple[str, str, bool]] = [
     (
         "auto_pr_preflight_gate_enabled",
         "HYDRAFLOW_AUTO_PR_PREFLIGHT_GATE_ENABLED",
+        True,
+    ),
+    (
+        "pr_base_freshness_guard_enabled",
+        "HYDRAFLOW_PR_BASE_FRESHNESS_GUARD_ENABLED",
         True,
     ),
     (
@@ -3877,6 +3883,30 @@ class HydraFlowConfig(BaseModel):
         description=(
             "Per-stage timeout in seconds for the auto-PR pre-flight gate "
             "(#10013). A stage that exceeds it counts as red."
+        ),
+    )
+    pr_base_freshness_guard_enabled: bool = Field(
+        default=True,
+        description=(
+            "Kill-switch for the implementer/pr_manager base-freshness guard "
+            "(#10101, the #9964 class): before ``gh pr create`` on a "
+            "long-lived implementer worktree, refuses (or auto "
+            "fetch+merges) a branch whose merge-base with the base branch "
+            "is older than ``pr_base_max_age_days``. Distinct from the "
+            "auto_pr pre-flight gate (#10013), which covers the "
+            "short-lived bot-PR worktree seam and always forks fresh."
+        ),
+    )
+    pr_base_max_age_days: int = Field(
+        default=3,
+        ge=1,
+        le=90,
+        description=(
+            "Max age in days of an implementer branch's merge-base with the "
+            "base branch before the base-freshness guard (#10101) treats it "
+            "as stale. Older than this triggers an in-worktree "
+            "fetch+merge-update attempt before falling back to refusing the "
+            "PR open."
         ),
     )
     implement_two_stage_review_enabled: bool = Field(

--- a/src/implement_phase.py
+++ b/src/implement_phase.py
@@ -7,7 +7,7 @@ import contextlib
 import logging
 import re
 import time
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -1069,8 +1069,16 @@ class ImplementPhase:
     ) -> PRInfo | None:
         """Create a new PR or recover an existing one, updating result.pr_info."""
         if not is_retry:
-            gh_issue = GitHubIssue.from_task(issue)
-            pr = await self._prs.create_pr(gh_issue, result.branch)
+            if await self._ensure_fresh_base(issue, result):
+                gh_issue = GitHubIssue.from_task(issue)
+                pr = await self._prs.create_pr(gh_issue, result.branch)
+            else:
+                # Base-freshness guard refused (#10101): the zero-PR sentinel
+                # routes through the existing "implementation succeeded but
+                # no PR exists" fallback (_handle_no_pr_fallback), which
+                # keeps the issue in the ready queue for retry instead of
+                # silently opening a born-red PR against a stale base.
+                pr = PRInfo(number=0, issue_number=issue.id, branch=result.branch)
         else:
             pr = await self._prs.find_open_pr_for_branch(
                 result.branch, issue_number=issue.id
@@ -1082,6 +1090,126 @@ class ImplementPhase:
                 await self._prs.update_pr_title(pr.number, expected_title)
         result.pr_info = pr
         return pr
+
+    @staticmethod
+    async def _run_git_read(
+        run_simple: Callable[..., Awaitable[object]],
+        cmd: list[str],
+        *,
+        cwd: str,
+        timeout: float,
+    ) -> str | None:
+        """Run a local read-only git command; stripped stdout, or None on any failure.
+
+        Shared by ``_merge_base_age_days``'s two reads. A non-string
+        ``stdout`` (e.g. an unconfigured test double) fails open the same
+        as a real git error — this helper must never raise.
+        """
+        try:
+            out = await run_simple(cmd, cwd=cwd, timeout=timeout)
+        except (TimeoutError, FileNotFoundError, OSError):
+            return None
+        stdout = getattr(out, "stdout", "")
+        if not isinstance(stdout, str):
+            return None
+        return stdout.strip()
+
+    async def _merge_base_age_days(self, result: WorkerResult) -> float | None:
+        """Return the age in days of *result.branch*'s merge-base with the base branch.
+
+        Mirrors ``_branch_changed_files``: reads locally via the agent
+        runner's ``run_simple`` so it works uniformly under host/Docker
+        execution without a dedicated Port (#10101). Fails open (returns
+        ``None``) on any git error, a missing runner, or an unparsable
+        result — a freshness check must never itself block a PR.
+        """
+        if not result.workspace_path or not Path(result.workspace_path).is_dir():
+            return None
+        runner = getattr(self._agents, "_runner", None)
+        run_simple = getattr(runner, "run_simple", None) if runner else None
+        if run_simple is None:
+            return None
+        base = self._config.base_branch()
+        timeout = self._config.git_command_timeout
+        sha = await self._run_git_read(
+            run_simple,
+            ["git", "merge-base", result.branch, f"origin/{base}"],
+            cwd=result.workspace_path,
+            timeout=timeout,
+        )
+        if not sha:
+            return None
+        ts_str = await self._run_git_read(
+            run_simple,
+            ["git", "log", "-1", "--format=%ct", sha],
+            cwd=result.workspace_path,
+            timeout=timeout,
+        )
+        if not ts_str or not ts_str.isdigit():
+            return None
+        epoch = int(ts_str)
+        return max(time.time() - epoch, 0.0) / 86400.0
+
+    async def _ensure_fresh_base(self, issue: Task, result: WorkerResult) -> bool:
+        """Refuse or auto-update a stale merge-base before ``gh pr create`` (#10101).
+
+        The #9964 class: a long-lived implementer worktree forks from the
+        base branch once at worktree-creation time, then the agent runs for
+        however long it takes. New guard rules landed on the base in the
+        meantime are invisible to the branch — its PR opens born-red
+        against a base that's since drifted. Computes the branch's
+        merge-base age with the configured base branch; when it exceeds
+        ``pr_base_max_age_days`` this tries an in-place update (fetch +
+        merge, reusing the same ``merge_main`` path as post-PR conflict
+        resolution) before falling back to refusing the PR open.
+
+        Returns True when it's safe to proceed with ``create_pr``.
+        """
+        if not self._config.pr_base_freshness_guard_enabled:
+            return True
+        age_days = await self._merge_base_age_days(result)
+        if age_days is None or age_days <= self._config.pr_base_max_age_days:
+            return True
+        logger.warning(
+            "Issue #%d: branch %s has a %.1f-day-old merge-base with %s "
+            "(threshold %d days) — attempting auto-update before PR open",
+            issue.id,
+            result.branch,
+            age_days,
+            self._config.base_branch(),
+            self._config.pr_base_max_age_days,
+        )
+        updated = False
+        if result.workspace_path:
+            try:
+                updated = bool(
+                    await self._workspaces.merge_main(
+                        Path(result.workspace_path), result.branch
+                    )
+                )
+            except (RuntimeError, OSError):
+                updated = False
+            if updated:
+                updated = bool(
+                    await self._prs.push_branch(
+                        Path(result.workspace_path), result.branch
+                    )
+                )
+        if updated:
+            logger.info(
+                "Issue #%d: base-freshness guard auto-updated %s to a fresh %s",
+                issue.id,
+                result.branch,
+                self._config.base_branch(),
+            )
+            return True
+        logger.warning(
+            "Issue #%d: base-freshness guard could not auto-update %s "
+            "(merge conflict or push failure) — refusing PR open",
+            issue.id,
+            result.branch,
+        )
+        return False
 
     async def _handle_successful_push(
         self, issue: Task, result: WorkerResult, is_retry: bool

--- a/src/settings_registry.py
+++ b/src/settings_registry.py
@@ -86,6 +86,11 @@ SETTINGS: dict[str, SettingSpec] = {
     "auto_pr_preflight_stage_timeout_s": SettingSpec(
         "CI & Quality", live=True, order=9
     ),
+    # Live: ImplementPhase reads both off its shared HydraFlowConfig
+    # reference on every PR-open (#10101), so a toggle applies to the next
+    # implementer PR without a restart.
+    "pr_base_freshness_guard_enabled": SettingSpec("CI & Quality", live=True, order=10),
+    "pr_base_max_age_days": SettingSpec("CI & Quality", live=True, order=11),
     # --- Scheduling ------------------------------------------------------
     "poll_interval": SettingSpec("Scheduling", live=True, order=0),
     "pr_unstick_interval": SettingSpec("Scheduling", live=True, order=1),

--- a/tests/test_implement_phase.py
+++ b/tests/test_implement_phase.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import sys
+import time
 from collections.abc import Generator
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -991,6 +993,227 @@ class TestReviewFeedbackPassing:
         mock_prs.create_pr.assert_awaited_once()
         assert results[0].pr_info is not None
         assert results[0].pr_info.number == 101
+
+
+# ---------------------------------------------------------------------------
+# Base-freshness guard (#10101, the #9964 class)
+# ---------------------------------------------------------------------------
+
+
+def _fake_git_runner(
+    *, merge_base_sha: str = "deadbeef", epoch: int
+) -> SimpleNamespace:
+    """Build a fake ``AgentRunner._runner`` with controllable git output.
+
+    Returns objects that only expose ``.stdout`` (like the real
+    ``execution.SimpleResult``) so ``_merge_base_age_days``'s
+    ``getattr(..., "stdout", "")`` reads work without importing the real
+    dataclass.
+    """
+
+    async def run_simple(
+        cmd: list[str], *, cwd: str | None = None, timeout: float | None = None
+    ) -> SimpleNamespace:
+        if cmd[:2] == ["git", "merge-base"]:
+            return SimpleNamespace(stdout=f"{merge_base_sha}\n")
+        if cmd[:2] == ["git", "log"]:
+            return SimpleNamespace(stdout=f"{epoch}\n")
+        raise AssertionError(f"unexpected command in fake git runner: {cmd}")
+
+    return SimpleNamespace(run_simple=AsyncMock(side_effect=run_simple))
+
+
+class TestBaseFreshnessGuard:
+    """Refuse/auto-update a stale merge-base before ``gh pr create``."""
+
+    @pytest.mark.asyncio
+    async def test_fresh_merge_base_creates_pr_normally(
+        self, config: HydraFlowConfig, tmp_path: Path
+    ) -> None:
+        """A merge-base within the age threshold does not trigger any update."""
+        issue = TaskFactory.create()
+        fresh_epoch = int(time.time()) - 3600  # 1 hour old — well under 3 days
+        phase, mock_wt, mock_prs = make_implement_phase(
+            config, [issue], create_pr_return=PRInfoFactory.create()
+        )
+        phase._agents._runner = _fake_git_runner(epoch=fresh_epoch)
+        result = WorkerResultFactory.create(
+            issue_number=issue.id,
+            branch="agent/issue-42",
+            workspace_path=str(tmp_path),
+        )
+
+        pr = await phase._resolve_pr(issue, result, is_retry=False)
+
+        mock_wt.merge_main.assert_not_awaited()
+        mock_prs.create_pr.assert_awaited_once()
+        assert pr is not None
+        assert pr.number != 0
+
+    @pytest.mark.asyncio
+    async def test_stale_merge_base_auto_updates_then_creates_pr(
+        self, config: HydraFlowConfig, tmp_path: Path
+    ) -> None:
+        """A merge-base older than the threshold triggers merge_main + push,
+        then still opens the PR once the branch is updated."""
+        issue = TaskFactory.create()
+        stale_epoch = int(time.time()) - (10 * 86400)  # 10 days old
+        phase, mock_wt, mock_prs = (
+            ImplementPhaseMockBuilder(config)
+            .with_issues([issue])
+            .with_create_pr_return(PRInfoFactory.create())
+            .with_wt_method("merge_main", AsyncMock(return_value=True))
+            .build()
+        )
+        phase._agents._runner = _fake_git_runner(epoch=stale_epoch)
+        result = WorkerResultFactory.create(
+            issue_number=issue.id,
+            branch="agent/issue-42",
+            workspace_path=str(tmp_path),
+        )
+
+        pr = await phase._resolve_pr(issue, result, is_retry=False)
+
+        mock_wt.merge_main.assert_awaited_once_with(tmp_path, "agent/issue-42")
+        mock_prs.push_branch.assert_awaited()
+        mock_prs.create_pr.assert_awaited_once()
+        assert pr is not None
+        assert pr.number != 0
+
+    @pytest.mark.asyncio
+    async def test_stale_merge_base_refuses_when_update_fails(
+        self, config: HydraFlowConfig, tmp_path: Path
+    ) -> None:
+        """When the auto-update can't complete (merge conflict), the PR is
+        never opened — a zero-number sentinel routes to the no-PR fallback."""
+        issue = TaskFactory.create()
+        stale_epoch = int(time.time()) - (10 * 86400)
+        phase, mock_wt, mock_prs = (
+            ImplementPhaseMockBuilder(config)
+            .with_issues([issue])
+            .with_create_pr_return(PRInfoFactory.create())
+            .with_wt_method("merge_main", AsyncMock(return_value=False))
+            .build()
+        )
+        phase._agents._runner = _fake_git_runner(epoch=stale_epoch)
+        result = WorkerResultFactory.create(
+            issue_number=issue.id,
+            branch="agent/issue-42",
+            workspace_path=str(tmp_path),
+        )
+
+        pr = await phase._resolve_pr(issue, result, is_retry=False)
+
+        mock_wt.merge_main.assert_awaited_once()
+        mock_prs.create_pr.assert_not_awaited()
+        assert pr is not None
+        assert pr.number == 0
+        assert result.pr_info is pr
+
+    @pytest.mark.asyncio
+    async def test_guard_disabled_skips_freshness_check(
+        self, config: HydraFlowConfig, tmp_path: Path
+    ) -> None:
+        """The kill-switch bypasses the check even on a very stale base."""
+        config.pr_base_freshness_guard_enabled = False
+        issue = TaskFactory.create()
+        stale_epoch = int(time.time()) - (365 * 86400)  # 1 year old
+        phase, mock_wt, mock_prs = make_implement_phase(
+            config, [issue], create_pr_return=PRInfoFactory.create()
+        )
+        phase._agents._runner = _fake_git_runner(epoch=stale_epoch)
+        result = WorkerResultFactory.create(
+            issue_number=issue.id,
+            branch="agent/issue-42",
+            workspace_path=str(tmp_path),
+        )
+
+        pr = await phase._resolve_pr(issue, result, is_retry=False)
+
+        mock_wt.merge_main.assert_not_awaited()
+        mock_prs.create_pr.assert_awaited_once()
+        assert pr is not None
+        assert pr.number != 0
+
+    @pytest.mark.asyncio
+    async def test_knob_threshold_is_configurable(
+        self, config: HydraFlowConfig, tmp_path: Path
+    ) -> None:
+        """Raising pr_base_max_age_days tolerates a base that would
+        otherwise be flagged stale under the default threshold."""
+        config.pr_base_max_age_days = 30
+        issue = TaskFactory.create()
+        ten_days_old = int(time.time()) - (10 * 86400)
+        phase, mock_wt, mock_prs = make_implement_phase(
+            config, [issue], create_pr_return=PRInfoFactory.create()
+        )
+        phase._agents._runner = _fake_git_runner(epoch=ten_days_old)
+        result = WorkerResultFactory.create(
+            issue_number=issue.id,
+            branch="agent/issue-42",
+            workspace_path=str(tmp_path),
+        )
+
+        pr = await phase._resolve_pr(issue, result, is_retry=False)
+
+        mock_wt.merge_main.assert_not_awaited()
+        mock_prs.create_pr.assert_awaited_once()
+        assert pr is not None
+        assert pr.number != 0
+
+    @pytest.mark.asyncio
+    async def test_retry_path_never_invokes_guard(
+        self, config: HydraFlowConfig, tmp_path: Path
+    ) -> None:
+        """The guard only gates ``gh pr create``; the retry/recovery path
+        (find_open_pr_for_branch) is untouched."""
+        issue = TaskFactory.create()
+        stale_epoch = int(time.time()) - (365 * 86400)
+        phase, mock_wt, mock_prs = (
+            ImplementPhaseMockBuilder(config)
+            .with_issues([issue])
+            .with_prs_method(
+                "find_open_pr_for_branch",
+                AsyncMock(return_value=PRInfoFactory.create()),
+            )
+            .build()
+        )
+        phase._agents._runner = _fake_git_runner(epoch=stale_epoch)
+        result = WorkerResultFactory.create(
+            issue_number=issue.id,
+            branch="agent/issue-42",
+            workspace_path=str(tmp_path),
+        )
+
+        pr = await phase._resolve_pr(issue, result, is_retry=True)
+
+        mock_wt.merge_main.assert_not_awaited()
+        mock_prs.create_pr.assert_not_awaited()
+        assert pr is not None
+        assert pr.number != 0
+
+    @pytest.mark.asyncio
+    async def test_missing_runner_fails_open(
+        self, config: HydraFlowConfig, tmp_path: Path
+    ) -> None:
+        """No agent runner available (e.g. never started) — never blocks the PR."""
+        issue = TaskFactory.create()
+        phase, mock_wt, mock_prs = make_implement_phase(
+            config, [issue], create_pr_return=PRInfoFactory.create()
+        )
+        phase._agents._runner = None
+        result = WorkerResultFactory.create(
+            issue_number=issue.id,
+            branch="agent/issue-42",
+            workspace_path=str(tmp_path),
+        )
+
+        pr = await phase._resolve_pr(issue, result, is_retry=False)
+
+        mock_wt.merge_main.assert_not_awaited()
+        mock_prs.create_pr.assert_awaited_once()
+        assert pr is not None
+        assert pr.number != 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #10101 (Part 2 of #10013; Part 1 shipped in #10058).

The implementer path was NOT already fresh: `WorkspaceManager.create()` fetches origin/<base> once at worktree creation, `_setup_worktree_and_branch` resumes existing worktrees without re-fetching, and `_resolve_pr`→`create_pr` then runs `gh pr create` with no freshness check — the #9964 stale-merge-base class on a long-lived worktree.

**Fix (src/implement_phase.py):** `_ensure_fresh_base` (gated by `pr_base_freshness_guard_enabled`) computes merge-base age; if older than `pr_base_max_age_days` (default 3, System-tab editable), it auto `merge_main()` + `push_branch()` (reusing the existing conflict-resolution path); refuses via the existing `PRInfo(number=0)` sentinel → `_handle_no_pr_fallback` (issue stays queued, no new escalation plumbing) if it can't. Fails open on any git-read error. auto_pr seam (Part 1) untouched.

7 new tests (fresh no-op / stale auto-update / stale+conflict refuse / kill-switch / threshold / retry-untouched / fail-open); full `tests/regressions` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)