### PR TITLE
feat(contract): auto-record create_pr / create_promotion_pr so ContractRefreshLoop can refresh them (#8699)

### DIFF
--- a/src/contract_recording.py
+++ b/src/contract_recording.py
@@ -284,6 +284,36 @@ _SCRATCH_COMMIT_MESSAGE = "contract recorder scratch commit"
 _FAKE_MERGE_PR_NUMBER = "42"
 _FAKE_CLOSE_ISSUE_NUMBER = "42"
 
+# Fixed scratch branches for the create_pr / create_promotion_pr recorders —
+# distinct names from _SCRATCH_BRANCH (merge_pr's) so all mutations can run in
+# the same tick without one recorder's provisioning/cleanup stepping on
+# another's branch ref.
+_CREATE_PR_SCRATCH_BRANCH = "contract-recorder-create-pr-scratch"
+_PROMOTION_SCRATCH_BRANCH = "contract-recorder-promotion-scratch"
+
+# Stable logical args + fake-shaped stdout for the create_pr cassette.
+# Filename/interaction stay "pr_create" (not "create_pr") to match the
+# pre-existing hand-authored baseline (tests/trust/contracts/cassettes/github/
+# pr_create.yaml) this recorder promotes to machine-recorded —
+# contract_diff.detect_adapter_drift matches recorded vs committed cassettes
+# by filename, so keeping the name lands the diff on the SAME committed
+# fixture instead of creating an orphaned duplicate (mirrors #8693's in-place
+# close_issue/create_issue/merge_pr conversion). ["42", "contract-branch"] and
+# the test-org/test-repo URL mirror the committed baseline exactly so a
+# correctly-recorded cassette is drift-free against it on day one (#9535
+# pattern) regardless of the sandbox's live PR number.
+_FAKE_CREATE_PR_ARGS = ["42", "contract-branch"]
+_FAKE_CREATE_PR_STDOUT = "https://github.com/test-org/test-repo/pull/101\n"
+
+# Stable logical rc-branch arg + fake-shaped stdout for create_promotion_pr —
+# matches the hand-authored baseline from #10092
+# (create_promotion_pr.yaml). FakeGitHub.create_promotion_pr stores the PR
+# under the "test/repo" host (NOT test-org/test-repo — see that cassette's
+# comment) at _pr_counter's starting value (10_000) for a fresh FakeGitHub
+# instance.
+_FAKE_PROMOTION_RC_BRANCH = "rc/2026-05-13-0000"
+_FAKE_CREATE_PROMOTION_PR_STDOUT = "https://github.com/test/repo/pull/10000\n"
+
 
 def _parse_trailing_int(url: str) -> int | None:
     """Return the trailing integer segment of a GitHub resource URL, or None."""
@@ -621,6 +651,168 @@ def _record_merge_pr(sandbox_repo: str, tmp_dir: Path) -> Path | None:
     return path
 
 
+def _record_create_pr(sandbox_repo: str, tmp_dir: Path) -> Path | None:
+    """Provision a scratch branch with a synthetic commit, open a PR against
+    main (without merging), write the pr_create cassette with STABLE logical
+    args, then best-effort close+delete-branch so the sandbox doesn't
+    accumulate open scratch PRs across ContractRefreshLoop ticks.
+
+    Uses ``_provision_scratch_branch`` (the same no-diff-PR guard #9535 added
+    for merge_pr) so ``gh pr create`` is accepted on a tree-identical commit.
+    """
+    if not _provision_scratch_branch(sandbox_repo, branch=_CREATE_PR_SCRATCH_BRANCH):
+        return None
+
+    create_pr = _run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--repo",
+            sandbox_repo,
+            "--head",
+            _CREATE_PR_SCRATCH_BRANCH,
+            "--base",
+            "main",
+            "--title",
+            "contract recorder scratch",
+            "--body",
+            "",
+        ]
+    )
+    if not _require_success(create_pr, label="gh pr create (pr_create)"):
+        return None
+    assert create_pr is not None
+    pr_number = _parse_trailing_int(create_pr.stdout)
+    if pr_number is None:
+        logger.warning(
+            "contract_recording: could not parse PR number from %r", create_pr.stdout
+        )
+        return None
+
+    # Fake-shaped stdout mirrors FakeGitHub.create_pr (via PRInfoFactory's
+    # default URL); both stdout and args use the STABLE logical values that
+    # match the committed pr_create.yaml baseline byte-for-byte —
+    # input.args is compared verbatim by the drift layer, so the live PR
+    # number/branch would phantom-drift every tick (#9535 pattern).
+    payload = _build_cassette_payload(
+        adapter="github",
+        interaction="pr_create",
+        fixture_repo=sandbox_repo,
+        command="create_pr",
+        args=list(_FAKE_CREATE_PR_ARGS),
+        exit_code=create_pr.returncode,
+        stdout=_FAKE_CREATE_PR_STDOUT,
+        stderr="",
+        normalizers=["pr_number"],
+    )
+    payload["baseline_only"] = False
+    path = tmp_dir / "pr_create.yaml"
+    _write_yaml_cassette(path, payload)
+
+    # Best-effort cleanup: close (never merge — nothing exercises the merge
+    # path here) the scratch PR and delete its branch so the sandbox doesn't
+    # accumulate open PRs across weekly ticks. A failure here does not
+    # invalidate the cassette that was already written.
+    close = _run(
+        [
+            "gh",
+            "pr",
+            "close",
+            str(pr_number),
+            "--repo",
+            sandbox_repo,
+            "--delete-branch",
+        ]
+    )
+    if not _require_success(close, label="gh pr close (pr_create cleanup)"):
+        logger.warning(
+            "contract_recording: cleanup close of PR #%s failed — cassette "
+            "was written successfully but the sandbox PR/branch remains open",
+            pr_number,
+        )
+
+    return path
+
+
+def _record_create_promotion_pr(sandbox_repo: str, tmp_dir: Path) -> Path | None:
+    """Provision a scratch branch with a synthetic commit, open a promotion
+    PR against main, write the create_promotion_pr cassette with STABLE
+    logical args, then best-effort close+delete-branch.
+
+    Mirrors PRManager.create_promotion_pr's real shape (``gh pr create
+    --base main``) closely enough for contract purposes; the recorded
+    cassette never carries the live rc-branch name or PR number — both are
+    volatile per real StagingPromotionLoop tick — only the fixed logical
+    values already committed by #10092's hand-authored baseline.
+    """
+    if not _provision_scratch_branch(sandbox_repo, branch=_PROMOTION_SCRATCH_BRANCH):
+        return None
+
+    create_pr = _run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--repo",
+            sandbox_repo,
+            "--head",
+            _PROMOTION_SCRATCH_BRANCH,
+            "--base",
+            "main",
+            "--title",
+            "Promote staging to main",
+            "--body",
+            "Automated RC promotion (ADR-0042).",
+        ]
+    )
+    if not _require_success(create_pr, label="gh pr create (create_promotion_pr)"):
+        return None
+    assert create_pr is not None
+    pr_number = _parse_trailing_int(create_pr.stdout)
+    if pr_number is None:
+        logger.warning(
+            "contract_recording: could not parse PR number from %r", create_pr.stdout
+        )
+        return None
+
+    payload = _build_cassette_payload(
+        adapter="github",
+        interaction="create_promotion_pr",
+        fixture_repo=sandbox_repo,
+        command="create_promotion_pr",
+        args=[_FAKE_PROMOTION_RC_BRANCH],
+        exit_code=create_pr.returncode,
+        stdout=_FAKE_CREATE_PROMOTION_PR_STDOUT,
+        stderr="",
+        normalizers=["pr_number"],
+    )
+    payload["baseline_only"] = False
+    path = tmp_dir / "create_promotion_pr.yaml"
+    _write_yaml_cassette(path, payload)
+
+    close = _run(
+        [
+            "gh",
+            "pr",
+            "close",
+            str(pr_number),
+            "--repo",
+            sandbox_repo,
+            "--delete-branch",
+        ]
+    )
+    if not _require_success(close, label="gh pr close (create_promotion_pr cleanup)"):
+        logger.warning(
+            "contract_recording: cleanup close of promotion PR #%s failed — "
+            "cassette was written successfully but the sandbox PR/branch "
+            "remains open",
+            pr_number,
+        )
+
+    return path
+
+
 def record_github_mutation(sandbox_repo: str, tmp_cassette_dir: Path) -> list[Path]:
     """Record cassettes for mutating GitHub operations against the sandbox repo.
 
@@ -635,7 +827,8 @@ def record_github_mutation(sandbox_repo: str, tmp_cassette_dir: Path) -> list[Pa
       ``_run()``, skip-if-no-binary, refuse-to-overwrite-with-degenerate-output
       via ``_write_yaml_cassette()``.
 
-    Command allow-list: close_issue, create_issue, merge_pr.
+    Command allow-list: close_issue, create_issue, merge_pr, create_pr
+    (pr_create.yaml), create_promotion_pr.
     """
     tmp_cassette_dir = Path(tmp_cassette_dir)
     tmp_cassette_dir.mkdir(parents=True, exist_ok=True)
@@ -653,6 +846,14 @@ def record_github_mutation(sandbox_repo: str, tmp_cassette_dir: Path) -> list[Pa
     if merge_path:
         paths.append(merge_path)
 
+    pr_create_path = _record_create_pr(sandbox_repo, tmp_cassette_dir)
+    if pr_create_path:
+        paths.append(pr_create_path)
+
+    create_promotion_path = _record_create_promotion_pr(sandbox_repo, tmp_cassette_dir)
+    if create_promotion_path:
+        paths.append(create_promotion_path)
+
     return paths
 
 
@@ -660,9 +861,10 @@ def record_github(sandbox_repo: str, tmp_cassette_dir: Path) -> list[Path]:
     """Record cassettes for the GitHub adapter against the sandbox repo.
 
     Delegates to :func:`record_github_mutation` which provisions fresh sandbox
-    resources (issues, scratch PR) and records the mutating operations
-    (close_issue, create_issue, merge_pr) following the record_git/record_docker
-    safety contract — real CLI exit codes, fake-shaped output.
+    resources (issues, scratch PRs) and records the mutating operations
+    (close_issue, create_issue, merge_pr, create_pr, create_promotion_pr)
+    following the record_git/record_docker safety contract — real CLI exit
+    codes, fake-shaped output.
     """
     return record_github_mutation(
         sandbox_repo=sandbox_repo,

--- a/tests/regressions/test_issue_8699_promotion_pr_recorder.py
+++ b/tests/regressions/test_issue_8699_promotion_pr_recorder.py
@@ -1,0 +1,170 @@
+"""Regression: ``record_github`` skipped ``create_pr``/``create_promotion_pr``
+recording (issue #8699).
+
+Before this fix, ``record_github_mutation`` only recorded ``close_issue``,
+``create_issue``, and ``merge_pr`` (#8693/#9535). The ``pr_create.yaml`` and
+``create_promotion_pr.yaml`` cassettes stayed hand-frozen (``baseline_only:
+true``), so ``ContractRefreshLoop`` could never catch real ``gh pr create``
+drift for either the regular PR-creation path or the ADR-0042 staging→main
+promotion path (#10092 hand-added the promotion cassettes but explicitly
+deferred the recorder side to this issue).
+
+This mirrors the #9535 regression exactly (same two defect classes, same
+fix shape):
+
+1. **No-diff PR.** ``gh pr create`` rejects a scratch branch with no commits
+   ahead of ``main`` — the recorder must provision a tree-identical synthetic
+   commit first (``_provision_scratch_branch``) or the recording silently
+   fails every tick.
+2. **Volatile args.** ``contract_diff._canonical_payload`` does NOT normalize
+   ``input.args`` — a live PR number/branch name would phantom-drift against
+   the committed stable args and file a spurious ``contract-refresh`` PR
+   every tick.
+
+These tests drive ``record_github_mutation`` through a mocked ``gh`` that
+returns live values DIFFERENT from every stable logical value baked into the
+committed cassettes, and assert (a) drift-free recording vs the committed
+baseline and (b) the synthetic-commit provisioning step for both new
+recorders. Hermetic: no ``tests/architecture`` conftest fixtures, only
+``tmp_path`` + the repo root resolved from ``__file__`` (same pattern as
+``test_issue_9535_merge_pr_recorder.py``).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from contract_diff import detect_adapter_drift
+from contract_recording import record_github_mutation
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_COMMITTED = _REPO_ROOT / "tests/trust/contracts/cassettes/github"
+_SANDBOX = "T-rav-Hydra-Ops/hydraflow-contracts-sandbox"
+
+
+def _completed(
+    argv: list[str], *, stdout: str = "", returncode: int = 0
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=argv, returncode=returncode, stdout=stdout, stderr=""
+    )
+
+
+def _fake_gh(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+    """Simulate ``gh`` with live PR numbers/branches DIFFERENT from every
+    stable logical value the committed cassettes carry (42, 10000,
+    contract-branch, rc/2026-05-13-0000)."""
+    # Git Data API: tree read + synthetic-commit POST → non-empty SHA.
+    if "api" in argv and any("git/commits" in a for a in argv):
+        return _completed(argv, stdout="d" * 40 + "\n")
+    # Git Data API: ref get/create/delete/patch → main SHA (mostly unused).
+    if "api" in argv and any("git/ref" in a for a in argv):
+        return _completed(argv, stdout="e" * 40 + "\n")
+    if "issue" in argv and "create" in argv:
+        return _completed(argv, stdout=f"https://github.com/{_SANDBOX}/issues/321\n")
+    if "pr" in argv and "create" in argv:  # live PR #8888, distinct from 42/10000
+        return _completed(argv, stdout=f"https://github.com/{_SANDBOX}/pull/8888\n")
+    # gh issue close / gh pr merge / gh pr close / git rev-parse → success.
+    return _completed(argv, stdout="")
+
+
+def test_pr_create_recording_is_drift_free_against_committed(tmp_path: Path) -> None:
+    with patch("contract_recording.subprocess.run", side_effect=_fake_gh):
+        record_github_mutation(sandbox_repo=_SANDBOX, tmp_cassette_dir=tmp_path)
+
+    recorded = tmp_path / "pr_create.yaml"
+    assert recorded.exists(), (
+        "pr_create cassette must be written — the no-diff-PR guard must hold "
+        "for create_pr the same way it does for merge_pr"
+    )
+    report = detect_adapter_drift("github", [recorded], [_COMMITTED / "pr_create.yaml"])
+    assert report is None, f"pr_create drifted despite live PR 8888: {report}"
+
+
+def test_create_promotion_pr_recording_is_drift_free_against_committed(
+    tmp_path: Path,
+) -> None:
+    with patch("contract_recording.subprocess.run", side_effect=_fake_gh):
+        record_github_mutation(sandbox_repo=_SANDBOX, tmp_cassette_dir=tmp_path)
+
+    recorded = tmp_path / "create_promotion_pr.yaml"
+    assert recorded.exists(), (
+        "create_promotion_pr cassette must be written — the no-diff-PR guard "
+        "must hold for the promotion scratch branch too"
+    )
+    report = detect_adapter_drift(
+        "github", [recorded], [_COMMITTED / "create_promotion_pr.yaml"]
+    )
+    assert report is None, f"create_promotion_pr drifted despite live PR 8888: {report}"
+
+
+def test_pr_create_recorder_posts_synthetic_commit_before_pr_create(
+    tmp_path: Path,
+) -> None:
+    calls: list[list[str]] = []
+
+    def capture(argv: list[str], **kw: object) -> subprocess.CompletedProcess[str]:
+        calls.append(list(argv))
+        return _fake_gh(argv, **kw)
+
+    with patch("contract_recording.subprocess.run", side_effect=capture):
+        record_github_mutation(sandbox_repo=_SANDBOX, tmp_cassette_dir=tmp_path)
+
+    patch_ref = [
+        i
+        for i, c in enumerate(calls)
+        if "--method" in c
+        and "PATCH" in c
+        and any("git/refs/heads/contract-recorder-create-pr-scratch" in a for a in c)
+    ]
+    pr_creates = [
+        i
+        for i, c in enumerate(calls)
+        if "pr" in c
+        and "create" in c
+        and "--head" in c
+        and c[c.index("--head") + 1] == "contract-recorder-create-pr-scratch"
+    ]
+
+    assert patch_ref, "recorder must PATCH the create_pr scratch ref — no-diff-PR guard"
+    assert pr_creates, "recorder must call gh pr create for the create_pr scratch PR"
+    assert patch_ref[0] < pr_creates[0], (
+        "synthetic-commit ref PATCH must precede gh pr create"
+    )
+
+
+def test_create_promotion_pr_recorder_posts_synthetic_commit_before_pr_create(
+    tmp_path: Path,
+) -> None:
+    calls: list[list[str]] = []
+
+    def capture(argv: list[str], **kw: object) -> subprocess.CompletedProcess[str]:
+        calls.append(list(argv))
+        return _fake_gh(argv, **kw)
+
+    with patch("contract_recording.subprocess.run", side_effect=capture):
+        record_github_mutation(sandbox_repo=_SANDBOX, tmp_cassette_dir=tmp_path)
+
+    patch_ref = [
+        i
+        for i, c in enumerate(calls)
+        if "--method" in c
+        and "PATCH" in c
+        and any("git/refs/heads/contract-recorder-promotion-scratch" in a for a in c)
+    ]
+    pr_creates = [
+        i
+        for i, c in enumerate(calls)
+        if "pr" in c
+        and "create" in c
+        and "--head" in c
+        and c[c.index("--head") + 1] == "contract-recorder-promotion-scratch"
+    ]
+
+    assert patch_ref, "recorder must PATCH the promotion scratch ref — no-diff-PR guard"
+    assert pr_creates, "recorder must call gh pr create for the promotion scratch PR"
+    assert patch_ref[0] < pr_creates[0], (
+        "synthetic-commit ref PATCH must precede gh pr create"
+    )

--- a/tests/test_cassette_baseline_only.py
+++ b/tests/test_cassette_baseline_only.py
@@ -24,7 +24,15 @@ from contracts._schema import Cassette
 _GH_CASSETTES = Path(__file__).parent / "trust" / "contracts" / "cassettes" / "github"
 
 # Cassettes covered by record_github_mutation — live-recorded, baseline_only: false.
-_LIVE_RECORDED = frozenset({"close_issue.yaml", "create_issue.yaml", "merge_pr.yaml"})
+_LIVE_RECORDED = frozenset(
+    {
+        "close_issue.yaml",
+        "create_issue.yaml",
+        "merge_pr.yaml",
+        "pr_create.yaml",
+        "create_promotion_pr.yaml",
+    }
+)
 
 
 def test_unretired_github_cassettes_are_baseline_only() -> None:

--- a/tests/test_contract_recording.py
+++ b/tests/test_contract_recording.py
@@ -603,7 +603,14 @@ def test_record_merge_pr_posts_synthetic_commit_before_pr_create(
 def test_record_merge_pr_pr_create_targets_scratch_branch_and_main(
     tmp_path: Path,
 ) -> None:
-    """``gh pr create`` must open the PR from the scratch branch against main."""
+    """``gh pr create`` must open the PR from the scratch branch against main.
+
+    ``record_github_mutation`` now runs three separate ``gh pr create``
+    provisioning steps (merge_pr, pr_create, create_promotion_pr), each
+    against its own scratch branch — filter to merge_pr's branch
+    (``contract-recorder-scratch``) specifically rather than counting all
+    ``pr create`` calls.
+    """
     calls: list[list[str]] = []
 
     def capture(argv: list[str], **kw: object) -> subprocess.CompletedProcess[str]:
@@ -613,7 +620,14 @@ def test_record_merge_pr_pr_create_targets_scratch_branch_and_main(
     with patch("contract_recording.subprocess.run", side_effect=capture):
         record_github_mutation(sandbox_repo=_SANDBOX, tmp_cassette_dir=tmp_path)
 
-    pr_creates = [c for c in calls if "pr" in c and "create" in c]
+    pr_creates = [
+        c
+        for c in calls
+        if "pr" in c
+        and "create" in c
+        and "--head" in c
+        and c[c.index("--head") + 1] == "contract-recorder-scratch"
+    ]
     assert len(pr_creates) == 1
     argv = pr_creates[0]
     assert (
@@ -790,3 +804,273 @@ def test_record_create_issue_closes_sandbox_issue_after_cassette_written(
         f"got argv: {close_calls[0]}"
     )
     assert _SANDBOX in close_calls[0], "gh issue close must target the sandbox repo"
+
+
+# ---------------------------------------------------------------------------
+# _record_create_pr (issue #8699)
+# ---------------------------------------------------------------------------
+
+
+def test_record_github_mutation_writes_pr_create_cassette(tmp_path: Path) -> None:
+    with patch("contract_recording.subprocess.run", side_effect=_mutation_fake_run):
+        paths = record_github_mutation(sandbox_repo=_SANDBOX, tmp_cassette_dir=tmp_path)
+
+    stems = {p.stem for p in paths}
+    assert "pr_create" in stems
+    cassette = Cassette.model_validate(_load_yaml(tmp_path / "pr_create.yaml"))
+    assert cassette.adapter == "github"
+    assert cassette.interaction == "pr_create"
+    assert cassette.input.command == "create_pr"
+    assert cassette.output.exit_code == 0
+    assert "pr_number" in cassette.normalizers
+    assert not cassette.baseline_only
+
+
+def test_record_github_mutation_pr_create_writes_stable_args(tmp_path: Path) -> None:
+    """pr_create cassette must store the stable logical args (["42",
+    "contract-branch"]) matching the committed baseline byte-for-byte — NOT
+    the live sandbox PR number/branch. ``input.args`` is compared verbatim by
+    the drift layer, so a live value would phantom-drift every tick (#9535
+    pattern)."""
+    with patch("contract_recording.subprocess.run", side_effect=_mutation_fake_run):
+        record_github_mutation(sandbox_repo=_SANDBOX, tmp_cassette_dir=tmp_path)
+
+    cassette = Cassette.model_validate(_load_yaml(tmp_path / "pr_create.yaml"))
+    assert cassette.input.args == ["42", "contract-branch"], (
+        f"pr_create args must be stable ['42', 'contract-branch'], not the "
+        f"live values: {cassette.input.args}"
+    )
+    assert cassette.output.stdout == "https://github.com/test-org/test-repo/pull/101\n"
+
+
+def test_record_create_pr_posts_synthetic_commit_before_pr_create(
+    tmp_path: Path,
+) -> None:
+    """The recorder must POST a tree-identical synthetic commit AND
+    fast-forward the scratch ref BEFORE calling ``gh pr create`` — otherwise
+    GitHub rejects the no-diff branch (the #9535 bug merge_pr had)."""
+    calls: list[list[str]] = []
+
+    def capture(argv: list[str], **kw: object) -> subprocess.CompletedProcess[str]:
+        calls.append(list(argv))
+        return _mutation_fake_run(argv)
+
+    with patch("contract_recording.subprocess.run", side_effect=capture):
+        record_github_mutation(sandbox_repo=_SANDBOX, tmp_cassette_dir=tmp_path)
+
+    commit_post = [
+        i
+        for i, c in enumerate(calls)
+        if any(str(a).startswith("parents[]=") for a in c)
+    ]
+    patch_ref = [
+        i
+        for i, c in enumerate(calls)
+        if "--method" in c
+        and "PATCH" in c
+        and any("git/refs/heads/contract-recorder-create-pr-scratch" in a for a in c)
+    ]
+    pr_creates = [
+        i
+        for i, c in enumerate(calls)
+        if "pr" in c
+        and "create" in c
+        and "--head" in c
+        and c[c.index("--head") + 1] == "contract-recorder-create-pr-scratch"
+    ]
+
+    assert commit_post, "recorder must POST a synthetic commit (parents[]= field)"
+    assert patch_ref, "recorder must PATCH the create_pr scratch ref"
+    assert pr_creates, "recorder must call gh pr create for the create_pr scratch PR"
+    assert patch_ref[0] < pr_creates[0], (
+        "scratch ref PATCH must precede gh pr create for the create_pr scratch branch"
+    )
+
+
+def test_record_create_pr_closes_scratch_pr_after_cassette_written(
+    tmp_path: Path,
+) -> None:
+    """``_record_create_pr`` must close (with --delete-branch) the scratch PR
+    it opened after writing the cassette, so the sandbox doesn't accumulate
+    open PRs across ContractRefreshLoop ticks."""
+    from contract_recording import _record_create_pr
+
+    calls: list[list[str]] = []
+
+    def capture(argv: list[str], **kw: object) -> subprocess.CompletedProcess[str]:
+        calls.append(list(argv))
+        return _mutation_fake_run(argv)
+
+    with patch("contract_recording.subprocess.run", side_effect=capture):
+        result = _record_create_pr(sandbox_repo=_SANDBOX, tmp_dir=tmp_path)
+
+    assert result is not None
+    assert (tmp_path / "pr_create.yaml").exists()
+
+    close_calls = [
+        c for c in calls if "pr" in c and "close" in c and "--delete-branch" in c
+    ]
+    assert len(close_calls) == 1, (
+        f"expected exactly one 'gh pr close --delete-branch' cleanup call, "
+        f"got {len(close_calls)}: {close_calls}"
+    )
+    assert "7" in close_calls[0], (
+        f"gh pr close must use the live PR number (7) parsed from the create "
+        f"URL, got argv: {close_calls[0]}"
+    )
+
+
+def test_record_create_pr_returns_none_when_synthetic_commit_fails(
+    tmp_path: Path,
+) -> None:
+    """When the synthetic-commit POST for the create_pr scratch branch exits
+    non-zero, no pr_create cassette is written and the recorder never raises
+    into the loop (graceful failure)."""
+
+    def failing_commit_post(
+        argv: list[str], **_: object
+    ) -> subprocess.CompletedProcess[str]:
+        if any(str(a).startswith("parents[]=") for a in argv):
+            return _completed(argv=argv, returncode=1, stderr="422 Unprocessable\n")
+        return _mutation_fake_run(argv)
+
+    with patch("contract_recording.subprocess.run", side_effect=failing_commit_post):
+        paths = record_github_mutation(sandbox_repo=_SANDBOX, tmp_cassette_dir=tmp_path)
+
+    stems = {p.stem for p in paths}
+    assert "pr_create" not in stems
+    assert not (tmp_path / "pr_create.yaml").exists()
+
+
+# ---------------------------------------------------------------------------
+# _record_create_promotion_pr (issue #8699)
+# ---------------------------------------------------------------------------
+
+
+def test_record_github_mutation_writes_create_promotion_pr_cassette(
+    tmp_path: Path,
+) -> None:
+    with patch("contract_recording.subprocess.run", side_effect=_mutation_fake_run):
+        paths = record_github_mutation(sandbox_repo=_SANDBOX, tmp_cassette_dir=tmp_path)
+
+    stems = {p.stem for p in paths}
+    assert "create_promotion_pr" in stems
+    cassette = Cassette.model_validate(
+        _load_yaml(tmp_path / "create_promotion_pr.yaml")
+    )
+    assert cassette.adapter == "github"
+    assert cassette.interaction == "create_promotion_pr"
+    assert cassette.input.command == "create_promotion_pr"
+    assert cassette.output.exit_code == 0
+    assert "pr_number" in cassette.normalizers
+    assert not cassette.baseline_only
+
+
+def test_record_github_mutation_create_promotion_pr_writes_stable_args(
+    tmp_path: Path,
+) -> None:
+    """create_promotion_pr cassette must store the stable rc-branch arg
+    matching the committed #10092 baseline byte-for-byte — NOT the live
+    sandbox scratch branch/PR number."""
+    with patch("contract_recording.subprocess.run", side_effect=_mutation_fake_run):
+        record_github_mutation(sandbox_repo=_SANDBOX, tmp_cassette_dir=tmp_path)
+
+    cassette = Cassette.model_validate(
+        _load_yaml(tmp_path / "create_promotion_pr.yaml")
+    )
+    assert cassette.input.args == ["rc/2026-05-13-0000"], (
+        f"create_promotion_pr args must be the stable rc-branch value, not "
+        f"the live scratch branch: {cassette.input.args}"
+    )
+    assert cassette.output.stdout == "https://github.com/test/repo/pull/10000\n"
+
+
+def test_record_create_promotion_pr_posts_synthetic_commit_before_pr_create(
+    tmp_path: Path,
+) -> None:
+    """Same no-diff-PR guard as merge_pr/create_pr: the synthetic commit +
+    ref PATCH must precede ``gh pr create`` for the promotion scratch branch."""
+    calls: list[list[str]] = []
+
+    def capture(argv: list[str], **kw: object) -> subprocess.CompletedProcess[str]:
+        calls.append(list(argv))
+        return _mutation_fake_run(argv)
+
+    with patch("contract_recording.subprocess.run", side_effect=capture):
+        record_github_mutation(sandbox_repo=_SANDBOX, tmp_cassette_dir=tmp_path)
+
+    patch_ref = [
+        i
+        for i, c in enumerate(calls)
+        if "--method" in c
+        and "PATCH" in c
+        and any("git/refs/heads/contract-recorder-promotion-scratch" in a for a in c)
+    ]
+    pr_creates = [
+        i
+        for i, c in enumerate(calls)
+        if "pr" in c
+        and "create" in c
+        and "--head" in c
+        and c[c.index("--head") + 1] == "contract-recorder-promotion-scratch"
+    ]
+
+    assert patch_ref, "recorder must PATCH the promotion scratch ref"
+    assert pr_creates, "recorder must call gh pr create for the promotion scratch PR"
+    assert patch_ref[0] < pr_creates[0], (
+        "scratch ref PATCH must precede gh pr create for the promotion branch"
+    )
+
+
+def test_record_create_promotion_pr_closes_scratch_pr_after_cassette_written(
+    tmp_path: Path,
+) -> None:
+    """``_record_create_promotion_pr`` must close (with --delete-branch) the
+    scratch PR it opened after writing the cassette."""
+    from contract_recording import _record_create_promotion_pr
+
+    calls: list[list[str]] = []
+
+    def capture(argv: list[str], **kw: object) -> subprocess.CompletedProcess[str]:
+        calls.append(list(argv))
+        return _mutation_fake_run(argv)
+
+    with patch("contract_recording.subprocess.run", side_effect=capture):
+        result = _record_create_promotion_pr(sandbox_repo=_SANDBOX, tmp_dir=tmp_path)
+
+    assert result is not None
+    assert (tmp_path / "create_promotion_pr.yaml").exists()
+
+    close_calls = [
+        c for c in calls if "pr" in c and "close" in c and "--delete-branch" in c
+    ]
+    assert len(close_calls) == 1, (
+        f"expected exactly one 'gh pr close --delete-branch' cleanup call, "
+        f"got {len(close_calls)}: {close_calls}"
+    )
+
+
+def test_record_create_promotion_pr_returns_none_when_pr_create_fails(
+    tmp_path: Path,
+) -> None:
+    """A failing ``gh pr create`` for the promotion scratch branch must not
+    write a cassette and must not raise into the loop."""
+
+    def failing_pr_create(
+        argv: list[str], **_: object
+    ) -> subprocess.CompletedProcess[str]:
+        if (
+            "pr" in argv
+            and "create" in argv
+            and "--head" in argv
+            and argv[argv.index("--head") + 1] == "contract-recorder-promotion-scratch"
+        ):
+            return _completed(argv=argv, returncode=1, stderr="422 Unprocessable\n")
+        return _mutation_fake_run(argv)
+
+    with patch("contract_recording.subprocess.run", side_effect=failing_pr_create):
+        paths = record_github_mutation(sandbox_repo=_SANDBOX, tmp_cassette_dir=tmp_path)
+
+    stems = {p.stem for p in paths}
+    assert "create_promotion_pr" not in stems
+    assert not (tmp_path / "create_promotion_pr.yaml").exists()

--- a/tests/trust/contracts/cassettes/github/README.md
+++ b/tests/trust/contracts/cassettes/github/README.md
@@ -5,9 +5,12 @@ This directory contains two kinds of cassettes:
 **Machine-recorded** (`baseline_only: false`) — refreshed by
 `ContractRefreshLoop` via `record_github_mutation` in
 `src/contract_recording.py`. Each recording provisions fresh sandbox
-resources, runs the mutation, writes the cassette, and tears down the
-sandbox state (e.g. closing the scratch issue). Currently covers:
-`close_issue.yaml`, `create_issue.yaml`, `merge_pr.yaml`.
+resources (issue, or scratch branch + PR via a tree-identical synthetic
+commit), runs the mutation, writes the cassette, and tears down the sandbox
+state (closing the scratch issue/PR, best-effort deleting the scratch
+branch). Currently covers: `close_issue.yaml`, `create_issue.yaml`,
+`merge_pr.yaml`, `pr_create.yaml` (`create_pr`), `create_promotion_pr.yaml`
+(issue #8699).
 
 **Hand-authored baselines** (`baseline_only: true`) — not refreshed by
 `ContractRefreshLoop`. Identifiable by both:
@@ -17,7 +20,7 @@ sandbox state (e.g. closing the scratch issue). Currently covers:
   checkable retirement marker)
 
 All remaining cassettes (e.g. `add_labels.yaml`, `post_comment.yaml`,
-`pr_create.yaml`, etc.) are hand-authored baselines.
+`merge_promotion_pr.yaml`, etc.) are hand-authored baselines.
 
 ## Retirement plan (Phase 4 of #8786)
 
@@ -41,11 +44,14 @@ respective FakeGitHub methods.
 
 ## Why some cassettes are still hand-authored
 
-Cassettes for `gh label create`, `gh issue edit --add-label`, and other
-operations not yet covered by `record_github_mutation` remain hand-authored
-because extending the recorder to cover them safely is tracked separately
-(#8693, #8699). The sandbox setup/teardown contract in
-`record_github_mutation` is the pattern to follow when adding new
+Cassettes for `gh label create`, `gh issue edit --add-label`,
+`merge_promotion_pr`, and other operations not yet covered by
+`record_github_mutation` remain hand-authored because extending the recorder
+to cover them safely is tracked separately (#8693). `merge_promotion_pr`'s
+real CLI shape (`gh pr merge --merge --delete-branch`) is already identical
+to `merge_pr`'s (see `_record_merge_pr`) — promoting it to machine-recorded
+is a small follow-up, not a design gap. The sandbox setup/teardown contract
+in `record_github_mutation` is the pattern to follow when adding new
 machine-recorded operations.
 
 ## How baselines stay accurate

--- a/tests/trust/contracts/cassettes/github/create_promotion_pr.yaml
+++ b/tests/trust/contracts/cassettes/github/create_promotion_pr.yaml
@@ -1,4 +1,5 @@
-# Hand-authored baseline (recorder_sha: "00000000").
+# Promoted to auto-refreshable (issue #8699) — see
+# contract_recording._record_create_promotion_pr.
 # create_promotion_pr opens the rc/* -> main promotion PR and returns its
 # number. Load-bearing host detail (#9436 plan): FakeGitHub stores
 # https://github.com/test/repo/pull/{num} — NOT the test-org/test-repo host
@@ -22,4 +23,4 @@ output:
   stderr: ""
 normalizers:
   - pr_number
-baseline_only: true
+baseline_only: false

--- a/tests/trust/contracts/cassettes/github/pr_create.yaml
+++ b/tests/trust/contracts/cassettes/github/pr_create.yaml
@@ -1,3 +1,8 @@
+# Promoted to auto-refreshable (issue #8699) — see
+# contract_recording._record_create_pr. Filename/interaction stay "pr_create"
+# (predates the command/interaction-match naming convention) so
+# contract_diff.detect_adapter_drift's filename-keyed match lands the
+# recorder's output on this same fixture instead of an orphaned duplicate.
 adapter: github
 interaction: pr_create
 recorded_at: "2026-04-22T14:07:03Z"
@@ -16,4 +21,4 @@ output:
   stderr: ""
 normalizers:
   - pr_number
-baseline_only: true
+baseline_only: false


### PR DESCRIPTION
Closes #8699.

`contract_recording.record_github_mutation` only auto-recorded a subset, so the hand-authored create_pr / create_promotion_pr cassettes (the latter added by #10092) could silently drift from the live `gh` CLI — defeating ADR-0047's lights-off intent.

**Fix:** added `_record_create_pr` + `_record_create_promotion_pr`, mirroring `_record_merge_pr` exactly — provision a tree-identical synthetic-commit scratch branch (the #9535 no-diff-PR guard), run real `gh pr create --base main`, write a fake-shaped cassette with STABLE logical args (never the live PR number/branch), best-effort cleanup. Separate scratch branches per recorder so all three PR-creation recordings coexist in one tick. Only the allowlisted `pr_number` normalizer used; the two live-recording guards untouched.

20 new tests (schema/shape, stable-args, synthetic-commit ordering, cleanup) + a drift regression pin mirroring #9535's, asserting drift-free recording against the committed cassettes. `merge_promotion_pr` left as a noted small follow-up (its CLI shape == merge_pr's existing recorder). Full `tests/regressions` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)