### PR TITLE
perf(ci): uv caching + parallel PR gate (coverage off critical path) + quality.yml dedup (Tier 1b/2a/2b)

### DIFF
--- a/.github/workflows/arch-regen.yml
+++ b/.github/workflows/arch-regen.yml
@@ -48,6 +48,9 @@ jobs:
           fi
       - uses: astral-sh/setup-uv@v4
         if: steps.skip_check.outputs.pure_regen != 'true'
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - uses: actions/setup-python@v5
         if: steps.skip_check.outputs.pure_regen != 'true'
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,8 @@ jobs:
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -212,6 +214,8 @@ jobs:
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -231,6 +235,8 @@ jobs:
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -252,6 +258,8 @@ jobs:
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -276,6 +284,8 @@ jobs:
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -283,8 +293,45 @@ jobs:
         run: uv sync --all-extras
       - name: Warning gate (targeted)
         run: PYTHONPATH=src uv run pytest tests/test_execution.py tests/test_agent_advanced.py tests/test_agent_cli.py tests/test_agent_execution.py tests/test_agent_lifecycle.py tests/test_agent_output.py tests/test_hitl_runner.py tests/test_prompt_telemetry.py tests/test_dashboard_routes_control.py tests/test_dashboard_routes_core.py tests/test_dashboard_routes_hitl.py tests/test_dashboard_routes_issue_history.py tests/test_dashboard_routes_metrics.py tests/test_dashboard_routes_repo.py tests/test_dashboard_routes_state.py -W error::RuntimeWarning -W error::pytest.PytestUnraisableExceptionWarning
-      - name: Run tests with coverage
-        run: PYTHONPATH=src uv run pytest tests/ --ignore=tests/regressions --cov=src --cov-fail-under=70 --cov-report=term-missing --cov-report=json
+      # PR merge gate (Tier 2a): FAST parallel pass/fail, no coverage. Coverage
+      # is single-threaded and too slow for the merge path — it moved to the
+      # trailing `coverage` job (push-to-staging + nightly). tests/scenarios is
+      # excluded here and run SERIALLY below: process-global OTel/loop-registry
+      # + convergence-timing state flakes across xdist workers (Tier 1a split).
+      - name: Run tests (fast, parallel — no coverage)
+        run: PYTHONPATH=src uv run pytest tests/ --ignore=tests/regressions --ignore=tests/scenarios -n auto --dist loadscope
+      - name: Run scenario tests (serial)
+        run: PYTHONPATH=src uv run pytest tests/scenarios
+
+  # Trailing coverage gate (Tier 2a). Coverage is SINGLE-THREADED (xdist + --cov
+  # is finicky) and therefore too slow for the PR merge path, so it runs OFF the
+  # PR critical path — on push to the default/staging branch and on the nightly
+  # schedule only (`if: github.event_name != 'pull_request'`). It STILL fails
+  # red if coverage drops below 70%, so the gate is preserved as a trailing
+  # safety net rather than dropped. The `changes` gating mirrors the `test` job.
+  # Deliberately NOT in ci-gate's `needs`: it must not gate the PR merge path.
+  coverage:
+    name: Coverage (trailing)
+    needs: changes
+    if: |
+      github.event_name != 'pull_request' &&
+      (needs.changes.outputs.core_python == 'true' || needs.changes.outputs.ci == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: uv sync --all-extras
+      - name: Run tests with coverage (single-threaded)
+        run: PYTHONPATH=src uv run pytest tests/ --cov=src --cov-fail-under=70 --cov-report=term-missing --cov-report=json -p no:xdist
       - name: Upload coverage.json
         if: always()
         uses: actions/upload-artifact@v4
@@ -311,6 +358,8 @@ jobs:
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -338,6 +387,8 @@ jobs:
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -359,6 +410,8 @@ jobs:
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -446,6 +499,8 @@ jobs:
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -553,6 +608,8 @@ jobs:
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,9 +299,13 @@ jobs:
       # excluded here and run SERIALLY below: process-global OTel/loop-registry
       # + convergence-timing state flakes across xdist workers (Tier 1a split).
       - name: Run tests (fast, parallel — no coverage)
-        run: PYTHONPATH=src uv run pytest tests/ --ignore=tests/regressions --ignore=tests/scenarios -n auto --dist loadscope
-      - name: Run scenario tests (serial)
-        run: PYTHONPATH=src uv run pytest tests/scenarios
+        # tests/scenarios + tests/test_review_phase_metrics.py are xdist-unsafe
+        # (process-global OTel/loop-registry/timing #10111; leaked review_advisor
+        # client mock) — excluded here, run serially below. Keep in sync with the
+        # Makefile PYTEST_SERIAL_PATHS.
+        run: PYTHONPATH=src uv run pytest tests/ --ignore=tests/regressions --ignore=tests/scenarios --ignore=tests/test_review_phase_metrics.py -n auto --dist loadscope --reruns 2 --reruns-delay 1
+      - name: Run serial (xdist-unsafe) tests
+        run: PYTHONPATH=src uv run pytest tests/scenarios tests/test_review_phase_metrics.py
 
   # Trailing coverage gate (Tier 2a). Coverage is SINGLE-THREADED (xdist + --cov
   # is finicky) and therefore too slow for the PR merge path, so it runs OFF the

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -141,6 +141,9 @@ jobs:
       - name: Set up uv
         if: ${{ needs.changes.outputs.code == 'true' && (hashFiles(format('{0}/Makefile', matrix.project_dir), format('{0}/makefile', matrix.project_dir), format('{0}/GNUmakefile', matrix.project_dir)) != '') }}
         uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - name: Set up Node
         if: ${{ needs.changes.outputs.code == 'true' && (hashFiles(format('{0}/package.json', matrix.project_dir)) != '') }}
         uses: actions/setup-node@v4
@@ -170,6 +173,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # #dedup: the repo ROOT's full quality is already covered by ci.yml's
+          # granular lanes (Lint/Tests/Type Check/Architecture Check), so running
+          # a full `make quality` on `.` here just runs the whole suite twice per
+          # PR. Skip it — the job still reports `quality (.)` SUCCESS (a required
+          # check), we just don't redo the work. Managed SUB-projects (e.g.
+          # src/ui) still get their own `make quality` below.
+          if [ "${{ matrix.project_dir }}" = "." ]; then
+            echo "Root covered by ci.yml lanes (#dedup); skipping redundant make quality."
+            exit 0
+          fi
           cd "${{ matrix.project_dir }}"
           if [ -f Makefile ] || [ -f makefile ] || [ -f GNUmakefile ]; then
             make quality
@@ -181,6 +194,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # #dedup: root smoke is covered by ci.yml's Smoke Tests lane.
+          if [ "${{ matrix.project_dir }}" = "." ]; then
+            echo "Root smoke covered by ci.yml (#dedup); skipping."
+            exit 0
+          fi
           cd "${{ matrix.project_dir }}"
           if [ -f Makefile ] || [ -f makefile ] || [ -f GNUmakefile ]; then
             if make -n smoke >/dev/null 2>&1; then

--- a/.github/workflows/rc-promotion-scenario.yml
+++ b/.github/workflows/rc-promotion-scenario.yml
@@ -83,6 +83,8 @@ jobs:
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -114,6 +116,8 @@ jobs:
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -158,6 +162,8 @@ jobs:
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,26 @@ DEPS_STAMP := $(VENV)/.deps-synced
 # assert convergence ORDERING/timing, so cross-worker scheduling makes them
 # flake. Making scenarios xdist-safe (per-worker OTel provider + registry
 # isolation) is a tracked follow-up. Override PYTEST_PARALLEL= to disable.
-PYTEST_PARALLEL ?= -n auto --dist loadscope
+# `--reruns` rescues TRANSIENT cross-worker flakes a newly-parallelized suite
+# surfaces (subprocess PID/timing races, e.g. the process-group reap tests) —
+# deterministic failures still fail on every retry and stay red, so real breaks
+# are not masked. PERSISTENT isolation leaks (a global mock left set) are NOT
+# rescued by reruns and are quarantined via PYTEST_SERIAL_PATHS instead.
+PYTEST_PARALLEL ?= -n auto --dist loadscope --reruns 2 --reruns-delay 1
+
+# Paths excluded from the parallel run and executed SERIALLY (xdist-unsafe:
+# process-global state that collides across workers). tests/scenarios: OTel
+# provider + loop-registration catalog + convergence-timing (#10111).
+# tests/test_review_phase_metrics.py: a leaked global review_advisor client mock
+# degrades the advisor under cross-worker ordering (passes single-threaded) —
+# tracked follow-up. Add a path here when a non-scenario test proves
+# xdist-unsafe; the real fix is per-test isolation, not growing this list.
+# tests/regressions runs serially too — it mirrors CI (the Regression Tests job
+# is single-threaded) and contains the subprocess-group reap tests (own
+# dedicated serial CI lane), which race under parallel workers (timing, not a
+# real bug). Keeps the local `make quality` split identical to CI's job layout.
+PYTEST_SERIAL_PATHS ?= tests/scenarios tests/regressions tests/test_review_phase_metrics.py
+PYTEST_SERIAL_IGNORE := $(addprefix --ignore=,$(PYTEST_SERIAL_PATHS))
 
 # Runtime overrides (used by `make hot`)
 WORKERS ?= 3
@@ -188,8 +207,8 @@ cover: coverage
 
 test: deps
 	@echo "$(BLUE)Running HydraFlow unit tests (parallel; scenarios serial)...$(RESET)"
-	@cd $(HYDRAFLOW_DIR) && PYTHONPATH=src $(UV) pytest tests/ --ignore=tests/scenarios $(PYTEST_PARALLEL) -q
-	@cd $(HYDRAFLOW_DIR) && PYTHONPATH=src $(UV) pytest tests/scenarios -q
+	@cd $(HYDRAFLOW_DIR) && PYTHONPATH=src $(UV) pytest tests/ $(PYTEST_SERIAL_IGNORE) $(PYTEST_PARALLEL) -q
+	@cd $(HYDRAFLOW_DIR) && PYTHONPATH=src $(UV) pytest $(PYTEST_SERIAL_PATHS) -q
 	@echo "$(GREEN)All tests passed$(RESET)"
 
 smoke: deps
@@ -396,8 +415,8 @@ quality: deps lint-ul
 	@cd $(HYDRAFLOW_DIR) && ( \
 		$(UV) pyright && echo "[typecheck OK]" & \
 		$(UV) bandit -c pyproject.toml -r . --severity-level medium && echo "[security OK]" & \
-		PYTHONPATH=src $(UV) pytest tests/ --ignore=tests/scenarios $(PYTEST_PARALLEL) && echo "[tests OK]" & \
-		PYTHONPATH=src $(UV) pytest tests/scenarios && echo "[scenarios OK]" & \
+		PYTHONPATH=src $(UV) pytest tests/ $(PYTEST_SERIAL_IGNORE) $(PYTEST_PARALLEL) && echo "[tests OK]" & \
+		PYTHONPATH=src $(UV) pytest $(PYTEST_SERIAL_PATHS) && echo "[serial-tests OK]" & \
 		PYTHONPATH=src $(UV) pytest tests/scenarios/ -m scenario_loops -q && echo "[scenario-loops OK]" & \
 		( $(UI_TEST_CMD) ) & \
 		wait_result=0; \

--- a/tests/architecture/test_setup_uv_caching.py
+++ b/tests/architecture/test_setup_uv_caching.py
@@ -1,0 +1,51 @@
+"""Guard: every `astral-sh/setup-uv` step across all CI workflows enables the
+uv cache.
+
+Without `enable-cache: true`, every job re-resolves and re-downloads the whole
+dependency set on each run (`uv sync --all-extras`) — the Tier 1b slowdown this
+ratchet exists to prevent regressing. Keying invalidation on `uv.lock` via
+`cache-dependency-glob` keeps the cache correct when deps change. A new workflow
+(or a new setup-uv step) that forgets caching fails here at PR time instead of
+silently burning minutes on every future run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOWS_DIR = _REPO_ROOT / ".github" / "workflows"
+
+
+def _setup_uv_steps() -> list[tuple[str, str, dict]]:
+    """Yield (workflow_file, job_name, step_dict) for every setup-uv step."""
+    found: list[tuple[str, str, dict]] = []
+    for wf in sorted(_WORKFLOWS_DIR.glob("*.yml")):
+        data = yaml.safe_load(wf.read_text(encoding="utf-8"))
+        for job_name, job in (data.get("jobs") or {}).items():
+            for step in job.get("steps") or []:
+                uses = (step or {}).get("uses", "")
+                if isinstance(uses, str) and uses.startswith("astral-sh/setup-uv"):
+                    found.append((wf.name, job_name, step))
+    return found
+
+
+def test_at_least_one_setup_uv_step_discovered():
+    # Sanity: the walker actually finds steps, so a green result below is not a
+    # vacuous pass from a broken parse/traversal.
+    assert _setup_uv_steps(), (
+        "no astral-sh/setup-uv steps found under .github/workflows"
+    )
+
+
+def test_every_setup_uv_step_enables_cache():
+    offenders: list[str] = []
+    for wf_name, job_name, step in _setup_uv_steps():
+        with_block = step.get("with") or {}
+        if with_block.get("enable-cache") is not True:
+            offenders.append(f"{wf_name}:{job_name} missing `enable-cache: true`")
+        if not with_block.get("cache-dependency-glob"):
+            offenders.append(f"{wf_name}:{job_name} missing `cache-dependency-glob`")
+    assert not offenders, "setup-uv steps without uv caching:\n" + "\n".join(offenders)


### PR DESCRIPTION
CI-speedup Tiers 1b+2a+2b. **1b:** uv caching on all setup-uv steps. **2a:** ci.yml Tests job → fast parallel gate (-n auto --dist loadscope --reruns 2; scenarios/regressions/review_phase_metrics serial, mirroring CI's job layout); coverage → new Coverage (trailing) job (push/schedule only, still fails <70%). **2b:** quality.yml dedup — 'quality (.)' stays a reporting (required) check but SKIPS the redundant make quality (ci.yml owns root); no branch-protection change. Quarantines: scenarios #10111, review_phase_metrics #10119. Guard test_setup_uv_caching.py. make quality green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)