### PR TITLE
perf(test): duration ratchet — fail tests over 60s budget unless grandfathered (Tier 4a)

### DIFF
--- a/tests/architecture/test_duration_ratchet.py
+++ b/tests/architecture/test_duration_ratchet.py
@@ -1,0 +1,77 @@
+"""Guard for the test-duration ratchet (CI-speedup Tier 4a).
+
+The ratchet lives in ``tests/conftest.py``: a ``pytest_runtest_makereport``
+hookwrapper that FAILS any test whose CALL phase exceeds ``_SLOW_TEST_BUDGET_S``
+unless its node id is in the shrink-only ``_SLOW_TEST_GRANDFATHER`` set. These
+static checks keep that machinery honest without running the slow tests
+themselves:
+
+  1. Every grandfather entry still resolves to a REAL, collectable test node —
+     so the set cannot rot, hide a typo, or grandfather a test that no longer
+     exists.
+  2. The hook is actually defined and is a hookwrapper (a plain hook would not
+     be able to mutate the report outcome).
+  3. Anti-vacuity — the budget is a positive number and the grandfather set is
+     non-empty, so the guard cannot pass by accident against an empty config.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests import conftest
+
+
+def test_grandfather_entries_resolve_to_real_tests(real_repo_root: Path) -> None:
+    """Each ``path::name`` entry points at a file that defines that test.
+
+    Static only — we parse for ``def <name>``; we never execute the slow tests.
+    Resolving the ids this way means a rename/deletion of a grandfathered test
+    (or a typo in the set) fails here instead of silently un-grandfathering.
+    """
+    missing: list[str] = []
+    for entry in conftest._SLOW_TEST_GRANDFATHER:
+        assert "::" in entry, f"grandfather entry is not 'path::name': {entry!r}"
+        rel_path, _, name = entry.partition("::")
+        test_file = real_repo_root / rel_path
+        if not test_file.is_file():
+            missing.append(f"{entry} (no such file: {rel_path})")
+            continue
+        source = test_file.read_text(encoding="utf-8")
+        if f"def {name}(" not in source:
+            missing.append(f"{entry} (no `def {name}(` in {rel_path})")
+
+    assert missing == [], (
+        "Grandfathered slow tests no longer resolve (rename/delete/typo?). "
+        "Fix or remove these entries in tests/conftest.py:\n  " + "\n  ".join(missing)
+    )
+
+
+def test_ratchet_hook_is_a_hookwrapper() -> None:
+    """The ratchet hook exists and is registered as a hookwrapper.
+
+    A non-wrapper hook cannot see/rewrite the report outcome, so the ratchet
+    would silently no-op. Assert the pluggy impl opts mark it as a wrapper.
+    """
+    hook = getattr(conftest, "pytest_runtest_makereport", None)
+    assert callable(hook), "tests.conftest.pytest_runtest_makereport must be defined"
+    impl_opts = getattr(hook, "pytest_impl", None)
+    assert impl_opts is not None, (
+        "pytest_runtest_makereport must be decorated with @pytest.hookimpl(...)"
+    )
+    assert impl_opts.get("hookwrapper") is True, (
+        "pytest_runtest_makereport must be a hookwrapper so it can rewrite the "
+        "report outcome to 'failed' for over-budget tests."
+    )
+
+
+def test_ratchet_config_is_not_vacuous() -> None:
+    """Budget is a positive number and the grandfather set is non-empty."""
+    budget = conftest._SLOW_TEST_BUDGET_S
+    assert isinstance(budget, int | float) and budget > 0, (
+        f"_SLOW_TEST_BUDGET_S must be a positive number, got {budget!r}"
+    )
+    assert isinstance(conftest._SLOW_TEST_GRANDFATHER, frozenset)
+    assert conftest._SLOW_TEST_GRANDFATHER, (
+        "_SLOW_TEST_GRANDFATHER must list the known-slow tests (non-empty)."
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,58 @@ def pytest_runtest_teardown(item: pytest.Item, nextitem: pytest.Item | None) -> 
         )
 
 
+# --- Test-duration ratchet (CI-speedup Tier 4a) -----------------------------
+# Prevent the suite from silently accumulating slow / hung tests. A test whose
+# CALL phase exceeds a deliberately generous budget FAILS with a clear message,
+# unless it is in the explicit shrink-only grandfather set below. This catches
+# new pathologically-slow or hung tests (a real one recently hung ~300s under
+# parallel execution) without flaking on ordinary machine variance.
+#
+# Follow-up (deliberately NOT done here): move genuinely-slow tests behind a
+# `@pytest.mark.slow` marker and run them in a dedicated nightly "slow" lane
+# instead of grandfathering them. That is a separate change; this ratchet only
+# guards the fast lane against regressions.
+_SLOW_TEST_BUDGET_S = 60.0
+# Tests legitimately over budget today (measured under parallel CPU contention,
+# so these are upper bounds). SHRINK-ONLY: optimize a test and remove it here;
+# never add a new one without justification. Optimizing these is tracked as a
+# follow-up.
+_SLOW_TEST_GRANDFATHER = frozenset(
+    {
+        "tests/test_audit_prompts.py::test_main_emits_report_to_expected_path",
+        "tests/test_audit_prompts.py::test_canary_cross_check_passes_when_every_trace_builder_registered",
+        "tests/test_audit_prompts.py::test_canary_cross_check_flags_drift_over_threshold",
+        "tests/test_orchestrator_integration.py::test_credit_pause_publishes_alerts_and_restores_loops",
+    }
+)
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[None]):  # noqa: ARG001 — call required by pytest hook signature
+    """Fail any test whose CALL phase exceeds the slow-test budget.
+
+    Grandfathered node ids are exempt (shrink-only — see
+    ``_SLOW_TEST_GRANDFATHER``). The budget is intentionally generous so normal
+    machine variance never trips it; only pathologically-slow or hung tests do.
+    """
+    outcome = yield
+    report = outcome.get_result()
+    if (
+        report.when == "call"
+        and report.passed
+        and report.duration > _SLOW_TEST_BUDGET_S
+    ):
+        nodeid = item.nodeid
+        if nodeid not in _SLOW_TEST_GRANDFATHER:
+            report.outcome = "failed"
+            report.longrepr = (
+                f"Duration ratchet: {nodeid} took {report.duration:.1f}s "
+                f"(> {_SLOW_TEST_BUDGET_S:.0f}s budget). Optimize it, or if it is "
+                f"unavoidably slow add it to _SLOW_TEST_GRANDFATHER in "
+                f"tests/conftest.py (shrink-only)."
+            )
+
+
 # Ensure source modules are importable from src/ layout.
 _REPO_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "src"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -252,6 +252,36 @@ def _reset_otel_tracer_provider():
 
 
 @pytest.fixture(autouse=True)
+def _restore_phase_utils_memory_seams():
+    """Snapshot + restore the ``phase_utils`` memory-suggestion seams per test.
+
+    Many modules patch ``phase_utils.file_memory_suggestion`` /
+    ``safe_file_memory_suggestion`` (review/implement/HITL phase hooks,
+    review-phase-metrics, phase-utils' own suite). If a patch escapes its test —
+    which xdist's cross-module worker scheduling can trigger — the module
+    attribute is left pointing at a stale ``AsyncMock``, so a LATER test's own
+    ``with patch(...)`` never rebinds the value the code under test resolves, and
+    that test's mock is "awaited 0 times". Snapshot + restore contains the leak
+    regardless of which test caused it (mirrors ``_restore_auto_pr_seams`` in
+    tests/scenarios/conftest.py). Fixes the whole memory-suggestion category
+    under -n auto (#10119 and the phase_utils flake).
+    """
+    import phase_utils
+
+    saved = (
+        phase_utils.file_memory_suggestion,
+        phase_utils.safe_file_memory_suggestion,
+    )
+    try:
+        yield
+    finally:
+        (
+            phase_utils.file_memory_suggestion,
+            phase_utils.safe_file_memory_suggestion,
+        ) = saved
+
+
+@pytest.fixture(autouse=True)
 def _disable_hitl_summary_autowarm(config) -> None:
     """Keep route tests deterministic unless a test explicitly opts in."""
     config.transcript_summarization_enabled = False


### PR DESCRIPTION
CI-speedup Tier 4a. Prevents silent slow-test accumulation: a test whose call phase exceeds a generous 60s budget FAILS with a clear message unless it is in a shrink-only grandfather set (a real test just hung 300s under parallel). Non-flaky — normal tests are <30s, so machine variance can't trip it. Grandfathers the 4 currently-slow tests (test_audit_prompts ×3, test_orchestrator_integration credit_pause); a guard test static-verifies the set resolves to real tests + the hook is a hookwrapper. Slow-test audit findings: top offenders are audit_prompts (88s) + orchestrator_integration (60s) + arch generators/drift (10-29s); optimizing them + moving @slow to a nightly lane is a follow-up. `make quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)