### PR TITLE
test(phase-utils): make TestMemorySuggester xdist-safe (unblocks the PR queue) (#10127)

### DIFF
--- a/tests/test_phase_utils.py
+++ b/tests/test_phase_utils.py
@@ -687,8 +687,10 @@ class TestMemorySuggester:
 
         suggest = MemorySuggester(config)
 
-        with patch(
-            "phase_utils.safe_file_memory_suggestion", new_callable=AsyncMock
+        with patch.object(
+            sys.modules[MemorySuggester.__module__],
+            "safe_file_memory_suggestion",
+            new_callable=AsyncMock,
         ) as mock_sfms:
             await suggest("transcript text", "planner", "issue #42")
 
@@ -706,8 +708,10 @@ class TestMemorySuggester:
 
         suggest = MemorySuggester(config)
 
-        with patch(
-            "phase_utils.safe_file_memory_suggestion", new_callable=AsyncMock
+        with patch.object(
+            sys.modules[MemorySuggester.__module__],
+            "safe_file_memory_suggestion",
+            new_callable=AsyncMock,
         ) as mock_sfms:
             await suggest("t1", "src1", "ref1")
             await suggest("t2", "src2", "ref2")


### PR DESCRIPTION
Closes #10127.

`tests/test_phase_utils.py::TestMemorySuggester::{test_delegates_to_safe_file_memory_suggestion,test_multiple_calls_reuse_bound_args}` failed under the parallel `Tests` lane (`-n auto`) on EVERY in-flight PR (#10116, #10084, factory #10125/#10126) — 'Expected safe_file_memory_suggestion to have been awaited once. Awaited 0 times' — while passing serially. The top queue-blocker.

**Root cause:** `patch("phase_utils.safe_file_memory_suggestion")` targets the module resolved from the import string; under `-n auto --dist loadscope` that can be a different module object than the one `MemorySuggester.__call__` resolves `safe_file_memory_suggestion` in (dual import identity, e.g. `phase_utils` vs `src.phase_utils`), so the installed AsyncMock is never the one awaited.

**Fix:** patch `sys.modules[MemorySuggester.__module__]` — the exact module object `MemorySuggester.__call__` looks the name up in — so the patch and the call-time lookup are guaranteed to hit the same attribute. Test-only; passes serially and is robust by construction under parallel scheduling. Same class as #10119; complements the #10111 xdist effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)