### PR TITLE
feat(sandbox): pipeline_poller e2e scenario + parity shim for the non-BaseBackgroundLoop stats emitter (#9441)

### DIFF
--- a/tests/sandbox_scenarios/scenarios/s76_pipeline_poller_emits_stats.py
+++ b/tests/sandbox_scenarios/scenarios/s76_pipeline_poller_emits_stats.py
@@ -1,0 +1,69 @@
+"""s76 — pipeline_poller emits a PIPELINE_STATS event.
+
+``pipeline_poller`` is the orchestrator-level ``_pipeline_stats_loop``
+(src/orchestrator.py ~965), NOT a ``BaseBackgroundLoop`` subclass — it is a
+hand-rolled ``while`` loop started directly from
+``HydraFlowOrchestrator``'s ``loop_factories`` list. It reports its heartbeat
+via ``BGWorkerManager.update_status`` (state only — no
+``BACKGROUND_WORKER_STATUS`` event), but each cycle it genuinely calls
+``orchestrator.emit_pipeline_stats()``, which publishes a ``PIPELINE_STATS``
+event (``EventType.PIPELINE_STATS`` == ``"pipeline_stats"``,
+src/events.py:86) onto the shared event bus (#9441).
+
+Because it is not in ``bg_loop_registry`` (only the caretaker/phase loops
+are), the docker sandbox always starts it as part of
+``HydraFlowOrchestrator.run()`` regardless of this scenario's
+``loops_enabled`` — its default cadence is 5 seconds
+(``bg_worker_manager.py``'s ``non_loop_defaults["pipeline_poller"] = 5``), so
+a PIPELINE_STATS event lands well within this scenario's poll timeout.
+
+``loops_enabled=["pipeline_poller"]`` still matters for the Tier-1 in-process
+parity test (``tests/scenarios/test_sandbox_parity.py``): it selects the
+``run_with_loops`` path, whose special case for this name drives the real
+``orchestrator.emit_pipeline_stats()`` instead of trying (and failing) to
+``LoopCatalog.instantiate("pipeline_poller")``.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s76_pipeline_poller_emits_stats"
+DESCRIPTION = (
+    "pipeline_poller (orchestrator-level _pipeline_stats_loop, not a "
+    "BaseBackgroundLoop) emits a PIPELINE_STATS event each cycle."
+)
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["pipeline_poller"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a PIPELINE_STATS event was published by pipeline_poller.
+
+    Scans the full ``/api/events`` history (not just the latest event) —
+    pipeline_poller publishes on every cycle, so any single event in the
+    history proves the emitter is wired end to end.
+    """
+    _ = page  # UI interaction not needed for this event-emission assertion
+
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list) and event.get("type") == "pipeline_stats"
+            for event in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    stats_events = [
+        event for event in events_payload if event.get("type") == "pipeline_stats"
+    ]
+    assert len(stats_events) >= 1, (
+        "Expected at least one pipeline_stats event from pipeline_poller; "
+        f"got none. All events: {events_payload!r}"
+    )

--- a/tests/scenarios/fakes/mock_world.py
+++ b/tests/scenarios/fakes/mock_world.py
@@ -784,6 +784,14 @@ class MockWorld:
 
         loop_instances = []
         for name in loops:
+            if name == "pipeline_poller":
+                # pipeline_poller is the orchestrator-level
+                # `_pipeline_stats_loop` (src/orchestrator.py ~965), NOT a
+                # BaseBackgroundLoop subclass, so LoopCatalog has no builder
+                # for it and instantiate() would raise "Unknown loop" (#9441).
+                # Handled as a special case in the execution loop below.
+                loop_instances.append((name, None))
+                continue
             instance = LoopCatalog.instantiate(
                 name, ports=self._loop_ports, config=config, deps=loop_deps
             )
@@ -791,11 +799,41 @@ class MockWorld:
 
         results: dict[str, dict[str, Any] | None] = {}
         for name, loop in loop_instances:
+            if name == "pipeline_poller":
+                orchestrator = await self._pipeline_poller_orchestrator()
+                stats: dict[str, Any] | None = None
+                for _ in range(cycles):
+                    await orchestrator.emit_pipeline_stats()
+                    stats = orchestrator.build_pipeline_stats().model_dump()
+                results[name] = stats
+                continue
             for _ in range(cycles):
                 stats = await loop._do_work()
                 results[name] = stats
 
         return results
+
+    async def _pipeline_poller_orchestrator(self) -> Any:
+        """Lazily build (and cache) a real orchestrator to drive pipeline_poller.
+
+        ``pipeline_poller`` is the orchestrator-level ``_pipeline_stats_loop``
+        (src/orchestrator.py ~965), not a ``BaseBackgroundLoop`` subclass, so
+        it has no ``_do_work()`` and ``LoopCatalog`` has no builder for it
+        (#9441). Rather than faking the emission, reuse the same
+        ``_build_wired_orchestrator`` helper the dashboard's
+        ``with_orchestrator=True`` path uses to construct a real
+        ``HydraFlowOrchestrator`` wired to this world's fakes, so
+        ``run_with_loops`` drives the genuine ``emit_pipeline_stats()`` and
+        publishes a real ``PIPELINE_STATS`` event on the harness bus — exactly
+        what happens in the docker sandbox stack. Cached on the world so
+        repeated calls (e.g. multiple scenarios in one test session) reuse the
+        same instance instead of re-wiring on every cycle.
+        """
+        if not hasattr(self, "_pipeline_orchestrator"):
+            self._pipeline_orchestrator = await self._build_wired_orchestrator(
+                self._harness.config, self._harness.bus, self._harness.state
+            )
+        return self._pipeline_orchestrator
 
     def _wire_seed_loop_seams(self, config: Any) -> None:
         """Wire seed-seam loop overrides from the last applied seed (#9543).


### PR DESCRIPTION
Closes #9441.

pipeline_poller is the orchestrator-level `_pipeline_stats_loop`, not a BaseBackgroundLoop, so `LoopCatalog.instantiate("pipeline_poller")` raised `Unknown loop` and the in-process parity path couldn't drive it; it also reports via `BGWorkerManager.update_status` (state only, no worker-status event), so the standard assertion couldn't observe it.

**Fix:** (1) parity shim — `MockWorld.run_with_loops` special-cases `pipeline_poller`, skipping `LoopCatalog.instantiate` and instead building a real wired `HydraFlowOrchestrator` (reusing `_build_wired_orchestrator`) and calling its genuine `emit_pipeline_stats()` each cycle — so Tier-1 exercises the production code path, not a fake. (2) new scenario `s76_pipeline_poller_emits_stats` whose `assert_outcome` polls `/api/events` for the `PIPELINE_STATS` event that `emit_pipeline_stats` genuinely publishes.

No MockWorldSeed field needed (uses existing loops_enabled/cycles_to_run); no golden-seed regen. Docker/Tier-2 needs no change — pipeline_poller already runs unconditionally in `orchestrator.run()`. Full parity suite 66/66 + tests/regressions green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)