### PR TITLE
feat(sandbox): per-issue updated_at seed field + stale_issue_gc fresh-skip active-trigger scenario (#9544)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,51 +1,51 @@
 {
-  "regenerated_at": "2026-07-21T08:13:01.056639+00:00",
-  "commit_sha": "99a8cda37c22d3072391a0efb3b2ba6a6b186aa6",
+  "regenerated_at": "2026-07-21T09:06:22.653857+00:00",
+  "commit_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86",
   "artifacts": {
     "loops.md": {
-      "source_sha": "99a8cda37c22d3072391a0efb3b2ba6a6b186aa6"
+      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
     },
     "ports.md": {
-      "source_sha": "99a8cda37c22d3072391a0efb3b2ba6a6b186aa6"
+      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
     },
     "labels.md": {
-      "source_sha": "99a8cda37c22d3072391a0efb3b2ba6a6b186aa6"
+      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
     },
     "modules.md": {
-      "source_sha": "99a8cda37c22d3072391a0efb3b2ba6a6b186aa6"
+      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
     },
     "events.md": {
-      "source_sha": "99a8cda37c22d3072391a0efb3b2ba6a6b186aa6"
+      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
     },
     "adr_xref.md": {
-      "source_sha": "99a8cda37c22d3072391a0efb3b2ba6a6b186aa6"
+      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
     },
     "mockworld.md": {
-      "source_sha": "99a8cda37c22d3072391a0efb3b2ba6a6b186aa6"
+      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
     },
     "changelog.md": {
-      "source_sha": "99a8cda37c22d3072391a0efb3b2ba6a6b186aa6"
+      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
     },
     "coverage_matrix.md": {
-      "source_sha": "99a8cda37c22d3072391a0efb3b2ba6a6b186aa6"
+      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
     },
     "adr-conformance.md": {
-      "source_sha": "99a8cda37c22d3072391a0efb3b2ba6a6b186aa6"
+      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
     },
     "ai_system_inventory.md": {
-      "source_sha": "99a8cda37c22d3072391a0efb3b2ba6a6b186aa6"
+      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
     },
     "traceability_matrix.md": {
-      "source_sha": "99a8cda37c22d3072391a0efb3b2ba6a6b186aa6"
+      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
     },
     "functional_areas.md": {
-      "source_sha": "99a8cda37c22d3072391a0efb3b2ba6a6b186aa6"
+      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
     },
     "ubiquitous-language.md": {
-      "source_sha": "99a8cda37c22d3072391a0efb3b2ba6a6b186aa6"
+      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "99a8cda37c22d3072391a0efb3b2ba6a6b186aa6"
+      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W30
 
+- `281548c` — feat(sandbox): seed BGWorkerManager registered_workers set + dead-man-switch stall-escalation e2e scenario (#10086) (#10131) (#10131) *(2026-07-21)*
 - `896486d` — feat(sandbox): seed materializer for EpicState + health trend/heartbeat history; s71/s72 active-trigger scenarios (#9643) (#10084) (#10084) *(2026-07-21)*
 - `0c629f3` — feat(erosion): pure change-spread sensor — modules-crossed + files-touched per change, baselined (#10105) (#10116) (#10116) *(2026-07-21)*
 - `97d7436` — feat(pr-red): Phase 1 infra-flake retrier caretaker loop — settled-red detect + bounded rerun (#10027) (#10124) (#10124) *(2026-07-21)*

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -59,7 +59,7 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 | `SkillPromptEvalLoop` | ✅ [0045] | ✅ [skill-prompt-eval-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_skill_prompt_eval_loop.py` | ✅ in catalog | ✅ `s17_skill_prompt_eval_clean_corpus.py` |
 | `StagingBisectLoop` | ✅ [0045, 0048, 0063] | ✅ [architecture.md] | ✅ loops.md | ✅ README.md | ✅ `test_staging_bisect_loop.py` | ✅ in catalog | ❌ |
 | `StagingPromotionLoop` | ✅ [0042] | ✅ [dependencies.md, patterns.md] | ✅ loops.md | ✅ README.md | ✅ `test_staging_promotion_loop.py` | ✅ in catalog | ❌ |
-| `StaleIssueGCLoop` | ✅ [0029, 0072] | ✅ [gotchas.md, stale-issue-gc-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_stale_issue_gc_loop.py` | ✅ in catalog | ❌ |
+| `StaleIssueGCLoop` | ✅ [0029, 0072] | ✅ [gotchas.md, stale-issue-gc-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_stale_issue_gc_loop.py` | ✅ in catalog | ✅ `s77_stale_issue_gc_skips_fresh_issue.py` |
 | `StaleIssueLoop` | ✅ [0072] | ✅ [gotchas.md, stale-issue-gc-loop.md, testing.md] | ✅ loops.md | ✅ README.md | ✅ `test_stale_issue_loop.py` | ✅ in catalog | ✅ `s05_hitl_after_review_exhaustion.py` |
 | `TermProposerLoop` | ✅ [0054, 0057, 0060, 0061, 0062, 0068] | ✅ [adr-council-reviewer.md, adr-index.md, adr-pre-validator.md, bot-pr-port.md, credentials.md, entry-evidence-loop.md, task.md, term-pruner-loop.md, tribal-wiki-store.md] | ✅ loops.md | ✅ README.md | ✅ `test_term_proposer_loop.py` | ✅ in catalog | ❌ |
 | `TermPrunerLoop` | ✅ [0057, 0060, 0062, 0068] | ✅ [term-pruner-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_term_pruner_loop.py` | ✅ in catalog | ❌ |

--- a/src/mockworld/fakes/fake_github.py
+++ b/src/mockworld/fakes/fake_github.py
@@ -183,6 +183,7 @@ class FakeGitHub:
                 body=issue_dict["body"],
                 labels=list(issue_dict.get("labels", [])),
                 state=issue_dict.get("state", "open"),
+                updated_at=issue_dict.get("updated_at"),
             )
         for issue_number, comment_dicts in seed.comments.items():
             for comment_dict in comment_dicts:
@@ -222,20 +223,32 @@ class FakeGitHub:
         body: str,
         labels: list[str] | None = None,
         state: str = "open",
+        updated_at: str | None = None,
     ) -> None:
         """Seed an issue. ``state`` accepts ``"open"`` (default) or ``"closed"``.
 
         A closed seed issue reports ``COMPLETED`` from ``get_issue_state``
         (close-reason defaulting mirrors gh, #10025) — the surface loops like
         workspace_gc/epic_sweeper consult before acting (#9543).
+
+        ``updated_at`` (#9544) lets a scenario control the issue's staleness
+        independently of ``FakeIssue``'s hard-coded ``2026-01-01T00:00:00Z``
+        default — needed to drive time-triggered loops like
+        ``stale_issue_gc`` down BOTH branches (closes a genuinely stale
+        issue, skips a genuinely fresh one) instead of every seeded issue
+        reading as equally stale. ``None`` (default) leaves ``FakeIssue``'s
+        own default untouched — back-compat for every pre-#9544 seed.
         """
-        self._issues[number] = FakeIssue(
+        issue = FakeIssue(
             number=number,
             title=title,
             body=body,
             labels=labels or [],
             state=state,
         )
+        if updated_at:
+            issue.updated_at = updated_at
+        self._issues[number] = issue
 
     def add_seeded_comment(
         self,

--- a/src/mockworld/seed.py
+++ b/src/mockworld/seed.py
@@ -27,6 +27,16 @@ class MockWorldSeed:
     # scenario exercise closed-issue reads (e.g. workspace_gc's is-it-safe-to-GC
     # check, epic_sweeper's are-all-children-done sweep) without driving the
     # whole pipeline to close it first (#9543).
+    #
+    # Also optionally ``updated_at`` (ISO-8601 string, #9544): overrides
+    # ``FakeIssue``'s hard-coded ``2026-01-01T00:00:00Z`` default so a
+    # scenario can seed a genuinely FRESH or genuinely STALE issue relative to
+    # real wall-clock ``datetime.now(UTC)`` — needed for time-triggered loops
+    # like ``stale_issue_gc`` (previously every seeded issue read as equally
+    # stale, making the "fresh issue is skipped" branch untestable). Both
+    # loaders (``FakeGitHub.from_seed`` for sandbox_main +
+    # ``MockWorld.apply_seed`` for the in-process harness) thread this through
+    # ``FakeGitHub.add_issue``. Absent key = no-op, back-compat preserved.
     issues: list[dict[str, Any]] = field(default_factory=list)
 
     # Per-issue seeded comments, keyed by issue number. Each entry is a dict

--- a/tests/sandbox_scenarios/scenarios/s77_stale_issue_gc_skips_fresh_issue.py
+++ b/tests/sandbox_scenarios/scenarios/s77_stale_issue_gc_skips_fresh_issue.py
@@ -1,0 +1,106 @@
+"""s77 — StaleIssueGCLoop closes a stale HITL issue but SKIPS a fresh one.
+
+Active-trigger scenario for #9544: before the per-issue seeded ``updated_at``
+(seed field consumed by both loaders' ``FakeGitHub.add_issue``),
+``FakeIssue.updated_at`` was a hard-coded ``2026-01-01T00:00:00Z`` constant —
+every seeded issue read as equally stale (or equally fresh, depending on the
+scenario's clock), so the "a fresh issue is skipped" branch of
+``StaleIssueGCLoop._do_work`` was untestable. This scenario seeds TWO HITL
+issues — one far past ``stale_issue_threshold_days`` (default 14) and one
+touched an hour ago — so a GC cycle must genuinely discriminate between them:
+close the stale one, skip the fresh one.
+
+Timestamps are computed relative to real wall-clock ``datetime.now(UTC)`` at
+seed-build time (mirroring the ``last_activity_age_days`` relative-offset
+convention used by the epic_states materializer) so the seed never rots —
+``StaleIssueGCLoop`` reads real time directly, unlike the age-offset
+materializer fields that back-date state at boot.
+
+No idle-poll counterpart exists yet for ``stale_issue_gc`` in the sandbox
+catalog; this is its first scenario.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s77_stale_issue_gc_skips_fresh_issue"
+DESCRIPTION = (
+    "StaleIssueGCLoop closes a seeded far-past-threshold HITL issue "
+    "(details.closed >= 1) but skips a seeded fresh one "
+    "(details.skipped >= 1), proving the fresh-issue-is-skipped branch."
+)
+
+# Distinct constant issue numbers across the seed and the assertions.
+_STALE_ISSUE = 7701
+_FRESH_ISSUE = 7702
+
+_HITL_LABEL = "hydraflow-hitl"
+
+
+def seed() -> MockWorldSeed:
+    now = datetime.now(UTC)
+    # 400 days >> any realistic stale_issue_threshold_days (default 14), so
+    # this issue is stale regardless of config drift.
+    stale_updated_at = (now - timedelta(days=400)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    # 1 hour << the threshold, so this issue reads as fresh regardless.
+    fresh_updated_at = (now - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return MockWorldSeed(
+        loops_enabled=["stale_issue_gc"],
+        cycles_to_run=2,
+        issues=[
+            {
+                "number": _STALE_ISSUE,
+                "title": "Stale HITL escalation",
+                "body": "No activity in a very long time.",
+                "labels": [_HITL_LABEL],
+                "updated_at": stale_updated_at,
+            },
+            {
+                "number": _FRESH_ISSUE,
+                "title": "Fresh HITL escalation",
+                "body": "Touched an hour ago.",
+                "labels": [_HITL_LABEL],
+                "updated_at": fresh_updated_at,
+            },
+        ],
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """A stale_issue_gc cycle closes the stale issue and skips the fresh one."""
+
+    def _acted(payload: object) -> bool:
+        events = payload if isinstance(payload, list) else []
+        return any(
+            e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "stale_issue_gc"
+            and (e.get("data", {}).get("details") or {}).get("closed", 0) >= 1
+            and (e.get("data", {}).get("details") or {}).get("skipped", 0) >= 1
+            for e in events
+        )
+
+    events_payload = await api.wait_until("/api/events", _acted, timeout=90.0)
+
+    gc_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "stale_issue_gc"
+    ]
+    assert any(
+        (e.get("data", {}).get("details") or {}).get("closed", 0) >= 1
+        for e in gc_events
+    ), (
+        f"Expected stale_issue_gc to close the seeded stale issue "
+        f"#{_STALE_ISSUE} (details.closed >= 1); worker events: {gc_events!r}"
+    )
+    assert any(
+        (e.get("data", {}).get("details") or {}).get("skipped", 0) >= 1
+        for e in gc_events
+    ), (
+        f"Expected stale_issue_gc to skip the seeded fresh issue "
+        f"#{_FRESH_ISSUE} (details.skipped >= 1); worker events: {gc_events!r}"
+    )

--- a/tests/scenarios/fakes/mock_world.py
+++ b/tests/scenarios/fakes/mock_world.py
@@ -370,6 +370,7 @@ class MockWorld:
         body: str,
         labels: list[str] | None = None,
         state: str = "open",
+        updated_at: str | None = None,
     ) -> MockWorld:
         self._issues[number] = {
             "number": number,
@@ -377,7 +378,9 @@ class MockWorld:
             "body": body,
             "labels": labels or ["hydraflow-find"],
         }
-        self._github.add_issue(number, title, body, labels=labels, state=state)
+        self._github.add_issue(
+            number, title, body, labels=labels, state=state, updated_at=updated_at
+        )
         return self
 
     def add_repo(
@@ -491,6 +494,7 @@ class MockWorld:
                 body=issue_dict["body"],
                 labels=list(issue_dict.get("labels", [])),
                 state=issue_dict.get("state", "open"),
+                updated_at=issue_dict.get("updated_at"),
             )
         for pr_dict in seed.prs:
             self._github.add_pr(

--- a/tests/scenarios/test_governance_active_trigger_scenarios.py
+++ b/tests/scenarios/test_governance_active_trigger_scenarios.py
@@ -41,6 +41,9 @@ from tests.sandbox_scenarios.scenarios import (
 from tests.sandbox_scenarios.scenarios import (
     s75_worker_stall_escalation as s75,
 )
+from tests.sandbox_scenarios.scenarios import (
+    s77_stale_issue_gc_skips_fresh_issue as s77,
+)
 
 
 async def _run(mock_world, scenario):
@@ -177,3 +180,24 @@ async def test_s75_health_monitor_escalates_stalled_registered_worker(
     )
     issue = mock_world._github._issues[stall_issues[0]["number"]]
     assert "Auto-restart attempted: `False`" in issue.body
+
+
+@pytest.mark.asyncio
+async def test_s77_stale_issue_gc_closes_stale_skips_fresh(mock_world) -> None:
+    """#9544 — a seeded per-issue ``updated_at`` lets stale_issue_gc genuinely
+    discriminate: close the far-past-threshold HITL issue, skip the fresh one.
+
+    Before the seeded ``updated_at`` seam, every ``FakeIssue`` shared the same
+    hard-coded ``2026-01-01T00:00:00Z`` default, so the "fresh issue is
+    skipped" branch of ``StaleIssueGCLoop._do_work`` was unreachable from a
+    scenario seed.
+    """
+    _seed, stats = await _run(mock_world, s77)
+
+    assert stats["stale_issue_gc"]["closed"] >= 1
+    assert stats["stale_issue_gc"]["skipped"] >= 1
+    # The world shows the side effects, not just the counters.
+    stale_issue = mock_world._github._issues[s77._STALE_ISSUE]
+    fresh_issue = mock_world._github._issues[s77._FRESH_ISSUE]
+    assert stale_issue.state == "closed"
+    assert fresh_issue.state == "open"

--- a/tests/scenarios/test_mock_world_apply_seed.py
+++ b/tests/scenarios/test_mock_world_apply_seed.py
@@ -86,6 +86,30 @@ async def test_apply_seed_threads_issue_state_and_pr_mergeable(mock_world) -> No
 
 
 @pytest.mark.asyncio
+async def test_apply_seed_threads_issue_updated_at(mock_world) -> None:
+    """#9544: a seeded per-issue ``updated_at`` reaches FakeIssue in the
+    in-process (Tier 1) loader too — dual-loader parity with FakeGitHub.from_seed."""
+    seed = MockWorldSeed(
+        issues=[
+            {
+                "number": 7701,
+                "title": "stale",
+                "body": "b",
+                "labels": [],
+                "updated_at": "2020-01-01T00:00:00Z",
+            },
+            {"number": 7702, "title": "no override", "body": "b", "labels": []},
+        ],
+    )
+
+    mock_world.apply_seed(seed)
+
+    assert mock_world._github._issues[7701].updated_at == "2020-01-01T00:00:00Z"
+    # Absent `updated_at` key still defaults to FakeIssue's own default.
+    assert mock_world._github._issues[7702].updated_at == "2026-01-01T00:00:00Z"
+
+
+@pytest.mark.asyncio
 async def test_apply_seed_threads_rulesets(mock_world) -> None:
     """#9543: seeded rulesets reach FakeGitHub.fetch_rulesets in Tier 1 too."""
     seed = MockWorldSeed(

--- a/tests/test_fake_github_from_seed.py
+++ b/tests/test_fake_github_from_seed.py
@@ -73,6 +73,31 @@ def test_from_seed_honors_issue_state() -> None:
     assert asyncio.run(gh.get_issue_state(7302)) == "OPEN"
 
 
+def test_from_seed_honors_issue_updated_at() -> None:
+    """#9544: a seeded ``updated_at`` overrides FakeIssue's hard-coded default,
+    so time-triggered loops (stale_issue_gc) can seed a genuinely fresh or
+    genuinely stale issue instead of every issue reading equally stale."""
+    seed = MockWorldSeed(
+        issues=[
+            {
+                "number": 7701,
+                "title": "stale",
+                "body": "b",
+                "labels": [],
+                "updated_at": "2020-01-01T00:00:00Z",
+            },
+            {"number": 7702, "title": "no override", "body": "b", "labels": []},
+        ],
+    )
+
+    gh = FakeGitHub.from_seed(seed)
+
+    assert gh._issues[7701].updated_at == "2020-01-01T00:00:00Z"
+    # Absent `updated_at` key still defaults to FakeIssue's own default —
+    # back-compat preserved for every pre-#9544 seed.
+    assert gh._issues[7702].updated_at == "2026-01-01T00:00:00Z"
+
+
 def test_from_seed_honors_pr_mergeable() -> None:
     """#9543: ``mergeable: false`` seeds a CONFLICTING PR the watcher can act on."""
     import asyncio

--- a/tests/test_mockworld_seed.py
+++ b/tests/test_mockworld_seed.py
@@ -305,6 +305,35 @@ def test_seed_round_trips_registered_workers_through_json() -> None:
     assert parsed.registered_workers["runs_gc"] == {}
 
 
+def test_seed_round_trips_issue_updated_at_through_json() -> None:
+    """#9544: a per-issue ``updated_at`` key survives JSON transfer intact.
+
+    ``issues`` entries are plain JSON-native dicts (no ``from_json``
+    coercion needed for this key, unlike the outer-key-as-int shapes
+    elsewhere in this file) — the equality check guards a future shape
+    that would need one.
+    """
+    original = MockWorldSeed(
+        issues=[
+            {
+                "number": 7701,
+                "title": "stale",
+                "body": "b",
+                "labels": ["hydraflow-hitl"],
+                "updated_at": "2020-01-01T00:00:00Z",
+            },
+            {"number": 7702, "title": "fresh", "body": "b", "labels": []},
+        ],
+    )
+
+    parsed = MockWorldSeed.from_json(original.to_json())
+
+    assert parsed == original
+    assert parsed.issues[0]["updated_at"] == "2020-01-01T00:00:00Z"
+    # Absent key round-trips as absent, not a coerced default.
+    assert "updated_at" not in parsed.issues[1]
+
+
 def test_seed_round_trips_active_trigger_seams_through_json() -> None:
     original = MockWorldSeed(
         issues=[


### PR DESCRIPTION
Closes #9544 (per-issue `updated_at` slice; the worker-status-history and wiki-fixture pieces are deferred follow-ups per the issue's own scope note).

MockWorldSeed.issues carried only number/title/body/labels, so stale_issue_gc could only be driven by FakeIssue's hard-coded `updated_at` default (2026-01-01) — the 'fresh issue is skipped' path was untestable.

**Fix:** `FakeGitHub.add_issue` (+ `from_seed`) and the in-process `MockWorld.add_issue`/`apply_seed` (dual-loader parity) thread an optional per-issue `updated_at`, only overriding the default when truthy. No new dataclass field — `issues` was already `list[dict]`, so no schema/serialization change and **golden seeds are unaffected** (regenerated all 6 → zero diff, confirming). New scenario `s77_stale_issue_gc_skips_fresh_issue`: seeds a 400-day-stale + a 1-hour-fresh issue (relative to real now, so the seed never rots) and asserts gc closes the stale one and skips the fresh one. Full pyramid; tests/regressions green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)