### PR TITLE
test(sandbox): per-test teardown guard closes the xdist blind spot in the seed-clean check (#10094 hardening)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,8 +32,34 @@ os.environ["HYDRAFLOW_SENTRY_DISABLED"] = "1"
 os.environ.pop("SENTRY_DSN", None)
 
 
+# #10094: committed sandbox seeds under tests/sandbox_scenarios/seeds/ must
+# never be mutated by the test suite (write_seed() materializing a
+# MockWorldSeed round-trip back onto its own source path adds schema
+# defaults like "comments": {} that then leak into unrelated commits).
+# tests/regressions/regression_issue_10094.py's `test_seed_dir_is_git_clean`
+# proves the dir was clean at ONE point in collection order; under
+# `-n auto --dist loadscope` a later test on a DIFFERENT xdist worker could
+# still dirty it afterward and go uncaught there. Snapshotting mtimes at
+# import time (before this process — controller or worker — runs its first
+# test) and re-checking after EVERY test's teardown closes that gap and, like
+# the MagicMock guard below, pins the exact offending test by name instead of
+# surfacing as an unexplained ` M` diff days later.
+_SANDBOX_SEEDS_DIR = Path(__file__).resolve().parent / "sandbox_scenarios" / "seeds"
+
+
+def _sandbox_seed_mtimes() -> dict[str, int]:
+    if not _SANDBOX_SEEDS_DIR.is_dir():
+        return {}
+    return {p.name: p.stat().st_mtime_ns for p in _SANDBOX_SEEDS_DIR.glob("*.json")}
+
+
+_sandbox_seed_baseline_mtimes = _sandbox_seed_mtimes()
+
+
 def pytest_runtest_teardown(item: pytest.Item, nextitem: pytest.Item | None) -> None:  # noqa: ARG001 — nextitem required by pytest hook signature
-    """Fail any test that leaves a ``MagicMock/`` directory in the repo root.
+    """Fail any test that leaves a ``MagicMock/`` directory in the repo root,
+
+    or that mutates a committed sandbox seed (#10094).
 
     Caused by passing a bare ``MagicMock()`` where production code expects a
     ``Path`` / config and calls ``.mkdir()`` on the result — the str() of the
@@ -54,6 +80,28 @@ def pytest_runtest_teardown(item: pytest.Item, nextitem: pytest.Item | None) -> 
             f"Mock-path pollution: test {item.nodeid} left {polluted} on disk. "
             "A MagicMock was used where a Path/config was expected. "
             "Use `MagicMock(spec=HydraFlowConfig)` or a real tmp_path-backed config."
+        )
+
+    current_seed_mtimes = _sandbox_seed_mtimes()
+    mutated_seeds = sorted(
+        name
+        for name, mtime in current_seed_mtimes.items()
+        if _sandbox_seed_baseline_mtimes.get(name) != mtime
+    )
+    if mutated_seeds:
+        # Absorb into the baseline so only the offending test is blamed —
+        # tests/regressions/regression_issue_10094.py::test_seed_dir_is_git_clean
+        # still catches the leftover git dirt from the actual content change.
+        _sandbox_seed_baseline_mtimes.update(
+            {name: current_seed_mtimes[name] for name in mutated_seeds}
+        )
+        pytest.fail(
+            f"Sandbox-seed tree-clean violation: test {item.nodeid} mutated "
+            f"committed seed(s) {mutated_seeds} in "
+            "tests/sandbox_scenarios/seeds/. Seeds are golden generated "
+            "artifacts — a test/fixture must never re-serialize a "
+            "materialized MockWorldSeed back to the source path; redirect the "
+            "write to tmp_path instead (#10094)."
         )
 
 

--- a/tests/regressions/regression_issue_10094.py
+++ b/tests/regressions/regression_issue_10094.py
@@ -14,7 +14,7 @@ then leaks into unrelated commits. Observed on
 ``s05_hitl_after_review_exhaustion.json`` but every committed generated seed
 was stale to some degree.
 
-Two guards, so the drift can never silently recur:
+Three guards, so the drift can never silently recur:
 
 1. **Freshness** — every committed *generated* seed must equal the current
    ``seed().to_json()`` for its scenario (exactly what ``write_seed`` would
@@ -26,6 +26,17 @@ Two guards, so the drift can never silently recur:
    this test (mirrors the repo's tree-clean hygiene guards, e.g. #9539). Fails
    loudly if a test or the harness mutates a committed seed in place. Skips
    cleanly outside a git checkout.
+
+3. **Round-trip isolation** — ``write_seed()`` run against the REAL scenario
+   module (not a mock — exercises the real ``MockWorldSeed.to_json()`` schema
+   round-trip that produces the default-valued-field drift) with ``SEEDS_DIR``
+   redirected to ``tmp_path`` must land ONLY in ``tmp_path`` and must leave the
+   real committed source file byte-for-byte and mtime untouched. Pins the fix
+   direction the issue asked for directly: a materialize round-trip writes to
+   a temp copy, never back to source. ``tests/test_sandbox_scenario_cli.py``
+   covers the CLI wiring but mocks ``load_scenario``/``to_json`` entirely, so
+   it never actually exercises the schema round-trip that causes the drift;
+   this guard closes that gap.
 
 ``_smoke.json`` is a hand-authored minimal fixture (a single-line payload, not
 ``write_seed`` output — it is deliberately NOT idempotent under
@@ -89,6 +100,45 @@ def test_committed_seed_matches_scenario_definition(seed_path: Path) -> None:
         "seed() and MUST be regenerated whenever MockWorldSeed or the scenario "
         "changes, or the next sandbox harness run rewrites them in place "
         "(#10094)."
+    )
+
+
+def test_write_seed_materialize_round_trip_never_touches_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``write_seed()`` must land ONLY in the injected ``SEEDS_DIR`` (#10094).
+
+    Exercises the REAL scenario module + REAL ``MockWorldSeed.to_json()`` —
+    not a mock — the same code path ``cmd_run``/``cmd_run-all``/``cmd_seed``
+    use, with ``SEEDS_DIR`` redirected to ``tmp_path``. Snapshots the real
+    committed seed's mtime and content before and after to prove the write
+    never lands on source, even if ``write_seed``'s target ever silently
+    drifted back to the real dir. This is the literal fix direction #10094
+    asked for: a materialize round-trip writes to a temp copy, never source.
+    """
+    from scripts import sandbox_scenario
+
+    stem = "s05_hitl_after_review_exhaustion"
+    real_seed_path = _SEEDS_DIR / f"{stem}.json"
+    content_before = real_seed_path.read_text()
+    mtime_before = real_seed_path.stat().st_mtime_ns
+
+    monkeypatch.setattr(sandbox_scenario, "SEEDS_DIR", tmp_path)
+    out = sandbox_scenario.write_seed(stem)
+
+    assert out == tmp_path / f"{stem}.json"
+    # Real round-trip through the current scenario/model — must match the
+    # freshness guard's expectation (both compute module.seed().to_json()).
+    module = importlib.import_module(f"tests.sandbox_scenarios.scenarios.{stem}")
+    assert out.read_text() == module.seed().to_json()
+
+    assert real_seed_path.read_text() == content_before, (
+        "write_seed() rewrote the COMMITTED source seed's content even "
+        "though SEEDS_DIR was redirected to tmp_path — the exact #10094 leak."
+    )
+    assert real_seed_path.stat().st_mtime_ns == mtime_before, (
+        "write_seed() touched the COMMITTED source seed's mtime even though "
+        "SEEDS_DIR was redirected to tmp_path — the exact #10094 leak."
     )
 
 

--- a/tests/test_sandbox_seed_tree_clean_guard.py
+++ b/tests/test_sandbox_seed_tree_clean_guard.py
@@ -1,0 +1,115 @@
+"""Verify the sandbox-seed tree-clean guard in tests/conftest.py fires (#10094).
+
+Mirrors tests/test_mock_path_pollution_guard.py's pattern: uses pytest's
+``pytester`` fixture to spin up an in-process pytest run against a
+self-contained conftest that reproduces the mtime-snapshot hook shape (not
+the real ``tests/conftest.py`` — that keeps this pinned to the guard's
+*mechanics*, independent of fragile path coupling to the repo root), then
+points it at synthetic tests that do/don't mutate a seed file. Must see the
+guard fire only when a seed is actually rewritten.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest_plugins = ["pytester"]
+
+_HOOK_CONFTEST = """
+    from pathlib import Path
+    import pytest
+
+    _SEEDS_DIR = Path(__file__).resolve().parent / "seeds"
+
+
+    def _mtimes():
+        if not _SEEDS_DIR.is_dir():
+            return {}
+        return {p.name: p.stat().st_mtime_ns for p in _SEEDS_DIR.glob("*.json")}
+
+
+    _baseline = _mtimes()
+
+
+    def pytest_runtest_teardown(item, nextitem):
+        current = _mtimes()
+        mutated = sorted(
+            name for name, mtime in current.items() if _baseline.get(name) != mtime
+        )
+        if mutated:
+            _baseline.update({name: current[name] for name in mutated})
+            pytest.fail(
+                f"Sandbox-seed tree-clean violation: test {item.nodeid} "
+                f"mutated committed seed(s) {mutated}."
+            )
+    """
+
+
+def test_guard_fires_when_a_test_rewrites_a_committed_seed(
+    pytester: pytest.Pytester,
+) -> None:
+    pytester.makeconftest(_HOOK_CONFTEST)
+    seeds_dir = pytester.path / "seeds"
+    seeds_dir.mkdir()
+    (seeds_dir / "s05_hitl_after_review_exhaustion.json").write_text('{"a": 1}')
+
+    pytester.makepyfile(
+        test_mutator="""
+        from pathlib import Path
+
+        def test_rewrites_committed_seed():
+            seed_path = (
+                Path(__file__).resolve().parent
+                / "seeds"
+                / "s05_hitl_after_review_exhaustion.json"
+            )
+            seed_path.write_text('{"a": 1, "comments": {}}')
+        """
+    )
+    result = pytester.runpytest("-q")
+    result.stdout.fnmatch_lines(["*Sandbox-seed tree-clean violation*"])
+    assert result.ret != 0
+
+
+def test_guard_quiet_when_no_seed_is_touched(pytester: pytest.Pytester) -> None:
+    pytester.makeconftest(_HOOK_CONFTEST)
+    seeds_dir = pytester.path / "seeds"
+    seeds_dir.mkdir()
+    (seeds_dir / "s05_hitl_after_review_exhaustion.json").write_text('{"a": 1}')
+
+    pytester.makepyfile(
+        test_reader="""
+        from pathlib import Path
+
+        def test_only_reads_the_seed():
+            seed_path = (
+                Path(__file__).resolve().parent
+                / "seeds"
+                / "s05_hitl_after_review_exhaustion.json"
+            )
+            assert seed_path.read_text() == '{"a": 1}'
+        """
+    )
+    result = pytester.runpytest("-q")
+    assert result.ret == 0
+
+
+def test_guard_quiet_when_test_writes_to_tmp_path_instead(
+    pytester: pytest.Pytester,
+) -> None:
+    """The prescribed #10094 fix shape: redirect the write to tmp_path."""
+    pytester.makeconftest(_HOOK_CONFTEST)
+    seeds_dir = pytester.path / "seeds"
+    seeds_dir.mkdir()
+    (seeds_dir / "s05_hitl_after_review_exhaustion.json").write_text('{"a": 1}')
+
+    pytester.makepyfile(
+        test_isolated_writer="""
+        def test_materializes_into_tmp_path_not_source(tmp_path):
+            (tmp_path / "s05_hitl_after_review_exhaustion.json").write_text(
+                '{"a": 1, "comments": {}}'
+            )
+        """
+    )
+    result = pytester.runpytest("-q")
+    assert result.ret == 0


### PR DESCRIPTION
Hardening on top of #10094 (already fixed by #10098). #10098 added `test_seed_dir_is_git_clean`, but that guard only proves the committed seeds dir is clean at ONE arbitrary point in collection order — under `-n auto --dist loadscope` a later test on a different worker could re-serialize a golden seed to source afterward and go uncaught (the exact drift class that repeatedly contaminated worktree branches this session).

**Adds:**
1. `tests/conftest.py` — a `pytest_runtest_teardown` mtime-snapshot guard (mirrors the existing MagicMock-pollution hook) that checks `tests/sandbox_scenarios/seeds/` after EVERY test on WHICHEVER xdist worker ran it, naming the offending test.
2. `tests/regressions/regression_issue_10094.py` — `test_write_seed_materialize_round_trip_never_touches_source`: runs the real `write_seed()` schema round-trip against s05 with `SEEDS_DIR`→`tmp_path`, asserting the committed file's content + mtime are untouched.
3. `tests/test_sandbox_seed_tree_clean_guard.py` — pytester mechanics test for the new hook (fires on mutation, quiet on clean / correct tmp_path writes).

Verified: full `pytest tests/ -n auto --dist loadscope` leaves the seeds dir clean; the write-trap sweep confirms only `scripts/sandbox_scenario.py::write_seed` (mounted read-only into the sandbox) ever targets SEEDS_DIR, and its one test already redirects to tmp_path. Test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)