### PR TITLE
feat(sandbox): seed worker-status event-history + trust_fleet_sanity active-trigger scenario (#10133 part 1)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,51 +1,51 @@
 {
-  "regenerated_at": "2026-07-21T09:06:22.653857+00:00",
-  "commit_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86",
+  "regenerated_at": "2026-07-21T09:51:38.521471+00:00",
+  "commit_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841",
   "artifacts": {
     "loops.md": {
-      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
+      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
     },
     "ports.md": {
-      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
+      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
     },
     "labels.md": {
-      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
+      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
     },
     "modules.md": {
-      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
+      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
     },
     "events.md": {
-      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
+      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
     },
     "adr_xref.md": {
-      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
+      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
     },
     "mockworld.md": {
-      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
+      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
     },
     "changelog.md": {
-      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
+      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
     },
     "coverage_matrix.md": {
-      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
+      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
     },
     "adr-conformance.md": {
-      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
+      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
     },
     "ai_system_inventory.md": {
-      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
+      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
     },
     "traceability_matrix.md": {
-      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
+      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
     },
     "functional_areas.md": {
-      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
+      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
     },
     "ubiquitous-language.md": {
-      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
+      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "281548c571d1a5d64d1d9ddd258cd94cd96f8d86"
+      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W30
 
+- `9af3aa2` — feat(sandbox): per-issue updated_at seed field + stale_issue_gc fresh-skip active-trigger scenario (#9544) (#10132) (#10132) *(2026-07-21)*
 - `281548c` — feat(sandbox): seed BGWorkerManager registered_workers set + dead-man-switch stall-escalation e2e scenario (#10086) (#10131) (#10131) *(2026-07-21)*
 - `896486d` — feat(sandbox): seed materializer for EpicState + health trend/heartbeat history; s71/s72 active-trigger scenarios (#9643) (#10084) (#10084) *(2026-07-21)*
 - `0c629f3` — feat(erosion): pure change-spread sensor — modules-crossed + files-touched per change, baselined (#10105) (#10116) (#10116) *(2026-07-21)*

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -64,7 +64,7 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 | `TermProposerLoop` | ✅ [0054, 0057, 0060, 0061, 0062, 0068] | ✅ [adr-council-reviewer.md, adr-index.md, adr-pre-validator.md, bot-pr-port.md, credentials.md, entry-evidence-loop.md, task.md, term-pruner-loop.md, tribal-wiki-store.md] | ✅ loops.md | ✅ README.md | ✅ `test_term_proposer_loop.py` | ✅ in catalog | ❌ |
 | `TermPrunerLoop` | ✅ [0057, 0060, 0062, 0068] | ✅ [term-pruner-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_term_pruner_loop.py` | ✅ in catalog | ❌ |
 | `TriageRetryLoop` | ✅ [0063] | ❌ | ✅ loops.md | ✅ README.md | ✅ `test_triage_retry_loop.py` | ✅ in catalog | ❌ |
-| `TrustFleetSanityLoop` | ✅ [0045, 0046, 0093] | ✅ [testing.md] | ✅ loops.md | ✅ README.md | ✅ `test_trust_fleet_sanity_loop.py` | ✅ in catalog | ❌ |
+| `TrustFleetSanityLoop` | ✅ [0045, 0046, 0093] | ✅ [testing.md] | ✅ loops.md | ✅ README.md | ✅ `test_trust_fleet_sanity_loop.py` | ✅ in catalog | ✅ `s78_trust_fleet_sanity_tick_error_ratio_breach.py` |
 | `WikiRotDetectorLoop` | ✅ [0045, 0056, 0089, 0099] | ✅ [wiki-rot-detector-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_wiki_rot_detector_loop.py` | ✅ in catalog | ❌ |
 | `WorkspaceGCLoop` | ✅ [0069, 0093] | ✅ [patterns.md, workspace-gc-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_workspace_gc_loop.py` | ✅ in catalog | ✅ `s46_workspace_gc_idle_poll.py` |
 ## Section 2: Ports

--- a/src/mockworld/sandbox_main.py
+++ b/src/mockworld/sandbox_main.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any, cast
 from bg_worker_manager import BGWorkerManager
 from branch_protection_audit import AuditReport, audit_repo
 from dashboard import HydraFlowDashboard
-from events import EventBus
+from events import EventBus, EventLog, EventType, HydraFlowEvent
 from file_util import append_jsonl, atomic_write
 from mockworld.fakes import (
     FakeGitHub,
@@ -36,7 +36,7 @@ from mockworld.fakes import (
 from mockworld.fakes.fake_docker import FakeDocker
 from mockworld.fakes.fake_subprocess_runner import FakeSubprocessRunner
 from mockworld.seed import MockWorldSeed
-from models import EpicState
+from models import BackgroundWorkerStatusPayload, EpicState
 from orchestrator import HydraFlowOrchestrator
 from ports import IssueFetcherPort, IssueStorePort, PRPort, WorkspacePort
 from runtime_config import load_runtime_config
@@ -447,6 +447,44 @@ def materialize_worker_heartbeats(state: Any, seed: MockWorldSeed) -> None:
         )
 
 
+def materialize_worker_status_history(
+    config: HydraFlowConfig, seed: MockWorldSeed
+) -> None:
+    """Append seeded BACKGROUND_WORKER_STATUS rows to the on-disk event log (#10133).
+
+    ``TrustFleetSanityLoop._collect_window_metrics`` computes its 24h
+    ticks/repair/error window via ``EventBus.load_events_since`` — a DISK
+    read (``EventLog.load``), not the in-memory ``EventBus._history`` list
+    ``/api/events`` falls back to. Each row is appended in the exact
+    ``HydraFlowEvent.model_dump_json()`` format ``EventLog.append`` writes
+    (mirrors that method's own ``append_jsonl`` call, minus its lock file —
+    nothing else writes to the log this early in boot). Each entry's relative
+    ``age_seconds`` (mirrors ``worker_heartbeats``) back-dates the row's
+    ``timestamp`` from boot, so the seed never rots. Writing the rows alone
+    is not sufficient — the caller must ALSO attach a real
+    ``EventLog(config.event_log_path)`` to the shared event bus (see
+    ``main()`` / ``MockWorld._wire_seed_loop_seams``), since the loop's read
+    goes through the bus, not this file directly. Empty
+    ``worker_status_history`` (every other scenario) writes nothing.
+    """
+    now = datetime.now(UTC)
+    for worker, entries in seed.worker_status_history.items():
+        for entry in entries:
+            age_seconds = float(entry.get("age_seconds", 0))
+            ts = (now - timedelta(seconds=age_seconds)).isoformat()
+            event = HydraFlowEvent(
+                type=EventType.BACKGROUND_WORKER_STATUS,
+                timestamp=ts,
+                data=BackgroundWorkerStatusPayload(
+                    worker=worker,
+                    status=str(entry.get("status", "ok")),
+                    last_run=ts,
+                    details=dict(entry.get("details") or {}),
+                ),
+            )
+            append_jsonl(config.event_log_path, event.model_dump_json())
+
+
 @dataclass
 class SeededRegisteredLoop:
     """Duck-typed ``BaseBackgroundLoop`` stand-in for a seeded registered worker.
@@ -632,7 +670,17 @@ async def main() -> None:
     # air-gapped sandbox network (see the helper for the per-flag rationale).
     _apply_sandbox_config_overrides(config)
     seed = _load_seed()
-    event_bus = EventBus()
+    # A real EventLog is only attached when a scenario seeds worker-status
+    # history (#10133) — every other scenario keeps the historical no-log
+    # ``EventBus()`` so ``/api/events`` continues falling back to in-memory
+    # history exactly as before. TrustFleetSanityLoop's window read
+    # (``EventBus.load_events_since``) needs the disk-backed log to see
+    # anything materialize_worker_status_history writes below.
+    event_bus = EventBus(
+        event_log=EventLog(config.event_log_path)
+        if seed.worker_status_history
+        else None
+    )
     state = build_state_tracker(config)
     stop_event = asyncio.Event()
 
@@ -704,6 +752,9 @@ async def main() -> None:
     materialize_epic_states(state, seed)
     materialize_health_metrics(config, seed)
     materialize_worker_heartbeats(state, seed)
+    # Worker-status event HISTORY (#10133) — pairs with the event_bus/EventLog
+    # wiring above; empty seed field writes nothing.
+    materialize_worker_status_history(config, seed)
 
     # Every async-touched ``subprocess.run`` site in production code now
     # specifies ``timeout=`` (PRs #8454, #8456, #8468 — enforced by

--- a/src/mockworld/seed.py
+++ b/src/mockworld/seed.py
@@ -297,6 +297,28 @@ class MockWorldSeed:
     # only exercise the read path) is unaffected.
     registered_workers: dict[str, dict[str, Any]] = field(default_factory=dict)
 
+    # Seeded BACKGROUND_WORKER_STATUS event HISTORY, materialized onto disk at
+    # boot (#10133, deferred from #9544). ``TrustFleetSanityLoop._collect_
+    # window_metrics`` computes its 24h ticks/repair/error window via
+    # ``EventBus.load_events_since`` — a DISK read (``EventLog.load``), NOT
+    # the in-memory ``EventBus._history`` list that ``/api/events`` falls back
+    # to. The sandbox's shared bus has historically been a bare ``EventBus()``
+    # with no ``EventLog`` attached, so that read returned ``None`` (coerced
+    # to ``[]`` by the loop) regardless of what a scenario seeded — the
+    # issues_per_hour / repair_ratio / tick_error_ratio breach paths had no
+    # active-trigger coverage. Keyed by worker name; each entry is a dict
+    # with ``age_seconds`` (numeric, relative — mirrors ``worker_heartbeats``;
+    # the materializer back-dates the row's timestamp from boot so the seed
+    # never rots), ``status`` (default "ok") and ``details`` (dict, default
+    # ``{}`` — the same shape ``BaseBackgroundLoop._execute_cycle`` publishes,
+    # e.g. ``{"filed": 20}`` for issues_per_hour or ``{"failed": 5}`` for
+    # repair_ratio). Both loaders (``sandbox_main.materialize_worker_status_
+    # history`` / ``MockWorld._wire_seed_loop_seams``) only attach a real
+    # ``EventLog`` to the loop's event bus when this field is non-empty —
+    # every other scenario keeps the historical no-log ``EventBus()``,
+    # unaffected. Default empty: no rows written, no EventLog attached.
+    worker_status_history: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+
     def to_json(self) -> str:
         """Serialize to JSON for cross-process transfer."""
         return json.dumps(asdict(self), indent=2)

--- a/tests/sandbox_scenarios/scenarios/s78_trust_fleet_sanity_tick_error_ratio_breach.py
+++ b/tests/sandbox_scenarios/scenarios/s78_trust_fleet_sanity_tick_error_ratio_breach.py
@@ -1,0 +1,82 @@
+"""s78 — TrustFleetSanityLoop's tick_error_ratio detector fires off seeded
+worker-status event HISTORY (#10133, deferred from #9544).
+
+Closes the read-side half of the #9643/#10086 materializer family: a seeded
+``worker_heartbeats`` entry answers HealthMonitorLoop's dead-man-switch
+staleness read (``state.get_worker_heartbeats()``), but
+``TrustFleetSanityLoop._collect_window_metrics`` — the anomaly detectors'
+24h ticks/repair/error window — reads through ``EventBus.load_events_since``,
+a DISK read (``EventLog.load``), not the in-memory ``EventBus._history`` list
+``worker_heartbeats`` never touches. The sandbox's shared bus has historically
+been a bare ``EventBus()`` with no ``EventLog`` attached, so that read always
+returned nothing regardless of what a scenario seeded — the
+issues_per_hour / repair_ratio / tick_error_ratio breach paths had no
+active-trigger coverage at all, docker or in-process.
+
+The seed here gives ``corpus_learning`` (one of the nine §4.1–§4.9 watched
+trust loops) five BACKGROUND_WORKER_STATUS rows spread across the loop's
+full 24h window (23h/18h/12h/6h/1h ago) — four errored, one ok. That clears
+both the tick_error_ratio threshold (0.2, ratio here is 0.8) and its
+min-sample floor (3, sample here is 5), and deliberately spans nearly the
+whole day rather than clustering in the last hour, so the scenario also
+proves the loop's day_cutoff window genuinely reaches back that far, not
+just its narrower issues_filed_hour bucket.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s78_trust_fleet_sanity_tick_error_ratio_breach"
+DESCRIPTION = (
+    "TrustFleetSanityLoop files a tick_error_ratio escalation for a watched "
+    "trust loop whose seeded ~24h BACKGROUND_WORKER_STATUS history skews "
+    "mostly errored, not just an idle heartbeat poll."
+)
+
+_WORKER = "corpus_learning"
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["trust_fleet_sanity"],
+        cycles_to_run=2,
+        worker_status_history={
+            _WORKER: [
+                {"age_seconds": 82_800, "status": "error", "details": {}},  # ~23h
+                {"age_seconds": 64_800, "status": "error", "details": {}},  # ~18h
+                {"age_seconds": 43_200, "status": "error", "details": {}},  # ~12h
+                {"age_seconds": 21_600, "status": "error", "details": {}},  # ~6h
+                {"age_seconds": 3_600, "status": "ok", "details": {}},  # ~1h
+            ],
+        },
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """A trust_fleet_sanity cycle escalates the seeded tick_error_ratio breach."""
+
+    def _escalated(payload: object) -> bool:
+        events = payload if isinstance(payload, list) else []
+        return any(
+            e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "trust_fleet_sanity"
+            and (e.get("data", {}).get("details") or {}).get("filed", 0) >= 1
+            for e in events
+        )
+
+    events_payload = await api.wait_until("/api/events", _escalated, timeout=90.0)
+
+    sanity_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "trust_fleet_sanity"
+    ]
+    assert any(
+        (e.get("data", {}).get("details") or {}).get("filed", 0) >= 1
+        for e in sanity_events
+    ), (
+        "Expected trust_fleet_sanity to file an escalation for the seeded "
+        f"tick_error_ratio breach; worker events: {sanity_events!r}"
+    )

--- a/tests/sandbox_scenarios/seeds/s01_happy_single_issue.json
+++ b/tests/sandbox_scenarios/seeds/s01_happy_single_issue.json
@@ -65,5 +65,6 @@
   "worker_heartbeats": {},
   "issue_refinement_backlog": [],
   "issue_refinement_verdicts": [],
-  "registered_workers": {}
+  "registered_workers": {},
+  "worker_status_history": {}
 }

--- a/tests/sandbox_scenarios/seeds/s05_hitl_after_review_exhaustion.json
+++ b/tests/sandbox_scenarios/seeds/s05_hitl_after_review_exhaustion.json
@@ -88,5 +88,6 @@
   "worker_heartbeats": {},
   "issue_refinement_backlog": [],
   "issue_refinement_verdicts": [],
-  "registered_workers": {}
+  "registered_workers": {},
+  "worker_status_history": {}
 }

--- a/tests/sandbox_scenarios/seeds/s53_model_routing_settings_ui.json
+++ b/tests/sandbox_scenarios/seeds/s53_model_routing_settings_ui.json
@@ -26,5 +26,6 @@
   "worker_heartbeats": {},
   "issue_refinement_backlog": [],
   "issue_refinement_verdicts": [],
-  "registered_workers": {}
+  "registered_workers": {},
+  "worker_status_history": {}
 }

--- a/tests/sandbox_scenarios/seeds/s54_decompose_to_converge.json
+++ b/tests/sandbox_scenarios/seeds/s54_decompose_to_converge.json
@@ -47,5 +47,6 @@
   "worker_heartbeats": {},
   "issue_refinement_backlog": [],
   "issue_refinement_verdicts": [],
-  "registered_workers": {}
+  "registered_workers": {},
+  "worker_status_history": {}
 }

--- a/tests/sandbox_scenarios/seeds/s55_nested_decompose.json
+++ b/tests/sandbox_scenarios/seeds/s55_nested_decompose.json
@@ -177,5 +177,6 @@
   "worker_heartbeats": {},
   "issue_refinement_backlog": [],
   "issue_refinement_verdicts": [],
-  "registered_workers": {}
+  "registered_workers": {},
+  "worker_status_history": {}
 }

--- a/tests/sandbox_scenarios/seeds/s56_skill_prompt_refine_proposal.json
+++ b/tests/sandbox_scenarios/seeds/s56_skill_prompt_refine_proposal.json
@@ -37,5 +37,6 @@
   "worker_heartbeats": {},
   "issue_refinement_backlog": [],
   "issue_refinement_verdicts": [],
-  "registered_workers": {}
+  "registered_workers": {},
+  "worker_status_history": {}
 }

--- a/tests/scenarios/fakes/mock_world.py
+++ b/tests/scenarios/fakes/mock_world.py
@@ -15,6 +15,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from events import EventBus, EventLog
 from mockworld.fakes.fake_clock import FakeClock
 
 if TYPE_CHECKING:
@@ -860,6 +861,7 @@ class MockWorld:
             materialize_health_metrics,
             materialize_registered_workers,
             materialize_worker_heartbeats,
+            materialize_worker_status_history,
             seed_stale_workspaces,
         )
 
@@ -906,6 +908,19 @@ class MockWorld:
             materialize_health_metrics(config, seed)
         if seed.worker_heartbeats:
             materialize_worker_heartbeats(self._harness.state, seed)
+        if seed.worker_status_history:
+            # Mirrors sandbox_main's ``main()`` wiring (#10133): the seeded
+            # rows only become readable once the loop's ``event_bus`` port
+            # has a REAL ``EventLog`` attached (``TrustFleetSanityLoop._
+            # collect_window_metrics`` reads via ``EventBus.load_events_
+            # since``, a disk read — the harness's default ``event_bus``
+            # port, when unseeded, falls back to a bare ``MagicMock`` whose
+            # ``load_events_since`` isn't awaitable at all, see
+            # ``_build_trust_fleet_sanity``).
+            materialize_worker_status_history(config, seed)
+            self._loop_ports.setdefault(
+                "event_bus", EventBus(event_log=EventLog(config.event_log_path))
+            )
         if seed.stale_workspaces:
             # Register the worktrees in the REAL harness StateTracker and hand
             # that tracker to the loop builder (its default is an empty-world

--- a/tests/scenarios/test_governance_active_trigger_scenarios.py
+++ b/tests/scenarios/test_governance_active_trigger_scenarios.py
@@ -44,6 +44,9 @@ from tests.sandbox_scenarios.scenarios import (
 from tests.sandbox_scenarios.scenarios import (
     s77_stale_issue_gc_skips_fresh_issue as s77,
 )
+from tests.sandbox_scenarios.scenarios import (
+    s78_trust_fleet_sanity_tick_error_ratio_breach as s78,
+)
 
 
 async def _run(mock_world, scenario):
@@ -201,3 +204,37 @@ async def test_s77_stale_issue_gc_closes_stale_skips_fresh(mock_world) -> None:
     fresh_issue = mock_world._github._issues[s77._FRESH_ISSUE]
     assert stale_issue.state == "closed"
     assert fresh_issue.state == "open"
+
+
+@pytest.mark.asyncio
+async def test_s78_trust_fleet_sanity_files_tick_error_ratio_escalation(
+    mock_world,
+) -> None:
+    """#10133 — seeded ~24h worker-status HISTORY drives a genuine breach,
+    not just an idle heartbeat poll (the read-side counterpart of the
+    #9643/#10086 heartbeat/registered-worker materializers).
+
+    Before ``worker_status_history``, ``TrustFleetSanityLoop._collect_
+    window_metrics`` could never see anything a scenario seeded — its read
+    goes through ``EventBus.load_events_since`` (a disk-backed read), and
+    the harness's default unseeded ``event_bus`` port is a bare
+    ``MagicMock`` whose ``load_events_since`` isn't awaitable, so every
+    breach detector silently saw zero ticks regardless of the seed.
+    """
+    _seed, stats = await _run(mock_world, s78)
+
+    assert stats["trust_fleet_sanity"]["status"] == "ok", stats
+    assert stats["trust_fleet_sanity"].get("filed", 0) >= 1, stats
+
+    titles = [issue.title for issue in mock_world._github._issues.values()]
+    assert any(s78._WORKER in t and "tick_error_ratio" in t for t in titles), (
+        f"expected a tick_error_ratio escalation for {s78._WORKER!r}; "
+        f"titles: {titles!r}"
+    )
+    issue = next(
+        i
+        for i in mock_world._github._issues.values()
+        if s78._WORKER in i.title and "tick_error_ratio" in i.title
+    )
+    assert "hitl-escalation" in issue.labels
+    assert "trust-loop-anomaly" in issue.labels

--- a/tests/test_mockworld_seed.py
+++ b/tests/test_mockworld_seed.py
@@ -305,6 +305,33 @@ def test_seed_round_trips_registered_workers_through_json() -> None:
     assert parsed.registered_workers["runs_gc"] == {}
 
 
+def test_default_seed_has_empty_worker_status_history() -> None:
+    """#10133 worker-status event-history seed field defaults empty."""
+    seed = MockWorldSeed()
+    assert seed.worker_status_history == {}
+
+
+def test_seed_round_trips_worker_status_history_through_json() -> None:
+    """Worker-status history entries are JSON-native string-keyed dicts of
+    lists — no ``from_json`` coercion is required (#10133)."""
+    original = MockWorldSeed(
+        worker_status_history={
+            "corpus_learning": [
+                {"age_seconds": 82_800, "status": "error", "details": {}},
+                {"age_seconds": 3_600, "status": "ok", "details": {"filed": 1}},
+            ],
+            "rc_budget": [],
+        },
+    )
+
+    parsed = MockWorldSeed.from_json(original.to_json())
+
+    assert parsed == original
+    assert parsed.worker_status_history["corpus_learning"][0]["age_seconds"] == 82_800
+    assert parsed.worker_status_history["corpus_learning"][1]["details"] == {"filed": 1}
+    assert parsed.worker_status_history["rc_budget"] == []
+
+
 def test_seed_round_trips_issue_updated_at_through_json() -> None:
     """#9544: a per-issue ``updated_at`` key survives JSON transfer intact.
 

--- a/tests/test_sandbox_main_smoke.py
+++ b/tests/test_sandbox_main_smoke.py
@@ -304,6 +304,64 @@ def test_materialize_worker_heartbeats_backdates_last_run(tmp_path) -> None:
     assert fresh > datetime.now(UTC) - timedelta(seconds=60)
 
 
+def test_materialize_worker_status_history_noops_when_empty(tmp_path) -> None:
+    """Empty ``worker_status_history`` writes nothing to the event log (#10133)."""
+    from mockworld.seed import MockWorldSeed
+
+    config = _seed_config(tmp_path)
+
+    sandbox_main.materialize_worker_status_history(config, MockWorldSeed())
+
+    assert not config.event_log_path.exists()
+
+
+def test_materialize_worker_status_history_writes_backdated_rows(tmp_path) -> None:
+    """Seeded entries land as BACKGROUND_WORKER_STATUS rows on disk, with a
+    relative ``age_seconds`` back-dating the row's timestamp from boot, and
+    the loop's OWN read path (``EventBus.load_events_since``) can see them
+    back (#10133) — the read side ``worker_heartbeats``/``registered_workers``
+    never had to prove, since those are read straight off ``StateTracker``.
+    """
+    import asyncio
+    from datetime import UTC, datetime, timedelta
+
+    from events import EventBus, EventLog, EventType
+    from mockworld.seed import MockWorldSeed
+
+    config = _seed_config(tmp_path)
+    seed = MockWorldSeed(
+        worker_status_history={
+            "corpus_learning": [
+                {"age_seconds": 82_800, "status": "error", "details": {}},
+                {"age_seconds": 3_600, "status": "ok", "details": {"filed": 2}},
+            ],
+        }
+    )
+
+    sandbox_main.materialize_worker_status_history(config, seed)
+
+    assert config.event_log_path.exists()
+    event_bus = EventBus(event_log=EventLog(config.event_log_path))
+    events = asyncio.run(
+        event_bus.load_events_since(datetime.now(UTC) - timedelta(days=1))
+    )
+    assert events is not None
+    assert len(events) == 2
+    by_status = {e.data["status"]: e for e in events}
+    assert set(by_status) == {"error", "ok"}
+    error_event = by_status["error"]
+    assert error_event.type == EventType.BACKGROUND_WORKER_STATUS
+    assert error_event.data["worker"] == "corpus_learning"
+    assert error_event.data["details"] == {}
+    error_ts = datetime.fromisoformat(error_event.timestamp)
+    assert error_ts.tzinfo is not None
+    assert error_ts < datetime.now(UTC) - timedelta(seconds=82_000)
+    ok_event = by_status["ok"]
+    assert ok_event.data["details"] == {"filed": 2}
+    ok_ts = datetime.fromisoformat(ok_event.timestamp)
+    assert ok_ts > datetime.now(UTC) - timedelta(seconds=3_700)
+
+
 def test_materialize_registered_workers_noops_when_empty(tmp_path) -> None:
     """Empty ``registered_workers`` returns ``None`` — no ``BGWorkerManager``
     is constructed and no state is touched (#10086)."""


### PR DESCRIPTION
Part of #10133 (Piece 1 — worker-status event-history; Piece 2, repo-wiki fixtures, remains open on the issue).

**Root cause found (deeper than the issue described):** `TrustFleetSanityLoop._collect_window_metrics` reads its 24h window via `EventBus.load_events_since()` — a **disk** read through an `EventLog`, not the in-memory `_history`. Both loaders (docker `sandbox_main` + in-process `MockWorld`) constructed a bare `EventBus()` with no `EventLog`, so the window was always empty and the `issues_per_hour`/`repair_ratio`/`tick_error_ratio` breach paths had zero active-trigger coverage.

**Fix:** new `worker_status_history` seed field (worker → `{age_seconds,status,details}`, relative-age like `worker_heartbeats`); `materialize_worker_status_history` appends back-dated BACKGROUND_WORKER_STATUS rows in the EventLog format; BOTH loaders now wire `EventBus(event_log=EventLog(...))` **only when the field is non-empty** (every other scenario keeps the historical no-log bus, unaffected). New scenario `s78_trust_fleet_sanity_tick_error_ratio_breach` seeds a 5-row 23h→1h history (4 errored) clearing the tick_error_ratio threshold + min-sample floor and asserts the loop files a `hitl-escalation`+`trust-loop-anomaly` issue. Full pyramid incl. a real EventBus/EventLog round-trip test (proves the consumer path, not just the write). All 6 golden seeds regenerated; tests/regressions green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)