### PR TITLE
feat(sandbox): seed repo-wiki broken-cite fixture + wiki_rot_detector active-trigger scenario (#10133 part 2)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,51 +1,51 @@
 {
-  "regenerated_at": "2026-07-21T09:51:38.521471+00:00",
-  "commit_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841",
+  "regenerated_at": "2026-07-21T10:33:16.607889+00:00",
+  "commit_sha": "76bc56ba2f203b60593ab34717cbb5466ff33d75",
   "artifacts": {
     "loops.md": {
-      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
+      "source_sha": "76bc56ba2f203b60593ab34717cbb5466ff33d75"
     },
     "ports.md": {
-      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
+      "source_sha": "76bc56ba2f203b60593ab34717cbb5466ff33d75"
     },
     "labels.md": {
-      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
+      "source_sha": "76bc56ba2f203b60593ab34717cbb5466ff33d75"
     },
     "modules.md": {
-      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
+      "source_sha": "76bc56ba2f203b60593ab34717cbb5466ff33d75"
     },
     "events.md": {
-      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
+      "source_sha": "76bc56ba2f203b60593ab34717cbb5466ff33d75"
     },
     "adr_xref.md": {
-      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
+      "source_sha": "76bc56ba2f203b60593ab34717cbb5466ff33d75"
     },
     "mockworld.md": {
-      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
+      "source_sha": "76bc56ba2f203b60593ab34717cbb5466ff33d75"
     },
     "changelog.md": {
-      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
+      "source_sha": "76bc56ba2f203b60593ab34717cbb5466ff33d75"
     },
     "coverage_matrix.md": {
-      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
+      "source_sha": "76bc56ba2f203b60593ab34717cbb5466ff33d75"
     },
     "adr-conformance.md": {
-      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
+      "source_sha": "76bc56ba2f203b60593ab34717cbb5466ff33d75"
     },
     "ai_system_inventory.md": {
-      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
+      "source_sha": "76bc56ba2f203b60593ab34717cbb5466ff33d75"
     },
     "traceability_matrix.md": {
-      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
+      "source_sha": "76bc56ba2f203b60593ab34717cbb5466ff33d75"
     },
     "functional_areas.md": {
-      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
+      "source_sha": "76bc56ba2f203b60593ab34717cbb5466ff33d75"
     },
     "ubiquitous-language.md": {
-      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
+      "source_sha": "76bc56ba2f203b60593ab34717cbb5466ff33d75"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "7e73fc08919fbe9db1d106f7b73eec883a293841"
+      "source_sha": "76bc56ba2f203b60593ab34717cbb5466ff33d75"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W30
 
+- `76bc56b` — feat(sandbox): seed worker-status event-history + trust_fleet_sanity active-trigger scenario (#10133) (#10135) (#10135) *(2026-07-21)*
 - `9af3aa2` — feat(sandbox): per-issue updated_at seed field + stale_issue_gc fresh-skip active-trigger scenario (#9544) (#10132) (#10132) *(2026-07-21)*
 - `281548c` — feat(sandbox): seed BGWorkerManager registered_workers set + dead-man-switch stall-escalation e2e scenario (#10086) (#10131) (#10131) *(2026-07-21)*
 - `896486d` — feat(sandbox): seed materializer for EpicState + health trend/heartbeat history; s71/s72 active-trigger scenarios (#9643) (#10084) (#10084) *(2026-07-21)*

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -65,7 +65,7 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 | `TermPrunerLoop` | ✅ [0057, 0060, 0062, 0068] | ✅ [term-pruner-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_term_pruner_loop.py` | ✅ in catalog | ❌ |
 | `TriageRetryLoop` | ✅ [0063] | ❌ | ✅ loops.md | ✅ README.md | ✅ `test_triage_retry_loop.py` | ✅ in catalog | ❌ |
 | `TrustFleetSanityLoop` | ✅ [0045, 0046, 0093] | ✅ [testing.md] | ✅ loops.md | ✅ README.md | ✅ `test_trust_fleet_sanity_loop.py` | ✅ in catalog | ✅ `s78_trust_fleet_sanity_tick_error_ratio_breach.py` |
-| `WikiRotDetectorLoop` | ✅ [0045, 0056, 0089, 0099] | ✅ [wiki-rot-detector-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_wiki_rot_detector_loop.py` | ✅ in catalog | ❌ |
+| `WikiRotDetectorLoop` | ✅ [0045, 0056, 0089, 0099] | ✅ [wiki-rot-detector-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_wiki_rot_detector_loop.py` | ✅ in catalog | ✅ `s79_wiki_rot_detector_broken_cite_fires.py` |
 | `WorkspaceGCLoop` | ✅ [0069, 0093] | ✅ [patterns.md, workspace-gc-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_workspace_gc_loop.py` | ✅ in catalog | ✅ `s46_workspace_gc_idle_poll.py` |
 ## Section 2: Ports
 

--- a/src/mockworld/sandbox_main.py
+++ b/src/mockworld/sandbox_main.py
@@ -39,6 +39,7 @@ from mockworld.seed import MockWorldSeed
 from models import BackgroundWorkerStatusPayload, EpicState
 from orchestrator import HydraFlowOrchestrator
 from ports import IssueFetcherPort, IssueStorePort, PRPort, WorkspacePort
+from repo_wiki import RepoWikiStore, WikiEntry
 from runtime_config import load_runtime_config
 from service_registry import (
     WorkerRegistryCallbacks,
@@ -485,6 +486,74 @@ def materialize_worker_status_history(
             append_jsonl(config.event_log_path, event.model_dump_json())
 
 
+def resolve_self_wiki_root(config: HydraFlowConfig) -> Path:
+    """Return the wiki_root a fresh ``RepoWikiStore`` should point at (#10133).
+
+    MIRRORS ``service_registry.build_services``'s ``repo_wiki_store``
+    construction EXACTLY (same fallback order): the self-repo's wiki lives
+    at ``docs/wiki/`` when it exists (git-tracked alongside the code), else
+    the runtime-cache ``config.data_path("repo_wiki")``. Dockerfile.agent
+    does NOT ship ``docs/`` into the sandbox image (only ``src``/``tests``/
+    ``templates``/``static`` are copied), so the docker tier always takes the
+    fallback branch; the in-process ``MockWorld`` harness usually does too
+    (its ``config.repo_root`` is a bare ``tmp_path``). A single source of
+    truth here keeps ``materialize_wiki_fixtures`` (below) and any port a
+    caller builds pointed at the exact same directory the real (read-only)
+    ``repo_wiki_store`` reads from.
+    """
+    wiki_root = config.repo_root / "docs" / "wiki"
+    if not wiki_root.exists():
+        wiki_root = config.data_path("repo_wiki")
+    return wiki_root
+
+
+def materialize_wiki_fixtures(config: HydraFlowConfig, seed: MockWorldSeed) -> None:
+    """Ingest seeded repo-wiki fixture entries via a REAL ``RepoWikiStore`` (#10133).
+
+    ``WikiRotDetectorLoop`` reads wiki content through the same structured
+    ``parse_topic_page`` parse ``RepoWikiStore`` uses to write itself (issue
+    #9936): a hand-written markdown blob falls back to the legacy whole-file
+    regex row and never carries ``source_type``/``source_issue``/
+    ``fixed_in_pr``/``code_refs`` as modeled ``WikiEntry`` fields. Routing
+    each fixture through ``RepoWikiStore.ingest`` — the same call the real
+    ingest pipeline makes — is what GUARANTEES that structured shape rather
+    than merely approximating it.
+
+    A throwaway WRITABLE store is built here (the composition root's own
+    ``repo_wiki_store`` is ``read_only=True`` — its roots live under the
+    operator's main checkout, see ``service_registry.build_services``) —
+    pointed at :func:`resolve_self_wiki_root` so it lands exactly where the
+    loop's own store later reads from. See ``MockWorldSeed.repo_wiki_
+    fixtures`` for the per-entry field shape and why each fixture names its
+    own ``repo_slug`` rather than always targeting the (empty-in-sandbox)
+    self-repo slug. Empty ``repo_wiki_fixtures`` (every other scenario)
+    creates nothing.
+    """
+    if not seed.repo_wiki_fixtures:
+        return
+    store = RepoWikiStore(
+        wiki_root=resolve_self_wiki_root(config),
+        tracked_root=config.repo_root / config.repo_wiki_path,
+        self_slug=config.repo,
+        read_only=False,
+    )
+    by_repo: dict[str, list[WikiEntry]] = {}
+    for fixture in seed.repo_wiki_fixtures:
+        repo_slug = str(fixture["repo_slug"])
+        source_issue = fixture.get("source_issue")
+        entry = WikiEntry(
+            title=str(fixture["title"]),
+            content=str(fixture.get("content", "")),
+            source_type=str(fixture.get("source_type", "manual")),
+            source_issue=int(source_issue) if source_issue is not None else None,
+            fixed_in_pr=fixture.get("fixed_in_pr"),
+            code_refs=tuple(fixture.get("code_refs") or ()),
+        )
+        by_repo.setdefault(repo_slug, []).append(entry)
+    for repo_slug, entries in by_repo.items():
+        store.ingest(repo_slug, entries)
+
+
 @dataclass
 class SeededRegisteredLoop:
     """Duck-typed ``BaseBackgroundLoop`` stand-in for a seeded registered worker.
@@ -755,6 +824,10 @@ async def main() -> None:
     # Worker-status event HISTORY (#10133) — pairs with the event_bus/EventLog
     # wiring above; empty seed field writes nothing.
     materialize_worker_status_history(config, seed)
+    # Repo-wiki fixture entries (#10133 PIECE 2) — ingested into the SAME
+    # wiki_root the real (read-only) ``repo_wiki_store`` below reads from;
+    # empty seed field writes nothing.
+    materialize_wiki_fixtures(config, seed)
 
     # Every async-touched ``subprocess.run`` site in production code now
     # specifies ``timeout=`` (PRs #8454, #8456, #8468 — enforced by

--- a/src/mockworld/seed.py
+++ b/src/mockworld/seed.py
@@ -319,6 +319,42 @@ class MockWorldSeed:
     # unaffected. Default empty: no rows written, no EventLog attached.
     worker_status_history: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
 
+    # Repo-wiki fixture entries, materialized into a REAL ``RepoWikiStore``
+    # at boot via ``RepoWikiStore.ingest`` (#10133, PIECE 2). Each entry is a
+    # dict with keys ``repo_slug`` (required — the wiki repo to ingest under),
+    # ``title`` (required), ``content`` (default ``""``), ``source_type``
+    # (default ``"manual"``), ``source_issue`` (optional int), ``fixed_in_pr``
+    # (optional str — a PR reference like ``"#8715"``) and ``code_refs``
+    # (optional list of ``path.py:symbol`` strings). Routing the fixture
+    # through the store's own ``ingest`` — rather than hand-writing topic-page
+    # markdown — is what GUARANTEES the STRUCTURED ``WikiEntry`` shape
+    # ``WikiRotDetectorLoop`` consumes since issue #9936
+    # (``source_type``/``source_issue``/``fixed_in_pr``/``code_refs`` as
+    # modeled fields, not an unstructured whole-file blob): it is the same
+    # production writer the real ingest pipeline uses.
+    #
+    # Deliberately keyed by an explicit ``repo_slug`` per entry rather than
+    # always targeting the running config's own ``config.repo`` (self-repo):
+    # in the air-gapped sandbox ``config.repo`` is EMPTY (no ``.git`` in the
+    # image — see ``mockworld.sandbox_main._apply_sandbox_config_overrides``
+    # docstring), so ``WikiRotDetectorLoop``'s ``is_self`` check
+    # (``slug == self_slug and bool(self_slug)``) can never be true there
+    # regardless of which slug a fixture uses. A fixture ingested under any
+    # OTHER (managed-repo-shaped) slug is scanned via the loop's non-self
+    # path (``verify_cite_grep`` against ``config.repo_root`` — no
+    # ``is_self`` gate), which is what actually drives the per-cite
+    # broken-cite fire end-to-end in the sandbox; a cite embedded in
+    # ``content`` (e.g. ``` `path/to.py:missing_symbol` ```) that does not
+    # resolve on disk is what makes the entry "broken" (mirrors
+    # ``fixed_in_pr``/``code_refs`` shipped-claim entries, which only verify
+    # on the self-repo path). Both loaders (``sandbox_main.
+    # materialize_wiki_fixtures`` / ``MockWorld._wire_seed_loop_seams``)
+    # ingest into the SAME wiki_root the real (read-only) ``repo_wiki_store``
+    # reads from — see ``sandbox_main.resolve_self_wiki_root``. Default
+    # empty: no wiki content is written, every existing seed payload
+    # unchanged.
+    repo_wiki_fixtures: list[dict[str, Any]] = field(default_factory=list)
+
     def to_json(self) -> str:
         """Serialize to JSON for cross-process transfer."""
         return json.dumps(asdict(self), indent=2)

--- a/tests/sandbox_scenarios/scenarios/s79_wiki_rot_detector_broken_cite_fires.py
+++ b/tests/sandbox_scenarios/scenarios/s79_wiki_rot_detector_broken_cite_fires.py
@@ -1,0 +1,94 @@
+"""s79 — WikiRotDetectorLoop actively files a finding for a seeded broken cite.
+
+Closes the read-side gap #10133 PIECE 2 left open: ``MockWorldSeed`` had no
+way to express a repo-wiki entry at all, so every wiki_rot_detector scenario
+had to hand-mock the ``wiki_store`` port (see
+``tests/scenarios/test_wiki_rot_detector_scenario.py``) — the seed-driven
+active-trigger path was untested end-to-end in either loader. The new
+``repo_wiki_fixtures`` seed field is routed through a REAL
+``RepoWikiStore.ingest`` call (``mockworld.sandbox_main.
+materialize_wiki_fixtures``), which is what guarantees the fixture lands in
+the STRUCTURED ``WikiEntry`` shape ``WikiRotDetectorLoop`` consumes since
+issue #9936 (``source_type``/``source_issue``/``fixed_in_pr``/``code_refs``
+as modeled fields, not a raw markdown blob the loop would fall back to
+whole-file regex parsing for).
+
+The fixture is ingested under a MANAGED repo slug (not the sandbox's own —
+``config.repo`` is EMPTY in the air-gapped image, no ``.git`` is shipped, so
+``WikiRotDetectorLoop``'s ``is_self`` check can never be true there
+regardless of slug — see ``MockWorldSeed.repo_wiki_fixtures``). Its
+``content`` embeds a ``path.py:symbol`` cite pointing at a module that does
+not exist on disk, verified via the loop's non-self ``verify_cite_grep``
+path (no ``is_self`` gate) — a genuinely broken cite the loop must actually
+detect and file, not just an idle scan. The entry ALSO carries
+``fixed_in_pr``/``code_refs`` (the "shipped claim" shape #9598/#9936
+modeled) for structural completeness, even though that pass only verifies
+on the self-repo path and does not fire here.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s79_wiki_rot_detector_broken_cite_fires"
+DESCRIPTION = (
+    "WikiRotDetectorLoop files a hydraflow-find + wiki-rot issue for a "
+    "seeded structured WikiEntry whose cite does not resolve on disk, not "
+    "just a heartbeat."
+)
+
+_SLUG = "acme/wiki-fixture-repo"
+_TITLE = "Sandbox fixture: broken cite"
+_BROKEN_CITE = "src/wiki_rot_sandbox_fixture_module.py:wiki_rot_sandbox_fixture_symbol"
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["wiki_rot_detector"],
+        cycles_to_run=2,
+        repo_wiki_fixtures=[
+            {
+                "repo_slug": _SLUG,
+                "title": _TITLE,
+                "content": (
+                    "Claims a fix shipped in #9999 via "
+                    f"`{_BROKEN_CITE}` — that module does not exist on "
+                    "disk, so the loop's cite-verification pass reliably "
+                    "reports this entry's cite broken."
+                ),
+                "source_type": "manual",
+                "source_issue": 9999,
+                "fixed_in_pr": "#9999",
+                "code_refs": [_BROKEN_CITE],
+            }
+        ],
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """A wiki_rot_detector cycle files a finding for the seeded broken cite."""
+
+    def _fired(payload: object) -> bool:
+        events = payload if isinstance(payload, list) else []
+        return any(
+            e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "wiki_rot_detector"
+            and (e.get("data", {}).get("details") or {}).get("issues_filed", 0) >= 1
+            for e in events
+        )
+
+    events_payload = await api.wait_until("/api/events", _fired, timeout=90.0)
+
+    wiki_rot_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "wiki_rot_detector"
+    ]
+    assert any(
+        (e.get("data", {}).get("details") or {}).get("issues_filed", 0) >= 1
+        for e in wiki_rot_events
+    ), (
+        "Expected wiki_rot_detector to file a finding for the seeded "
+        f"broken cite; worker events: {wiki_rot_events!r}"
+    )

--- a/tests/sandbox_scenarios/seeds/s01_happy_single_issue.json
+++ b/tests/sandbox_scenarios/seeds/s01_happy_single_issue.json
@@ -66,5 +66,6 @@
   "issue_refinement_backlog": [],
   "issue_refinement_verdicts": [],
   "registered_workers": {},
-  "worker_status_history": {}
+  "worker_status_history": {},
+  "repo_wiki_fixtures": []
 }

--- a/tests/sandbox_scenarios/seeds/s05_hitl_after_review_exhaustion.json
+++ b/tests/sandbox_scenarios/seeds/s05_hitl_after_review_exhaustion.json
@@ -89,5 +89,6 @@
   "issue_refinement_backlog": [],
   "issue_refinement_verdicts": [],
   "registered_workers": {},
-  "worker_status_history": {}
+  "worker_status_history": {},
+  "repo_wiki_fixtures": []
 }

--- a/tests/sandbox_scenarios/seeds/s53_model_routing_settings_ui.json
+++ b/tests/sandbox_scenarios/seeds/s53_model_routing_settings_ui.json
@@ -27,5 +27,6 @@
   "issue_refinement_backlog": [],
   "issue_refinement_verdicts": [],
   "registered_workers": {},
-  "worker_status_history": {}
+  "worker_status_history": {},
+  "repo_wiki_fixtures": []
 }

--- a/tests/sandbox_scenarios/seeds/s54_decompose_to_converge.json
+++ b/tests/sandbox_scenarios/seeds/s54_decompose_to_converge.json
@@ -48,5 +48,6 @@
   "issue_refinement_backlog": [],
   "issue_refinement_verdicts": [],
   "registered_workers": {},
-  "worker_status_history": {}
+  "worker_status_history": {},
+  "repo_wiki_fixtures": []
 }

--- a/tests/sandbox_scenarios/seeds/s55_nested_decompose.json
+++ b/tests/sandbox_scenarios/seeds/s55_nested_decompose.json
@@ -178,5 +178,6 @@
   "issue_refinement_backlog": [],
   "issue_refinement_verdicts": [],
   "registered_workers": {},
-  "worker_status_history": {}
+  "worker_status_history": {},
+  "repo_wiki_fixtures": []
 }

--- a/tests/sandbox_scenarios/seeds/s56_skill_prompt_refine_proposal.json
+++ b/tests/sandbox_scenarios/seeds/s56_skill_prompt_refine_proposal.json
@@ -38,5 +38,6 @@
   "issue_refinement_backlog": [],
   "issue_refinement_verdicts": [],
   "registered_workers": {},
-  "worker_status_history": {}
+  "worker_status_history": {},
+  "repo_wiki_fixtures": []
 }

--- a/tests/scenarios/fakes/mock_world.py
+++ b/tests/scenarios/fakes/mock_world.py
@@ -860,8 +860,10 @@ class MockWorld:
             materialize_expired_runs,
             materialize_health_metrics,
             materialize_registered_workers,
+            materialize_wiki_fixtures,
             materialize_worker_heartbeats,
             materialize_worker_status_history,
+            resolve_self_wiki_root,
             seed_stale_workspaces,
         )
 
@@ -945,6 +947,26 @@ class MockWorld:
 
             materialize_expired_runs(config, seed)
             self._loop_ports.setdefault("run_recorder", RunRecorder(config))
+        if seed.repo_wiki_fixtures:
+            # Mirrors sandbox_main's ``main()`` wiring (#10133 PIECE 2): the
+            # catalog's ``wiki_store`` port defaults to a MagicMock whose
+            # ``list_repos`` returns ``[]`` (see ``_build_wiki_rot_detector``),
+            # so a seeded fixture is invisible to WikiRotDetectorLoop unless a
+            # REAL ``RepoWikiStore`` pointed at the exact same wiki_root the
+            # materializer wrote to replaces it — ``resolve_self_wiki_root``
+            # is the single source of truth both loaders share, so this
+            # never drifts from sandbox_main's own construction.
+            from repo_wiki import RepoWikiStore  # noqa: PLC0415
+
+            materialize_wiki_fixtures(config, seed)
+            self._loop_ports.setdefault(
+                "wiki_store",
+                RepoWikiStore(
+                    wiki_root=resolve_self_wiki_root(config),
+                    tracked_root=config.repo_root / config.repo_wiki_path,
+                    self_slug=config.repo,
+                ),
+            )
         epic_labels = set(getattr(config, "epic_label", None) or ["hydraflow-epic"])
         if any(epic_labels & set(i.get("labels", [])) for i in seed.issues):
             # Give epic_sweeper a real fetcher over the shared FakeGitHub so a

--- a/tests/scenarios/test_governance_active_trigger_scenarios.py
+++ b/tests/scenarios/test_governance_active_trigger_scenarios.py
@@ -47,6 +47,9 @@ from tests.sandbox_scenarios.scenarios import (
 from tests.sandbox_scenarios.scenarios import (
     s78_trust_fleet_sanity_tick_error_ratio_breach as s78,
 )
+from tests.sandbox_scenarios.scenarios import (
+    s79_wiki_rot_detector_broken_cite_fires as s79,
+)
 
 
 async def _run(mock_world, scenario):
@@ -238,3 +241,50 @@ async def test_s78_trust_fleet_sanity_files_tick_error_ratio_escalation(
     )
     assert "hitl-escalation" in issue.labels
     assert "trust-loop-anomaly" in issue.labels
+
+
+@pytest.mark.asyncio
+async def test_s79_wiki_rot_detector_files_broken_cite_finding(mock_world) -> None:
+    """#10133 PIECE 2 — a seeded repo-wiki fixture (structured ``WikiEntry``
+    shape, issue #9936) with a broken code-symbol cite drives
+    ``WikiRotDetectorLoop``'s genuine per-cite finding, not just an idle
+    scan.
+
+    Before ``repo_wiki_fixtures``, ``MockWorldSeed`` had no way to express a
+    repo-wiki entry at all — every wiki_rot_detector coverage had to
+    hand-mock the ``wiki_store`` port directly (see
+    ``tests/scenarios/test_wiki_rot_detector_scenario.py``), leaving the
+    seed-driven active-trigger path (both loaders) unproven end-to-end.
+
+    Unlike the sandbox tier (``config.repo`` is EMPTY there — see
+    ``MockWorldSeed.repo_wiki_fixtures``), this harness's default
+    ``config.repo`` (``"test-org/test-repo"``) is non-empty, so
+    ``WikiRotDetectorLoop`` ALSO scans the self-repo slug — and, because the
+    self-repo's ``RepoWikiStore.repo_dir`` is the flat ``wiki_root`` itself,
+    its ``rglob`` picks up the seeded fixture's nested managed-repo file too,
+    additionally firing the self-only shipped-claim pass
+    (``fixed_in_pr``/``code_refs``, issue #9598) for the SAME entry. Both
+    passes are genuine — assert on the per-cite finding specifically (it
+    fires in every environment, including the sandbox) rather than assuming
+    a fixed issue count or list order.
+    """
+    _seed, stats = await _run(mock_world, s79)
+
+    assert stats["wiki_rot_detector"]["status"] == "fired", stats
+    assert stats["wiki_rot_detector"]["issues_filed"] >= 1, stats
+
+    issues = await mock_world.github.list_issues_by_label("wiki-rot")
+    assert issues, "expected a wiki-rot finding for the seeded broken cite"
+    cite_findings = [
+        i
+        for i in issues
+        if s79._BROKEN_CITE in mock_world.github.issue(i["number"]).title
+    ]
+    assert cite_findings, (
+        f"expected a finding naming the broken cite {s79._BROKEN_CITE!r}; "
+        f"filed: {issues!r}"
+    )
+    for i in issues:
+        issue = mock_world.github.issue(i["number"])
+        assert "hydraflow-find" in issue.labels
+        assert "wiki-rot" in issue.labels

--- a/tests/test_mockworld_seed.py
+++ b/tests/test_mockworld_seed.py
@@ -332,6 +332,38 @@ def test_seed_round_trips_worker_status_history_through_json() -> None:
     assert parsed.worker_status_history["rc_budget"] == []
 
 
+def test_default_seed_has_empty_repo_wiki_fixtures() -> None:
+    """#10133 PIECE 2 repo-wiki-fixture seed field defaults empty."""
+    seed = MockWorldSeed()
+    assert seed.repo_wiki_fixtures == []
+
+
+def test_seed_round_trips_repo_wiki_fixtures_through_json() -> None:
+    """Repo-wiki fixture entries are JSON-native dicts — no ``from_json``
+    coercion is required (#10133 PIECE 2)."""
+    original = MockWorldSeed(
+        repo_wiki_fixtures=[
+            {
+                "repo_slug": "acme/widget",
+                "title": "Broken cite fixture",
+                "content": "See `src/gone.py:vanished` for details.",
+                "source_type": "manual",
+                "source_issue": 9999,
+                "fixed_in_pr": "#9999",
+                "code_refs": ["src/gone.py:vanished"],
+            }
+        ],
+    )
+
+    parsed = MockWorldSeed.from_json(original.to_json())
+
+    assert parsed == original
+    fixture = parsed.repo_wiki_fixtures[0]
+    assert fixture["repo_slug"] == "acme/widget"
+    assert fixture["fixed_in_pr"] == "#9999"
+    assert fixture["code_refs"] == ["src/gone.py:vanished"]
+
+
 def test_seed_round_trips_issue_updated_at_through_json() -> None:
     """#9544: a per-issue ``updated_at`` key survives JSON transfer intact.
 

--- a/tests/test_sandbox_main_smoke.py
+++ b/tests/test_sandbox_main_smoke.py
@@ -362,6 +362,99 @@ def test_materialize_worker_status_history_writes_backdated_rows(tmp_path) -> No
     assert ok_ts > datetime.now(UTC) - timedelta(seconds=3_700)
 
 
+def test_resolve_self_wiki_root_falls_back_to_data_path_when_docs_wiki_absent(
+    tmp_path,
+) -> None:
+    """#10133 PIECE 2 — no ``docs/wiki`` on disk (the sandbox image ships no
+    ``docs/``) falls back to the runtime-cache ``config.data_path("repo_wiki")``.
+    """
+    config = _seed_config(tmp_path)
+
+    wiki_root = sandbox_main.resolve_self_wiki_root(config)
+
+    assert wiki_root == config.data_path("repo_wiki")
+
+
+def test_resolve_self_wiki_root_prefers_docs_wiki_when_present(tmp_path) -> None:
+    """#10133 PIECE 2 — a real ``docs/wiki`` (the self-repo's git-tracked
+    wiki) wins over the runtime-cache fallback, mirroring
+    ``service_registry.build_services``'s ``repo_wiki_store`` construction.
+    """
+    config = _seed_config(tmp_path)
+    docs_wiki = config.repo_root / "docs" / "wiki"
+    docs_wiki.mkdir(parents=True)
+
+    wiki_root = sandbox_main.resolve_self_wiki_root(config)
+
+    assert wiki_root == docs_wiki
+
+
+def test_materialize_wiki_fixtures_noops_when_empty(tmp_path) -> None:
+    """Empty ``repo_wiki_fixtures`` writes nothing (#10133 PIECE 2)."""
+    from mockworld.seed import MockWorldSeed
+
+    config = _seed_config(tmp_path)
+
+    sandbox_main.materialize_wiki_fixtures(config, MockWorldSeed())
+
+    assert not sandbox_main.resolve_self_wiki_root(config).exists()
+
+
+def test_materialize_wiki_fixtures_round_trips_structured_wiki_entry(tmp_path) -> None:
+    """A seeded fixture round-trips through a REAL ``RepoWikiStore.ingest``
+    into the STRUCTURED ``WikiEntry`` shape ``WikiRotDetectorLoop`` consumes
+    (issue #9936) — ``source_type``/``source_issue``/``fixed_in_pr``/
+    ``code_refs`` all survive as modeled fields, not an unstructured blob
+    (#10133 PIECE 2).
+    """
+    from mockworld.seed import MockWorldSeed
+    from repo_wiki import RepoWikiStore
+
+    config = _seed_config(tmp_path)
+    slug = "acme/wiki-fixture-repo"
+    broken_cite = (
+        "src/wiki_rot_sandbox_fixture_module.py:wiki_rot_sandbox_fixture_symbol"
+    )
+    seed = MockWorldSeed(
+        repo_wiki_fixtures=[
+            {
+                "repo_slug": slug,
+                "title": "Broken cite fixture",
+                "content": f"See `{broken_cite}` for the (missing) fix.",
+                "source_type": "manual",
+                "source_issue": 9999,
+                "fixed_in_pr": "#9999",
+                "code_refs": [broken_cite],
+            }
+        ]
+    )
+
+    sandbox_main.materialize_wiki_fixtures(config, seed)
+
+    wiki_root = sandbox_main.resolve_self_wiki_root(config)
+    assert wiki_root.exists()
+    read_store = RepoWikiStore(
+        wiki_root=wiki_root,
+        tracked_root=config.repo_root / config.repo_wiki_path,
+        self_slug=config.repo,
+    )
+    assert slug in read_store.list_repos()
+    repo_dir = read_store.repo_dir(slug)
+    entries = [
+        entry
+        for md_path in sorted(repo_dir.glob("*.md"))
+        for entry in read_store.load_topic_entries(md_path)
+    ]
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.title == "Broken cite fixture"
+    assert entry.source_type == "manual"
+    assert entry.source_issue == 9999
+    assert entry.fixed_in_pr == "#9999"
+    assert entry.code_refs == (broken_cite,)
+    assert broken_cite in entry.content
+
+
 def test_materialize_registered_workers_noops_when_empty(tmp_path) -> None:
     """Empty ``registered_workers`` returns ``None`` — no ``BGWorkerManager``
     is constructed and no state is touched (#10086)."""


### PR DESCRIPTION
Closes #10133 (Piece 2 — repo-wiki fixtures; Piece 1, worker-status history, shipped in #10135).

wiki_rot_detector had no active-trigger sandbox coverage because MockWorldSeed couldn't express a broken-cite wiki entry. **Fix:** new `repo_wiki_fixtures` seed field + `materialize_wiki_fixtures` (BOTH loaders) that ingests each fixture through a REAL `RepoWikiStore.ingest()` — guaranteeing the structured `WikiEntry` shape (source_type/source_issue/fixed_in_pr/code_refs) the #9936 structured cite-pass reads, not a hand-rolled markdown blob.

**Key finding:** the loop's shipped-claim pass only fires when `is_self` (config.repo non-empty), but the air-gapped sandbox always has empty config.repo (no .git in the image). So the fixture is ingested under a managed-repo slug with a broken `path:symbol` cite, reliably firing the per-cite `verify_cite_grep` path (no is_self gate) in both tiers. New scenario `s79_wiki_rot_detector_broken_cite_fires`; full pyramid incl. a round-trip test confirming the structured fields survive; 6 golden seeds regenerated; tests/regressions green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)