### PR TITLE
feat(sandbox): active-trigger e2e for label_drift_watcher — last #9155 backfill loop (#9155)

### DIFF
--- a/tests/sandbox_scenarios/scenarios/s81_label_drift_watcher_reconciles_pr_ahead.py
+++ b/tests/sandbox_scenarios/scenarios/s81_label_drift_watcher_reconciles_pr_ahead.py
@@ -1,0 +1,103 @@
+"""s81 — LabelDriftWatcherLoop reconciles a seeded issue/PR label-drift pair.
+
+Last #9155 test-pyramid backfill loop: LabelDriftWatcherLoop (ADR-0088) had
+unit coverage (``tests/test_label_drift_watcher_loop.py``,
+``tests/test_label_drift_watcher_integration.py``) and a MockWorld scenario
+(``tests/scenarios/test_label_drift_watcher_scenario.py``) but no sandbox
+Tier-2 scenario, so its trigger had never run end-to-end through the real
+Docker/UI stack.
+
+Seeds an issue at ``hydraflow-plan`` (a pre-PR label) alongside its PR at
+``hydraflow-review`` with commits — ``FakeGitHub.find_label_drift``
+classifies this as ``pr_ahead_of_issue`` drift (see
+``FakeGitHub.find_label_drift`` and ``LabelDrift`` in ``src/models.py``):
+the issue lags behind the PR's stage, so a watcher cycle must pull it
+forward. ``FakePR.commits`` defaults to 1, so no new ``MockWorldSeed`` field
+is needed — the existing ``issues``/``prs`` seed fields already express the
+trigger.
+
+The loop's real side effect (``LabelDriftWatcherLoop._reconcile``) is a
+``swap_pipeline_labels`` call moving the issue to ``hydraflow-review`` plus
+an audit comment on the issue — not a heartbeat. This scenario asserts the
+loop's own reported counters (``detected``/``reconciled``, the only surface
+the sandbox Tier-2 ``/api/events`` stream exposes); the Tier-1 companion in
+``tests/scenarios/test_governance_active_trigger_scenarios.py`` additionally
+asserts the label swap and comment against the shared FakeGitHub state.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s81_label_drift_watcher_reconciles_pr_ahead"
+DESCRIPTION = (
+    "LabelDriftWatcherLoop reconciles a seeded pr_ahead_of_issue label-drift "
+    "pair (details.reconciled >= 1), not just a heartbeat."
+)
+
+# One constant pair across the seeded issue/PR and the assertions.
+_ISSUE = 8100
+_PR = 8101
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["label_drift_watcher"],
+        cycles_to_run=2,
+        issues=[
+            {
+                "number": _ISSUE,
+                "title": "Feature work lagging its PR",
+                "body": "Issue label hasn't caught up to the PR's review stage.",
+                "labels": ["hydraflow-plan"],
+            }
+        ],
+        # No explicit commits field on the seed's ``prs`` dict — ``FakePR``
+        # defaults ``commits=1``, which is exactly what the drift classifier
+        # requires (commits > 0) for the ``pr_ahead_of_issue`` kind.
+        prs=[
+            {
+                "number": _PR,
+                "issue_number": _ISSUE,
+                "branch": f"hf/issue-{_ISSUE}",
+                "labels": ["hydraflow-review"],
+            }
+        ],
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """A label_drift_watcher cycle detects and reconciles the seeded pair."""
+
+    def _reconciled(payload: object) -> bool:
+        events = payload if isinstance(payload, list) else []
+        return any(
+            e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "label_drift_watcher"
+            and (e.get("data", {}).get("details") or {}).get("reconciled", 0) >= 1
+            for e in events
+        )
+
+    events_payload = await api.wait_until("/api/events", _reconciled, timeout=90.0)
+
+    watcher_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "label_drift_watcher"
+    ]
+    assert any(
+        (e.get("data", {}).get("details") or {}).get("detected", 0) >= 1
+        for e in watcher_events
+    ), (
+        f"Expected label_drift_watcher to detect drift for issue #{_ISSUE} / "
+        f"PR #{_PR} (details.detected >= 1); worker events: {watcher_events!r}"
+    )
+    assert any(
+        (e.get("data", {}).get("details") or {}).get("reconciled", 0) >= 1
+        for e in watcher_events
+    ), (
+        f"Expected label_drift_watcher to reconcile the seeded drift for "
+        f"issue #{_ISSUE} / PR #{_PR} (details.reconciled >= 1); worker "
+        f"events: {watcher_events!r}"
+    )

--- a/tests/scenarios/test_governance_active_trigger_scenarios.py
+++ b/tests/scenarios/test_governance_active_trigger_scenarios.py
@@ -50,6 +50,9 @@ from tests.sandbox_scenarios.scenarios import (
 from tests.sandbox_scenarios.scenarios import (
     s79_wiki_rot_detector_broken_cite_fires as s79,
 )
+from tests.sandbox_scenarios.scenarios import (
+    s81_label_drift_watcher_reconciles_pr_ahead as s81,
+)
 
 
 async def _run(mock_world, scenario):
@@ -288,3 +291,32 @@ async def test_s79_wiki_rot_detector_files_broken_cite_finding(mock_world) -> No
         issue = mock_world.github.issue(i["number"])
         assert "hydraflow-find" in issue.labels
         assert "wiki-rot" in issue.labels
+
+
+@pytest.mark.asyncio
+async def test_s81_label_drift_watcher_reconciles_pr_ahead(mock_world) -> None:
+    """#9155 — last test-pyramid backfill loop: a seeded issue at a pre-PR
+    label (``hydraflow-plan``) alongside its PR already at
+    ``hydraflow-review`` drives ``LabelDriftWatcherLoop``'s real
+    ``pr_ahead_of_issue`` reconciliation, not just a heartbeat.
+
+    The sandbox Tier-2 counterpart asserts the loop's own reported counters
+    (the only surface ``/api/events`` exposes); this Tier-1 companion
+    additionally asserts the label swap and audit comment against the
+    shared FakeGitHub state.
+    """
+    _seed, stats = await _run(mock_world, s81)
+
+    assert stats["label_drift_watcher"]["detected"] >= 1
+    assert stats["label_drift_watcher"]["reconciled"] >= 1
+    # The world shows the side effect, not just the counters: the issue's
+    # pipeline label actually moved to match the PR's stage.
+    issue = mock_world._github._issues[s81._ISSUE]
+    assert "hydraflow-review" in issue.labels
+    assert "hydraflow-plan" not in issue.labels
+    drift_comments = [
+        body
+        for number, body in mock_world._github._comments
+        if number == s81._ISSUE and "LabelDriftWatcher" in body
+    ]
+    assert drift_comments, "expected a LabelDriftWatcher audit comment on the issue"


### PR DESCRIPTION
Closes #9155 — the sandbox e2e backfill is complete. Of the ~13 loops the audit named, 12 were covered by the s65-s70 governance batch + this session's s71-s80; `label_drift_watcher` was the last uncovered one.

New `s81_label_drift_watcher_reconciles_pr_ahead`: seeds an issue at `hydraflow-plan` with its PR at `hydraflow-review` (existing seed fields; FakePR.commits=1 satisfies find_label_drift's pr_ahead gate — no new field, no golden-seed regen). Asserts the loop detects + reconciles the drift (`details.detected>=1`, `reconciled>=1` via /api/events) + a Tier-1 companion that checks the actual side-effect: the issue's label advanced plan→review and a LabelDriftWatcher audit comment landed. tests/regressions green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)