### PR TITLE
fix(factory): perf/ auto-merge + worktree arch-meta merge driver

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,51 +1,51 @@
 {
-  "regenerated_at": "2026-07-21T11:16:42.817039+00:00",
-  "commit_sha": "769843e62bfaf259b73601f3405a8089a9f33520",
+  "regenerated_at": "2026-07-21T14:37:42.718099+00:00",
+  "commit_sha": "3bc450187bf57844b4c63d0d10c4bb7899b42838",
   "artifacts": {
     "loops.md": {
-      "source_sha": "769843e62bfaf259b73601f3405a8089a9f33520"
+      "source_sha": "3bc450187bf57844b4c63d0d10c4bb7899b42838"
     },
     "ports.md": {
-      "source_sha": "769843e62bfaf259b73601f3405a8089a9f33520"
+      "source_sha": "3bc450187bf57844b4c63d0d10c4bb7899b42838"
     },
     "labels.md": {
-      "source_sha": "769843e62bfaf259b73601f3405a8089a9f33520"
+      "source_sha": "3bc450187bf57844b4c63d0d10c4bb7899b42838"
     },
     "modules.md": {
-      "source_sha": "769843e62bfaf259b73601f3405a8089a9f33520"
+      "source_sha": "3bc450187bf57844b4c63d0d10c4bb7899b42838"
     },
     "events.md": {
-      "source_sha": "769843e62bfaf259b73601f3405a8089a9f33520"
+      "source_sha": "3bc450187bf57844b4c63d0d10c4bb7899b42838"
     },
     "adr_xref.md": {
-      "source_sha": "769843e62bfaf259b73601f3405a8089a9f33520"
+      "source_sha": "3bc450187bf57844b4c63d0d10c4bb7899b42838"
     },
     "mockworld.md": {
-      "source_sha": "769843e62bfaf259b73601f3405a8089a9f33520"
+      "source_sha": "3bc450187bf57844b4c63d0d10c4bb7899b42838"
     },
     "changelog.md": {
-      "source_sha": "769843e62bfaf259b73601f3405a8089a9f33520"
+      "source_sha": "3bc450187bf57844b4c63d0d10c4bb7899b42838"
     },
     "coverage_matrix.md": {
-      "source_sha": "769843e62bfaf259b73601f3405a8089a9f33520"
+      "source_sha": "3bc450187bf57844b4c63d0d10c4bb7899b42838"
     },
     "adr-conformance.md": {
-      "source_sha": "769843e62bfaf259b73601f3405a8089a9f33520"
+      "source_sha": "3bc450187bf57844b4c63d0d10c4bb7899b42838"
     },
     "ai_system_inventory.md": {
-      "source_sha": "769843e62bfaf259b73601f3405a8089a9f33520"
+      "source_sha": "3bc450187bf57844b4c63d0d10c4bb7899b42838"
     },
     "traceability_matrix.md": {
-      "source_sha": "769843e62bfaf259b73601f3405a8089a9f33520"
+      "source_sha": "3bc450187bf57844b4c63d0d10c4bb7899b42838"
     },
     "functional_areas.md": {
-      "source_sha": "769843e62bfaf259b73601f3405a8089a9f33520"
+      "source_sha": "3bc450187bf57844b4c63d0d10c4bb7899b42838"
     },
     "ubiquitous-language.md": {
-      "source_sha": "769843e62bfaf259b73601f3405a8089a9f33520"
+      "source_sha": "3bc450187bf57844b4c63d0d10c4bb7899b42838"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "769843e62bfaf259b73601f3405a8089a9f33520"
+      "source_sha": "3bc450187bf57844b4c63d0d10c4bb7899b42838"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W30
 
+- `e556096` — feat(erosion): ErosionMetricsLoop v1 — Pattern-B caretaker files change-spread/concept-scatter drift to triage (#10107) (#10138) (#10138) *(2026-07-21)*
 - `769843e` — feat(sandbox): seed repo-wiki broken-cite fixture + wiki_rot_detector active-trigger scenario (#10133) (#10137) (#10137) *(2026-07-21)*
 - `2c34150` — feat(erosion): v1 concept-scatter sensor — newly-added symbol across K>=3 modules (#10106) (#10136) (#10136) *(2026-07-21)*
 - `76bc56b` — feat(sandbox): seed worker-status event-history + trust_fleet_sanity active-trigger scenario (#10133) (#10135) (#10135) *(2026-07-21)*

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -40,7 +40,7 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 | `HealthMonitorLoop` | ✅ [0045, 0046, 0093, 0106] | ✅ [testing.md] | ✅ loops.md | ✅ README.md | ✅ `test_health_monitor_loop_primary_cycle.py` | ✅ in catalog | ✅ `s48_health_monitor_idle_poll.py` |
 | `HumanSteeringLoop` | ✅ [0103] | ✅ [human-steering-loop.md, steering-channel.md, steering-state.md] | ❌ | ❌ | ✅ `test_human_steering_loop.py` | ✅ in catalog | ✅ `s52_human_steering_directive.py` |
 | `IssueRefinementLoop` | ❌ | ❌ | ✅ loops.md | ✅ (caretaker loop) | ✅ `test_issue_refinement_loop.py` | ✅ in catalog | ✅ `s57_issue_refinement_digest.py` |
-| `LabelDriftWatcherLoop` | ✅ [0088] | ❌ | ✅ loops.md | ✅ README.md | ✅ `test_label_drift_watcher_loop.py` | ✅ in catalog | ❌ |
+| `LabelDriftWatcherLoop` | ✅ [0088] | ❌ | ✅ loops.md | ✅ README.md | ✅ `test_label_drift_watcher_loop.py` | ✅ in catalog | ✅ `s81_label_drift_watcher_reconciles_pr_ahead.py` |
 | `LiveCorpusReplayLoop` | ✅ [0086] | ✅ [live-corpus-replay-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_live_corpus_replay_loop.py` | ✅ in catalog | ✅ `s43_live_corpus_replay_idle.py` |
 | `LogIngestLoop` | ❌ | ❌ | ✅ loops.md | ✅ (caretaker loop) | ✅ `test_log_ingest_loop.py` | ✅ in catalog | ❌ |
 | `MemoryBacklogLoop` | ✅ [0089] | ✅ [README.md] | ✅ loops.md | ✅ README.md | ✅ `test_memory_backlog_loop.py` | ✅ in catalog | ❌ |

--- a/src/dependabot_merge_loop.py
+++ b/src/dependabot_merge_loop.py
@@ -55,6 +55,16 @@ _AUTO_AGENT_BRANCH_PREFIX = "agent/auto-agent-"
 # deploy-time kill-switch below, the existing draft exclusion, the CH-3
 # merge policy (which reads fresh PR labels, so policy-override:*/deny
 # still apply), and a per-PR ``no-auto-merge`` label opt-out.
+#
+# The set is the Conventional-Commit type family: every one names a class of
+# real, mergeable work that otherwise has NO merge path off a human/agent
+# branch (the exact gap the class-5 shepherd exists to close). ``perf/``,
+# ``ci/`` and ``build/`` were added after a factory session hand-merged a
+# batch of green ``perf/`` CI-speedup PRs one by one — they were green and
+# non-conflicting but fell outside the prefix set, so the shepherd ignored
+# them. GitHub branch protection (a merge with an unsatisfied required check
+# is rejected server-side) plus the ``no-auto-merge`` opt-out remain the
+# backstops for the CI-touching prefixes.
 _HUMAN_SHEPHERD_BRANCH_PREFIXES = (
     "fix/",
     "feat/",
@@ -62,6 +72,9 @@ _HUMAN_SHEPHERD_BRANCH_PREFIXES = (
     "test/",
     "chore/",
     "refactor/",
+    "perf/",
+    "ci/",
+    "build/",
 )
 _HUMAN_SHEPHERD_OPT_OUT_LABEL = "no-auto-merge"
 

--- a/src/workspace.py
+++ b/src/workspace.py
@@ -981,6 +981,10 @@ class WorkspaceManager:
         In host mode, sets ``core.hooksPath`` to the shared ``.githooks`` dir.
         In docker mode, copies individual hook files into the worktree's git
         hooks directory so the worktree is self-contained.
+
+        Either way, registers the ``arch-meta`` merge driver so the worktree
+        gets the same conflict-free ``docs/arch/.meta.json`` handling that
+        ``make ensure-hooks`` gives a developer checkout.
         """
         if self._config.execution_mode == "docker":
             await self._install_hooks_docker(wt_path)
@@ -996,6 +1000,44 @@ class WorkspaceManager:
                 )
             except RuntimeError as exc:
                 logger.warning("git hooks setup failed: %s", exc)
+        await self._register_arch_meta_merge_driver(wt_path)
+
+    async def _register_arch_meta_merge_driver(self, wt_path: Path) -> None:
+        """Register the ``arch-meta`` git merge driver in the worktree.
+
+        ``.gitattributes`` maps ``docs/arch/.meta.json`` to ``merge=arch-meta``
+        so a staging advance auto-resolves the regenerated stamp instead of
+        conflicting on it (#10099). That mapping is INERT unless the driver is
+        registered in git config — and ``make ensure-hooks`` (which registers
+        it for a developer checkout) never runs during factory worktree setup.
+        Without this, every agent worktree still hits the ``.meta.json``
+        conflict on each rebase onto staging, forcing the arch-heal loop to
+        regen it. Values mirror ``make ensure-hooks`` exactly; the sibling
+        ``changelog.md merge=union`` needs no driver (``union`` is built in).
+
+        Best-effort: on failure the branch simply falls back to the old
+        conflict-then-heal path, so we warn and continue rather than fail
+        worktree setup.
+        """
+        for key, value in (
+            (
+                "merge.arch-meta.name",
+                "keep incoming arch .meta.json (regenerated on mainline)",
+            ),
+            ("merge.arch-meta.driver", "cp -- %B %A"),
+        ):
+            try:
+                await run_subprocess(
+                    "git",
+                    "config",
+                    key,
+                    value,
+                    cwd=wt_path,
+                    gh_token=self._credentials.gh_token,
+                )
+            except RuntimeError as exc:
+                logger.warning("arch-meta merge driver setup failed (%s): %s", key, exc)
+                return
 
     async def _install_hooks_docker(self, wt_path: Path) -> None:
         """Copy hook files from .githooks/ into the worktree's git hooks dir."""

--- a/tests/regressions/test_factory_self_operation_gaps.py
+++ b/tests/regressions/test_factory_self_operation_gaps.py
@@ -1,0 +1,47 @@
+"""Regression: factory self-operation gaps closed in PR #10143.
+
+Two gaps forced manual operator toil in the 2026-07-21 session and must not
+silently reopen:
+
+1. The class-5 human-branch shepherd (``DependabotMergeLoop``, #9889)
+   auto-merges CI-green human/agent work branches, but its prefix set omitted
+   ``perf/``/``ci/``/``build/`` — a batch of green ``perf/`` CI-speedup PRs
+   had NO merge path and were hand-merged one at a time. Pin the three
+   Conventional-Commit prefixes into the allowlist.
+
+2. ``.gitattributes`` maps ``docs/arch/.meta.json`` to ``merge=arch-meta``
+   (#10099) but the driver is registered only by ``make ensure-hooks``, which
+   never runs during factory worktree setup. ``WorkspaceManager._install_hooks``
+   must register the driver itself — in BOTH host and docker modes — or the
+   mapping is inert and every agent worktree re-conflicts on the regen stamp.
+   Pin that the registration exists, uses the ensure-hooks driver command, and
+   is wired into ``_install_hooks``.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from dependabot_merge_loop import _HUMAN_SHEPHERD_BRANCH_PREFIXES
+from workspace import WorkspaceManager
+
+
+def test_shepherd_allowlist_covers_perf_ci_build() -> None:
+    for prefix in ("perf/", "ci/", "build/"):
+        assert prefix in _HUMAN_SHEPHERD_BRANCH_PREFIXES, (
+            f"{prefix} dropped from the shepherd allowlist — green {prefix} PRs "
+            "would again have no auto-merge path (PR #10143)"
+        )
+
+
+def test_install_hooks_registers_arch_meta_driver() -> None:
+    # The registration helper exists and mirrors `make ensure-hooks` exactly.
+    driver_src = inspect.getsource(WorkspaceManager._register_arch_meta_merge_driver)
+    assert "merge.arch-meta.driver" in driver_src
+    assert "cp -- %B %A" in driver_src
+
+    # …and _install_hooks actually calls it, so the driver reaches the worktree
+    # regardless of host vs docker mode. Without this wiring the .meta.json
+    # merge=arch-meta mapping is inert in factory worktrees.
+    install_src = inspect.getsource(WorkspaceManager._install_hooks)
+    assert "_register_arch_meta_merge_driver" in install_src

--- a/tests/test_dependabot_merge_loop.py
+++ b/tests/test_dependabot_merge_loop.py
@@ -874,6 +874,28 @@ class TestHumanBranchShepherd:
         prs.merge_pr.assert_awaited_once_with(42, auto_rebase=True)
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("prefix", ["perf/", "ci/", "build/"])
+    async def test_green_conventional_prefix_branch_is_merged(
+        self, tmp_path: Path, prefix: str
+    ) -> None:
+        """Every Conventional-Commit work prefix gets the shepherd merge path.
+
+        Regression for a factory session that hand-merged a batch of green
+        ``perf/`` CI-speedup PRs because ``perf/``/``ci/``/``build/`` were
+        outside the shepherd prefix set — they had no merge path at all.
+        """
+        loop, _, _, prs, _ = _make_loop(
+            tmp_path,
+            open_prs=[_make_pr(42, author="T-rav", branch=f"{prefix}some-work")],
+        )
+
+        with patch("dependabot_merge_loop.fetch_pr_labels", AsyncMock(return_value=[])):
+            result = await loop._do_work()
+
+        assert result["merged"] == 1
+        prs.merge_pr.assert_awaited_once_with(42, auto_rebase=True)
+
+    @pytest.mark.asyncio
     async def test_kill_switch_restores_no_merge_path(self, tmp_path: Path) -> None:
         loop, _, _, prs, _ = _make_loop(
             tmp_path,

--- a/tests/test_workspace_docker.py
+++ b/tests/test_workspace_docker.py
@@ -367,13 +367,53 @@ class TestInstallHooksDocker:
         ) as mock_exec:
             await manager._install_hooks(tmp_path)
 
-        mock_exec.assert_called_once()
-        assert mock_exec.call_args.args[:4] == (
+        # core.hooksPath is set first; the arch-meta merge driver follows.
+        assert mock_exec.call_args_list[0].args[:4] == (
             "git",
             "config",
             "core.hooksPath",
             ".githooks",
         )
+
+    @pytest.mark.asyncio
+    async def test_install_hooks_docker_registers_arch_meta_driver(
+        self, tmp_path: Path
+    ) -> None:
+        """Docker mode also registers the arch-meta merge driver.
+
+        The driver must reach the worktree in BOTH modes so docs/arch/.meta.json
+        auto-resolves on a staging advance (#10099 follow-up); docker copies
+        hook files rather than sharing core.hooksPath, but the git-config merge
+        driver is orthogonal to how hooks are installed.
+        """
+        manager = make_docker_manager(tmp_path)
+        repo_root = manager._repo_root
+        repo_root.mkdir(parents=True, exist_ok=True)
+        (repo_root / ".githooks").mkdir()
+
+        wt_path = tmp_path / "worktree"
+        wt_path.mkdir()
+        hooks_dir = wt_path / ".git" / "hooks"
+        hooks_dir.mkdir(parents=True)
+
+        calls: list[tuple] = []
+
+        async def _record(*args, **_kwargs):
+            calls.append(args)
+            if "rev-parse" in args:
+                return str(hooks_dir)
+            return ""
+
+        with patch("workspace.run_subprocess", side_effect=_record):
+            await manager._install_hooks(wt_path)
+
+        config_calls = [a[:4] for a in calls]
+        assert (
+            "git",
+            "config",
+            "merge.arch-meta.driver",
+            "cp -- %B %A",
+        ) in config_calls
 
     @pytest.mark.asyncio
     async def test_install_hooks_docker_copies_multiple_hooks(

--- a/tests/test_workspace_env.py
+++ b/tests/test_workspace_env.py
@@ -588,12 +588,42 @@ class TestInstallHooks:
         ) as mock_exec:
             await manager._install_hooks(tmp_path)
 
-        mock_exec.assert_called_once()
-        assert mock_exec.call_args.args[:4] == (
+        # core.hooksPath is set first; the arch-meta merge driver follows.
+        assert mock_exec.call_args_list[0].args[:4] == (
             "git",
             "config",
             "core.hooksPath",
             ".githooks",
+        )
+
+    @pytest.mark.asyncio
+    async def test_install_hooks_registers_arch_meta_driver(
+        self, config, tmp_path: Path
+    ) -> None:
+        """Host mode registers the arch-meta merge driver (mirrors ensure-hooks).
+
+        Without this, docs/arch/.meta.json's ``merge=arch-meta`` mapping in
+        .gitattributes is inert in factory worktrees and every rebase onto
+        staging re-conflicts on the regen stamp (#10099 follow-up).
+        """
+        manager = WorkspaceManager(config)
+        success_proc = make_proc()
+
+        with patch(
+            "asyncio.create_subprocess_exec", return_value=success_proc
+        ) as mock_exec:
+            await manager._install_hooks(tmp_path)
+
+        config_calls = [c.args[:4] for c in mock_exec.call_args_list]
+        assert (
+            "git",
+            "config",
+            "merge.arch-meta.driver",
+            "cp -- %B %A",
+        ) in config_calls
+        assert any(
+            call[:3] == ("git", "config", "merge.arch-meta.name")
+            for call in config_calls
         )
 
     @pytest.mark.asyncio
@@ -608,4 +638,4 @@ class TestInstallHooks:
             # Should not raise
             await manager._install_hooks(tmp_path)
 
-        mock_exec.assert_called_once()
+        assert mock_exec.called


### PR DESCRIPTION
## What

Closes two factory **self-operation gaps** that the overnight session serviced by hand.

### 1. Shepherd now auto-merges `perf/`, `ci/`, `build/` branches
`DependabotMergeLoop`'s class-5 shepherd (#9889) auto-merges CI-green human/agent work branches, but its prefix set was missing three Conventional-Commit types. A batch of green `perf/` CI-speedup PRs therefore had **no merge path at all** and were merged one at a time by hand. Added `perf/`, `ci/`, `build/`. GitHub branch protection (a merge with an unsatisfied required check is rejected server-side) and the `no-auto-merge` opt-out label remain the backstops.

### 2. Factory worktrees now register the `arch-meta` merge driver
`.gitattributes` maps `docs/arch/.meta.json` → `merge=arch-meta` (#10099) so a staging advance auto-resolves the regen stamp instead of conflicting on it. But that driver is only registered by `make ensure-hooks`, which **never runs in a factory worktree** — so `WorkspaceManager._install_hooks` left the mapping inert and every agent worktree kept re-conflicting on `.meta.json` on each rebase onto staging. Now registered in `_install_hooks` for **both** host and docker modes, mirroring `ensure-hooks` exactly. (`changelog.md`'s `merge=union` needs no driver — it's built in.)

### Also: arch drift fix
`origin/staging` was already drifted — scenario `s81_label_drift_watcher_reconciles_pr_ahead.py` landed in #10139 without an `arch-regen`. Ran `make arch-regen`; the only content change is the `LabelDriftWatcherLoop` row in `coverage_matrix.md`.

## Testing
- `make quality` green locally: **19572 + 719 passed**, 1 pre-existing arch drift (fixed by the regen above).
- New unit coverage: shepherd merges `perf/`/`ci/`/`build/` (parametrized); `_install_hooks` registers the `arch-meta` driver in host **and** docker modes.

## Follow-ups filed (the larger, loop-sized gaps)
- #10141 — teach `FlakeTrackerLoop` to detect xdist-isolation flakes and auto-quarantine into `PYTEST_SERIAL_PATHS`
- #10142 — pre-merge guard: a workflow change must not orphan a branch-protection required check (complements the post-hoc GateHealthLoop #9974)
- #10027 — added a new red class: stale ratchet/audit baseline semantic merge-commit conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)