### PR TITLE
feat(pipeline): planner-invoked discover/shape helpers behind collapse_discover_shape gate (#9773 step 1)

### DIFF
--- a/src/issue_cache.py
+++ b/src/issue_cache.py
@@ -233,6 +233,8 @@ class IssueCache:
         complexity_rank: str,
         routing_outcome: str,
         reasoning: str = "",
+        clarity_score: int = 10,
+        needs_discovery: bool = False,
     ) -> None:
         """Record a triage classification (#6422 amendment).
 
@@ -247,6 +249,17 @@ class IssueCache:
         a classified-then-parked issue must NOT satisfy the plan-stage
         gate. Callers that don't know the routing outcome yet should
         pass ``"unknown"``.
+
+        ``clarity_score`` / ``needs_discovery`` (ADR-0107) mirror
+        ``TriageResult``'s fields. When ``collapse_discover_shape`` is on,
+        Triage no longer treats them as a routing verdict — instead the
+        planner's decision gate (``plan_phase.py:_should_discover_helper``)
+        reads them back via :meth:`latest_classification` as HINTS for
+        whether an on-demand discover/shape helper is warranted before
+        planning. Defaults (``10``, ``False``) describe a well-specified
+        issue so callers that don't pass them (or issues with no
+        classification record at all) read as "no helper needed" — the
+        gate's conservative default.
         """
         self.record(
             CacheRecord(
@@ -258,6 +271,8 @@ class IssueCache:
                     "complexity_rank": complexity_rank,
                     "routing_outcome": routing_outcome,
                     "reasoning": reasoning,
+                    "clarity_score": clarity_score,
+                    "needs_discovery": needs_discovery,
                 },
             )
         )

--- a/src/plan_phase.py
+++ b/src/plan_phase.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -15,11 +16,15 @@ from events import EventBus
 from exception_classify import reraise_on_credit_or_bug
 from harness_insights import FailureCategory, HarnessInsightStore
 from models import (
+    ConversationTurn,
+    DiscoverResult,
     EpicGapReview,
     IssueOutcomeType,
     PipelineStage,
     PlanResult,
     PlanReview,
+    ShapeConversation,
+    ShapeTurnResult,
     Task,
 )
 from phase_utils import (
@@ -54,11 +59,13 @@ from wiki_maint_queue import enqueue_wiki_ingest
 
 if TYPE_CHECKING:
     from beads_manager import BeadsManager
+    from discover_runner import DiscoverRunner
     from epic import EpicManager
     from issue_cache import IssueCache
     from plan_reviewer import PlanReviewer
     from plan_touchpoint_expander import PlanTouchpointExpander
     from ports import IssueStorePort, PRPort
+    from shape_runner import ShapeRunner
     from wiki_compiler import CorroborationDecision, WikiCompiler  # noqa: TCH004
 
 logger = logging.getLogger("hydraflow.plan_phase")
@@ -129,6 +136,8 @@ class PlanPhase:
         issue_cache: IssueCache | None = None,
         plan_reviewer: PlanReviewer | None = None,
         touchpoint_expander: PlanTouchpointExpander | None = None,
+        discover_runner: DiscoverRunner | None = None,
+        shape_runner: ShapeRunner | None = None,
     ) -> None:
         self._config = config
         self._state = state
@@ -147,6 +156,14 @@ class PlanPhase:
         self._wiki_compiler = wiki_compiler
         self._issue_cache = issue_cache
         self._plan_reviewer = plan_reviewer
+        # ADR-0107 (collapse_discover_shape): the discover/shape engines,
+        # reused as on-demand helpers the planner's decision gate invokes
+        # (_should_discover_helper / _should_shape_helper) instead of them
+        # running as standalone pipeline phases. Optional — when None (the
+        # default, and always true while the flag is off), the gates always
+        # return False and behavior is unaffected.
+        self._discover_runner = discover_runner
+        self._shape_runner = shape_runner
         # Touchpoint expander (ADR-0063 W3b). Dispatched on the FIRST
         # PlanReviewer blocking-finding failure to enrich the next
         # review pass with cross-referenced ADRs, recent PR conflict
@@ -393,6 +410,19 @@ class PlanPhase:
         )
         self._persist_adversarial_state(issue, adv)
 
+    def _has_escalation_label(self, issue: Task) -> bool:
+        """True if *issue* carries one of ``config.research_escalation_labels``.
+
+        Shared by :meth:`_should_research` and the ADR-0107 discover-helper
+        gate (:meth:`_should_discover_helper`) — both treat an
+        operator/loop-applied escalation label as a signal that the issue
+        warrants deeper pre-planning work.
+        """
+        escalation_labels = {
+            lbl.lower() for lbl in self._config.research_escalation_labels
+        }
+        return any(tag.lower() in escalation_labels for tag in issue.tags)
+
     def _should_research(self, issue: Task) -> bool:
         """Return True if the research pre-pass should run before planning *issue*.
 
@@ -417,10 +447,192 @@ class PlanPhase:
         if self._state.get_route_back_count(issue.id) > 0:
             return True
         # Escalated: operator/loop flagged the issue for deeper handling.
-        escalation_labels = {
-            lbl.lower() for lbl in self._config.research_escalation_labels
-        }
-        return any(tag.lower() in escalation_labels for tag in issue.tags)
+        return self._has_escalation_label(issue)
+
+    def _triage_hints(self, issue: Task) -> tuple[int, bool]:
+        """Return ``(clarity_score, needs_discovery)`` triage HINTS for *issue*.
+
+        ADR-0107: with ``collapse_discover_shape`` on, Triage no longer treats
+        these as a routing verdict — it records them on the issue's
+        ``IssueCache`` classification record and the planner's decision gate
+        reads them back here. Missing cache / no classification record yet
+        (e.g. ``issue_cache`` disabled, or the issue predates classification)
+        reads as the well-specified default ``(10, False)`` — the gate's
+        conservative "no helper needed" reading.
+        """
+        if self._issue_cache is None:
+            return 10, False
+        record = self._issue_cache.latest_classification(issue.id)
+        if record is None:
+            return 10, False
+        return (
+            int(record.payload.get("clarity_score", 10)),
+            bool(record.payload.get("needs_discovery", False)),
+        )
+
+    def _should_discover_helper(self, issue: Task) -> bool:
+        """ADR-0107 planner decision gate: run the discover helper before planning?
+
+        Only consulted when ``collapse_discover_shape`` is on and a
+        ``DiscoverRunner`` is wired — with the flag off (or no runner), this
+        always returns False and Triage's existing fork to the standalone
+        Discover phase is unaffected (byte-identical current behavior).
+
+        Conservative default (per ADR-0107): a well-specified issue plans
+        directly with no helper. The gate fires when any of —
+
+        - **needs_discovery hint** — Triage's LLM flagged the issue as vague.
+        - **clarity_score hint** below ``config.clarity_threshold``.
+        - **Cycled / failing to land** — routed back to plan at least once
+          (``StateTracker.get_route_back_count``).
+        - **Escalated** — issue carries a ``research_escalation_labels`` tag.
+
+        Epic children are excluded outright: they are already-scoped
+        decomposition output from a parent epic's planning pass, so
+        re-running product discovery on them would be redundant.
+        """
+        if not self._config.collapse_discover_shape:
+            return False
+        if self._discover_runner is None:
+            return False
+        if self._is_epic_child(issue):
+            return False
+        clarity_score, needs_discovery = self._triage_hints(issue)
+        return (
+            needs_discovery
+            or clarity_score < self._config.clarity_threshold
+            or self._state.get_route_back_count(issue.id) > 0
+            or self._has_escalation_label(issue)
+        )
+
+    async def _run_discover_helper(
+        self, issue: Task, *, guidance: str
+    ) -> DiscoverResult | None:
+        """Invoke ``DiscoverRunner`` as an on-demand research pre-pass (ADR-0107).
+
+        This is a synchronous in-process helper call, not a stage transition —
+        the engine is reused unmodified; only the caller changes. Bounded
+        internally by ``config.max_discover_attempts`` /
+        ``max_discover_expansions`` (read by ``DiscoverRunner.discover``
+        itself), the same knobs that bounded the standalone Discover phase —
+        they now bound this planner-invoked sub-step instead. Returns
+        ``None`` (never raises) on failure so planning proceeds without a
+        research brief rather than being blocked by it.
+        """
+        assert self._discover_runner is not None  # guarded by caller
+        try:
+            result = await self._discover_runner.discover(issue, guidance=guidance)
+        except Exception as exc:
+            # Dark-factory contract: credit/auth/likely-bug exceptions must
+            # propagate so the loop pauses on the billing signal instead of
+            # silently planning without research.
+            reraise_on_credit_or_bug(exc)
+            logger.warning(
+                "Discover helper failed for issue #%d — planning without a "
+                "research brief",
+                issue.id,
+                exc_info=True,
+            )
+            return None
+        try:
+            await self._prs.post_comment(
+                issue.id, self._format_discover_brief(issue, result)
+            )
+        except Exception:
+            logger.warning(
+                "Failed to post discover-helper brief for issue #%d",
+                issue.id,
+                exc_info=True,
+            )
+        return result
+
+    @staticmethod
+    def _format_discover_brief(issue: Task, result: DiscoverResult) -> str:
+        """Format a ``DiscoverResult`` as a GitHub comment for the audit trail."""
+        lines = [
+            "## Discovery Research (planner-invoked helper)",
+            "",
+            f"*ADR-0107 — issue #{issue.id} routed Triage → Plan directly; "
+            f"the planner's decision gate determined discovery research was "
+            f"warranted before planning.*",
+            "",
+            result.research_brief,
+        ]
+        if result.opportunities:
+            lines.extend(["", "### Opportunities", ""])
+            lines.extend(f"- {o}" for o in result.opportunities)
+        return "\n".join(lines)
+
+    def _should_shape_helper(
+        self, issue: Task, discover_result: DiscoverResult | None
+    ) -> bool:
+        """ADR-0107 planner decision gate: does discovery warrant a shaping turn?
+
+        Only consulted after the discover helper has already run — shaping
+        without a discovery brief has nothing to shape. Fires when the brief
+        surfaced genuinely divergent opportunities (2+) that need a human
+        choice, per ADR-0107's framing of shaping as direction-selection
+        rather than open-ended exploration. Requires a ``ShapeRunner`` to be
+        wired; with the flag off or no runner this always returns False.
+        """
+        if not self._config.collapse_discover_shape:
+            return False
+        if self._shape_runner is None or discover_result is None:
+            return False
+        return len(discover_result.opportunities) >= 2
+
+    async def _run_shape_helper(
+        self, issue: Task, discover_result: DiscoverResult, *, guidance: str
+    ) -> ShapeTurnResult | None:
+        """Invoke ``ShapeRunner`` for one bounded conversation turn (ADR-0107).
+
+        Reuses the same ``ShapeConversation`` state slot the standalone Shape
+        phase used (``StateTracker.get/set_shape_conversation``) so this
+        helper composes with that machinery rather than reimplementing it.
+        Bounded by ``config.max_shape_turns`` (conversation-length ceiling —
+        returns ``None`` once hit, same as the standalone phase forcing
+        finalization) and ``config.max_shape_attempts`` (retried internally
+        by ``ShapeRunner.run_turn`` against the shape-coherence evaluator).
+
+        Because shaping is human-interactive, a non-final result is NOT
+        waited on synchronously — the caller (``_plan_one``) escalates to
+        HITL per ADR-0107's "yield to the existing human-steering channel"
+        design rather than blocking the plan tick.
+        """
+        assert self._shape_runner is not None  # guarded by caller
+        conv = self._state.get_shape_conversation(issue.id) or ShapeConversation(
+            issue_number=issue.id,
+            started_at=datetime.now(UTC).isoformat(),
+        )
+        if len(conv.turns) >= self._config.max_shape_turns:
+            logger.warning(
+                "Shape helper hit max_shape_turns (%d) for issue #%d without "
+                "finalizing",
+                self._config.max_shape_turns,
+                issue.id,
+            )
+            return None
+        try:
+            result = await self._shape_runner.run_turn(
+                issue,
+                conv,
+                research_brief=discover_result.research_brief,
+                guidance=guidance,
+            )
+        except Exception as exc:
+            reraise_on_credit_or_bug(exc)
+            logger.warning("Shape helper failed for issue #%d", issue.id, exc_info=True)
+            return None
+        conv.turns.append(
+            ConversationTurn(
+                role="agent",
+                content=result.content,
+                timestamp=datetime.now(UTC).isoformat(),
+            )
+        )
+        conv.last_activity_at = datetime.now(UTC).isoformat()
+        self._state.set_shape_conversation(issue.id, conv)
+        return result
 
     async def _handle_already_satisfied(self, issue: Task, result: PlanResult) -> bool:
         """Validate evidence and close issue as already-satisfied.
@@ -1199,6 +1411,19 @@ class PlanPhase:
 
             with _sentry_transaction("pipeline.plan", f"plan:#{issue.id}"):
                 async with store_lifecycle(self._store, issue.id, "plan"):
+                    # Human-on-the-loop continuous steering (ADR-0099 #4):
+                    # fold live operator guidance into the plan prompt.
+                    # Reference signal only — never blocking; empty when
+                    # the feature is off or no guidance was posted for
+                    # this issue. Named `human_guidance` (not bare
+                    # `guidance`) to avoid colliding with the unrelated
+                    # `EpicGapReview.guidance` field used elsewhere in
+                    # this module. Fetched up front (not just before the
+                    # planner call) so the ADR-0107 discover/shape helpers
+                    # below can also thread it into their prompts.
+                    human_guidance = (
+                        self._state.get_human_steering(str(issue.id)).guidance or ""
+                    )
                     research_context = ""
                     if self._should_research(issue):
                         research_result = await self._research_runner.research(issue)  # type: ignore[union-attr]
@@ -1228,6 +1453,105 @@ class PlanPhase:
                                 issue.id,
                                 research_result.error,
                             )
+
+                    # ADR-0107 (collapse_discover_shape): the planner's
+                    # on-demand discover/shape decision gate. Both gates
+                    # always return False with the flag off (or no runner
+                    # wired), so this block is a pure no-op in that mode —
+                    # existing behavior is byte-identical.
+                    discover_result: DiscoverResult | None = None
+                    if self._should_discover_helper(issue):
+                        discover_result = await self._run_discover_helper(
+                            issue, guidance=human_guidance
+                        )
+                        if discover_result is not None:
+                            research_context = (
+                                f"{research_context}\n\n{discover_result.research_brief}"
+                            ).strip()
+
+                        if self._should_shape_helper(issue, discover_result):
+                            assert discover_result is not None  # gate requires it
+                            shape_result = await self._run_shape_helper(
+                                issue, discover_result, guidance=human_guidance
+                            )
+                            if shape_result is None or not shape_result.is_final:
+                                # Divergent directions need a human choice.
+                                # Shaping is human-interactive (ADR-0107) —
+                                # yield to the existing HITL / human-steering
+                                # channel instead of blocking this plan tick
+                                # on a synchronous wait for a reply.
+                                options_text = (
+                                    shape_result.content
+                                    if shape_result is not None
+                                    else "Shaping could not produce directions "
+                                    "within the configured turn budget."
+                                )
+                                try:
+                                    await self._prs.post_comment(
+                                        issue.id,
+                                        "## Product Directions (planner-invoked "
+                                        f"shaping helper)\n\n{options_text}\n\n"
+                                        "---\n*A human choice is needed before "
+                                        "planning can continue — reply with your "
+                                        "preferred direction or use human "
+                                        "steering, then re-queue for planning.*",
+                                    )
+                                except Exception:
+                                    logger.warning(
+                                        "Failed to post shape-helper options "
+                                        "for issue #%d",
+                                        issue.id,
+                                        exc_info=True,
+                                    )
+                                await self._escalator(
+                                    issue,
+                                    cause="Shape helper surfaced divergent "
+                                    "product directions needing a human choice",
+                                    details=options_text[:500],
+                                    category=FailureCategory.HITL_ESCALATION,
+                                )
+                                logger.info(
+                                    "Issue #%d shape helper escalated to HITL "
+                                    "for a direction choice",
+                                    issue.id,
+                                )
+                                return PlanResult(
+                                    issue_number=issue.id, error="shape_escalated"
+                                )
+                            # Finalized on this turn — fold the selected
+                            # direction into research_context (synchronous,
+                            # no re-fetch needed) and require the same
+                            # decomposition the standalone Shape phase asked
+                            # for, since this is still a broad product
+                            # direction rather than one implementable task.
+                            research_context = (
+                                f"{research_context}\n\n{shape_result.content}\n\n"
+                                "IMPORTANT — DECOMPOSITION REQUIRED: this issue "
+                                "came through the ADR-0107 planner-invoked shaping "
+                                "helper and MUST be decomposed into 3-8 concrete "
+                                "sub-issues using NEW_ISSUES_START/NEW_ISSUES_END "
+                                "markers."
+                            ).strip()
+                            try:
+                                await self._prs.post_comment(
+                                    issue.id,
+                                    "## Final Product Direction (planner-invoked "
+                                    f"shaping helper)\n\n{shape_result.content}\n\n"
+                                    "\n### Planning Guidance — DECOMPOSITION "
+                                    "REQUIRED\n\nThis issue was shaped via the "
+                                    "planner's on-demand helper. It is a BROAD "
+                                    "product direction, NOT a single "
+                                    "implementable task. You MUST decompose this "
+                                    "into 3-8 concrete sub-issues using the "
+                                    "NEW_ISSUES_START/NEW_ISSUES_END format.",
+                                )
+                            except Exception:
+                                logger.warning(
+                                    "Failed to post finalized shape direction "
+                                    "for issue #%d",
+                                    issue.id,
+                                    exc_info=True,
+                                )
 
                     from trace_rollup import write_phase_rollup  # noqa: PLC0415
                     from tracing_context import (  # noqa: PLC0415
@@ -1268,17 +1592,6 @@ class PlanPhase:
                             source="planner",
                             run_id=run_id,
                         )
-                    )
-                    # Human-on-the-loop continuous steering (ADR-0099 #4):
-                    # fold live operator guidance into the plan prompt.
-                    # Reference signal only — never blocking; empty when
-                    # the feature is off or no guidance was posted for
-                    # this issue. Named `human_guidance` (not bare
-                    # `guidance`) to avoid colliding with the unrelated
-                    # `EpicGapReview.guidance` field used elsewhere in
-                    # this module.
-                    human_guidance = (
-                        self._state.get_human_steering(str(issue.id)).guidance or ""
                     )
                     try:
                         result = await self._planners.plan(

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -1033,6 +1033,14 @@ def build_services(
         wiki_compiler=wiki_compiler,
         issue_cache=issue_cache,
         plan_reviewer=plan_reviewer,
+        # ADR-0107 (collapse_discover_shape): share the SAME DiscoverRunner /
+        # ShapeRunner instances DiscoverPhase / ShapePhase already bound
+        # escalation deps onto above, so the planner-invoked helper gates
+        # (plan_phase.py:_should_discover_helper / _should_shape_helper)
+        # can invoke them without re-binding. Both gates are no-ops with
+        # the flag off, so this wiring is inert until the flag flips.
+        discover_runner=discover_runner,
+        shape_runner=shape_runner,
     )
 
     # Earlier-adversarial pipeline AgentLike wiring (ADR-0064).

--- a/src/triage_phase.py
+++ b/src/triage_phase.py
@@ -449,6 +449,11 @@ class TriagePhase:
         # accepting a classification whose issue was parked or sent
         # to discover — the gate checks routing_outcome == "plan".
         # Best-effort: cache failures never raise into the domain layer.
+        #
+        # clarity_score / needs_discovery (ADR-0107) ride along so the
+        # planner's decision gate can read them back as HINTS via
+        # ``IssueCache.latest_classification`` when collapse_discover_shape
+        # is on — see plan_phase.py:_should_discover_helper.
         if self._issue_cache is not None:
             self._issue_cache.record_classification(
                 issue.id,
@@ -457,6 +462,8 @@ class TriagePhase:
                 complexity_rank=self._complexity_rank(result.complexity_score),
                 routing_outcome=routing_outcome,
                 reasoning="; ".join(result.reasons) if result.reasons else "",
+                clarity_score=result.clarity_score,
+                needs_discovery=result.needs_discovery,
             )
 
         # Reproduce bug-classified issues that were routed to plan

--- a/tests/scenarios/test_discover_shape_planner_gate_scenario.py
+++ b/tests/scenarios/test_discover_shape_planner_gate_scenario.py
@@ -1,0 +1,163 @@
+"""MockWorld scenario for the ADR-0107 planner-invoked discover helper.
+
+Collapse-Discover-Shape step 1 (#9773): with ``collapse_discover_shape`` on,
+Triage routes a ready issue straight to Plan regardless of clarity — no
+``hydraflow-discover`` hop. The clarity/needs-discovery signals ride along as
+HINTS on the shared ``IssueCache`` classification record (mirroring
+``service_registry.py``'s production wiring, where Triage and Plan share one
+``IssueCache`` instance). The planner's decision gate
+(``plan_phase.py:_should_discover_helper``) reads those hints back and, for a
+low-clarity issue, invokes the ``DiscoverRunner``-backed helper before
+planning — and the issue still reaches a successful plan afterward.
+
+Scenario 2 covers the conservative default: a well-specified (high-clarity)
+issue plans directly with no helper invocation, exactly like the flag-off
+path — proving the gate doesn't fire indiscriminately just because the flag
+is on.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from models import DiscoverResult, Task
+
+pytestmark = pytest.mark.scenario
+
+
+class _ScriptedDiscoverRunner:
+    """Records calls and returns a scripted ``DiscoverResult``.
+
+    Stands in for the real subprocess-backed ``DiscoverRunner`` the same way
+    ``test_plan_touchpoint_expander_scenario.py``'s ``_ScriptedReviewer`` /
+    ``_ScriptedExpander`` stand in for their real engines — the planner-gate
+    wiring under test doesn't care which concrete engine it invokes.
+    """
+
+    def __init__(self, result: DiscoverResult) -> None:
+        self._result = result
+        self.calls: list[Task] = []
+
+    async def discover(self, task: Task, *, guidance: str = "") -> DiscoverResult:
+        self.calls.append(task)
+        return self._result
+
+
+def _wire_shared_issue_cache(harness: Any, tmp_path: Any) -> Any:
+    """Wire a real ``IssueCache`` shared by TriagePhase + PlanPhase.
+
+    Mirrors ``service_registry.py``'s production wiring, where a single
+    ``IssueCache`` instance is passed to both phases — Triage's
+    ``record_classification`` call is how the ADR-0107 clarity/needs-
+    discovery hints reach the planner's decision gate
+    (``plan_phase.py:_triage_hints`` reads them back via
+    ``latest_classification``). The harness's default ``PipelineHarness``
+    wiring leaves both phases' ``_issue_cache`` at ``None``.
+    """
+    from issue_cache import IssueCache
+
+    cache = IssueCache(tmp_path / "issue_cache")
+    harness.triage_phase._issue_cache = cache
+    harness.plan_phase._issue_cache = cache
+    return cache
+
+
+class TestS1LowClarityIssueGetsDiscoverHelper:
+    """Flag ON: a low-clarity ready issue routes Triage -> Plan directly,
+    the planner's gate invokes the discover helper before planning, and the
+    issue still reaches a successful plan."""
+
+    async def test_low_clarity_issue_discovers_then_plans(
+        self, mock_world, tmp_path
+    ) -> None:
+        world = mock_world
+        harness = world.harness
+        harness.config.collapse_discover_shape = True
+        _wire_shared_issue_cache(harness, tmp_path)
+
+        discover_runner = _ScriptedDiscoverRunner(
+            DiscoverResult(
+                issue_number=401,
+                research_brief=(
+                    "Competitive landscape: three adjacent tools, one clear gap."
+                ),
+                opportunities=["Ship a focused MVP targeting the gap"],
+            )
+        )
+        harness.plan_phase._discover_runner = discover_runner
+
+        world.add_issue(
+            401,
+            "Improve onboarding experience",
+            "Users drop off during signup. " * 5,
+            labels=["hydraflow-find"],
+        )
+        world._llm.script_triage(
+            401,
+            [{"ready": True, "clarity_score": 3, "needs_discovery": False}],
+        )
+        world._llm.script_plan(
+            401,
+            [{"success": True, "plan": "## Plan\n\n1. Redesign signup flow"}],
+        )
+
+        result = await world.run_pipeline()
+
+        # Triage routed straight to Plan — no hydraflow-discover hop, per
+        # the keystone's flag-gated routing (triage_phase.py).
+        outcome = result.issue(401)
+        assert "hydraflow-discover" not in outcome.labels
+
+        # The planner's decision gate invoked the discover helper before
+        # planning, reading the low-clarity hint back off the shared cache.
+        assert len(discover_runner.calls) == 1
+        assert discover_runner.calls[0].id == 401
+
+        # Planning still completed successfully — discovery didn't block it.
+        assert outcome.plan_result is not None
+        assert outcome.plan_result.success is True
+        assert outcome.final_stage != "triage"
+
+
+class TestS2WellSpecifiedIssueSkipsHelper:
+    """Flag ON, conservative default: a well-specified (high-clarity) issue
+    plans directly with no helper invocation."""
+
+    async def test_high_clarity_issue_plans_without_discover_helper(
+        self, mock_world, tmp_path
+    ) -> None:
+        world = mock_world
+        harness = world.harness
+        harness.config.collapse_discover_shape = True
+        _wire_shared_issue_cache(harness, tmp_path)
+
+        discover_runner = _ScriptedDiscoverRunner(
+            DiscoverResult(issue_number=402, research_brief="should not be reached")
+        )
+        harness.plan_phase._discover_runner = discover_runner
+
+        world.add_issue(
+            402,
+            "Add pagination to the users endpoint",
+            "Add limit/offset query params to GET /users. " * 3,
+            labels=["hydraflow-find"],
+        )
+        world._llm.script_triage(
+            402,
+            [{"ready": True, "clarity_score": 9, "needs_discovery": False}],
+        )
+        world._llm.script_plan(
+            402,
+            [{"success": True, "plan": "## Plan\n\n1. Add pagination params"}],
+        )
+
+        result = await world.run_pipeline()
+
+        outcome = result.issue(402)
+        assert "hydraflow-discover" not in outcome.labels
+        assert discover_runner.calls == []
+        assert outcome.plan_result is not None
+        assert outcome.plan_result.success is True
+        assert outcome.final_stage != "triage"

--- a/tests/test_issue_cache.py
+++ b/tests/test_issue_cache.py
@@ -165,7 +165,31 @@ class TestClassificationRecord:
             "complexity_rank": "high",
             "routing_outcome": "plan",
             "reasoning": "touches 3 modules",
+            # ADR-0107: clarity_score/needs_discovery default to the
+            # well-specified reading when the caller doesn't pass them.
+            "clarity_score": 10,
+            "needs_discovery": False,
         }
+
+    def test_record_classification_carries_adr_0107_hints(self, tmp_path: Path) -> None:
+        """ADR-0107: clarity_score/needs_discovery ride along on the
+        classification record so the planner's decision gate
+        (plan_phase.py:_should_discover_helper) can read them back as
+        HINTS via latest_classification."""
+        cache = _cache(tmp_path)
+        cache.record_classification(
+            42,
+            issue_type="feature",
+            complexity_score=4,
+            complexity_rank="medium",
+            routing_outcome="plan",
+            clarity_score=3,
+            needs_discovery=True,
+        )
+        latest = cache.latest_classification(42)
+        assert latest is not None
+        assert latest.payload["clarity_score"] == 3
+        assert latest.payload["needs_discovery"] is True
 
     def test_latest_classification_returns_most_recent(self, tmp_path: Path) -> None:
         cache = _cache(tmp_path)

--- a/tests/test_plan_phase.py
+++ b/tests/test_plan_phase.py
@@ -14,7 +14,15 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from typing import TYPE_CHECKING
 
-from models import PlanResult, ResearchResult, Task
+from models import (
+    ConversationTurn,
+    DiscoverResult,
+    PlanResult,
+    ResearchResult,
+    ShapeConversation,
+    ShapeTurnResult,
+    Task,
+)
 from tests.conftest import AnalysisResultFactory, PlanResultFactory, TaskFactory
 from tests.helpers import make_plan_phase, supply_once
 
@@ -1610,3 +1618,456 @@ class TestPlanConvergenceLedger:
         ledger = state.get_convergence_ledger(204)
         assert ledger is not None, "Ledger must be created"
         assert ledger.stage_state["plan"].last_verdict == "ADVANCE"
+
+
+# ---------------------------------------------------------------------------
+# ADR-0107: planner-invoked discover/shape helpers behind collapse_discover_shape
+# ---------------------------------------------------------------------------
+
+
+class TestPlanPhaseDiscoverShapeHelpers:
+    """The planner's on-demand discover/shape decision gate (ADR-0107).
+
+    Conservative default: a well-specified issue plans directly with no
+    helper. Both gates always return False with the flag off (or no runner
+    wired) — Triage's fork to the standalone Discover phase is unaffected.
+    """
+
+    # -- _triage_hints ----------------------------------------------------
+
+    def test_triage_hints_default_when_no_issue_cache(
+        self, config: HydraFlowConfig
+    ) -> None:
+        phase, *_ = make_plan_phase(config)
+        issue = TaskFactory.create(id=1)
+        assert phase._triage_hints(issue) == (10, False)
+
+    def test_triage_hints_default_when_no_classification_record(
+        self, config: HydraFlowConfig
+    ) -> None:
+        from unittest.mock import MagicMock
+
+        phase, *_ = make_plan_phase(config)
+        mock_cache = MagicMock()
+        mock_cache.latest_classification.return_value = None
+        phase._issue_cache = mock_cache
+        issue = TaskFactory.create(id=1)
+        assert phase._triage_hints(issue) == (10, False)
+
+    def test_triage_hints_reads_classification_payload(
+        self, config: HydraFlowConfig
+    ) -> None:
+        from unittest.mock import MagicMock
+
+        phase, *_ = make_plan_phase(config)
+        record = MagicMock()
+        record.payload = {"clarity_score": 3, "needs_discovery": True}
+        mock_cache = MagicMock()
+        mock_cache.latest_classification.return_value = record
+        phase._issue_cache = mock_cache
+        issue = TaskFactory.create(id=1)
+        assert phase._triage_hints(issue) == (3, True)
+
+    # -- _should_discover_helper ------------------------------------------
+
+    def test_should_discover_helper_false_when_flag_off(
+        self, config: HydraFlowConfig
+    ) -> None:
+        phase, *_ = make_plan_phase(config)
+        phase._discover_runner = AsyncMock()
+        issue = TaskFactory.create(id=1)
+        assert phase._should_discover_helper(issue) is False
+
+    def test_should_discover_helper_false_when_no_runner(
+        self, config: HydraFlowConfig
+    ) -> None:
+        collapsed = config.model_copy(update={"collapse_discover_shape": True})
+        phase, *_ = make_plan_phase(collapsed)
+        issue = TaskFactory.create(id=1)
+        assert phase._should_discover_helper(issue) is False
+
+    def test_should_discover_helper_false_for_well_specified_issue(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Conservative default: no hints, no signals -> plans directly."""
+        collapsed = config.model_copy(update={"collapse_discover_shape": True})
+        phase, *_ = make_plan_phase(collapsed)
+        phase._discover_runner = AsyncMock()
+        issue = TaskFactory.create(id=1)
+        assert phase._should_discover_helper(issue) is False
+
+    def test_should_discover_helper_true_for_needs_discovery_hint(
+        self, config: HydraFlowConfig
+    ) -> None:
+        from unittest.mock import MagicMock
+
+        collapsed = config.model_copy(update={"collapse_discover_shape": True})
+        phase, *_ = make_plan_phase(collapsed)
+        phase._discover_runner = AsyncMock()
+        record = MagicMock()
+        record.payload = {"clarity_score": 10, "needs_discovery": True}
+        mock_cache = MagicMock()
+        mock_cache.latest_classification.return_value = record
+        phase._issue_cache = mock_cache
+        issue = TaskFactory.create(id=1)
+        assert phase._should_discover_helper(issue) is True
+
+    def test_should_discover_helper_true_for_low_clarity_hint(
+        self, config: HydraFlowConfig
+    ) -> None:
+        from unittest.mock import MagicMock
+
+        collapsed = config.model_copy(update={"collapse_discover_shape": True})
+        phase, *_ = make_plan_phase(collapsed)
+        phase._discover_runner = AsyncMock()
+        record = MagicMock()
+        record.payload = {"clarity_score": 3, "needs_discovery": False}
+        mock_cache = MagicMock()
+        mock_cache.latest_classification.return_value = record
+        phase._issue_cache = mock_cache
+        issue = TaskFactory.create(id=1)
+        assert phase._should_discover_helper(issue) is True
+
+    def test_should_discover_helper_true_for_cycled_issue(
+        self, config: HydraFlowConfig
+    ) -> None:
+        collapsed = config.model_copy(update={"collapse_discover_shape": True})
+        phase, state, *_ = make_plan_phase(collapsed)
+        phase._discover_runner = AsyncMock()
+        issue = TaskFactory.create(id=7)
+        state.increment_route_back_count(issue.id)
+        assert phase._should_discover_helper(issue) is True
+
+    def test_should_discover_helper_true_for_escalation_label(
+        self, config: HydraFlowConfig
+    ) -> None:
+        collapsed = config.model_copy(update={"collapse_discover_shape": True})
+        phase, *_ = make_plan_phase(collapsed)
+        phase._discover_runner = AsyncMock()
+        issue = TaskFactory.create(id=1, tags=[config.research_escalation_labels[0]])
+        assert phase._should_discover_helper(issue) is True
+
+    def test_should_discover_helper_false_for_epic_child(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Epic children are already-scoped decomposition output — skip
+        discovery outright even when the clarity hints would otherwise
+        fire the gate."""
+        from unittest.mock import MagicMock
+
+        collapsed = config.model_copy(update={"collapse_discover_shape": True})
+        phase, *_ = make_plan_phase(collapsed)
+        phase._discover_runner = AsyncMock()
+        phase._is_epic_child = lambda _issue: True  # type: ignore[method-assign]
+        record = MagicMock()
+        record.payload = {"clarity_score": 2, "needs_discovery": True}
+        mock_cache = MagicMock()
+        mock_cache.latest_classification.return_value = record
+        phase._issue_cache = mock_cache
+        issue = TaskFactory.create(id=1)
+        assert phase._should_discover_helper(issue) is False
+
+    # -- _should_shape_helper -----------------------------------------------
+
+    def test_should_shape_helper_false_when_flag_off(
+        self, config: HydraFlowConfig
+    ) -> None:
+        phase, *_ = make_plan_phase(config)
+        phase._shape_runner = AsyncMock()
+        result = DiscoverResult(issue_number=1, opportunities=["a", "b"])
+        issue = TaskFactory.create(id=1)
+        assert phase._should_shape_helper(issue, result) is False
+
+    def test_should_shape_helper_false_when_no_runner(
+        self, config: HydraFlowConfig
+    ) -> None:
+        collapsed = config.model_copy(update={"collapse_discover_shape": True})
+        phase, *_ = make_plan_phase(collapsed)
+        result = DiscoverResult(issue_number=1, opportunities=["a", "b"])
+        issue = TaskFactory.create(id=1)
+        assert phase._should_shape_helper(issue, result) is False
+
+    def test_should_shape_helper_false_when_no_discover_result(
+        self, config: HydraFlowConfig
+    ) -> None:
+        collapsed = config.model_copy(update={"collapse_discover_shape": True})
+        phase, *_ = make_plan_phase(collapsed)
+        phase._shape_runner = AsyncMock()
+        issue = TaskFactory.create(id=1)
+        assert phase._should_shape_helper(issue, None) is False
+
+    def test_should_shape_helper_false_for_single_opportunity(
+        self, config: HydraFlowConfig
+    ) -> None:
+        collapsed = config.model_copy(update={"collapse_discover_shape": True})
+        phase, *_ = make_plan_phase(collapsed)
+        phase._shape_runner = AsyncMock()
+        result = DiscoverResult(issue_number=1, opportunities=["only one"])
+        issue = TaskFactory.create(id=1)
+        assert phase._should_shape_helper(issue, result) is False
+
+    def test_should_shape_helper_true_for_divergent_opportunities(
+        self, config: HydraFlowConfig
+    ) -> None:
+        collapsed = config.model_copy(update={"collapse_discover_shape": True})
+        phase, *_ = make_plan_phase(collapsed)
+        phase._shape_runner = AsyncMock()
+        result = DiscoverResult(issue_number=1, opportunities=["a", "b"])
+        issue = TaskFactory.create(id=1)
+        assert phase._should_shape_helper(issue, result) is True
+
+    # -- _run_discover_helper ------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_run_discover_helper_posts_brief_and_returns_result(
+        self, config: HydraFlowConfig
+    ) -> None:
+        phase, _state, _planners, prs, _store, _stop = make_plan_phase(config)
+        discover_mock = AsyncMock()
+        discover_mock.discover = AsyncMock(
+            return_value=DiscoverResult(
+                issue_number=1,
+                research_brief="Brief text",
+                opportunities=["Opp A"],
+            )
+        )
+        phase._discover_runner = discover_mock
+        issue = TaskFactory.create(id=1)
+
+        result = await phase._run_discover_helper(issue, guidance="")
+
+        discover_mock.discover.assert_awaited_once()
+        assert result is not None
+        assert result.research_brief == "Brief text"
+        prs.post_comment.assert_awaited_once()
+        posted = prs.post_comment.call_args.args[1]
+        assert "Discovery Research" in posted
+        assert "Brief text" in posted
+
+    @pytest.mark.asyncio
+    async def test_run_discover_helper_returns_none_on_failure(
+        self, config: HydraFlowConfig
+    ) -> None:
+        phase, _state, _planners, prs, _store, _stop = make_plan_phase(config)
+        discover_mock = AsyncMock()
+        discover_mock.discover = AsyncMock(side_effect=RuntimeError("boom"))
+        phase._discover_runner = discover_mock
+        issue = TaskFactory.create(id=1)
+
+        result = await phase._run_discover_helper(issue, guidance="")
+
+        assert result is None
+        prs.post_comment.assert_not_awaited()
+
+    # -- _run_shape_helper -----------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_run_shape_helper_returns_none_at_turn_ceiling(
+        self, config: HydraFlowConfig
+    ) -> None:
+        collapsed = config.model_copy(update={"max_shape_turns": 2})
+        phase, state, _planners, _prs, _store, _stop = make_plan_phase(collapsed)
+        shape_mock = AsyncMock()
+        phase._shape_runner = shape_mock
+        issue = TaskFactory.create(id=1)
+        conv = ShapeConversation(
+            issue_number=1,
+            turns=[
+                ConversationTurn(role="agent", content="x"),
+                ConversationTurn(role="agent", content="y"),
+            ],
+        )
+        state.set_shape_conversation(1, conv)
+        discover_result = DiscoverResult(
+            issue_number=1, research_brief="b", opportunities=["a", "b"]
+        )
+
+        result = await phase._run_shape_helper(issue, discover_result, guidance="")
+
+        assert result is None
+        shape_mock.run_turn.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_run_shape_helper_persists_conversation_turn(
+        self, config: HydraFlowConfig
+    ) -> None:
+        phase, state, _planners, _prs, _store, _stop = make_plan_phase(config)
+        shape_mock = AsyncMock()
+        shape_mock.run_turn = AsyncMock(
+            return_value=ShapeTurnResult(content="Directions...", is_final=False)
+        )
+        phase._shape_runner = shape_mock
+        issue = TaskFactory.create(id=1)
+        discover_result = DiscoverResult(
+            issue_number=1, research_brief="b", opportunities=["a", "b"]
+        )
+
+        result = await phase._run_shape_helper(issue, discover_result, guidance="")
+
+        assert result is not None
+        assert result.is_final is False
+        conv = state.get_shape_conversation(1)
+        assert conv is not None
+        assert len(conv.turns) == 1
+        assert conv.turns[0].content == "Directions..."
+
+    # -- integration via plan_issues() ------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_flag_off_never_touches_discover_or_shape_runner(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Flag OFF: byte-identical behavior — helpers never invoked even if wired."""
+        phase, _state, planners, _prs, store, _stop = make_plan_phase(config)
+        discover_mock = AsyncMock()
+        phase._discover_runner = discover_mock
+        shape_mock = AsyncMock()
+        phase._shape_runner = shape_mock
+        # Tags/labels that WOULD trigger the gate if the flag were on.
+        issue = TaskFactory.create(id=1, tags=[config.research_escalation_labels[0]])
+        plan_result = PlanResultFactory.create(
+            issue_number=1, success=True, plan="p", use_defaults=True
+        )
+        planners.plan = AsyncMock(return_value=plan_result)
+        store.get_plannable = supply_once([issue])
+
+        await phase.plan_issues()
+
+        discover_mock.discover.assert_not_awaited()
+        shape_mock.run_turn.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_flag_on_well_specified_issue_plans_directly_no_helper(
+        self, config: HydraFlowConfig
+    ) -> None:
+        collapsed = config.model_copy(update={"collapse_discover_shape": True})
+        phase, _state, planners, _prs, store, _stop = make_plan_phase(collapsed)
+        discover_mock = AsyncMock()
+        phase._discover_runner = discover_mock
+        issue = TaskFactory.create(id=1)  # no hints / no cache => well-specified
+        plan_result = PlanResultFactory.create(
+            issue_number=1, success=True, plan="p", use_defaults=True
+        )
+        planners.plan = AsyncMock(return_value=plan_result)
+        store.get_plannable = supply_once([issue])
+
+        await phase.plan_issues()
+
+        discover_mock.discover.assert_not_awaited()
+        planners.plan.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_flag_on_low_clarity_issue_gets_discover_helper(
+        self, config: HydraFlowConfig
+    ) -> None:
+        from unittest.mock import MagicMock
+
+        collapsed = config.model_copy(update={"collapse_discover_shape": True})
+        phase, _state, planners, _prs, store, _stop = make_plan_phase(collapsed)
+        record = MagicMock()
+        record.payload = {"clarity_score": 3, "needs_discovery": False}
+        mock_cache = MagicMock()
+        mock_cache.latest_classification.return_value = record
+        phase._issue_cache = mock_cache
+        discover_mock = AsyncMock()
+        discover_mock.discover = AsyncMock(
+            return_value=DiscoverResult(
+                issue_number=1,
+                research_brief="Discovered context",
+                opportunities=["Only one"],
+            )
+        )
+        phase._discover_runner = discover_mock
+        issue = TaskFactory.create(id=1)
+        plan_result = PlanResultFactory.create(
+            issue_number=1, success=True, plan="p", use_defaults=True
+        )
+        planners.plan = AsyncMock(return_value=plan_result)
+        store.get_plannable = supply_once([issue])
+
+        await phase.plan_issues()
+
+        discover_mock.discover.assert_awaited_once()
+        planners.plan.assert_awaited_once()
+        research_context = planners.plan.call_args.kwargs["research_context"]
+        assert "Discovered context" in research_context
+
+    @pytest.mark.asyncio
+    async def test_flag_on_divergent_directions_escalates_and_skips_planning(
+        self, config: HydraFlowConfig
+    ) -> None:
+        from unittest.mock import MagicMock
+
+        collapsed = config.model_copy(update={"collapse_discover_shape": True})
+        phase, _state, planners, prs, store, _stop = make_plan_phase(collapsed)
+        record = MagicMock()
+        record.payload = {"clarity_score": 2, "needs_discovery": True}
+        mock_cache = MagicMock()
+        mock_cache.latest_classification.return_value = record
+        phase._issue_cache = mock_cache
+        discover_mock = AsyncMock()
+        discover_mock.discover = AsyncMock(
+            return_value=DiscoverResult(
+                issue_number=1,
+                research_brief="Discovered context",
+                opportunities=["A", "B"],
+            )
+        )
+        phase._discover_runner = discover_mock
+        shape_mock = AsyncMock()
+        shape_mock.run_turn = AsyncMock(
+            return_value=ShapeTurnResult(content="Direction A vs B", is_final=False)
+        )
+        phase._shape_runner = shape_mock
+        issue = TaskFactory.create(id=1)
+        store.get_plannable = supply_once([issue])
+
+        results = await phase.plan_issues()
+
+        shape_mock.run_turn.assert_awaited_once()
+        planners.plan.assert_not_awaited()
+        assert any(r.error == "shape_escalated" for r in results)
+        assert prs.post_comment.await_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_flag_on_finalized_shape_injects_decomposition_guidance(
+        self, config: HydraFlowConfig
+    ) -> None:
+        from unittest.mock import MagicMock
+
+        collapsed = config.model_copy(update={"collapse_discover_shape": True})
+        phase, _state, planners, _prs, store, _stop = make_plan_phase(collapsed)
+        record = MagicMock()
+        record.payload = {"clarity_score": 2, "needs_discovery": True}
+        mock_cache = MagicMock()
+        mock_cache.latest_classification.return_value = record
+        phase._issue_cache = mock_cache
+        discover_mock = AsyncMock()
+        discover_mock.discover = AsyncMock(
+            return_value=DiscoverResult(
+                issue_number=1,
+                research_brief="Discovered context",
+                opportunities=["A", "B"],
+            )
+        )
+        phase._discover_runner = discover_mock
+        shape_mock = AsyncMock()
+        shape_mock.run_turn = AsyncMock(
+            return_value=ShapeTurnResult(
+                content="Final direction chosen", is_final=True
+            )
+        )
+        phase._shape_runner = shape_mock
+        issue = TaskFactory.create(id=1)
+        plan_result = PlanResultFactory.create(
+            issue_number=1, success=True, plan="p", use_defaults=True
+        )
+        planners.plan = AsyncMock(return_value=plan_result)
+        store.get_plannable = supply_once([issue])
+
+        await phase.plan_issues()
+
+        planners.plan.assert_awaited_once()
+        research_context = planners.plan.call_args.kwargs["research_context"]
+        assert "Final direction chosen" in research_context
+        assert "DECOMPOSITION REQUIRED" in research_context

--- a/tests/test_triage_phase.py
+++ b/tests/test_triage_phase.py
@@ -431,6 +431,43 @@ class TestTriagePhase:
 
         prs.transition.assert_called_once_with(14, "plan")
 
+    @pytest.mark.asyncio
+    async def test_classification_record_carries_clarity_hints(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """ADR-0107: clarity_score / needs_discovery ride along on the
+        classification record regardless of the collapse flag, so the
+        planner's decision gate can read them back as hints later
+        (plan_phase.py:_should_discover_helper / _triage_hints)."""
+        from unittest.mock import MagicMock
+
+        from issue_cache import IssueCache
+
+        phase, _state, triage, prs, store, _stop = make_triage_phase(config)
+        mock_cache = MagicMock(spec=IssueCache)
+        mock_cache.record_classification = MagicMock()
+        phase._issue_cache = mock_cache
+
+        issue = TaskFactory.create(
+            id=15, title="Build a better Calendly", body="A" * 100
+        )
+        triage.evaluate = AsyncMock(
+            return_value=TriageResultFactory.create(
+                issue_number=15,
+                ready=True,
+                needs_discovery=True,
+                clarity_score=3,
+            )
+        )
+        store.get_triageable = supply_once([issue])
+
+        await phase.triage_issues()
+
+        mock_cache.record_classification.assert_called_once()
+        kwargs = mock_cache.record_classification.call_args.kwargs
+        assert kwargs["clarity_score"] == 3
+        assert kwargs["needs_discovery"] is True
+
 
 class TestTriagePhaseBatchScaling:
     """Pool respects max_triagers for concurrency control."""


### PR DESCRIPTION
Step 1 of 7 in the #9773 rip-out (keystone #10145 landed the ADR-0107 + flag + Triage→Plan routing). This is the PLANNER GATE: when `collapse_discover_shape` is ON, an issue routed Triage→Plan-direct still gets discovery/shaping WHEN THE PLANNER DECIDES IT'S WARRANTED — closing the plan-quality regression the ADR warns about.

- `_should_discover_helper` gate: off unless flag ON + DiscoverRunner wired; then conservative default (well-specified → no helper) unless `needs_discovery` hint, `clarity_score < threshold`, route-back-count>0, or a research-escalation label. Epic children excluded. Hints (not verdicts) read off the IssueCache classification Triage now writes.
- `_should_shape_helper`: fires only after discovery surfaced ≥2 divergent opportunities.
- Helpers invoke the EXISTING DiscoverRunner/ShapeRunner unmodified, bounded by the existing `max_discover_*`/`max_shape_*` knobs (no reimplementation, phase modules untouched — that's steps 2-6). Shaping yields to HITL (ADR-0107) rather than reimplementing a wait loop.

**Flag stays OFF (default) — byte-identical current behavior**, verified by the full suite staying green + an explicit `test_flag_off_never_touches_discover_or_shape_runner`. New tests cover the flag-ON gate/helper paths. 218 unit + 5 scenario + full tests/regressions green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)