### PR TITLE
test(scenarios): make xdist-safe so they run in the parallel lane (#10111)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,17 +295,17 @@ jobs:
         run: PYTHONPATH=src uv run pytest tests/test_execution.py tests/test_agent_advanced.py tests/test_agent_cli.py tests/test_agent_execution.py tests/test_agent_lifecycle.py tests/test_agent_output.py tests/test_hitl_runner.py tests/test_prompt_telemetry.py tests/test_dashboard_routes_control.py tests/test_dashboard_routes_core.py tests/test_dashboard_routes_hitl.py tests/test_dashboard_routes_issue_history.py tests/test_dashboard_routes_metrics.py tests/test_dashboard_routes_repo.py tests/test_dashboard_routes_state.py -W error::RuntimeWarning -W error::pytest.PytestUnraisableExceptionWarning
       # PR merge gate (Tier 2a): FAST parallel pass/fail, no coverage. Coverage
       # is single-threaded and too slow for the merge path — it moved to the
-      # trailing `coverage` job (push-to-staging + nightly). tests/scenarios is
-      # excluded here and run SERIALLY below: process-global OTel/loop-registry
-      # + convergence-timing state flakes across xdist workers (Tier 1a split).
+      # trailing `coverage` job (push-to-staging + nightly). tests/scenarios now
+      # runs in the parallel bulk (#10111): its loop-registry leak is contained
+      # by the _restore_loop_catalog_registry autouse fixture and OTel state is
+      # reset per test, so scenarios are xdist-safe.
       - name: Run tests (fast, parallel — no coverage)
-        # tests/scenarios + tests/test_review_phase_metrics.py are xdist-unsafe
-        # (process-global OTel/loop-registry/timing #10111; leaked review_advisor
-        # client mock) — excluded here, run serially below. Keep in sync with the
-        # Makefile PYTEST_SERIAL_PATHS.
-        run: PYTHONPATH=src uv run pytest tests/ --ignore=tests/regressions --ignore=tests/scenarios --ignore=tests/test_review_phase_metrics.py -n auto --dist loadscope --reruns 2 --reruns-delay 1
+        # Only tests/test_review_phase_metrics.py stays xdist-unsafe here (a
+        # leaked review_advisor client mock, #10119) — excluded and run serially
+        # below. Keep in sync with the Makefile PYTEST_SERIAL_PATHS.
+        run: PYTHONPATH=src uv run pytest tests/ --ignore=tests/regressions --ignore=tests/test_review_phase_metrics.py -n auto --dist loadscope --reruns 2 --reruns-delay 1
       - name: Run serial (xdist-unsafe) tests
-        run: PYTHONPATH=src uv run pytest tests/scenarios tests/test_review_phase_metrics.py
+        run: PYTHONPATH=src uv run pytest tests/test_review_phase_metrics.py
 
   # Trailing coverage gate (Tier 2a). Coverage is SINGLE-THREADED (xdist + --cov
   # is finicky) and therefore too slow for the PR merge path, so it runs OFF the

--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,13 @@ UV := VIRTUAL_ENV=$(VENV) UV_CACHE_DIR=$(PROJECT_ROOT)/.uv-cache uv run --active
 DEPS_STAMP := $(VENV)/.deps-synced
 
 # Parallel test execution (pytest-xdist). `--dist loadscope` keeps a module's
-# tests on one worker (safe for module-level fixtures). tests/scenarios/ is
-# excluded from parallel runs and executed SERIALLY: those tests share
-# process-global state (OTel TracerProvider, the loop-registration catalog) and
-# assert convergence ORDERING/timing, so cross-worker scheduling makes them
-# flake. Making scenarios xdist-safe (per-worker OTel provider + registry
-# isolation) is a tracked follow-up. Override PYTEST_PARALLEL= to disable.
+# tests on one worker (safe for module-level fixtures). tests/scenarios/ now
+# runs in the parallel bulk: its one cross-worker leak (a sibling test wiped the
+# process-global loop-registration catalog and left it empty) is contained by
+# the `_restore_loop_catalog_registry` autouse fixture in
+# tests/scenarios/conftest.py, and OTel provider state is already reset per test
+# by `_reset_otel_tracer_provider` in tests/conftest.py (#10111). Override
+# PYTEST_PARALLEL= to disable.
 # `--reruns` rescues TRANSIENT cross-worker flakes a newly-parallelized suite
 # surfaces (subprocess PID/timing races, e.g. the process-group reap tests) —
 # deterministic failures still fail on every retry and stay red, so real breaks
@@ -28,11 +29,10 @@ DEPS_STAMP := $(VENV)/.deps-synced
 PYTEST_PARALLEL ?= -n auto --dist loadscope --reruns 2 --reruns-delay 1
 
 # Paths excluded from the parallel run and executed SERIALLY (xdist-unsafe:
-# process-global state that collides across workers). tests/scenarios: OTel
-# provider + loop-registration catalog + convergence-timing (#10111).
+# process-global state that collides across workers).
 # tests/test_review_phase_metrics.py: a leaked global review_advisor client mock
 # degrades the advisor under cross-worker ordering (passes single-threaded) —
-# tracked follow-up. Add a path here when a non-scenario test proves
+# tracked follow-up (#10119). Add a path here when a non-scenario test proves
 # xdist-unsafe; the real fix is per-test isolation, not growing this list.
 # Subprocess-group reap tests race under parallel workers (a child's process
 # group / reap timing collides cross-worker; they have a dedicated serial CI
@@ -44,10 +44,10 @@ REAP_TESTS := tests/regressions/test_reap_processlookuperror.py \
   tests/regressions/test_issue_9911_stop_path_reap.py \
   tests/regressions/test_issue_9641_unified_group_kill.py \
   tests/regressions/test_hostrunner_reap_grandchildren.py
-# Paths run SERIALLY (excluded from the parallel run). scenarios: OTel/loop-
-# registry/timing (#10111). review_phase_metrics: leaked review_advisor mock
-# (#10119). REAP_TESTS: subprocess-group reap races. Everything else parallelizes.
-PYTEST_SERIAL_PATHS ?= tests/scenarios tests/test_review_phase_metrics.py $(REAP_TESTS)
+# Paths run SERIALLY (excluded from the parallel run). review_phase_metrics:
+# leaked review_advisor mock (#10119). REAP_TESTS: subprocess-group reap races.
+# Everything else — including tests/scenarios (#10111) — parallelizes.
+PYTEST_SERIAL_PATHS ?= tests/test_review_phase_metrics.py $(REAP_TESTS)
 PYTEST_SERIAL_IGNORE := $(addprefix --ignore=,$(PYTEST_SERIAL_PATHS))
 
 # Runtime overrides (used by `make hot`)

--- a/tests/scenarios/conftest.py
+++ b/tests/scenarios/conftest.py
@@ -38,6 +38,30 @@ def _restore_auto_pr_seams():
         ) = saved
 
 
+@pytest.fixture(autouse=True)
+def _restore_loop_catalog_registry():
+    """Keep the process-global ``LoopCatalog`` registry populated across the tree.
+
+    ``catalog/test_loop_catalog.py`` wipes ``LoopCatalog._registry`` in its own
+    autouse teardown and never repopulates it; because ``loop_registrations`` is
+    cached in ``sys.modules`` a re-import does not re-run ``ensure_registered()``.
+    So a later scenario file on the same xdist worker that calls
+    ``run_with_loops`` hits ``KeyError: Unknown loop`` (registry empty) — the
+    scheduling-dependent flake that kept ``tests/scenarios`` out of the parallel
+    lane (#10111). Repopulate + snapshot on setup and restore on teardown, around
+    every scenario, so no test can leave the registry empty for the next.
+    Mirrors ``_restore_auto_pr_seams``.
+    """
+    from tests.scenarios.catalog.loop_catalog import LoopCatalog
+
+    _loop_registrations.ensure_registered()
+    snapshot = dict(LoopCatalog._registry)
+    try:
+        yield
+    finally:
+        LoopCatalog._registry = snapshot
+
+
 @pytest.fixture
 async def mock_world(tmp_path):
     """Provide a fresh MockWorld for scenario tests."""


### PR DESCRIPTION
## What

Closes #10111. Makes `tests/scenarios/` xdist-safe so they run in the parallel `-n auto` bulk instead of a serial lane — the last big chunk of the suite that was still single-threaded.

## Root cause (reproduced deterministically)

The scheduling-dependent flake that kept scenarios serial was a single cross-worker leak: `tests/scenarios/catalog/test_loop_catalog.py` wipes the **process-global** `LoopCatalog._registry` in its own autouse teardown and never repopulates it. Because `loop_registrations` is cached in `sys.modules`, a re-import doesn't re-run `ensure_registered()`. So any later scenario file on the same worker that calls `run_with_loops` hits `KeyError: Unknown loop` (registry empty).

Reproducible with no xdist at all:
```
pytest tests/scenarios/catalog/test_loop_catalog.py \
       tests/scenarios/fakes/test_mock_world.py::TestMockWorldLoopCatalog::test_run_with_loops_uses_catalog
# → KeyError: "Unknown loop: 'ci_monitor'; registered: []"
```

The other two "collisions" named in the issue were non-issues: **OTel** provider state is already reset per test by `_reset_otel_tracer_provider` (tests/conftest.py); the **"convergence timing"** tests assert step-based close-ordering, not wall-clock (a misnomer) — their only exposure was the registry leak.

## Fix

- **`tests/scenarios/conftest.py`** — add `_restore_loop_catalog_registry`, an autouse snapshot/restore fixture (mirrors the existing `_restore_auto_pr_seams`): repopulate + snapshot the registry on setup, restore on teardown, around every scenario. No scenario can leave it empty for the next, and `test_loop_catalog.py`'s own tests still see an empty registry during their bodies (its file-local fixture runs inside this one).
- **`Makefile`** / **`.github/workflows/ci.yml`** — drop `tests/scenarios` from `PYTEST_SERIAL_PATHS` / the serial lane so scenarios join the parallel bulk. Comments updated.

## Testing

- `pytest tests/scenarios -n auto --dist loadscope` (no reruns) green across **3 runs** — 636 passed each.
- Full `make quality` green: **20336 passed** in the parallel bulk (now including scenarios), serial lane down to 88.

Closes #10111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)