### PR TITLE
feat(flake-tracker): file consent-package quarantines from the xdist audit (#10141)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -346,6 +346,7 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
     ("pr_base_max_age_days", "HYDRAFLOW_PR_BASE_MAX_AGE_DAYS", 3),
     ("flake_tracker_interval", "HYDRAFLOW_FLAKE_TRACKER_INTERVAL", 14400),
     ("flake_threshold", "HYDRAFLOW_FLAKE_THRESHOLD", 3),
+    ("xdist_quarantine_threshold", "HYDRAFLOW_XDIST_QUARANTINE_THRESHOLD", 2),
     ("skill_prompt_eval_interval", "HYDRAFLOW_SKILL_PROMPT_EVAL_INTERVAL", 604800),
     (
         "skill_prompt_eval_adversarial_timeout_seconds",
@@ -730,6 +731,7 @@ _ENV_BOOL_OVERRIDES: list[tuple[str, str, bool]] = [
         True,
     ),
     ("flake_tracker_loop_enabled", "HYDRAFLOW_FLAKE_TRACKER_LOOP_ENABLED", True),
+    ("xdist_quarantine_enabled", "HYDRAFLOW_XDIST_QUARANTINE_ENABLED", True),
     ("github_cache_loop_enabled", "HYDRAFLOW_GITHUB_CACHE_LOOP_ENABLED", True),
     ("health_monitor_loop_enabled", "HYDRAFLOW_HEALTH_MONITOR_LOOP_ENABLED", True),
     (
@@ -3398,6 +3400,15 @@ class HydraFlowConfig(BaseModel):
         le=20,
         description="Flake count in last 20 runs that triggers an issue (>=)",
     )
+    xdist_quarantine_threshold: int = Field(
+        default=2,
+        ge=1,
+        le=20,
+        description=(
+            "xdist-audit runs a test must be flagged fail-parallel/pass-serial "
+            "in before FlakeTrackerLoop files a quarantine issue (>=)"
+        ),
+    )
 
     # Trust fleet — SkillPromptEvalLoop (spec §4.6)
     skill_prompt_eval_interval: int = Field(
@@ -4390,6 +4401,13 @@ class HydraFlowConfig(BaseModel):
     flake_tracker_loop_enabled: bool = Field(
         default=True,
         description="Deploy-time kill-switch for FlakeTrackerLoop.",
+    )
+    xdist_quarantine_enabled: bool = Field(
+        default=True,
+        description=(
+            "Kill-switch for FlakeTrackerLoop's xdist-quarantine detection "
+            "(reads the xdist-audit report; independent of flake tracking)."
+        ),
     )
     github_cache_loop_enabled: bool = Field(
         default=True,

--- a/src/flake_tracker_loop.py
+++ b/src/flake_tracker_loop.py
@@ -15,6 +15,7 @@ auto-close via the shared `EscalationReconciler` (#9618 class).
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 import tempfile
@@ -39,6 +40,31 @@ logger = logging.getLogger("hydraflow.flake_tracker_loop")
 
 _MAX_ATTEMPTS = 3
 _RUN_WINDOW = 20
+
+# xdist-quarantine detection (#10141): read the nightly xdist-audit report
+# (produced by .github/workflows/xdist-audit.yml → scripts/xdist_audit.py) and
+# file a consent-package quarantine issue for a test consistently flagged
+# fail-parallel/pass-serial across the window. The workflow name is
+# single-sourced in github_cache_loop.XDIST_AUDIT_WORKFLOW (the cache lists it).
+_XDIST_AUDIT_ARTIFACT = "xdist-audit"
+_XDIST_AUDIT_REPORT = "xdist-audit.json"
+
+
+def _quarantine_path_hint(test_id: str) -> str:
+    """Best-effort test FILE path from a ``{classname}.{name}`` JUnit id.
+
+    pytest's ``classname`` is the dotted module path, optionally suffixed with
+    the class (``tests.scenarios.test_foo.TestBar``). Drop the test name and any
+    trailing ``Capitalized`` class components to recover the module, then map
+    dots to a ``.py`` path. Only a HINT for the consent package — a human
+    confirms the exact ``PYTEST_SERIAL_PATHS`` entry.
+    """
+    classname = test_id.rsplit(".", 1)[0] if "." in test_id else test_id
+    parts = classname.split(".")
+    while parts and parts[-1][:1].isupper():
+        parts.pop()
+    return "/".join(parts) + ".py" if parts else ""
+
 
 # Marker label on the HITL escalation issue. Single-sourced so the filing
 # path (`_file_escalation`) and the reconciler can never drift apart — no
@@ -279,6 +305,139 @@ class FlakeTrackerLoop(BaseBackgroundLoop):
         """
         await self._escalations.reconcile_closed()
 
+    async def _fetch_xdist_audit_runs(self) -> list[dict[str, Any]]:
+        """Recent ``xdist-audit`` runs from the shared cache (no per-tick gh).
+
+        Mirrors :meth:`_fetch_recent_runs`: served from the demand-refreshed
+        ``GitHubDataCache`` snapshot so the 4h tick costs at most one gh call per
+        freshness window and a gh outage degrades to an empty list (#9814).
+        """
+        rows = await self._github_cache.get_xdist_audit_runs()
+        return [
+            {
+                "databaseId": row.get("id"),
+                "url": row.get("url", ""),
+                "conclusion": row.get("conclusion", ""),
+                "createdAt": row.get("created_at", ""),
+            }
+            for row in rows[:_RUN_WINDOW]
+        ]
+
+    async def _download_xdist_audit(self, run: dict[str, Any]) -> list[str]:
+        """Download a run's ``xdist-audit`` artifact; return its ``xdist_unsafe`` list."""
+        run_id = str(run.get("databaseId", ""))
+        if not run_id:
+            return []
+        with tempfile.TemporaryDirectory() as td:
+            cmd = [
+                "gh",
+                "run",
+                "download",
+                run_id,
+                "--repo",
+                self._config.repo,
+                "--name",
+                _XDIST_AUDIT_ARTIFACT,
+                "--dir",
+                td,
+            ]
+            try:
+                result = await run_subprocess_result(*cmd, timeout=_GH_TIMEOUT_SECONDS)
+            except SubprocessTimeoutError:
+                return []
+            if result.returncode != 0:
+                return []
+            for report in Path(td).rglob(_XDIST_AUDIT_REPORT):
+                try:
+                    data = json.loads(report.read_text(encoding="utf-8"))
+                except (json.JSONDecodeError, OSError):
+                    continue
+                unsafe = data.get("xdist_unsafe", []) if isinstance(data, dict) else []
+                return [str(t) for t in unsafe] if isinstance(unsafe, list) else []
+            return []
+
+    @staticmethod
+    def _tally_xdist_unsafe(per_run: list[list[str]]) -> dict[str, int]:
+        """Count the audit runs (not occurrences) that flagged each test."""
+        counts: dict[str, int] = {}
+        for run_unsafe in per_run:
+            for test_id in set(run_unsafe):
+                counts[test_id] = counts.get(test_id, 0) + 1
+        return counts
+
+    async def _file_xdist_quarantine_issue(
+        self, test_id: str, flagged: int, total: int
+    ) -> int:
+        """File a consent-package issue to quarantine an xdist-unsafe test.
+
+        Mirrors the GateHealthLoop consent-package shape (evidence +
+        recommendation + exact command); human-gated — the loop never edits the
+        serial list itself.
+        """
+        path_hint = _quarantine_path_hint(test_id)
+        hint_line = f"`{path_hint}`" if path_hint else "_(derive from the test id)_"
+        title = f"xdist-unsafe test: {test_id}"
+        body = (
+            "## Evidence (xdist-audit, automated)\n\n"
+            "| metric | value |\n|---|---|\n"
+            f"| test | `{test_id}` |\n"
+            f"| flagged fail-parallel/pass-serial | {flagged} of the last "
+            f"{total} audit run(s) |\n"
+            f"| likely file | {hint_line} |\n\n"
+            "This test fails under `pytest -n auto` but passes serially across "
+            "the audit window — a process-global isolation leak. Moving it to "
+            "the serial lane unblocks the parallel bulk while the root isolation "
+            "issue is fixed.\n\n"
+            "## Consent package\n\n"
+            "**Recommendation:** quarantine into `PYTEST_SERIAL_PATHS`, then "
+            "fix the isolation leak and remove it again (shrink-only baseline).\n\n"
+            "**Exact edit:** append the file to `PYTEST_SERIAL_PATHS` in the "
+            "`Makefile` and keep the `ci.yml` serial lane in sync — add "
+            f"`--ignore={path_hint or '<file>'}` to the parallel `test` step and "
+            f"`{path_hint or '<file>'}` to the serial step. (A path already under "
+            "`tests/regressions/` is covered by the blanket `--ignore=tests/"
+            "regressions` in ci.yml; only the Makefile needs it.)\n\n"
+            "Human-gated: `flake_tracker` will NOT apply this edit.\n\n"
+            "_Auto-filed by HydraFlow's `flake_tracker` loop (#10141)._"
+        )
+        return await self._pr.create_issue(
+            title, body, ["hydraflow-find", "flaky-test"]
+        )
+
+    async def _run_xdist_quarantine_detection(self) -> dict[str, int]:
+        """Detect + file consent-package quarantines from the xdist-audit report.
+
+        Independent of the RC flake-tally path: windows the nightly audit so a
+        one-off transient parallel failure never triggers a quarantine (only a
+        test flagged in ``xdist_quarantine_threshold`` runs). Dedup-keyed
+        separately (``xdist_quarantine:``) from the flake keys.
+        """
+        if not self._config.xdist_quarantine_enabled:
+            return {"filed": 0}
+        runs = await self._fetch_xdist_audit_runs()
+        if not runs:
+            return {"filed": 0}
+        per_run = [await self._download_xdist_audit(run) for run in runs[:_RUN_WINDOW]]
+        counts = self._tally_xdist_unsafe(per_run)
+        threshold = self._config.xdist_quarantine_threshold
+
+        dedup = set(self._dedup.get())
+        filed = 0
+        dirty = False
+        for test_id, flagged in counts.items():
+            if flagged < threshold:
+                continue
+            key = f"xdist_quarantine:{test_id}"
+            if key in dedup:
+                continue
+            await self._file_xdist_quarantine_issue(test_id, flagged, len(runs))
+            dedup.add(key)
+            dirty = True
+            filed += 1
+        if dirty:
+            self._dedup.set_all(dedup)
+        return {"filed": filed}
+
     async def _do_work(self) -> WorkCycleResult:
         """One flake-tracking cycle (spec §4.5)."""
         if not self._enabled_cb(self._worker_name):
@@ -289,9 +448,14 @@ class FlakeTrackerLoop(BaseBackgroundLoop):
         t0 = time.perf_counter()
         await self._reconcile_closed_escalations()
 
+        # xdist-quarantine detection is independent of the RC flake tally
+        # (different data source) — run it first so an empty RC window still
+        # processes the audit report.
+        xdist = await self._run_xdist_quarantine_detection()
+
         runs = await self._fetch_recent_runs()
         if not runs:
-            return {"status": "no_runs", "filed": 0}
+            return {"status": "no_runs", "filed": 0, "xdist_filed": xdist["filed"]}
 
         per_run_results: list[dict[str, str]] = []
         for run in runs:
@@ -368,6 +532,7 @@ class FlakeTrackerLoop(BaseBackgroundLoop):
             "resolved": resolved,
             "autoclosed": autoclosed,
             "tests_seen": len(counts),
+            "xdist_filed": xdist["filed"],
         }
 
     def _emit_trace(self, t0: float, *, runs_seen: int) -> None:

--- a/src/github_cache_loop.py
+++ b/src/github_cache_loop.py
@@ -35,10 +35,18 @@ logger = logging.getLogger("hydraflow.github_cache")
 # rc_budget) can never drift on which workflow they read.
 RC_PROMOTION_WORKFLOW = "rc-promotion-scenario.yml"
 
+# Nightly xdist-isolation audit workflow (#10141). FlakeTrackerLoop reads its
+# run list through the same cache so the 4h loop never issues a per-tick raw
+# ``gh run list`` (the #9814 principle) — single-sourced like the RC workflow.
+XDIST_AUDIT_WORKFLOW = "xdist-audit.yml"
+
 # One snapshot fetch covers every consumer's window: rc_budget previously
 # ran ``gh run list --limit 100`` (30-day window), flake_tracker ``--limit
 # 20``. Also the REST runs endpoint's per_page cap.
 _RC_RUNS_FETCH_LIMIT = 100
+
+# The xdist audit is nightly (≤~30 runs/month); a smaller window suffices.
+_XDIST_AUDIT_FETCH_LIMIT = 20
 
 # On refresh failure a stale snapshot is still served while younger than
 # this multiple of the caller's bound — the same x3 convention the
@@ -102,6 +110,10 @@ class GitHubDataCache:
         # loop first-ticks coalesces on one gh call.
         self._rc_workflow_runs = CacheSnapshot()
         self._rc_workflow_runs_lock = asyncio.Lock()
+        # xdist-audit CI runs (#10141): same demand-refresh contract as the RC
+        # runs, so FlakeTrackerLoop reads them without a per-tick gh call.
+        self._xdist_audit_runs = CacheSnapshot()
+        self._xdist_audit_runs_lock = asyncio.Lock()
         # Shared issue-list-by-label snapshots (#9814): keyed by
         # ``state:label:limit``, demand-refreshed like the RC runs. One
         # lock for all keys — refreshes are rare (one per key per TTL) and
@@ -201,6 +213,46 @@ class GitHubDataCache:
                 )
                 return list(snap.data) if serve_stale else []
             self._rc_workflow_runs = CacheSnapshot(
+                data=runs, fetched_at=datetime.now(UTC)
+            )
+            self._save_to_disk()
+            return list(runs)
+
+    async def get_xdist_audit_runs(
+        self, *, max_age_seconds: float | None = None
+    ) -> list[dict[str, Any]]:
+        """Return the shared xdist-audit workflow-run snapshot (#10141).
+
+        Same demand-refresh contract as :meth:`get_rc_workflow_runs` (staleness
+        bound, single-flight lock, stale-serve grace, empty on hard failure) so
+        FlakeTrackerLoop's 4h tick never issues a per-tick raw ``gh run list``.
+        Rows use the port shape; newest first.
+        """
+        if max_age_seconds is None:
+            max_age_seconds = float(self._config.data_poll_interval * 3)
+        snap = self._xdist_audit_runs
+        if snap.data is not None and snap.age_seconds <= max_age_seconds:
+            return list(snap.data)
+        async with self._xdist_audit_runs_lock:
+            snap = self._xdist_audit_runs
+            if snap.data is not None and snap.age_seconds <= max_age_seconds:
+                return list(snap.data)
+            try:
+                runs = await self._prs.list_runs_for_workflow(
+                    XDIST_AUDIT_WORKFLOW, limit=_XDIST_AUDIT_FETCH_LIMIT
+                )
+            except Exception as exc:
+                reraise_on_credit_or_bug(exc)
+                grace = max_age_seconds * _STALE_SERVE_MULTIPLIER
+                serve_stale = snap.data is not None and snap.age_seconds <= grace
+                logger.warning(
+                    "xdist_audit_runs refresh failed (age=%.0fs); %s",
+                    snap.age_seconds,
+                    "serving stale snapshot" if serve_stale else "returning empty",
+                    exc_info=True,
+                )
+                return list(snap.data) if serve_stale else []
+            self._xdist_audit_runs = CacheSnapshot(
                 data=runs, fetched_at=datetime.now(UTC)
             )
             self._save_to_disk()

--- a/src/mockworld/sandbox_main.py
+++ b/src/mockworld/sandbox_main.py
@@ -113,6 +113,11 @@ SANDBOX_SEAMS: dict[str, str] = {
     # seams replace ``_refinement_llm`` so dup/priority judgments never shell
     # out to a real ``claude``.
     "issue_refinement_loop": "seed_seam",
+    # FlakeTrackerLoop reads CI JUnit / xdist-audit reports via raw ``gh run
+    # download`` (_download_junit, _download_xdist_audit). It is a caretaker
+    # loop no sandbox scenario exercises, so the whole loop is config-disabled
+    # below rather than seeding those reads.
+    "flake_tracker_loop": "config_disable",
 }
 
 
@@ -160,6 +165,12 @@ def _apply_sandbox_config_overrides(config: HydraFlowConfig) -> None:
     # and the watcher's active outcome is unobservable. The reconciler has its
     # own unit tests; the sandbox exercises the conflict watcher.
     object.__setattr__(config, "approval_records_enabled", False)
+    # FlakeTrackerLoop (#10141): both its CI-report reads (_download_junit RC
+    # JUnit, _download_xdist_audit) are raw ``gh run download`` spawns that hang
+    # on the air-gapped network. No sandbox scenario exercises this caretaker
+    # loop, so disable it wholesale (retires the grandfathered _download_junit
+    # spawn and air-gaps the new xdist-audit read).
+    object.__setattr__(config, "flake_tracker_loop_enabled", False)
 
 
 def _load_seed() -> MockWorldSeed:

--- a/tests/architecture/test_sandbox_seam_completeness.py
+++ b/tests/architecture/test_sandbox_seam_completeness.py
@@ -53,7 +53,6 @@ GRANDFATHERED_SPAWN_BASELINE: dict[str, int] = {
     "src/adr_touchpoint_auditor_loop.py::AdrTouchpointAuditorLoop._list_recent_merged_prs::run_subprocess_result": 1,
     "src/fake_coverage_auditor_loop.py::FakeCoverageAuditorLoop._grep_scenario_for_helper::run_subprocess_result": 1,
     "src/fake_coverage_auditor_loop.py::FakeCoverageAuditorLoop._list_open_rollup_titles::run_subprocess_result": 1,
-    "src/flake_tracker_loop.py::FlakeTrackerLoop._download_junit::run_subprocess_result": 1,
     "src/health_monitor_loop.py::HealthMonitorLoop._check_stale_code::run_subprocess": 1,
     "src/memory_backlog_loop.py::MemoryBacklogLoop._commit_mirror_updates::run_subprocess_result": 2,
     "src/principles_audit_loop.py::PrinciplesAuditLoop._run_audit::run_subprocess_result": 1,

--- a/tests/regressions/test_issue_9814_cached_run_reads.py
+++ b/tests/regressions/test_issue_9814_cached_run_reads.py
@@ -135,6 +135,9 @@ def _loop_kwargs(tmp_path: Path, gh_cache: MagicMock) -> dict[str, object]:
 def _cache_mock(rows: list[dict[str, object]]) -> MagicMock:
     gh_cache = MagicMock()
     gh_cache.get_rc_workflow_runs = AsyncMock(return_value=rows)
+    # FlakeTracker also reads the xdist-audit run list from the cache (#10141);
+    # default to an empty audit so the xdist path is a cached-read no-op.
+    gh_cache.get_xdist_audit_runs = AsyncMock(return_value=[])
     return gh_cache
 
 
@@ -302,7 +305,7 @@ class TestFlakeTrackerCachedReads:
 
         result = await loop._do_work()
 
-        assert result == {"status": "no_runs", "filed": 0}
+        assert result == {"status": "no_runs", "filed": 0, "xdist_filed": 0}
 
 
 class TestRcBudgetCachedReads:

--- a/tests/scenarios/catalog/loop_registrations.py
+++ b/tests/scenarios/catalog/loop_registrations.py
@@ -533,6 +533,11 @@ def _build_flake_tracker(ports: dict[str, Any], config: Any, deps: Any) -> Any:
     * ``flake_fetch_runs`` → ``_fetch_recent_runs``
     * ``flake_download_junit`` → ``_download_junit``
     * ``flake_reconcile_closed`` → ``_reconcile_closed_escalations``
+    * ``flake_fetch_xdist_runs`` → ``_fetch_xdist_audit_runs`` (#10141)
+    * ``flake_download_xdist`` → ``_download_xdist_audit`` (#10141)
+
+    The xdist-audit seams default to an EMPTY audit (no gh, no quarantine)
+    so the detection is a no-op unless a test seeds them.
 
     ``state`` and ``dedup`` default to MagicMocks that behave like a clean
     slate (no prior flake counts, no prior dedup keys). Tests may override
@@ -577,6 +582,16 @@ def _build_flake_tracker(ports: dict[str, Any], config: Any, deps: Any) -> Any:
     reconcile = ports.get("flake_reconcile_closed")
     if reconcile is not None:
         loop._reconcile_closed_escalations = reconcile  # type: ignore[method-assign]
+
+    # xdist-quarantine external gh I/O (#10141) — air-gapped like the flake
+    # seams above. Default fetch to an empty audit so _run_xdist_quarantine_
+    # detection is a no-op (no gh, no _download call) unless a test seeds it.
+    loop._fetch_xdist_audit_runs = ports.get(  # type: ignore[method-assign]
+        "flake_fetch_xdist_runs"
+    ) or AsyncMock(return_value=[])
+    xdist_download = ports.get("flake_download_xdist")
+    if xdist_download is not None:
+        loop._download_xdist_audit = xdist_download  # type: ignore[method-assign]
 
     return loop
 

--- a/tests/test_flake_tracker_loop.py
+++ b/tests/test_flake_tracker_loop.py
@@ -17,6 +17,7 @@ from flake_tracker_loop import FlakeTrackerLoop, parse_junit_xml
 def _gh_cache() -> MagicMock:
     cache = MagicMock()
     cache.get_rc_workflow_runs = AsyncMock(return_value=[])
+    cache.get_xdist_audit_runs = AsyncMock(return_value=[])
     return cache
 
 
@@ -711,3 +712,112 @@ async def test_reconcile_open_clears_exact_spaced_subject_on_close(
     closed = await loop._escalations.reconcile_open(active_subjects=set())
     assert closed == 1
     state.clear_flake_attempts.assert_called_once_with(spaced_id)
+
+
+# ---------------------------------------------------------------------------
+# xdist-quarantine detection (#10141)
+# ---------------------------------------------------------------------------
+
+
+def test_quarantine_path_hint_module_level() -> None:
+    from flake_tracker_loop import _quarantine_path_hint
+
+    assert _quarantine_path_hint("tests.test_foo.test_bar") == "tests/test_foo.py"
+
+
+def test_quarantine_path_hint_drops_class_component() -> None:
+    from flake_tracker_loop import _quarantine_path_hint
+
+    assert (
+        _quarantine_path_hint("tests.scenarios.test_x.TestY.test_z")
+        == "tests/scenarios/test_x.py"
+    )
+
+
+def test_tally_xdist_unsafe_counts_runs_not_occurrences() -> None:
+    per_run = [["a", "b", "a"], ["a"], ["a", "b"]]
+    assert FlakeTrackerLoop._tally_xdist_unsafe(per_run) == {"a": 3, "b": 2}
+
+
+@pytest.mark.asyncio
+async def test_xdist_files_consent_package_at_threshold(loop_env, monkeypatch) -> None:
+    cfg, _state, pr, _dedup = loop_env
+    cfg.xdist_quarantine_threshold = 2
+    loop = _make_loop(loop_env)
+    monkeypatch.setattr(
+        loop,
+        "_fetch_xdist_audit_runs",
+        AsyncMock(
+            return_value=[{"databaseId": 1}, {"databaseId": 2}, {"databaseId": 3}]
+        ),
+    )
+    # test_a flagged in 2 runs (>= threshold), test_b in 1 (below).
+    monkeypatch.setattr(
+        loop,
+        "_download_xdist_audit",
+        AsyncMock(
+            side_effect=[
+                ["tests.test_a.test_x"],
+                ["tests.test_a.test_x"],
+                ["tests.test_b.test_y"],
+            ]
+        ),
+    )
+
+    result = await loop._run_xdist_quarantine_detection()
+
+    assert result["filed"] == 1
+    pr.create_issue.assert_awaited_once()
+    title, body, labels = pr.create_issue.await_args.args
+    assert title == "xdist-unsafe test: tests.test_a.test_x"
+    assert "Consent package" in body
+    assert "PYTEST_SERIAL_PATHS" in body
+    assert "tests/test_a.py" in body
+    assert "flaky-test" in labels
+
+
+@pytest.mark.asyncio
+async def test_xdist_dedup_skips_refile(loop_env, monkeypatch) -> None:
+    cfg, _state, pr, dedup = loop_env
+    cfg.xdist_quarantine_threshold = 1
+    dedup.get.return_value = {"xdist_quarantine:tests.test_a.test_x"}
+    loop = _make_loop(loop_env)
+    monkeypatch.setattr(
+        loop, "_fetch_xdist_audit_runs", AsyncMock(return_value=[{"databaseId": 1}])
+    )
+    monkeypatch.setattr(
+        loop,
+        "_download_xdist_audit",
+        AsyncMock(return_value=["tests.test_a.test_x"]),
+    )
+
+    result = await loop._run_xdist_quarantine_detection()
+
+    assert result["filed"] == 0
+    pr.create_issue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_xdist_kill_switch_short_circuits(loop_env, monkeypatch) -> None:
+    cfg, _state, _pr, _dedup = loop_env
+    cfg.xdist_quarantine_enabled = False
+    loop = _make_loop(loop_env)
+    fetch = AsyncMock(return_value=[{"databaseId": 1}])
+    monkeypatch.setattr(loop, "_fetch_xdist_audit_runs", fetch)
+
+    result = await loop._run_xdist_quarantine_detection()
+
+    assert result["filed"] == 0
+    fetch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_xdist_no_runs_is_noop(loop_env, monkeypatch) -> None:
+    _cfg, _state, pr, _dedup = loop_env
+    loop = _make_loop(loop_env)
+    monkeypatch.setattr(loop, "_fetch_xdist_audit_runs", AsyncMock(return_value=[]))
+
+    result = await loop._run_xdist_quarantine_detection()
+
+    assert result["filed"] == 0
+    pr.create_issue.assert_not_awaited()

--- a/tests/test_github_cache_loop.py
+++ b/tests/test_github_cache_loop.py
@@ -734,3 +734,34 @@ class TestGitHubCacheLoopRun:
         await loop.run()
 
         cache.poll.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# xdist-audit workflow-run snapshot (#10141)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_xdist_audit_runs_refreshes_then_serves_cached(
+    tmp_path: Path,
+) -> None:
+    cache, prs, _ = _make_cache(tmp_path)
+    rows = [{"id": 1, "url": "u", "conclusion": "success", "created_at": "t"}]
+    prs.list_runs_for_workflow = AsyncMock(return_value=rows)
+
+    first = await cache.get_xdist_audit_runs()
+    assert first == rows
+    prs.list_runs_for_workflow.assert_awaited_once_with("xdist-audit.yml", limit=20)
+
+    # Second call within the freshness window is served from the snapshot.
+    second = await cache.get_xdist_audit_runs()
+    assert second == rows
+    prs.list_runs_for_workflow.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_xdist_audit_runs_empty_on_refresh_failure(tmp_path: Path) -> None:
+    cache, prs, _ = _make_cache(tmp_path)
+    prs.list_runs_for_workflow = AsyncMock(side_effect=RuntimeError("gh down"))
+
+    assert await cache.get_xdist_audit_runs() == []


### PR DESCRIPTION
## What

Slice 2 of 2 for #10141 — the **consumer** of the xdist-audit report (slice 1 = #10151, merged). Closes #10141.

Each FlakeTrackerLoop tick reads recent `xdist-audit` runs, downloads the report artifact, and **windows** the `xdist_unsafe` list: a test flagged fail-parallel/pass-serial in ≥ `xdist_quarantine_threshold` audit runs (default 2) gets **one** consent-package issue — an evidence table plus the exact `PYTEST_SERIAL_PATHS` / `ci.yml` serial-lane edit — dedup-keyed `xdist_quarantine:` and **human-gated** (the loop never edits the serial list itself). Mirrors the GateHealthLoop consent-package shape.

Windowing is the safety net: a one-off transient parallel failure never triggers a quarantine — only a test that's consistently isolation-unsafe across the audit window.

## Design notes (things that shaped the diff)

- **No per-tick raw `gh`** — the run LIST goes through `GitHubDataCache.get_xdist_audit_runs` (mirrors `get_rc_workflow_runs`), honoring the #9814 principle. Only the artifact download is a raw spawn.
- **Sandbox air-gap** — the whole caretaker loop is config-disabled in `_apply_sandbox_config_overrides` (no sandbox scenario exercises it). This covers both `gh` reads **and retires the grandfathered `_download_junit` spawn** from the seam baseline (ratchet shrinks). Seam declared in `SANDBOX_SEAMS`; caught because `scenario_loops`/sandbox guards aren't in `make quality`.
- **Scenario air-gap** — `_build_flake_tracker` rebinds the two new `gh` seams to an empty audit by default.
- config: `xdist_quarantine_enabled` (kill-switch, ADR-0049) + `xdist_quarantine_threshold`.

## Testing
`make quality` green: 20352 passed. New unit coverage for the classifier/windowing/dedup/kill-switch, the cache method, and the path hint; flake `scenario_loops` validated with `-m ""` (123 green).

Closes #10141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)