### PR TITLE
ci(codeql): add workflow_dispatch so scans can run on demand (#9143 enabler)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,10 @@ on:
     branches: [main]
   schedule:
     - cron: "30 3 * * 1"
+  # On-demand runs so a security fix (e.g. a sanitizer model-pack, #9143) can be
+  # validated against a branch without waiting for the weekly scan or an
+  # RC-promotion PR to main — CodeQL otherwise never runs on staging branches.
+  workflow_dispatch:
 
 permissions:
   security-events: write


### PR DESCRIPTION
## What

Adds `workflow_dispatch:` to `codeql.yml`. Triggers-only change — no analysis change.

## Why

CodeQL currently runs **only** on push/PR to `main` + the weekly schedule. That means a CodeQL fix (e.g. the `scrub_secrets` sanitizer model-pack tracked in **#9143**) can't be validated against a staging branch or on demand — you'd have to wait for an RC→main promotion or the weekly scan, so "did this model actually clear the alert?" is unverifiable. That un-verifiability is the main thing blocking #9143 (see the [research comment](https://github.com/T-rav/hydraflow/issues/9143) there).

With `workflow_dispatch`, any branch can be scanned on demand (`gh workflow run codeql.yml --ref <branch>`), unblocking verification for #9143 and every future CodeQL fix.

## Testing
Workflow-trigger-only (zero Python impact). YAML validated; the workflow-parsing guards (`test_setup_uv_caching`, `test_required_matrix_contexts`, `test_arch_regen_workflow_skip`) pass. Full CI runs on this PR.

Refs #9143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)