### PR TITLE
feat(skills): make test-adequacy blocking to shift the missing_tests catch left (#9227)

### DIFF
--- a/src/skill_registry.py
+++ b/src/skill_registry.py
@@ -145,7 +145,14 @@ BUILTIN_SKILLS: list[AgentSkill] = [
         name="test-adequacy",
         purpose="Assess whether changed production code has adequate test coverage, edge cases, and regression safety",
         config_key="max_test_adequacy_attempts",
-        blocking=False,
+        # Blocking (#9227): the deterministic coverage-delta check + LLM verdict
+        # already run here pre-review, but as advisory warnings the implementer
+        # never had to act on — so `missing_tests` kept recurring as a review
+        # finding. Gating it (like diff-sanity/scope-check) shifts the catch
+        # left: an uncovered changed line RETRIES the implementer via the
+        # existing prior_failure seam before review ever classifies it. Disable
+        # via max_test_adequacy_attempts=0 if it ever over-gates.
+        blocking=True,
         prompt_builder=build_test_adequacy_prompt,
         result_parser=parse_test_adequacy_result,
         coverage_check=True,

--- a/tests/regressions/test_issue_9998_skill_telemetry_source.py
+++ b/tests/regressions/test_issue_9998_skill_telemetry_source.py
@@ -233,7 +233,9 @@ class TestSkillSourcesDriveRefineOrder:
         telemetry = PromptTelemetry(
             telemetry_config, pricing=ModelPricingTable(pricing_path)
         )
-        assert len(_BLOCKING_SKILL_NAMES) == 4
+        # diff-sanity, scope-check, discover-completeness, shape-coherence, and
+        # test-adequacy (blocking as of #9227).
+        assert len(_BLOCKING_SKILL_NAMES) == 5
 
         # Cheapest-first seeding: cost rises with position, so the
         # worst-first efficiency ranking must invert the seeded order.

--- a/tests/test_skill_registry.py
+++ b/tests/test_skill_registry.py
@@ -41,7 +41,9 @@ class TestAgentSkill:
     def test_test_adequacy_skill(self):
         skill = BUILTIN_SKILLS[3]
         assert skill.name == "test-adequacy"
-        assert skill.blocking is False
+        # Blocking as of #9227 — an uncovered changed line gates the implementer
+        # (shift-left) instead of recurring as a `missing_tests` review finding.
+        assert skill.blocking is True
         assert skill.config_key == "max_test_adequacy_attempts"
 
     def test_skill_is_frozen(self):


### PR DESCRIPTION
## What

Closes #9227 — the recurring `missing_tests` review finding. The fix is a **shift-left gate**, and the machinery already existed: the `test-adequacy` skill runs a **deterministic coverage-delta check** (`make coverage 0` → `coverage_delta.py`) plus an LLM verdict *pre-review* — but it was registered `blocking=False`, so an uncovered changed line was only a log warning the implementer never had to act on. It then recurred as a review finding.

**Change:** flip `test-adequacy` to `blocking=True` (like `diff-sanity` / `scope-check`). A failure now routes through the existing blocking branch → the implementer's `prior_failure` retry seam, catching insufficient new-code coverage **before** review classifies it as `missing_tests`. No new gate, no new plumbing — reuses the proven blocking path.

## Why this catches it fully

- `coverage.run source = ["src"]`, so fully-untested **new** files also surface at 0% and are flagged (not just partially-covered files).
- The LLM verdict (also blocking now) is the backstop for anything the deterministic check misses.
- On make-failure/timeout the coverage check preserves the LLM verdict, so infra hiccups don't false-block.

## Reversibility

Kill-switch is the existing `max_test_adequacy_attempts=0` (disables the skill), matching the convention for the other blocking skills.

## Acceptance / self-closing

`RetrospectiveLoop.verify_proposals` auto-marks the `missing_tests` proposal resolved once the category drops >50% over the review-insight window (`_PROPOSAL_IMPROVEMENT_THRESHOLD=0.5`).

## Testing
`make quality` green: 20430 passed. Unit (`test_skill_registry` assertion), the `test_agent_realistic` scenario (test-adequacy OK path), and `test_issue_9998` (`_BLOCKING_SKILL_NAMES` now 5) all updated/pass.

Closes #9227.

🤖 Generated with [Claude Code](https://claude.com/claude-code)