### PR TITLE
test(fake-coverage): FakeGitHub adapter-surface slice 5 — gap→0 (#9768)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,51 +1,51 @@
 {
-  "regenerated_at": "2026-07-21T20:08:07.152729+00:00",
-  "commit_sha": "953eaf8b4dc30a6e931cdffa1d7e44b17c971978",
+  "regenerated_at": "2026-07-21T20:23:48.406410+00:00",
+  "commit_sha": "32da94af0aa7b7273db4e3cd82bb6ff572c4c6a3",
   "artifacts": {
     "loops.md": {
-      "source_sha": "953eaf8b4dc30a6e931cdffa1d7e44b17c971978"
+      "source_sha": "32da94af0aa7b7273db4e3cd82bb6ff572c4c6a3"
     },
     "ports.md": {
-      "source_sha": "953eaf8b4dc30a6e931cdffa1d7e44b17c971978"
+      "source_sha": "32da94af0aa7b7273db4e3cd82bb6ff572c4c6a3"
     },
     "labels.md": {
-      "source_sha": "953eaf8b4dc30a6e931cdffa1d7e44b17c971978"
+      "source_sha": "32da94af0aa7b7273db4e3cd82bb6ff572c4c6a3"
     },
     "modules.md": {
-      "source_sha": "953eaf8b4dc30a6e931cdffa1d7e44b17c971978"
+      "source_sha": "32da94af0aa7b7273db4e3cd82bb6ff572c4c6a3"
     },
     "events.md": {
-      "source_sha": "953eaf8b4dc30a6e931cdffa1d7e44b17c971978"
+      "source_sha": "32da94af0aa7b7273db4e3cd82bb6ff572c4c6a3"
     },
     "adr_xref.md": {
-      "source_sha": "953eaf8b4dc30a6e931cdffa1d7e44b17c971978"
+      "source_sha": "32da94af0aa7b7273db4e3cd82bb6ff572c4c6a3"
     },
     "mockworld.md": {
-      "source_sha": "953eaf8b4dc30a6e931cdffa1d7e44b17c971978"
+      "source_sha": "32da94af0aa7b7273db4e3cd82bb6ff572c4c6a3"
     },
     "changelog.md": {
-      "source_sha": "953eaf8b4dc30a6e931cdffa1d7e44b17c971978"
+      "source_sha": "32da94af0aa7b7273db4e3cd82bb6ff572c4c6a3"
     },
     "coverage_matrix.md": {
-      "source_sha": "953eaf8b4dc30a6e931cdffa1d7e44b17c971978"
+      "source_sha": "32da94af0aa7b7273db4e3cd82bb6ff572c4c6a3"
     },
     "adr-conformance.md": {
-      "source_sha": "953eaf8b4dc30a6e931cdffa1d7e44b17c971978"
+      "source_sha": "32da94af0aa7b7273db4e3cd82bb6ff572c4c6a3"
     },
     "ai_system_inventory.md": {
-      "source_sha": "953eaf8b4dc30a6e931cdffa1d7e44b17c971978"
+      "source_sha": "32da94af0aa7b7273db4e3cd82bb6ff572c4c6a3"
     },
     "traceability_matrix.md": {
-      "source_sha": "953eaf8b4dc30a6e931cdffa1d7e44b17c971978"
+      "source_sha": "32da94af0aa7b7273db4e3cd82bb6ff572c4c6a3"
     },
     "functional_areas.md": {
-      "source_sha": "953eaf8b4dc30a6e931cdffa1d7e44b17c971978"
+      "source_sha": "32da94af0aa7b7273db4e3cd82bb6ff572c4c6a3"
     },
     "ubiquitous-language.md": {
-      "source_sha": "953eaf8b4dc30a6e931cdffa1d7e44b17c971978"
+      "source_sha": "32da94af0aa7b7273db4e3cd82bb6ff572c4c6a3"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "953eaf8b4dc30a6e931cdffa1d7e44b17c971978"
+      "source_sha": "32da94af0aa7b7273db4e3cd82bb6ff572c4c6a3"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,17 +6,11 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W30
 
-- `953eaf8` — Merge remote-tracking branch 'origin/staging' into feat/10140-loop-self-repair-actuator *(2026-07-21)*
-- `7961771` — chore(arch): regen after staging merge (#10140) (#10140) *(2026-07-21)*
+- `32da94a` — test(fake-coverage): cover final FakeGitHub adapter-surface slice — gap→0 (#9768) (#9768) *(2026-07-21)*
+- `37dcabe` — feat(health): loop self-repair actuator — persistent error-heartbeat → auto-repair or file (#10140) (#10155) (#10155) *(2026-07-21)*
 - `94be7b3` — fix(fake-fidelity): FakeGitHub PR-title format matches real PRManager (#10153) (#10160) (#10160) *(2026-07-21)*
-- `ac24c1e` — Merge remote-tracking branch 'origin/staging' into feat/10140-loop-self-repair-actuator *(2026-07-21)*
 - `31e4cbd` — test(fake-coverage): cover next FakeGitHub adapter-surface slice (#9768) (#10161) (#10161) *(2026-07-21)*
-- `e19f18f` — fix(sandbox): air-gap HealthMonitorLoop._repo_probe via injected RepoProber (#10140) (#10140) *(2026-07-21)*
-- `a666fc8` — Merge remote-tracking branch 'origin/staging' into feat/10140-loop-self-repair-actuator *(2026-07-21)*
 - `e9115b0` — feat(pr-red): Phase 2 — dispatch auto-agent to fix real (non-infra) settled CI reds on their branch (#10027) (#10157) (#10157) *(2026-07-21)*
-- `94976a6` — chore(arch): regen (#10140) (#10140) *(2026-07-21)*
-- `b4f2f8d` — Merge remote-tracking branch 'origin/staging' into feat/10140-loop-self-repair-actuator *(2026-07-21)*
-- `be2470a` — feat(health): loop self-repair actuator — persistent error-heartbeat → auto-repair or file (#10140) (#10140) *(2026-07-21)*
 - `90d56c9` — test(trust): cassette FakeGitHub PR-review/label cluster — 11 methods (#9768 slice 3) (#10152) (#10152) *(2026-07-21)*
 - `f76c267` — feat(adr): AdrDriftResolverLoop — triage-before-escalate so drift rollups self-resolve (#9976) (#10146) (#10146) *(2026-07-21)*
 - `0d66c52` — feat(pipeline): ADR-0107 + flag-gated Triage→Plan routing — keystone for collapsing Discover/Shape (#9773) (#10145) (#10145) *(2026-07-21)*

--- a/tests/regressions/test_issue_9768.py
+++ b/tests/regressions/test_issue_9768.py
@@ -1,4 +1,4 @@
-"""Regression pin for issue #9768 (slices 1–4) — cassette-cluster pins.
+"""Regression pin for issue #9768 (slices 1–5) — cassette-cluster pins.
 
 Issue #9768 is the canonical ``fake_coverage_auditor`` rollup for the
 FakeGitHub adapter surface. The first carved slice (subsuming #9436) closes
@@ -18,7 +18,17 @@ the **PR/label read & query cluster** — 11 methods covering open-PR lookup
 ``list_open_prs`` / ``list_all_open_prs`` / ``list_conflicting_prs``), HITL
 listing (``list_hitl_items``), label-count aggregation (``get_label_counts``),
 and PR content reads (``get_pr_diff`` / ``get_pr_diff_names`` /
-``get_pr_head_sha`` / ``get_pr_recent_commit_diffs``). Each pin uses
+``get_pr_head_sha`` / ``get_pr_recent_commit_diffs``). Slice 5 — the FINAL
+slice — closes the **workflow-run / CI-log / git-op / alerts cluster**: the
+last 12 methods covering workflow-run reads (``list_workflow_runs`` /
+``list_runs_for_workflow`` / ``get_workflow_run_jobs`` /
+``count_workflow_run_artifacts``), security-alert reads
+(``fetch_code_scanning_alerts`` / ``get_dependabot_alerts``), CI-log reads
+(``fetch_ci_failure_logs``), and git/branch ops (``push_branch`` /
+``branch_has_diff_from_main`` / ``pull_main`` /
+``refresh_pr_branch_with_arch_regen`` / ``upload_screenshot``). With slice 5
+the FakeGitHub adapter surface is fully cassetted and
+``GRANDFATHERED_UNCASSETTED["FakeGitHub"]`` is empty. Each pin uses
 the auditor's *own* catalog functions so it fails for exactly the reason the
 auditor would re-file:
 
@@ -218,4 +228,67 @@ def test_issue_9768_pr_read_query_cluster_is_cassetted() -> None:
         "PR-read-query-cluster methods lost cassette coverage under "
         f"{cassette_dir.relative_to(_REPO_ROOT)}/ (input.command is the "
         f"coverage key, not the filename): {uncovered}"
+    )
+
+
+# The #9768 slice-5 cluster (FINAL): workflow-run reads, security-alert reads,
+# CI-log reads, and git/branch ops. Closing this empties
+# GRANDFATHERED_UNCASSETTED["FakeGitHub"] — the whole adapter surface is
+# cassetted.
+_WORKFLOW_GITOP_CLUSTER = frozenset(
+    {
+        "branch_has_diff_from_main",
+        "count_workflow_run_artifacts",
+        "fetch_ci_failure_logs",
+        "fetch_code_scanning_alerts",
+        "get_dependabot_alerts",
+        "get_workflow_run_jobs",
+        "list_runs_for_workflow",
+        "list_workflow_runs",
+        "pull_main",
+        "push_branch",
+        "refresh_pr_branch_with_arch_regen",
+        "upload_screenshot",
+    }
+)
+
+
+def test_issue_9768_workflow_gitop_cluster_is_cassetted() -> None:
+    """Every workflow-run/CI-log/git-op/alerts method stays covered by a cassette."""
+    catalog = catalog_fake_methods(_FAKE_DIR, repo_root=_REPO_ROOT)
+    assert "FakeGitHub" in catalog, "FakeGitHub not found in fakes catalog"
+
+    surface = set(catalog["FakeGitHub"]["adapter-surface"])
+    misclassified = sorted(_WORKFLOW_GITOP_CLUSTER - surface)
+    assert misclassified == [], (
+        "Workflow-gitop-cluster methods no longer classified adapter-surface "
+        f"(auditor accounting drift?): {misclassified}"
+    )
+
+    cassette_dir = _CASSETTE_ROOT / _FAKE_TO_CASSETTE_DIR["FakeGitHub"]
+    cassetted = catalog_cassette_methods(cassette_dir)
+    uncovered = sorted(_WORKFLOW_GITOP_CLUSTER - cassetted)
+    assert uncovered == [], (
+        "Workflow-gitop-cluster methods lost cassette coverage under "
+        f"{cassette_dir.relative_to(_REPO_ROOT)}/ (input.command is the "
+        f"coverage key, not the filename): {uncovered}"
+    )
+
+
+def test_issue_9768_fakegithub_surface_fully_cassetted() -> None:
+    """The whole point of #9768: FakeGitHub has zero uncovered surface methods.
+
+    Slice 5 is the closing slice. This end-state pin fails loudly if any
+    future adapter-surface method lands without a cassette — the gap must
+    never silently reopen now that the rollup is closed.
+    """
+    catalog = catalog_fake_methods(_FAKE_DIR, repo_root=_REPO_ROOT)
+    surface = set(catalog["FakeGitHub"]["adapter-surface"])
+    cassette_dir = _CASSETTE_ROOT / _FAKE_TO_CASSETTE_DIR["FakeGitHub"]
+    cassetted = catalog_cassette_methods(cassette_dir)
+    uncovered = sorted(surface - cassetted)
+    assert uncovered == [], (
+        "FakeGitHub adapter surface regressed to a non-zero coverage gap "
+        f"(#9768 was closed at zero): {uncovered}. Record a cassette + "
+        "dispatcher branch for each."
     )

--- a/tests/trust/contracts/cassettes/github/branch_has_diff_from_main.yaml
+++ b/tests/trust/contracts/cassettes/github/branch_has_diff_from_main.yaml
@@ -1,0 +1,23 @@
+# Hand-authored baseline (recorder_sha: "00000000").
+# branch_has_diff_from_main reports whether a branch has commits ahead of
+# main (`git rev-list`). The fake conservatively returns True always so
+# callers never falsely skip a branch as empty.
+adapter: github
+interaction: branch_has_diff_from_main
+recorded_at: '2026-07-21T00:00:00Z'
+recorder_sha: '00000000'
+fixture_repo: T-rav-Hydra-Ops/hydraflow-contracts-sandbox
+input:
+  command: branch_has_diff_from_main
+  args:
+  - feat/diff-me
+  stdin: null
+  env: {}
+output:
+  exit_code: 0
+  stdout: 'True
+
+    '
+  stderr: ''
+normalizers: []
+baseline_only: true

--- a/tests/trust/contracts/cassettes/github/count_workflow_run_artifacts.yaml
+++ b/tests/trust/contracts/cassettes/github/count_workflow_run_artifacts.yaml
@@ -1,0 +1,23 @@
+# Hand-authored baseline (recorder_sha: "00000000").
+# count_workflow_run_artifacts returns how many artifacts a run uploaded
+# (`gh api .../artifacts`). The dispatcher seeds a run with 3 artifacts
+# so the count is non-zero, not a vacuous default.
+adapter: github
+interaction: count_workflow_run_artifacts
+recorded_at: '2026-07-21T00:00:00Z'
+recorder_sha: '00000000'
+fixture_repo: T-rav-Hydra-Ops/hydraflow-contracts-sandbox
+input:
+  command: count_workflow_run_artifacts
+  args:
+  - '5401'
+  stdin: null
+  env: {}
+output:
+  exit_code: 0
+  stdout: '3
+
+    '
+  stderr: ''
+normalizers: []
+baseline_only: true

--- a/tests/trust/contracts/cassettes/github/fetch_ci_failure_logs.yaml
+++ b/tests/trust/contracts/cassettes/github/fetch_ci_failure_logs.yaml
@@ -1,0 +1,23 @@
+# Hand-authored baseline (recorder_sha: "00000000").
+# fetch_ci_failure_logs returns aggregated CI failure logs for a PR
+# (`gh run view --log-failed`). The dispatcher seeds a failure-log line
+# via seed_ci_failure_log so the read returns a non-empty payload.
+adapter: github
+interaction: fetch_ci_failure_logs
+recorded_at: '2026-07-21T00:00:00Z'
+recorder_sha: '00000000'
+fixture_repo: T-rav-Hydra-Ops/hydraflow-contracts-sandbox
+input:
+  command: fetch_ci_failure_logs
+  args:
+  - '811'
+  stdin: null
+  env: {}
+output:
+  exit_code: 0
+  stdout: 'FAILED tests/test_x.py::test_y
+
+    '
+  stderr: ''
+normalizers: []
+baseline_only: true

--- a/tests/trust/contracts/cassettes/github/fetch_code_scanning_alerts.yaml
+++ b/tests/trust/contracts/cassettes/github/fetch_code_scanning_alerts.yaml
@@ -1,0 +1,26 @@
+# Hand-authored baseline (recorder_sha: "00000000").
+# fetch_code_scanning_alerts returns open code-scanning alerts for a
+# branch as CodeScanningAlert projections (number/severity/path/rule/...).
+# The dispatcher seeds one high-severity alert via add_alerts so the read
+# returns a populated row, not the empty default.
+adapter: github
+interaction: fetch_code_scanning_alerts
+recorded_at: '2026-07-21T00:00:00Z'
+recorder_sha: '00000000'
+fixture_repo: T-rav-Hydra-Ops/hydraflow-contracts-sandbox
+input:
+  command: fetch_code_scanning_alerts
+  args:
+  - feat/scan
+  stdin: null
+  env: {}
+output:
+  exit_code: 0
+  stdout: '[{"number": 7, "severity": "error", "security_severity": "high", "path":
+    "src/app.py", "start_line": 42, "rule": "py/sql-injection", "message": "Possible
+    SQL injection"}]
+
+    '
+  stderr: ''
+normalizers: []
+baseline_only: true

--- a/tests/trust/contracts/cassettes/github/get_dependabot_alerts.yaml
+++ b/tests/trust/contracts/cassettes/github/get_dependabot_alerts.yaml
@@ -1,0 +1,24 @@
+# Hand-authored baseline (recorder_sha: "00000000").
+# get_dependabot_alerts returns Dependabot alert dicts
+# (`gh api repos/{repo}/dependabot/alerts`). FIDELITY GAP: FakeGitHub has
+# no dependabot seed hook and always returns [] (the air-gapped sandbox
+# surfaces no supply-chain alerts). This pins the empty-list shape the
+# real adapter also returns in dry-run / on-error mode.
+adapter: github
+interaction: get_dependabot_alerts
+recorded_at: '2026-07-21T00:00:00Z'
+recorder_sha: '00000000'
+fixture_repo: T-rav-Hydra-Ops/hydraflow-contracts-sandbox
+input:
+  command: get_dependabot_alerts
+  args: []
+  stdin: null
+  env: {}
+output:
+  exit_code: 0
+  stdout: '[]
+
+    '
+  stderr: ''
+normalizers: []
+baseline_only: true

--- a/tests/trust/contracts/cassettes/github/get_workflow_run_jobs.yaml
+++ b/tests/trust/contracts/cassettes/github/get_workflow_run_jobs.yaml
@@ -1,0 +1,26 @@
+# Hand-authored baseline (recorder_sha: "00000000").
+# get_workflow_run_jobs returns the jobs of one run
+# {name, status, conclusion, started_at, completed_at, steps} — the
+# timing/steps fields feed GateHealthLoop's suspected-hang classifier
+# and PrRedRepairLoop's settled-red predicate. One failing job is seeded.
+adapter: github
+interaction: get_workflow_run_jobs
+recorded_at: '2026-07-21T00:00:00Z'
+recorder_sha: '00000000'
+fixture_repo: T-rav-Hydra-Ops/hydraflow-contracts-sandbox
+input:
+  command: get_workflow_run_jobs
+  args:
+  - '5301'
+  stdin: null
+  env: {}
+output:
+  exit_code: 0
+  stdout: '[{"name": "test (3.13)", "status": "completed", "conclusion": "failure",
+    "started_at": "2026-07-01T00:00:10Z", "completed_at": "2026-07-01T00:04:00Z",
+    "steps": [{"name": "Run pytest", "status": "completed", "conclusion": "failure"}]}]
+
+    '
+  stderr: ''
+normalizers: []
+baseline_only: true

--- a/tests/trust/contracts/cassettes/github/list_runs_for_workflow.yaml
+++ b/tests/trust/contracts/cassettes/github/list_runs_for_workflow.yaml
@@ -1,0 +1,29 @@
+# Hand-authored baseline (recorder_sha: "00000000").
+# list_runs_for_workflow returns runs of ONE workflow file newest-first
+# in the CI-history shape {id, url, status, conclusion, created_at,
+# run_started_at, updated_at} (behind GitHubDataCache.get_rc_workflow_runs).
+# A run of a different workflow is seeded and must be excluded.
+adapter: github
+interaction: list_runs_for_workflow
+recorded_at: '2026-07-21T00:00:00Z'
+recorder_sha: '00000000'
+fixture_repo: T-rav-Hydra-Ops/hydraflow-contracts-sandbox
+input:
+  command: list_runs_for_workflow
+  args:
+  - ci.yml
+  stdin: null
+  env: {}
+output:
+  exit_code: 0
+  stdout: '[{"id": 5202, "url": "https://github.com/_/_/actions/runs/5202", "status":
+    "completed", "conclusion": "failure", "created_at": "2026-07-03T00:00:00Z", "run_started_at":
+    "2026-07-03T00:00:10Z", "updated_at": "2026-07-03T00:05:00Z"}, {"id": 5201, "url":
+    "https://github.com/_/_/actions/runs/5201", "status": "completed", "conclusion":
+    "success", "created_at": "2026-07-01T00:00:00Z", "run_started_at": "2026-07-01T00:00:10Z",
+    "updated_at": "2026-07-01T00:05:00Z"}]
+
+    '
+  stderr: ''
+normalizers: []
+baseline_only: true

--- a/tests/trust/contracts/cassettes/github/list_workflow_runs.yaml
+++ b/tests/trust/contracts/cassettes/github/list_workflow_runs.yaml
@@ -1,0 +1,25 @@
+# Hand-authored baseline (recorder_sha: "00000000").
+# list_workflow_runs returns recent workflow runs newest-first
+# (`gh run list --json ...`) in the repo-wide blame-correlation shape
+# {id, workflow, conclusion, created_at, pr_number}. The dispatcher
+# seeds two runs at distinct timestamps so the ordering is exercised.
+adapter: github
+interaction: list_workflow_runs
+recorded_at: '2026-07-21T00:00:00Z'
+recorder_sha: '00000000'
+fixture_repo: T-rav-Hydra-Ops/hydraflow-contracts-sandbox
+input:
+  command: list_workflow_runs
+  args: []
+  stdin: null
+  env: {}
+output:
+  exit_code: 0
+  stdout: '[{"id": 5102, "workflow": "arch-regen.yml", "conclusion": "failure", "created_at":
+    "2026-07-02T00:00:00Z", "pr_number": 0}, {"id": 5101, "workflow": "ci.yml", "conclusion":
+    "success", "created_at": "2026-07-01T00:00:00Z", "pr_number": 901}]
+
+    '
+  stderr: ''
+normalizers: []
+baseline_only: true

--- a/tests/trust/contracts/cassettes/github/pull_main.yaml
+++ b/tests/trust/contracts/cassettes/github/pull_main.yaml
@@ -1,0 +1,20 @@
+# Hand-authored baseline (recorder_sha: "00000000").
+# pull_main pulls latest main into the local repo. FIDELITY GAP: the
+# fake returns None (the real PRPort returns bool); with no git remote in
+# the sandbox it is a no-op, so the contract records the empty stdout.
+adapter: github
+interaction: pull_main
+recorded_at: '2026-07-21T00:00:00Z'
+recorder_sha: '00000000'
+fixture_repo: T-rav-Hydra-Ops/hydraflow-contracts-sandbox
+input:
+  command: pull_main
+  args: []
+  stdin: null
+  env: {}
+output:
+  exit_code: 0
+  stdout: ''
+  stderr: ''
+normalizers: []
+baseline_only: true

--- a/tests/trust/contracts/cassettes/github/push_branch.yaml
+++ b/tests/trust/contracts/cassettes/github/push_branch.yaml
@@ -1,0 +1,24 @@
+# Hand-authored baseline (recorder_sha: "00000000").
+# push_branch(worktree_path, branch, *, force=...) pushes a branch to
+# origin, returning True on success. The air-gapped fake ignores its
+# args (no real remote) and always reports success.
+adapter: github
+interaction: push_branch
+recorded_at: '2026-07-21T00:00:00Z'
+recorder_sha: '00000000'
+fixture_repo: T-rav-Hydra-Ops/hydraflow-contracts-sandbox
+input:
+  command: push_branch
+  args:
+  - /tmp/wt-feat
+  - feat/push-me
+  stdin: null
+  env: {}
+output:
+  exit_code: 0
+  stdout: 'True
+
+    '
+  stderr: ''
+normalizers: []
+baseline_only: true

--- a/tests/trust/contracts/cassettes/github/refresh_pr_branch_with_arch_regen.yaml
+++ b/tests/trust/contracts/cassettes/github/refresh_pr_branch_with_arch_regen.yaml
@@ -1,0 +1,25 @@
+# Hand-authored baseline (recorder_sha: "00000000").
+# refresh_pr_branch_with_arch_regen self-heals a bot PR stuck red on
+# stale docs/arch/generated/: merge base, re-run arch-regen, push. Returns
+# True when a refresh commit was pushed (default). The dispatcher asserts
+# the call was recorded (arch_refresh_call_count == 1).
+adapter: github
+interaction: refresh_pr_branch_with_arch_regen
+recorded_at: '2026-07-21T00:00:00Z'
+recorder_sha: '00000000'
+fixture_repo: T-rav-Hydra-Ops/hydraflow-contracts-sandbox
+input:
+  command: refresh_pr_branch_with_arch_regen
+  args:
+  - '810'
+  - feat/heal-arch
+  stdin: null
+  env: {}
+output:
+  exit_code: 0
+  stdout: 'True
+
+    '
+  stderr: ''
+normalizers: []
+baseline_only: true

--- a/tests/trust/contracts/cassettes/github/upload_screenshot.yaml
+++ b/tests/trust/contracts/cassettes/github/upload_screenshot.yaml
@@ -1,0 +1,21 @@
+# Hand-authored baseline (recorder_sha: "00000000").
+# upload_screenshot uploads a local PNG and returns its URL (empty on
+# failure). FIDELITY GAP: the air-gapped fake never uploads an asset and
+# returns the empty URL — the contract records empty stdout for it.
+adapter: github
+interaction: upload_screenshot
+recorded_at: '2026-07-21T00:00:00Z'
+recorder_sha: '00000000'
+fixture_repo: T-rav-Hydra-Ops/hydraflow-contracts-sandbox
+input:
+  command: upload_screenshot
+  args:
+  - /tmp/shot.png
+  stdin: null
+  env: {}
+output:
+  exit_code: 0
+  stdout: ''
+  stderr: ''
+normalizers: []
+baseline_only: true

--- a/tests/trust/contracts/test_cassette_surface_parity.py
+++ b/tests/trust/contracts/test_cassette_surface_parity.py
@@ -51,25 +51,15 @@ _CASSETTE_ROOT = _REPO_ROOT / "tests" / "trust" / "contracts" / "cassettes"
 # green on the current tree. This is the honest, current coverage gap — the
 # weekly ``FakeCoverageAuditorLoop`` would file a rollup for exactly these.
 # SHRINK ONLY: record a cassette (and prune the entry here) to close a gap.
-# A NEW uncovered method must be cassetted, NOT added below. FakeGit and
-# FakeDocker are fully cassetted today, hence empty baselines.
+# A NEW uncovered method must be cassetted, NOT added below. All three audited
+# fakes (FakeGitHub, FakeGit, FakeDocker) are fully cassetted today, hence the
+# empty baselines — the adapter-surface audit is at zero uncovered methods.
 GRANDFATHERED_UNCASSETTED: dict[str, frozenset[str]] = {
-    "FakeGitHub": frozenset(
-        {
-            "branch_has_diff_from_main",
-            "count_workflow_run_artifacts",
-            "fetch_ci_failure_logs",
-            "fetch_code_scanning_alerts",
-            "get_dependabot_alerts",
-            "get_workflow_run_jobs",
-            "list_runs_for_workflow",
-            "list_workflow_runs",
-            "pull_main",
-            "push_branch",
-            "refresh_pr_branch_with_arch_regen",
-            "upload_screenshot",
-        }
-    ),
+    # FakeGitHub is now FULLY cassetted (#9768 closed by slice 5 — the final
+    # workflow-run / CI-log / git-op / alerts cluster). All three audited fakes
+    # have empty baselines; the FakeCoverageAuditorLoop adapter-surface audit is
+    # at zero uncovered methods.
+    "FakeGitHub": frozenset(),
     "FakeDocker": frozenset(),
     "FakeGit": frozenset(),
 }

--- a/tests/trust/contracts/test_fake_github_contract.py
+++ b/tests/trust/contracts/test_fake_github_contract.py
@@ -650,6 +650,191 @@ async def _invoke_fake_github(cassette: Cassette) -> FakeOutput:  # noqa: PLR091
         diffs = await fake.get_pr_recent_commit_diffs(pr_number)
         return FakeOutput(exit_code=0, stdout=f"{diffs}\n", stderr="")
 
+    # --- Workflow-run / CI-log / git-op / alerts cluster (#9768 slice 5) ---
+
+    if method == "list_workflow_runs":
+        import json as _json
+
+        # Two runs at distinct timestamps so the newest-first ordering the
+        # method promises is actually exercised, not a single-row shape.
+        fake.add_workflow_run(
+            5101,
+            workflow="ci.yml",
+            conclusion="success",
+            created_at="2026-07-01T00:00:00Z",
+            pr_number=901,
+        )
+        fake.add_workflow_run(
+            5102,
+            workflow="arch-regen.yml",
+            conclusion="failure",
+            created_at="2026-07-02T00:00:00Z",
+            pr_number=0,
+        )
+        runs = await fake.list_workflow_runs()
+        assert [r["id"] for r in runs] == [5102, 5101], (
+            f"list_workflow_runs not newest-first: {[r['id'] for r in runs]}"
+        )
+        return FakeOutput(exit_code=0, stdout=_json.dumps(runs) + "\n", stderr="")
+
+    if method == "list_runs_for_workflow":
+        import json as _json
+
+        workflow = str(args[0])
+        # Two runs of the target workflow (newest-first) + one run of a
+        # different workflow the method must exclude.
+        fake.add_workflow_run(
+            5201,
+            workflow=workflow,
+            conclusion="success",
+            created_at="2026-07-01T00:00:00Z",
+            url="https://github.com/_/_/actions/runs/5201",
+            run_started_at="2026-07-01T00:00:10Z",
+            updated_at="2026-07-01T00:05:00Z",
+        )
+        fake.add_workflow_run(
+            5202,
+            workflow=workflow,
+            conclusion="failure",
+            created_at="2026-07-03T00:00:00Z",
+            url="https://github.com/_/_/actions/runs/5202",
+            run_started_at="2026-07-03T00:00:10Z",
+            updated_at="2026-07-03T00:05:00Z",
+        )
+        fake.add_workflow_run(
+            5203,
+            workflow="other.yml",
+            conclusion="success",
+            created_at="2026-07-04T00:00:00Z",
+        )
+        runs = await fake.list_runs_for_workflow(workflow)
+        assert [r["id"] for r in runs] == [5202, 5201], (
+            f"list_runs_for_workflow leaked/misordered rows: {[r['id'] for r in runs]}"
+        )
+        return FakeOutput(exit_code=0, stdout=_json.dumps(runs) + "\n", stderr="")
+
+    if method == "get_workflow_run_jobs":
+        import json as _json
+
+        run_id = int(args[0])
+        job = {
+            "name": "test (3.13)",
+            "status": "completed",
+            "conclusion": "failure",
+            "started_at": "2026-07-01T00:00:10Z",
+            "completed_at": "2026-07-01T00:04:00Z",
+            "steps": [
+                {"name": "Run pytest", "status": "completed", "conclusion": "failure"}
+            ],
+        }
+        fake.add_workflow_run(
+            run_id, workflow="ci.yml", conclusion="failure", jobs=[job]
+        )
+        jobs = await fake.get_workflow_run_jobs(run_id)
+        assert [j["name"] for j in jobs] == ["test (3.13)"], (
+            f"get_workflow_run_jobs returned unexpected jobs: {jobs}"
+        )
+        return FakeOutput(exit_code=0, stdout=_json.dumps(jobs) + "\n", stderr="")
+
+    if method == "count_workflow_run_artifacts":
+        run_id = int(args[0])
+        fake.add_workflow_run(
+            run_id, workflow="ci.yml", conclusion="success", artifact_count=3
+        )
+        count = await fake.count_workflow_run_artifacts(run_id)
+        assert count == 3, f"count_workflow_run_artifacts returned {count}, want 3"
+        return FakeOutput(exit_code=0, stdout=f"{count}\n", stderr="")
+
+    if method == "fetch_code_scanning_alerts":
+        import json as _json
+
+        from models import CodeScanningAlert
+
+        branch = str(args[0])
+        # Seed one open alert on the branch so the read returns the
+        # CodeScanningAlert projection, not a vacuous empty list.
+        alert = CodeScanningAlert(
+            number=7,
+            severity="error",
+            security_severity="high",
+            path="src/app.py",
+            start_line=42,
+            rule="py/sql-injection",
+            message="Possible SQL injection",
+        )
+        fake.add_alerts(branch=branch, alerts=[alert])
+        alerts = await fake.fetch_code_scanning_alerts(branch)
+        assert [a.number for a in alerts] == [7], (
+            f"fetch_code_scanning_alerts returned unexpected alerts: {alerts}"
+        )
+        stdout = _json.dumps([a.model_dump(mode="json") for a in alerts]) + "\n"
+        return FakeOutput(exit_code=0, stdout=stdout, stderr="")
+
+    if method == "get_dependabot_alerts":
+        import json as _json
+
+        # FIDELITY GAP: FakeGitHub.get_dependabot_alerts has no seed hook and
+        # always returns [] (the air-gapped sandbox never surfaces supply-chain
+        # alerts). Documented in the cassette header; the contract pins the
+        # empty-list shape the real adapter also returns in dry-run/error mode.
+        alerts = await fake.get_dependabot_alerts()
+        assert alerts == [], f"get_dependabot_alerts unexpectedly non-empty: {alerts}"
+        return FakeOutput(exit_code=0, stdout=_json.dumps(alerts) + "\n", stderr="")
+
+    if method == "push_branch":
+        # push_branch(worktree_path, branch, *, force=...) — the fake ignores
+        # its args (air-gapped: no real remote) and reports success.
+        ok = await fake.push_branch(str(args[0]), str(args[1]))
+        assert ok is True, f"push_branch returned {ok!r}, want True"
+        return FakeOutput(exit_code=0, stdout=f"{ok}\n", stderr="")
+
+    if method == "branch_has_diff_from_main":
+        # The fake conservatively reports a diff always exists so callers never
+        # falsely skip a branch as empty.
+        branch = str(args[0])
+        has_diff = await fake.branch_has_diff_from_main(branch)
+        assert has_diff is True, f"branch_has_diff_from_main returned {has_diff!r}"
+        return FakeOutput(exit_code=0, stdout=f"{has_diff}\n", stderr="")
+
+    if method == "pull_main":
+        # FIDELITY GAP: the fake's pull_main returns None (the real PRPort
+        # returns bool). No git remote exists in the sandbox, so it is a
+        # no-op; the contract records the empty stdout the no-op produces.
+        result = await fake.pull_main()
+        assert result is None, f"pull_main returned {result!r}, want None"
+        return FakeOutput(exit_code=0, stdout="", stderr="")
+
+    if method == "refresh_pr_branch_with_arch_regen":
+        pr_number = int(args[0])
+        branch = str(args[1])
+        fake.add_pr(number=pr_number, issue_number=1, branch=branch)
+        ok = await fake.refresh_pr_branch_with_arch_regen(pr_number, branch)
+        assert ok is True, f"refresh_pr_branch_with_arch_regen returned {ok!r}"
+        assert fake.arch_refresh_call_count(pr_number) == 1, (
+            "refresh_pr_branch_with_arch_regen did not record the call on "
+            f"PR #{pr_number}"
+        )
+        return FakeOutput(exit_code=0, stdout=f"{ok}\n", stderr="")
+
+    if method == "upload_screenshot":
+        # FIDELITY GAP: the air-gapped fake never uploads an asset and returns
+        # the empty URL (documented in the cassette header). The real adapter
+        # returns a gist URL, or "" on failure — the shape the fake pins.
+        url = await fake.upload_screenshot(png_path=str(args[0]))
+        assert url == "", f"upload_screenshot returned {url!r}, want empty string"
+        return FakeOutput(exit_code=0, stdout="", stderr="")
+
+    if method == "fetch_ci_failure_logs":
+        pr_number = int(args[0])
+        fake.add_pr(number=pr_number, issue_number=1, branch="b")
+        # Seed the failure-log text so the read returns a non-empty payload.
+        fake.seed_ci_failure_log(pr_number, "FAILED tests/test_x.py::test_y")
+        logs = await fake.fetch_ci_failure_logs(pr_number)
+        assert logs == "FAILED tests/test_x.py::test_y", (
+            f"fetch_ci_failure_logs returned unexpected text: {logs!r}"
+        )
+        return FakeOutput(exit_code=0, stdout=f"{logs}\n", stderr="")
+
     msg = f"FakeGitHub has no contract-tested method {method!r}"
     raise NotImplementedError(msg)
 


### PR DESCRIPTION
Closes #9768. Final slice: covers the last 12 methods (list_workflow_runs, list_runs_for_workflow, get_workflow_run_jobs, count_workflow_run_artifacts, fetch_code_scanning_alerts, get_dependabot_alerts, fetch_ci_failure_logs, push_branch, branch_has_diff_from_main, pull_main, refresh_pr_branch_with_arch_regen, upload_screenshot). FakeGitHub adapter surface is now fully contract-covered — `GRANDFATHERED_UNCASSETTED["FakeGitHub"]` emptied and the FakeCoverageAuditorLoop adapter-surface audit is at zero uncovered methods.

Each method gets a hand-authored baseline cassette (recorder_sha 00000000, baseline_only, normalizers []) paired atomically with a self-checking dispatcher branch in test_fake_github_contract.py; cassette stdout was generated by re-invoking the actual dispatcher so fake and recorded output match by construction. Fidelity gaps (get_dependabot_alerts has no seed hook → empty; pull_main returns None vs bool; upload_screenshot returns empty URL) are documented in the cassette headers rather than faked. A 5th cluster pin plus an end-state 'surface fully cassetted' pin land in tests/regressions/test_issue_9768.py.

Verification: `pytest tests/trust/contracts/ tests/regressions/test_issue_9768.py` → 143 passed; `make arch-regen` (docs/arch staged); `make quality-lite` → lint OK, typecheck OK, security OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)